### PR TITLE
Introduce @Internal annotation and hide command handler methods.

### DIFF
--- a/core-java/src/main/java/org/spine3/Internal.java
+++ b/core-java/src/main/java/org/spine3/Internal.java
@@ -18,13 +18,26 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+package org.spine3;
+
+import java.lang.annotation.*;
+
 /**
- * Classes and interfaces in this package are for internal use of the framework.
+ * Annotates a program element which is internal to Spine, not part of the public API, and should not
+ * be used outside of the Spine codebase.
+ *
+ * @author Alexander Yevsyukov
  */
 @Internal
-@ParametersAreNonnullByDefault
-package org.spine3.internal;
+@Retention(RetentionPolicy.SOURCE)
+@Target({
+        ElementType.ANNOTATION_TYPE,
+        ElementType.CONSTRUCTOR,
+        ElementType.FIELD,
+        ElementType.METHOD,
+        ElementType.PACKAGE,
+        ElementType.TYPE})
+@Documented
+public @interface Internal {
+}
 
-import org.spine3.Internal;
-
-import javax.annotation.ParametersAreNonnullByDefault;

--- a/core-java/src/main/java/org/spine3/eventbus/EventBus.java
+++ b/core-java/src/main/java/org/spine3/eventbus/EventBus.java
@@ -216,14 +216,18 @@ public class EventBus {
                 try {
                     final Collection<EventHandlerMethod> currentSubscribers = handlersByClass.get(c);
                     if (!currentSubscribers.contains(handler)) {
-                        throw new IllegalArgumentException(
-                                "Missing event handler for the annotated method. Is " + handler.getFullName() + " registered?");
+                        throw handlerMethodWasNotRegistered(handler);
                     }
                     currentSubscribers.remove(handler);
                 } finally {
                     lockOnHandlersByClass.writeLock().unlock();
                 }
             }
+        }
+
+        private static IllegalArgumentException handlerMethodWasNotRegistered(EventHandlerMethod handler) {
+            return new IllegalArgumentException(
+                    "Cannot un-subscribe the event handler, which was not subscribed before:" + handler.getFullName());
         }
 
         private Collection<EventHandlerMethod> getHandlers(EventClass c) {

--- a/core-java/src/main/java/org/spine3/protobuf/MessageFields.java
+++ b/core-java/src/main/java/org/spine3/protobuf/MessageFields.java
@@ -46,11 +46,15 @@ public class MessageFields {
      * The prefix of generated getter methods for fields.
      */
     private static final String GETTER_METHOD_PREFIX = "get";
+
     /**
      * By convention underscore is used for separating words in field names of Protobuf messages.
      */
     private static final char PROPERTY_NAME_SEPARATOR = '_';
 
+    /**
+     * A map from fields defined as couples of {@code [Java class, field index]} to corresponding getter methods.
+     */
     private static final Map<AccessorMethodKey, Method> methodsMap = Maps.newHashMap();
 
     private MessageFields() {

--- a/core-java/src/main/java/org/spine3/protobuf/Messages.java
+++ b/core-java/src/main/java/org/spine3/protobuf/Messages.java
@@ -41,6 +41,7 @@ import static com.google.common.base.Throwables.propagate;
 @SuppressWarnings("UtilityClass")
 public class Messages {
 
+    @SuppressWarnings("DuplicateStringLiteralInspection") // This constant is used in generated classes.
     private static final String METHOD_GET_DESCRIPTOR = "getDescriptor";
 
     private Messages() {}

--- a/core-java/src/main/java/org/spine3/protobuf/TypeToClassMap.java
+++ b/core-java/src/main/java/org/spine3/protobuf/TypeToClassMap.java
@@ -51,7 +51,6 @@ public class TypeToClassMap {
 
     private static final char CLASS_PACKAGE_DELIMITER = '.';
 
-    //TODO:2015-09-09:mikhail.mikhaylov: Find a way to read it from gradle properties.
     /**
      * File, containing Protobuf messages' typeUrls and their appropriate class names.
      * Is generated with Gradle during build process.

--- a/core-java/src/main/java/org/spine3/server/CommandDispatcher.java
+++ b/core-java/src/main/java/org/spine3/server/CommandDispatcher.java
@@ -68,19 +68,19 @@ public class CommandDispatcher {
      * @param object a {@code non-null} object of the required type
      * @throws IllegalArgumentException if the object is not of required class
      */
-    public void register(Object object) {
+    void register(CommandHandlingObject object) {
         checkNotNull(object);
         checkClass(object);
 
-        final Map<CommandClass, CommandHandlerMethod> handlers = CommandHandlerMethod.scan((CommandHandlingObject)object);
+        final Map<CommandClass, CommandHandlerMethod> handlers = CommandHandlerMethod.scan(object);
         registerMap(handlers);
     }
 
-    public void unregister(Object object) {
+    void unregister(CommandHandlingObject object) {
         checkNotNull(object);
         checkClass(object);
 
-        final Map<CommandClass, CommandHandlerMethod> subscribers = CommandHandlerMethod.scan((CommandHandlingObject)object);
+        final Map<CommandClass, CommandHandlerMethod> subscribers = CommandHandlerMethod.scan(object);
         unregisterMap(subscribers);
     }
 

--- a/core-java/src/main/java/org/spine3/server/Engine.java
+++ b/core-java/src/main/java/org/spine3/server/Engine.java
@@ -115,7 +115,7 @@ public final class Engine {
         repositories.add(repository);
 
         if (repository instanceof CommandHandlingObject) {
-            getCommandDispatcher().register(repository);
+            getCommandDispatcher().register((CommandHandlingObject) repository);
         }
 
         getEventBus().register(repository);
@@ -138,7 +138,7 @@ public final class Engine {
 
     private void unregister(Repository<?, ?> repository) {
         if (repository instanceof CommandHandlingObject) {
-            getCommandDispatcher().unregister(repository);
+            getCommandDispatcher().unregister((CommandHandlingObject)repository);
         }
 
         getEventBus().unregister(repository);

--- a/core-java/src/main/java/org/spine3/server/Engine.java
+++ b/core-java/src/main/java/org/spine3/server/Engine.java
@@ -30,6 +30,7 @@ import org.spine3.eventbus.EventBus;
 import org.spine3.protobuf.Messages;
 import org.spine3.server.aggregate.Aggregate;
 import org.spine3.server.aggregate.AggregateRepository;
+import org.spine3.server.internal.CommandHandlingObject;
 import org.spine3.server.storage.AggregateStorage;
 import org.spine3.server.storage.StorageFactory;
 import org.spine3.util.Events;
@@ -113,7 +114,10 @@ public final class Engine {
 
         repositories.add(repository);
 
-        getCommandDispatcher().register(repository);
+        if (repository instanceof CommandHandlingObject) {
+            getCommandDispatcher().register(repository);
+        }
+
         getEventBus().register(repository);
     }
 
@@ -133,7 +137,10 @@ public final class Engine {
     }
 
     private void unregister(Repository<?, ?> repository) {
-        getCommandDispatcher().unregister(repository);
+        if (repository instanceof CommandHandlingObject) {
+            getCommandDispatcher().unregister(repository);
+        }
+
         getEventBus().unregister(repository);
         repository.assignStorage(null);
     }
@@ -152,7 +159,6 @@ public final class Engine {
 
         store(request);
 
-        //TODO:2015-11-13:alexander.yevsyukov: We need to do this asynchronously
         final CommandResult result = dispatch(request);
         storeAndPostEvents(result.getEventRecordList());
 
@@ -185,7 +191,6 @@ public final class Engine {
             final CommandResult result = Events.toCommandResult(eventRecords, Collections.<Any>emptyList());
             return result;
         } catch (InvocationTargetException | RuntimeException e) {
-            //TODO:2015-06-15:mikhail.melnik: handle errors
             throw propagate(e);
         }
     }

--- a/core-java/src/main/java/org/spine3/server/Entity.java
+++ b/core-java/src/main/java/org/spine3/server/Entity.java
@@ -30,10 +30,27 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.protobuf.util.TimeUtil.getCurrentTime;
 
 /**
- * A server-side wrapper for message objects with identity stored by a repository.
+ * A server-side wrapper for objects with identity.
  *
- * @param <I> the type of object IDs
- * @param <M> the type of object states.
+ * <p>An entity ID value can be of one of the following types:
+ *   <ul>
+ *      <li>String</li>
+ *      <li>Long</li>
+ *      <li>Integer</li>
+ *      <li>A class implementing {@link Message}</li>
+ *   </ul>
+ *
+ * <p>Consider using {@code Message}-based IDs if you want to have typed IDs in your code, and/or
+ * if you need to have IDs with some structure inside. Examples of such structural IDs are:
+ *   <ul>
+ *      <li>EAN value used in bar codes</li>
+ *      <li>ISBN</li>
+ *      <li>Phone number</li>
+ *      <li>email address as a couple of local-part and domain</li>
+ *   </ul>
+ *
+ * @param <I> the type of the entity ID
+ * @param <M> the type of the entity state
  */
 public abstract class Entity<I, M extends Message> {
 

--- a/core-java/src/main/java/org/spine3/server/EntityId.java
+++ b/core-java/src/main/java/org/spine3/server/EntityId.java
@@ -18,34 +18,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.spine3.server.internal;
+package org.spine3.server;
 
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
-import org.spine3.server.Entity;
 import org.spine3.util.Identifiers;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * A base for {@link Entity} ID value object.
- *
- * <p>An entity ID value can be of one of the following types:
- *   <ul>
- *      <li>String</li>
- *      <li>Long</li>
- *      <li>Integer</li>
- *      <li>A class implementing {@link Message}</li>
- *   </ul>
- *
- * <p>Consider using {@code Message}-based IDs if you want to have typed IDs in your code, and/or
- * if you need to have IDs with some structure inside. Examples of such structural IDs are:
- *   <ul>
- *      <li>EAN value used in bar codes</li>
- *      <li>ISBN</li>
- *      <li>Phone number</li>
- *      <li>email address as a couple of local-part and domain</li>
- *   </ul>
  *
  * @param <I> the type of entity IDs
  *
@@ -69,8 +51,8 @@ public abstract class EntityId<I> {
      *
      * @return
      *  <ul>
-     *      <li>Short Protobuf type name if the value is {@link Message}</li>
-     *      <li>Simple class name of the value, otherwise</li>
+     *      <li>Short Protobuf type name if the value is {@link Message}.</li>
+     *      <li>Simple class name of the value, otherwise.</li>
      *  </ul>
      */
     public String getShortTypeName() {

--- a/core-java/src/main/java/org/spine3/server/MultiHandler.java
+++ b/core-java/src/main/java/org/spine3/server/MultiHandler.java
@@ -22,7 +22,6 @@ package org.spine3.server;
 
 import com.google.common.collect.Multimap;
 import com.google.protobuf.Message;
-import org.spine3.server.internal.CommandHandlingObject;
 
 import java.lang.reflect.Method;
 
@@ -32,7 +31,7 @@ import java.lang.reflect.Method;
  *
  * @author Alexander Yevsyukov
  */
-public interface MultiHandler extends CommandHandlingObject {
+public interface MultiHandler {
 
     /**
      * Returns a map from methods to message classes they handle.

--- a/core-java/src/main/java/org/spine3/server/MultiHandler.java
+++ b/core-java/src/main/java/org/spine3/server/MultiHandler.java
@@ -22,6 +22,7 @@ package org.spine3.server;
 
 import com.google.common.collect.Multimap;
 import com.google.protobuf.Message;
+import org.spine3.server.internal.CommandHandlingObject;
 
 import java.lang.reflect.Method;
 
@@ -31,7 +32,7 @@ import java.lang.reflect.Method;
  *
  * @author Alexander Yevsyukov
  */
-public interface MultiHandler {
+public interface MultiHandler extends CommandHandlingObject {
 
     /**
      * Returns a map from methods to message classes they handle.

--- a/core-java/src/main/java/org/spine3/server/RepositoryBase.java
+++ b/core-java/src/main/java/org/spine3/server/RepositoryBase.java
@@ -113,6 +113,7 @@ public abstract class RepositoryBase<I, E extends Entity<I, ?>> implements Repos
     /**
      * {@inheritDoc}
      */
+    @Override
     public E create(I id) {
         try {
             final E result = entityConstructor.newInstance(id);

--- a/core-java/src/main/java/org/spine3/server/aggregate/AggregateCommandHandler.java
+++ b/core-java/src/main/java/org/spine3/server/aggregate/AggregateCommandHandler.java
@@ -18,10 +18,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.spine3.server.internal;
+package org.spine3.server.aggregate;
 
 import com.google.common.base.Predicate;
 import com.google.protobuf.Message;
+import org.spine3.Internal;
+import org.spine3.server.internal.CommandHandlerMethod;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.Method;
@@ -30,13 +32,14 @@ import java.util.List;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * The wrapper for a command handler method of an Aggregate Root.
+ * The wrapper for a command handler method of an Aggregate.
  *
  * @author Alexander Litus
  */
-public class AggregateCommandHandler extends CommandHandlerMethod {
+@Internal
+class AggregateCommandHandler extends CommandHandlerMethod {
 
-    public static final Predicate<Method> IS_AGGREGATE_COMMAND_HANDLER = new Predicate<Method>() {
+    static final Predicate<Method> IS_AGGREGATE_COMMAND_HANDLER = new Predicate<Method>() {
         @Override
         public boolean apply(@Nullable Method method) {
             checkNotNull(method);
@@ -50,7 +53,7 @@ public class AggregateCommandHandler extends CommandHandlerMethod {
      * @param target object to which the method applies
      * @param method subscriber method
      */
-    public AggregateCommandHandler(Object target, Method method) {
+    AggregateCommandHandler(Object target, Method method) {
         super(target, method);
     }
 
@@ -60,7 +63,7 @@ public class AggregateCommandHandler extends CommandHandlerMethod {
      * @param method a method to check
      * @return {@code true} if the method is a command handler, {@code false} otherwise
      */
-    public static boolean isAggregateCommandHandler(Method method) {
+    static boolean isAggregateCommandHandler(Method method) {
         if (!isAnnotatedCorrectly(method)){
             return false;
         }

--- a/core-java/src/main/java/org/spine3/server/aggregate/AggregateId.java
+++ b/core-java/src/main/java/org/spine3/server/aggregate/AggregateId.java
@@ -24,8 +24,8 @@ import com.google.protobuf.Message;
 import org.spine3.base.EventContext;
 import org.spine3.protobuf.MessageFields;
 import org.spine3.protobuf.Messages;
+import org.spine3.server.EntityId;
 import org.spine3.server.aggregate.error.MissingAggregateIdException;
-import org.spine3.server.internal.EntityId;
 
 import static org.spine3.util.Identifiers.ID_PROPERTY_SUFFIX;
 

--- a/core-java/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
+++ b/core-java/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
@@ -25,6 +25,7 @@ import org.spine3.base.CommandContext;
 import org.spine3.base.EventRecord;
 import org.spine3.server.MultiHandler;
 import org.spine3.server.Repository;
+import org.spine3.server.internal.CommandHandlingObject;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -38,7 +39,7 @@ import java.util.List;
  * @param <A> aggregate type
  * @author Alexander Yevsyukov
  */
-public interface AggregateRepository<I, A extends Aggregate<I, ?>> extends Repository<I, A>, MultiHandler {
+public interface AggregateRepository<I, A extends Aggregate<I, ?>> extends Repository<I, A>, MultiHandler, CommandHandlingObject {
 
     /**
      * Loads or creates an aggregate with the passed ID.

--- a/core-java/src/main/java/org/spine3/server/aggregate/AggregateRepositoryBase.java
+++ b/core-java/src/main/java/org/spine3/server/aggregate/AggregateRepositoryBase.java
@@ -19,12 +19,15 @@
  */
 package org.spine3.server.aggregate;
 
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import com.google.protobuf.Message;
+import org.spine3.Internal;
 import org.spine3.base.CommandContext;
 import org.spine3.base.EventRecord;
 import org.spine3.server.RepositoryBase;
+import org.spine3.server.internal.CommandHandlerMethod;
 import org.spine3.server.storage.AggregateEvents;
 import org.spine3.server.storage.AggregateStorage;
 
@@ -127,6 +130,18 @@ public abstract class AggregateRepositoryBase<I extends Message,
         } catch (NoSuchMethodException e) {
             throw propagate(e);
         }
+    }
+
+    @Internal
+    @Override
+    public CommandHandlerMethod createMethod(Method method) {
+        return new AggregateRepositoryDispatchMethod(this, method);
+    }
+
+    @Internal
+    @Override
+    public Predicate<Method> getHandlerMethodPredicate() {
+        return AggregateCommandHandler.IS_AGGREGATE_COMMAND_HANDLER;
     }
 
     /**

--- a/core-java/src/main/java/org/spine3/server/aggregate/AggregateRepositoryDispatchMethod.java
+++ b/core-java/src/main/java/org/spine3/server/aggregate/AggregateRepositoryDispatchMethod.java
@@ -18,13 +18,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+package org.spine3.server.aggregate;
+
+import java.lang.reflect.Method;
+
 /**
- * Classes and interfaces in this package are for internal use of the framework.
+ * @author Alexander Yevsyukov
  */
-@Internal
-@ParametersAreNonnullByDefault
-package org.spine3.internal;
+class AggregateRepositoryDispatchMethod extends AggregateCommandHandler {
 
-import org.spine3.Internal;
-
-import javax.annotation.ParametersAreNonnullByDefault;
+    /**
+     * {@inheritDoc}
+     */
+    AggregateRepositoryDispatchMethod(Object target, Method method) {
+        super(target, method);
+    }
+}

--- a/core-java/src/main/java/org/spine3/server/internal/CommandHandlerMethod.java
+++ b/core-java/src/main/java/org/spine3/server/internal/CommandHandlerMethod.java
@@ -29,12 +29,11 @@ import com.google.protobuf.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spine3.CommandClass;
+import org.spine3.Internal;
 import org.spine3.base.CommandContext;
 import org.spine3.internal.MessageHandlerMethod;
 import org.spine3.server.Assign;
 import org.spine3.server.MultiHandler;
-import org.spine3.server.aggregate.Aggregate;
-import org.spine3.server.aggregate.AggregateRepository;
 import org.spine3.util.MethodMap;
 import org.spine3.util.Methods;
 
@@ -44,12 +43,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.singletonList;
-import static org.spine3.server.internal.AggregateCommandHandler.IS_AGGREGATE_COMMAND_HANDLER;
-import static org.spine3.server.internal.ProcessManagerCommandHandler.IS_PM_COMMAND_HANDLER;
 
 /**
  * The wrapper for a command handler method.
@@ -57,6 +55,7 @@ import static org.spine3.server.internal.ProcessManagerCommandHandler.IS_PM_COMM
  * @author Alexander Yevsyukov
  */
 @SuppressWarnings("AbstractClassWithoutAbstractMethods")
+@Internal
 public abstract class CommandHandlerMethod extends MessageHandlerMethod<Object, CommandContext> {
 
     private static final int MESSAGE_PARAM_INDEX = 0;
@@ -113,8 +112,6 @@ public abstract class CommandHandlerMethod extends MessageHandlerMethod<Object, 
      *
      * @param handlingResult the command handler method return value. Could be a {@link Message} or a list of messages.
      * @return the list of events as messages
-     * @see AggregateCommandHandler#isAggregateCommandHandler(Method)
-     * @see ProcessManagerCommandHandler#isProcessManagerCommandHandler(Method)
      */
     protected <R> List<? extends Message> commandHandlingResultToEvents(R handlingResult) {
         final Class<?> resultClass = handlingResult.getClass();
@@ -138,58 +135,47 @@ public abstract class CommandHandlerMethod extends MessageHandlerMethod<Object, 
      */
     @CheckReturnValue
     public static Map<CommandClass, CommandHandlerMethod> scan(Object object) {
+        if (!(object instanceof CommandHandlingObject)) {
+            // If the passed object is not of one of the types that can hold command handler methods,
+            // return an empty map.
+            // We do not throw exception because this method is used for checking of presence of command handling methods.
+            return Collections.emptyMap();
+        }
+
         final ImmutableMap.Builder<CommandClass, CommandHandlerMethod> result = ImmutableMap.builder();
 
-        final Map<CommandClass, CommandHandlerMethod> regularHandlers = getRegularHandlers(object);
+        final CommandHandlingObject commandHandler = (CommandHandlingObject) object;
+        final Map<CommandClass, CommandHandlerMethod> regularHandlers = getHandlers(commandHandler);
         result.putAll(regularHandlers);
 
         if (object instanceof MultiHandler) {
             final MultiHandler multiHandler = (MultiHandler) object;
-            final Map<CommandClass, CommandHandlerMethod> multiHandlers = getMultiHandlers(multiHandler);
+            final Map<CommandClass, CommandHandlerMethod> multiHandlers = getHandlersFromMultiHandler(multiHandler);
             checkModifiers(toMethods(multiHandlers.values()));
             result.putAll(multiHandlers);
         }
         return result.build();
     }
 
-    private static Map<CommandClass, CommandHandlerMethod> getRegularHandlers(Object object) {
+    private static Map<CommandClass, CommandHandlerMethod> getHandlers(CommandHandlingObject object) {
         final ImmutableMap.Builder<CommandClass, CommandHandlerMethod> result = ImmutableMap.builder();
 
-        final Predicate<Method> isHandlerPredicate = getHandlerMethodPredicate(object);
+        final Predicate<Method> isHandlerPredicate = object.getHandlerMethodPredicate();
         final MethodMap handlers = new MethodMap(object.getClass(), isHandlerPredicate);
         checkModifiers(handlers.values());
         for (Map.Entry<Class<? extends Message>, Method> entry : handlers.entrySet()) {
             final CommandClass commandClass = CommandClass.of(entry.getKey());
-            final CommandHandlerMethod handler = getCommandHandler(object, entry.getValue());
+            final CommandHandlerMethod handler = object.createMethod(entry.getValue());
             result.put(commandClass, handler);
         }
         return result.build();
-    }
-
-    // TODO:2015-12-03:alexander.litus: avoid instanceof checks
-    private static CommandHandlerMethod getCommandHandler(Object object, Method value) {
-        //noinspection IfMayBeConditional
-        if (object instanceof Aggregate || object instanceof AggregateRepository) {
-            return new AggregateCommandHandler(object, value);
-        } else {
-            return new ProcessManagerCommandHandler(object, value);
-        }
-    }
-
-    private static Predicate<Method> getHandlerMethodPredicate(Object object) {
-        //noinspection IfMayBeConditional
-        if (object instanceof Aggregate || object instanceof AggregateRepository) {
-            return IS_AGGREGATE_COMMAND_HANDLER;
-        } else {
-            return IS_PM_COMMAND_HANDLER;
-        }
     }
 
     /**
      * Creates a command handler map from the passed instance of {@link MultiHandler}.
      */
     @CheckReturnValue
-    private static Map<CommandClass, CommandHandlerMethod> getMultiHandlers(MultiHandler obj) {
+    private static Map<CommandClass, CommandHandlerMethod> getHandlersFromMultiHandler(MultiHandler obj) {
         final ImmutableMap.Builder<CommandClass, CommandHandlerMethod> builder = ImmutableMap.builder();
         final Multimap<Method, Class<? extends Message>> methodsToClasses = obj.getHandlers();
         for (Method method : methodsToClasses.keySet()) {
@@ -211,13 +197,13 @@ public abstract class CommandHandlerMethod extends MessageHandlerMethod<Object, 
      * @param classes the classes of messages handled by the method
      * @return immutable map of command handlers
      */
-    private static Map<CommandClass, CommandHandlerMethod> createMap(Object target,
+    private static Map<CommandClass, CommandHandlerMethod> createMap(CommandHandlingObject target,
                                                                      Method method,
                                                                      Iterable<Class<? extends Message>> classes) {
         final ImmutableMap.Builder<CommandClass, CommandHandlerMethod> builder = ImmutableMap.builder();
         for (Class<? extends Message> messageClass : classes) {
             final CommandClass key = CommandClass.of(messageClass);
-            final CommandHandlerMethod value = getCommandHandler(target, method);
+            final CommandHandlerMethod value = target.createMethod(method);
             builder.put(key, value);
         }
         return builder.build();

--- a/core-java/src/main/java/org/spine3/server/internal/CommandHandlerMethod.java
+++ b/core-java/src/main/java/org/spine3/server/internal/CommandHandlerMethod.java
@@ -43,7 +43,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -58,9 +57,19 @@ import static java.util.Collections.singletonList;
 @Internal
 public abstract class CommandHandlerMethod extends MessageHandlerMethod<Object, CommandContext> {
 
+    /**
+     * A command must be the first parameter of a handling method.
+     */
     private static final int MESSAGE_PARAM_INDEX = 0;
+
+    /**
+     * A {@code CommandContext} must be the second parameter of the handling method.
+     */
     private static final int COMMAND_CONTEXT_PARAM_INDEX = 1;
 
+    /**
+     * A command handling method accepts two parameters.
+     */
     private static final int COMMAND_HANDLER_PARAM_COUNT = 2;
 
     /**
@@ -133,19 +142,12 @@ public abstract class CommandHandlerMethod extends MessageHandlerMethod<Object, 
      * @param object the object that keeps command handler methods
      * @return immutable map
      */
+    @Internal
     @CheckReturnValue
-    public static Map<CommandClass, CommandHandlerMethod> scan(Object object) {
-        if (!(object instanceof CommandHandlingObject)) {
-            // If the passed object is not of one of the types that can hold command handler methods,
-            // return an empty map.
-            // We do not throw exception because this method is used for checking of presence of command handling methods.
-            return Collections.emptyMap();
-        }
-
+    public static Map<CommandClass, CommandHandlerMethod> scan(CommandHandlingObject object) {
         final ImmutableMap.Builder<CommandClass, CommandHandlerMethod> result = ImmutableMap.builder();
 
-        final CommandHandlingObject commandHandler = (CommandHandlingObject) object;
-        final Map<CommandClass, CommandHandlerMethod> regularHandlers = getHandlers(commandHandler);
+        final Map<CommandClass, CommandHandlerMethod> regularHandlers = getHandlers(object);
         result.putAll(regularHandlers);
 
         if (object instanceof MultiHandler) {

--- a/core-java/src/main/java/org/spine3/server/internal/CommandHandlerMethod.java
+++ b/core-java/src/main/java/org/spine3/server/internal/CommandHandlerMethod.java
@@ -174,17 +174,21 @@ public abstract class CommandHandlerMethod extends MessageHandlerMethod<Object, 
     }
 
     /**
-     * Creates a command handler map from the passed instance of {@link MultiHandler}.
+     * Creates a command handler map from the passed instance of {@link MultiHandler} (which is also
+     * a {@link CommandHandlingObject}).
      */
     @CheckReturnValue
     private static Map<CommandClass, CommandHandlerMethod> getHandlersFromMultiHandler(MultiHandler obj) {
         final ImmutableMap.Builder<CommandClass, CommandHandlerMethod> builder = ImmutableMap.builder();
+
+        final CommandHandlingObject commandHandler = (CommandHandlingObject)obj;
+
         final Multimap<Method, Class<? extends Message>> methodsToClasses = obj.getHandlers();
         for (Method method : methodsToClasses.keySet()) {
             // check if the method accepts a command context (and is not an event handler)
             if (acceptsCorrectParams(method)) {
                 final Collection<Class<? extends Message>> classes = methodsToClasses.get(method);
-                builder.putAll(createMap(obj, method, classes));
+                builder.putAll(createMap(commandHandler, method, classes));
             }
         }
         return builder.build();

--- a/core-java/src/main/java/org/spine3/server/internal/CommandHandlingObject.java
+++ b/core-java/src/main/java/org/spine3/server/internal/CommandHandlingObject.java
@@ -18,13 +18,28 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/**
- * Classes and interfaces in this package are for internal use of the framework.
- */
-@Internal
-@ParametersAreNonnullByDefault
-package org.spine3.internal;
+package org.spine3.server.internal;
 
+import com.google.common.base.Predicate;
 import org.spine3.Internal;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+import java.lang.reflect.Method;
+
+/**
+ * An internal interface for classes that can declare command handling methods.
+ *
+ * @author Alexander Yevsyukov
+ */
+@Internal
+public interface CommandHandlingObject {
+
+    /**
+     * Creates a method wrapper, which holds reference to this object and the passed method.
+     */
+    CommandHandlerMethod createMethod(Method method);
+
+    /**
+     * Returns the predicate for filtering command handling methods.
+     */
+    Predicate<Method> getHandlerMethodPredicate();
+}

--- a/core-java/src/main/java/org/spine3/server/internal/package-info.java
+++ b/core-java/src/main/java/org/spine3/server/internal/package-info.java
@@ -21,6 +21,10 @@
 /**
  * Classes and interfaces in this package are for internal use of the framework.
  */
-@ParametersAreNonnullByDefault package org.spine3.server.internal;
+@Internal
+@ParametersAreNonnullByDefault
+package org.spine3.server.internal;
+
+import org.spine3.Internal;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/core-java/src/main/java/org/spine3/server/procman/PmCommandHandler.java
+++ b/core-java/src/main/java/org/spine3/server/procman/PmCommandHandler.java
@@ -22,7 +22,6 @@ package org.spine3.server.procman;
 
 import com.google.common.base.Predicate;
 import com.google.protobuf.Message;
-import org.spine3.Internal;
 import org.spine3.server.internal.CommandHandlerMethod;
 
 import javax.annotation.Nullable;
@@ -37,8 +36,7 @@ import static java.util.Collections.emptyList;
  *
  * @author Alexander Litus
  */
-@Internal
-class ProcessManagerCommandHandler extends CommandHandlerMethod {
+class PmCommandHandler extends CommandHandlerMethod {
 
     static final Predicate<Method> IS_PM_COMMAND_HANDLER = new Predicate<Method>() {
         @Override
@@ -54,7 +52,7 @@ class ProcessManagerCommandHandler extends CommandHandlerMethod {
      * @param target object to which the method applies
      * @param method subscriber method
      */
-    ProcessManagerCommandHandler(Object target, Method method) {
+    PmCommandHandler(Object target, Method method) {
         super(target, method);
     }
 

--- a/core-java/src/main/java/org/spine3/server/procman/PmRepositoryDispatchMethod.java
+++ b/core-java/src/main/java/org/spine3/server/procman/PmRepositoryDispatchMethod.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.procman;
+
+import com.google.protobuf.Message;
+import org.spine3.base.CommandContext;
+import org.spine3.server.internal.CommandHandlerMethod;
+
+import java.lang.reflect.Method;
+
+/**
+ * A wrapper for {@link ProcessManagerRepository#dispatchCommand(Message, CommandContext)}.
+ *
+ * <p>This specific type of {@code CommandHandlerMethod} is needed for distinguishing the dispatching
+ * method of a repository for actual handling methods.
+ *
+ * @author Alexander Yevsyukov
+ */
+class PmRepositoryDispatchMethod extends CommandHandlerMethod {
+    /**
+     * Creates a new instance to wrap {@code method} on {@code target}.
+     *
+     * @param target object to which the method applies
+     * @param method subscriber method
+     */
+    protected PmRepositoryDispatchMethod(Object target, Method method) {
+        super(target, method);
+    }
+}

--- a/core-java/src/main/java/org/spine3/server/procman/ProcessManager.java
+++ b/core-java/src/main/java/org/spine3/server/procman/ProcessManager.java
@@ -46,7 +46,7 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.spine3.internal.EventHandlerMethod.IS_EVENT_HANDLER;
 import static org.spine3.internal.EventHandlerMethod.checkModifiers;
-import static org.spine3.server.procman.ProcessManagerCommandHandler.IS_PM_COMMAND_HANDLER;
+import static org.spine3.server.procman.PmCommandHandler.IS_PM_COMMAND_HANDLER;
 
 /**
  * An independent component that reacts to domain events in a cross-aggregate, eventually consistent manner.
@@ -132,7 +132,7 @@ public abstract class ProcessManager<I, M extends Message> extends Entity<I, M> 
         if (method == null) {
             throw missingCommandHandler(commandClass);
         }
-        final CommandHandlerMethod commandHandler = new ProcessManagerCommandHandler(this, method);
+        final CommandHandlerMethod commandHandler = new PmCommandHandler(this, method);
         final List<? extends Message> events = commandHandler.invoke(command, context);
         final List<EventRecord> eventRecords = toEventRecords(events, context.getCommandId());
         return eventRecords;
@@ -251,13 +251,13 @@ public abstract class ProcessManager<I, M extends Message> extends Entity<I, M> 
     @Internal
     @Override
     public CommandHandlerMethod createMethod(Method method) {
-        return new ProcessManagerCommandHandler(this, method);
+        return new PmCommandHandler(this, method);
     }
 
     @Internal
     @Override
     public Predicate<Method> getHandlerMethodPredicate() {
-        return ProcessManagerCommandHandler.IS_PM_COMMAND_HANDLER;
+        return PmCommandHandler.IS_PM_COMMAND_HANDLER;
     }
 
     /**

--- a/core-java/src/main/java/org/spine3/server/procman/ProcessManagerCommandHandler.java
+++ b/core-java/src/main/java/org/spine3/server/procman/ProcessManagerCommandHandler.java
@@ -18,10 +18,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.spine3.server.internal;
+package org.spine3.server.procman;
 
 import com.google.common.base.Predicate;
 import com.google.protobuf.Message;
+import org.spine3.Internal;
+import org.spine3.server.internal.CommandHandlerMethod;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.Method;
@@ -35,10 +37,10 @@ import static java.util.Collections.emptyList;
  *
  * @author Alexander Litus
  */
-@SuppressWarnings("UtilityClass")
-public class ProcessManagerCommandHandler extends CommandHandlerMethod {
+@Internal
+class ProcessManagerCommandHandler extends CommandHandlerMethod {
 
-    public static final Predicate<Method> IS_PM_COMMAND_HANDLER = new Predicate<Method>() {
+    static final Predicate<Method> IS_PM_COMMAND_HANDLER = new Predicate<Method>() {
         @Override
         public boolean apply(@Nullable Method method) {
             checkNotNull(method);
@@ -52,7 +54,7 @@ public class ProcessManagerCommandHandler extends CommandHandlerMethod {
      * @param target object to which the method applies
      * @param method subscriber method
      */
-    public ProcessManagerCommandHandler(Object target, Method method) {
+    ProcessManagerCommandHandler(Object target, Method method) {
         super(target, method);
     }
 
@@ -62,7 +64,7 @@ public class ProcessManagerCommandHandler extends CommandHandlerMethod {
      * @param method a method to check
      * @return {@code true} if the method is a command handler, {@code false} otherwise
      */
-    public static boolean isProcessManagerCommandHandler(Method method) {
+    static boolean isProcessManagerCommandHandler(Method method) {
         if (!isAnnotatedCorrectly(method)){
             return false;
         }

--- a/core-java/src/main/java/org/spine3/server/procman/ProcessManagerId.java
+++ b/core-java/src/main/java/org/spine3/server/procman/ProcessManagerId.java
@@ -22,7 +22,7 @@ package org.spine3.server.procman;
 
 import com.google.protobuf.Message;
 import org.spine3.protobuf.MessageFields;
-import org.spine3.server.internal.EntityId;
+import org.spine3.server.EntityId;
 import org.spine3.server.procman.error.MissingProcessManagerIdException;
 
 import static org.spine3.util.Identifiers.ID_PROPERTY_SUFFIX;

--- a/core-java/src/main/java/org/spine3/server/procman/ProcessManagerId.java
+++ b/core-java/src/main/java/org/spine3/server/procman/ProcessManagerId.java
@@ -36,16 +36,6 @@ import static org.spine3.util.Identifiers.ID_PROPERTY_SUFFIX;
 public class ProcessManagerId<I> extends EntityId<I> {
 
     /**
-     * The standard name for properties holding an ID of a process manager.
-     */
-    public static final String PROPERTY_NAME = "processManagerId";
-
-    /**
-     * The standard name for a parameter containing a process manager ID.
-     */
-    public static final String PARAM_NAME = PROPERTY_NAME;
-
-    /**
      * The process manager ID must be the first field in events/commands.
      */
     public static final int PROCESS_MANAGER_ID_FIELD_INDEX = 0;

--- a/core-java/src/main/java/org/spine3/server/procman/ProcessManagerId.java
+++ b/core-java/src/main/java/org/spine3/server/procman/ProcessManagerId.java
@@ -48,7 +48,7 @@ public class ProcessManagerId<I> extends EntityId<I> {
     /**
      * The process manager ID must be the first field in events/commands.
      */
-    public static final int PROCESS_MANAGER_ID_FIELD_INDEX_IN_MESSAGES = 0;
+    public static final int PROCESS_MANAGER_ID_FIELD_INDEX = 0;
 
     private ProcessManagerId(I value) {
         super(value);
@@ -73,12 +73,12 @@ public class ProcessManagerId<I> extends EntityId<I> {
      * @return value of the id
      */
     public static ProcessManagerId from(Message message) {
-        final String fieldName = MessageFields.getFieldName(message, PROCESS_MANAGER_ID_FIELD_INDEX_IN_MESSAGES);
+        final String fieldName = MessageFields.getFieldName(message, PROCESS_MANAGER_ID_FIELD_INDEX);
         if (!fieldName.endsWith(ID_PROPERTY_SUFFIX)) {
             throw new MissingProcessManagerIdException(message.getClass().getName(), fieldName);
         }
         try {
-            final Message value = (Message) MessageFields.getFieldValue(message, PROCESS_MANAGER_ID_FIELD_INDEX_IN_MESSAGES);
+            final Message value = (Message) MessageFields.getFieldValue(message, PROCESS_MANAGER_ID_FIELD_INDEX);
             return new ProcessManagerId<>(value);
         } catch (RuntimeException e) {
             throw new MissingProcessManagerIdException(message, MessageFields.toAccessorMethodName(fieldName), e);

--- a/core-java/src/main/java/org/spine3/server/procman/ProcessManagerRepository.java
+++ b/core-java/src/main/java/org/spine3/server/procman/ProcessManagerRepository.java
@@ -160,13 +160,13 @@ public abstract class ProcessManagerRepository<I, PM extends ProcessManager<I, M
     @Internal
     @Override
     public CommandHandlerMethod createMethod(Method method) {
-        return new ProcessManagerCommandHandler(this, method);
+        return new PmRepositoryDispatchMethod(this, method);
     }
 
     @Internal
     @Override
     public Predicate<Method> getHandlerMethodPredicate() {
-        return ProcessManagerCommandHandler.IS_PM_COMMAND_HANDLER;
+        return PmCommandHandler.IS_PM_COMMAND_HANDLER;
     }
 
     /**

--- a/core-java/src/main/java/org/spine3/server/procman/ProcessManagerRepository.java
+++ b/core-java/src/main/java/org/spine3/server/procman/ProcessManagerRepository.java
@@ -20,14 +20,17 @@
 
 package org.spine3.server.procman;
 
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import com.google.protobuf.Message;
+import org.spine3.Internal;
 import org.spine3.base.CommandContext;
 import org.spine3.base.EventContext;
 import org.spine3.base.EventRecord;
 import org.spine3.server.EntityRepository;
 import org.spine3.server.MultiHandler;
+import org.spine3.server.internal.CommandHandlerMethod;
 
 import javax.annotation.Nonnull;
 import java.lang.reflect.InvocationTargetException;
@@ -152,6 +155,18 @@ public abstract class ProcessManagerRepository<I, PM extends ProcessManager<I, M
         return ImmutableMultimap.<Method, Class<? extends Message>>builder()
                 .putAll(handler, eventClasses)
                 .build();
+    }
+
+    @Internal
+    @Override
+    public CommandHandlerMethod createMethod(Method method) {
+        return new ProcessManagerCommandHandler(this, method);
+    }
+
+    @Internal
+    @Override
+    public Predicate<Method> getHandlerMethodPredicate() {
+        return ProcessManagerCommandHandler.IS_PM_COMMAND_HANDLER;
     }
 
     /**

--- a/core-java/src/main/java/org/spine3/server/procman/ProcessManagerRepository.java
+++ b/core-java/src/main/java/org/spine3/server/procman/ProcessManagerRepository.java
@@ -31,6 +31,7 @@ import org.spine3.base.EventRecord;
 import org.spine3.server.EntityRepository;
 import org.spine3.server.MultiHandler;
 import org.spine3.server.internal.CommandHandlerMethod;
+import org.spine3.server.internal.CommandHandlingObject;
 
 import javax.annotation.Nonnull;
 import java.lang.reflect.InvocationTargetException;
@@ -50,7 +51,7 @@ import static com.google.common.base.Throwables.propagate;
  * @author Alexander Litus
  */
 public abstract class ProcessManagerRepository<I, PM extends ProcessManager<I, M>, M extends Message>
-        extends EntityRepository<I, PM, M> implements MultiHandler {
+        extends EntityRepository<I, PM, M> implements MultiHandler, CommandHandlingObject {
 
     /**
      * The name of the method used for dispatching commands to process managers.

--- a/core-java/src/main/java/org/spine3/server/projection/ProjectionRepository.java
+++ b/core-java/src/main/java/org/spine3/server/projection/ProjectionRepository.java
@@ -98,7 +98,7 @@ public abstract class ProjectionRepository<I, P extends Projection<I, M>, M exte
      * @see Projection#handle(Message, EventContext)
      */
     @SuppressWarnings("unused") // This method is used by reflection
-    protected void dispatch(Message event, EventContext context) {
+    public void dispatch(Message event, EventContext context) {
         final I id = getEntityId(event, context);
         final P p = load(id);
         p.handle(event, context);

--- a/core-java/src/test/java/org/spine3/server/EngineShould.java
+++ b/core-java/src/test/java/org/spine3/server/EngineShould.java
@@ -21,6 +21,7 @@
 package org.spine3.server;
 
 import com.google.protobuf.Duration;
+import com.google.protobuf.Empty;
 import com.google.protobuf.Timestamp;
 import org.junit.After;
 import org.junit.Before;
@@ -31,6 +32,8 @@ import org.spine3.eventbus.Subscribe;
 import org.spine3.server.aggregate.AggregateRepositoryBase;
 import org.spine3.server.aggregate.AggregateShould;
 import org.spine3.server.error.UnsupportedCommandException;
+import org.spine3.server.procman.ProcessManager;
+import org.spine3.server.procman.ProcessManagerRepository;
 import org.spine3.server.storage.StorageFactory;
 import org.spine3.server.storage.memory.InMemoryStorageFactory;
 import org.spine3.test.project.ProjectId;
@@ -84,6 +87,39 @@ public class EngineShould {
         engine.stop();
     }
 
+    /**
+     * Registers all test repositories, handlers etc.
+     */
+    private void registerAll() {
+        engine.register(new ProjectAggregateRepository());
+        engine.getEventBus().register(handler);
+        handlersRegistered = true;
+    }
+
+    private List<CommandResult> processRequests(Iterable<CommandRequest> requests) {
+
+        final List<CommandResult> results = newLinkedList();
+        for (CommandRequest request : requests) {
+            final CommandResult result = engine.process(request);
+            results.add(result);
+        }
+        return results;
+    }
+
+    private List<CommandRequest> generateRequests() {
+
+        final Duration delta = seconds(10);
+        final Timestamp time1 = getCurrentTime();
+        final Timestamp time2 = add(time1, delta);
+        final Timestamp time3 = add(time2, delta);
+
+        final CommandRequest createProject = createProject(userId, projectId, time1);
+        final CommandRequest addTask = addTask(userId, projectId, time2);
+        final CommandRequest startProject = startProject(userId, projectId, time3);
+
+        return newArrayList(createProject, addTask, startProject);
+    }
+
     @Test
     public void return_instance_if_started() {
         assertNotNull(engine);
@@ -111,8 +147,13 @@ public class EngineShould {
     }
 
     @Test
-    public void register_test_repositories_and_handlers() {
-        registerAll();
+    public void register_AggregateRepository() {
+        engine.register(new ProjectAggregateRepository());
+    }
+
+    @Test
+    public void register_ProcessManagerRepository() {
+        engine.register(new ProjectPmRepo());
     }
 
     @Test
@@ -157,39 +198,6 @@ public class EngineShould {
         assertEquals(projectId, actualProjectId);
         assertEquals(userId, actualCommandId.getActor());
         assertEquals(expectedTime, actualCommandId.getTimestamp());
-    }
-
-    /**
-     * Registers all test repositories, handlers etc.
-     */
-    private void registerAll() {
-        engine.register(new ProjectAggregateRepository());
-        engine.getEventBus().register(handler);
-        handlersRegistered = true;
-    }
-
-    private List<CommandResult> processRequests(Iterable<CommandRequest> requests) {
-
-        final List<CommandResult> results = newLinkedList();
-        for (CommandRequest request : requests) {
-            final CommandResult result = engine.process(request);
-            results.add(result);
-        }
-        return results;
-    }
-
-    private List<CommandRequest> generateRequests() {
-
-        final Duration delta = seconds(10);
-        final Timestamp time1 = getCurrentTime();
-        final Timestamp time2 = add(time1, delta);
-        final Timestamp time3 = add(time2, delta);
-
-        final CommandRequest createProject = createProject(userId, projectId, time1);
-        final CommandRequest addTask = addTask(userId, projectId, time2);
-        final CommandRequest startProject = startProject(userId, projectId, time3);
-
-        return newArrayList(createProject, addTask, startProject);
     }
 
     @Test(expected = NullPointerException.class)
@@ -282,5 +290,21 @@ public class EngineShould {
         @Subscribe
         public void on(ProjectStarted event, EventContext context) {
         }
+    }
+
+    private static class ProjectProcessManager extends ProcessManager<ProjectId, Empty> {
+
+        @SuppressWarnings("PublicConstructorInNonPublicClass") // Constructor must be public to be called from a repository. It's a part of PM public API.
+        public ProjectProcessManager(ProjectId id) {
+            super(id);
+        }
+
+        @Override
+        protected Empty getDefaultState() {
+            return Empty.getDefaultInstance();
+        }
+    }
+
+    private static class ProjectPmRepo extends ProcessManagerRepository<ProjectId, ProjectProcessManager, Empty> {
     }
 }

--- a/core-java/src/test/java/org/spine3/server/EngineShould.java
+++ b/core-java/src/test/java/org/spine3/server/EngineShould.java
@@ -34,6 +34,8 @@ import org.spine3.server.aggregate.AggregateShould;
 import org.spine3.server.error.UnsupportedCommandException;
 import org.spine3.server.procman.ProcessManager;
 import org.spine3.server.procman.ProcessManagerRepository;
+import org.spine3.server.projection.Projection;
+import org.spine3.server.projection.ProjectionRepository;
 import org.spine3.server.storage.StorageFactory;
 import org.spine3.server.storage.memory.InMemoryStorageFactory;
 import org.spine3.test.project.ProjectId;
@@ -154,6 +156,11 @@ public class EngineShould {
     @Test
     public void register_ProcessManagerRepository() {
         engine.register(new ProjectPmRepo());
+    }
+
+    @Test
+    public void register_ProjectionRepository() {
+        engine.register(new ProjectReportRepository());
     }
 
     @Test
@@ -294,7 +301,8 @@ public class EngineShould {
 
     private static class ProjectProcessManager extends ProcessManager<ProjectId, Empty> {
 
-        @SuppressWarnings("PublicConstructorInNonPublicClass") // Constructor must be public to be called from a repository. It's a part of PM public API.
+        @SuppressWarnings("PublicConstructorInNonPublicClass")
+        // Constructor must be public to be called from a repository. It's a part of PM public API.
         public ProjectProcessManager(ProjectId id) {
             super(id);
         }
@@ -306,5 +314,22 @@ public class EngineShould {
     }
 
     private static class ProjectPmRepo extends ProcessManagerRepository<ProjectId, ProjectProcessManager, Empty> {
+    }
+
+    private static class ProjectReport extends Projection<ProjectId, Empty> {
+
+        @SuppressWarnings("PublicConstructorInNonPublicClass")
+        // Public constructor is a part of projection public API. It's called by a repository.
+        public ProjectReport(ProjectId id) {
+            super(id);
+        }
+
+        @Override
+        protected Empty getDefaultState() {
+            return Empty.getDefaultInstance();
+        }
+    }
+
+    private static class ProjectReportRepository extends ProjectionRepository<ProjectId, ProjectReport, Empty> {
     }
 }

--- a/core-java/src/test/java/org/spine3/server/EngineShould.java
+++ b/core-java/src/test/java/org/spine3/server/EngineShould.java
@@ -166,7 +166,6 @@ public class EngineShould {
      */
     private void registerAll() {
         engine.register(new ProjectAggregateRepository());
-        engine.register(new TestEntityRepository());
         engine.getEventBus().register(handler);
         handlersRegistered = true;
     }
@@ -269,9 +268,6 @@ public class EngineShould {
     }
 
     private static class ProjectAggregateRepository extends AggregateRepositoryBase<ProjectId, AggregateShould.ProjectAggregate> {
-    }
-
-    private static class TestEntityRepository extends EntityRepository<String, TestEntity, Project> {
     }
 
     public static class TestEntity extends Entity<String, Project> {

--- a/core-java/src/test/java/org/spine3/server/EngineShould.java
+++ b/core-java/src/test/java/org/spine3/server/EngineShould.java
@@ -33,7 +33,6 @@ import org.spine3.server.aggregate.AggregateShould;
 import org.spine3.server.error.UnsupportedCommandException;
 import org.spine3.server.storage.StorageFactory;
 import org.spine3.server.storage.memory.InMemoryStorageFactory;
-import org.spine3.test.project.Project;
 import org.spine3.test.project.ProjectId;
 import org.spine3.test.project.event.ProjectCreated;
 import org.spine3.test.project.event.ProjectStarted;
@@ -41,7 +40,6 @@ import org.spine3.test.project.event.TaskAdded;
 import org.spine3.testdata.TestAggregateIdFactory;
 import org.spine3.util.Users;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
@@ -268,18 +266,6 @@ public class EngineShould {
     }
 
     private static class ProjectAggregateRepository extends AggregateRepositoryBase<ProjectId, AggregateShould.ProjectAggregate> {
-    }
-
-    public static class TestEntity extends Entity<String, Project> {
-        public TestEntity(String id) {
-            super(id);
-        }
-
-        @Nonnull
-        @Override
-        protected Project getDefaultState() {
-            return Project.getDefaultInstance();
-        }
     }
 
     @SuppressWarnings("UnusedParameters") // It is intended in this empty handler class.


### PR DESCRIPTION
Introduced internal interface for CommandHandlingObject.
MultiHandler is CommandHandlingObject now.
Also avoided instanceof's in scanning for methods in CommandHandlerMethod.
Hide AggregateCommandHandler and ProcessManagerCommandHandler from public API.
Added special case of method object for AggregateRepositoryDispatchMethod. It may help in debug in the future.
Made EntityId a part of public API.