### PR TITLE
Migrate to "io.grpc:grpc-all" and "io.grpc:protoc-gen-grpc-java" 0.9.0

### DIFF
--- a/core-java-sample/src/main/java/org/spine3/sample/Application.java
+++ b/core-java-sample/src/main/java/org/spine3/sample/Application.java
@@ -61,12 +61,11 @@ public class Application {
 
     /**
      * The entry point of the sample.
-     * To change the storage implementation, change {@link Application#getStorageFactory()} method implementation.
+     * To change the storage implementation, change {@link #getStorageFactory()} method implementation.
      */
     public static void main(String[] args) {
 
         final StorageFactory factory = getStorageFactory();
-
         final Application app = new Application(factory);
 
         app.execute();
@@ -165,13 +164,14 @@ public class Application {
         return org.spine3.server.storage.memory.InMemoryStorageFactory.getInstance();
 
         /**
-         * To run the sample on the filesystem storage, uncomment the following line (and comment out return statement above).
+         * To run the sample on the file system storage, use the following line instead of one above.
          */
         // return org.spine3.server.storage.filesystem.FileSystemStorageFactory.newInstance(Sample.class);
 
         /**
-         * To run the sample on GAE local Datastore, uncomment the following line (and comment out return statement above).
-         * Instructions on how to configure the local Datastore environment:
+         * To run the sample on GAE local Datastore, use the following return statement instead of one above.
+         *
+         * See instructions on configuring local Datastore environment on this page:
          * https://github.com/SpineEventEngine/core-java/wiki/Configuring-Local-Datastore-Environment
          */
         // return org.spine3.server.storage.datastore.LocalDatastoreStorageFactory.getDefaultInstance();

--- a/core-java-sample/src/main/java/org/spine3/sample/Application.java
+++ b/core-java-sample/src/main/java/org/spine3/sample/Application.java
@@ -67,7 +67,7 @@ public class Application {
 
         final StorageFactory factory = getStorageFactory();
 
-        Application app = new Application(factory);
+        final Application app = new Application(factory);
 
         app.execute();
     }

--- a/grpc-sample/src/main/java/org/spine3/sample/Client.java
+++ b/grpc-sample/src/main/java/org/spine3/sample/Client.java
@@ -20,9 +20,8 @@
 
 package org.spine3.sample;
 
-import io.grpc.ChannelImpl;
-import io.grpc.netty.NegotiationType;
-import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spine3.base.CommandRequest;
@@ -48,16 +47,16 @@ public class Client {
     private static final String RPC_FAILED = "RPC failed";
     private static final int SHUTDOWN_TIMEOUT_SEC = 5;
 
-    private final ChannelImpl channel;
+    private final ManagedChannel channel;
     private final CommandServiceGrpc.CommandServiceBlockingStub blockingStub;
 
     /**
      * Construct the client connecting to server at {@code host:port}.
      */
     public Client(String host, int port) {
-        channel = NettyChannelBuilder
+        channel = ManagedChannelBuilder
                 .forAddress(host, port)
-                .negotiationType(NegotiationType.PLAINTEXT)
+                .usePlaintext(true)
                 .build();
         blockingStub = CommandServiceGrpc.newBlockingStub(channel);
     }
@@ -68,7 +67,7 @@ public class Client {
     public static void main(String[] args) throws InterruptedException {
 
         // Access a service running on the local machine
-        Client client = new Client(LOCALHOST, SERVER_PORT);
+        final Client client = new Client(LOCALHOST, SERVER_PORT);
 
         final List<CommandRequest> requests = Application.generateRequests();
 
@@ -77,12 +76,9 @@ public class Client {
             for (CommandRequest request : requests) {
 
                 log().info("Sending a request: " + request.getCommand().getTypeUrl() + "...");
-
                 final CommandResult result = client.send(request);
-
                 log().info("Result: " + toText(result));
             }
-
         } finally {
             client.shutdown();
         }
@@ -100,6 +96,7 @@ public class Client {
      * Sends a request to the server.
      */
     public CommandResult send(CommandRequest request) {
+
         CommandResult result = null;
         try {
             result = blockingStub.handle(request);
@@ -111,7 +108,6 @@ public class Client {
 
     private enum LogSingleton {
         INSTANCE;
-
         @SuppressWarnings("NonSerializableFieldInSerializableClass")
         private final Logger value = LoggerFactory.getLogger(Client.class);
     }

--- a/grpc-sample/src/main/java/org/spine3/sample/server/Server.java
+++ b/grpc-sample/src/main/java/org/spine3/sample/server/Server.java
@@ -19,9 +19,8 @@
  */
 package org.spine3.sample.server;
 
-import io.grpc.ServerImpl;
+import io.grpc.ServerBuilder;
 import io.grpc.ServerServiceDefinition;
-import io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +46,7 @@ public class Server {
      */
     public static final int SERVER_PORT = 50051;
 
-    private final ServerImpl serverImpl;
+    private final io.grpc.Server server;
     private final Application application;
 
     /**
@@ -56,7 +55,7 @@ public class Server {
      */
     public Server(int serverPort, StorageFactory storageFactory) {
 
-        this.serverImpl = buildServerImpl(serverPort);
+        this.server = buildServer(serverPort);
         this.application = new Application(storageFactory);
     }
 
@@ -64,7 +63,7 @@ public class Server {
      * The entry point of the sample.
      * To change the storage implementation, change {@link Application#getStorageFactory()} method implementation.
      */
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, InterruptedException {
 
         final StorageFactory storageFactory = Application.getStorageFactory();
 
@@ -75,6 +74,8 @@ public class Server {
         log().info("Server started, listening on the port " + SERVER_PORT);
 
         addShutdownHook(server);
+
+        server.awaitTermination();
     }
 
     /**
@@ -84,7 +85,7 @@ public class Server {
     public void start() throws IOException {
 
         application.setUp();
-        serverImpl.start();
+        server.start();
     }
 
     /**
@@ -93,7 +94,15 @@ public class Server {
     public void stop() {
 
         application.tearDown();
-        serverImpl.shutdown();
+        server.shutdown();
+    }
+
+    /**
+     * Waits for the server to become terminated.
+     */
+    public void awaitTermination() throws InterruptedException {
+
+        server.awaitTermination();
     }
 
     private static void addShutdownHook(final Server server) {
@@ -114,12 +123,13 @@ public class Server {
 
         @Override
         public void handle(CommandRequest req, StreamObserver<CommandResult> responseObserver) {
-            final CommandResult reply = Engine.getInstance().process(req);
 
-            responseObserver.onValue(reply);
+            final CommandResult reply = Engine.getInstance().process(req);
+            responseObserver.onNext(reply);
             responseObserver.onCompleted();
         }
 
+        @SuppressWarnings("ReturnOfNull")
         @Override
         public StreamObserver<CommandRequest> handleStream(StreamObserver<CommandResult> responseObserver) {
             //TODO:2015-06-25:mikhail.melnik: implement
@@ -127,8 +137,9 @@ public class Server {
         }
     }
 
-    private static ServerImpl buildServerImpl(int serverPort) {
-        final NettyServerBuilder builder = NettyServerBuilder.forPort(serverPort);
+    private static io.grpc.Server buildServer(int serverPort) {
+
+        final ServerBuilder builder = ServerBuilder.forPort(serverPort);
         final ServerServiceDefinition service = CommandServiceGrpc.bindService(new CommandServiceImpl());
         builder.addService(service);
         return builder.build();

--- a/grpc-sample/src/main/java/org/spine3/sample/server/Server.java
+++ b/grpc-sample/src/main/java/org/spine3/sample/server/Server.java
@@ -60,8 +60,9 @@ public class Server {
     }
 
     /**
-     * The entry point of the sample.
-     * To change the storage implementation, change {@link Application#getStorageFactory()} method implementation.
+     * The entry point of the server application.
+     *
+     * <p/>To change the storage implementation, modify {@link Application#getStorageFactory()}.
      */
     public static void main(String[] args) throws IOException, InterruptedException {
 
@@ -129,7 +130,6 @@ public class Server {
             responseObserver.onCompleted();
         }
 
-        @SuppressWarnings("ReturnOfNull")
         @Override
         public StreamObserver<CommandRequest> handleStream(StreamObserver<CommandResult> responseObserver) {
             //TODO:2015-06-25:mikhail.melnik: implement

--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 
 dependencies {
     compile group: 'com.google.protobuf', name: 'protobuf-java', version: "${project.PROTOBUF_VERSION}"
-    compile group: 'io.grpc', name: 'grpc-all', version: '0.8.0'
+    compile group: 'io.grpc', name: 'grpc-all', version: '0.9.0'
 
     compile project(':core-java')
 }
@@ -29,7 +29,7 @@ sourceSets {
 protobuf {
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:0.8.0'
+            artifact = 'io.grpc:protoc-gen-grpc-java:0.9.0'
         }
     }
     generateProtoTasks {


### PR DESCRIPTION
Migrate to "io.grpc:grpc-all" and "io.grpc:protoc-gen-grpc-java" 0.9.0;
replace internal API usages, use preferred API.