### PR TITLE
Remove string aggregate ID from aggregate storage record

### DIFF
--- a/server/src/main/java/org/spine3/server/Entity.java
+++ b/server/src/main/java/org/spine3/server/Entity.java
@@ -99,7 +99,6 @@ public abstract class Entity<I, M extends Message> {
      * @param state the state object to set
      * @param version the entity version to set
      * @param whenLastModified the time of the last modification to set
-     * @throws NullPointerException if the state or whenLastModified is {@code null}
      * @see #validate(M)
      */
     protected void setState(M state, int version, Timestamp whenLastModified) {

--- a/server/src/main/java/org/spine3/server/storage/AbstractStorage.java
+++ b/server/src/main/java/org/spine3/server/storage/AbstractStorage.java
@@ -58,7 +58,6 @@ public abstract class AbstractStorage<I, R extends Message> implements AutoClose
      * @param id the ID for the record
      * @param record a record to store
      * @throws IllegalStateException if the storage was closed before
-     * @throws NullPointerException if the ID or record is {@code null}
      */
     public abstract void write(I id, R record);
 

--- a/server/src/main/java/org/spine3/server/storage/AbstractStorage.java
+++ b/server/src/main/java/org/spine3/server/storage/AbstractStorage.java
@@ -58,6 +58,7 @@ public abstract class AbstractStorage<I, R extends Message> implements AutoClose
      * @param id the ID for the record
      * @param record a record to store
      * @throws IllegalStateException if the storage was closed before
+     * @throws NullPointerException if the ID or record is {@code null}
      */
     public abstract void write(I id, R record);
 

--- a/server/src/main/java/org/spine3/server/storage/memory/InMemoryAggregateStorage.java
+++ b/server/src/main/java/org/spine3/server/storage/memory/InMemoryAggregateStorage.java
@@ -21,6 +21,7 @@
 package org.spine3.server.storage.memory;
 
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Ordering;
 import com.google.common.collect.TreeMultimap;
 import org.spine3.protobuf.Timestamps;
 import org.spine3.server.storage.AggregateStorage;
@@ -30,9 +31,6 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.spine3.server.util.Identifiers.idToString;
-
 /**
  * In-memory storage for aggregate root events and snapshots.
  *
@@ -41,9 +39,9 @@ import static org.spine3.server.util.Identifiers.idToString;
 @SuppressWarnings("ComparatorNotSerializable")
 class InMemoryAggregateStorage<I> extends AggregateStorage<I> {
 
-    private final Multimap<String, AggregateStorageRecord> storage = TreeMultimap.create(
-            new StringComparator(),
-            new AggregateStorageRecordReverseComparator()
+    private final Multimap<I, AggregateStorageRecord> storage = TreeMultimap.create(
+            Ordering.arbitrary(), // key comparator
+            new AggregateStorageRecordReverseComparator() // value comparator
     );
 
     /**
@@ -54,17 +52,13 @@ class InMemoryAggregateStorage<I> extends AggregateStorage<I> {
     }
 
     @Override
-    protected void writeInternal(AggregateStorageRecord record) {
-        checkNotNull(record);
-        checkNotNull(record.getAggregateId());
-        storage.put(record.getAggregateId(), record);
+    protected void writeInternal(I id, AggregateStorageRecord record) {
+        storage.put(id, record);
     }
 
     @Override
     protected Iterator<AggregateStorageRecord> historyBackward(I id) {
-
-        final String idString = idToString(id);
-        final Collection<AggregateStorageRecord> records = storage.get(idString);
+        final Collection<AggregateStorageRecord> records = storage.get(id);
         return records.iterator();
     }
 
@@ -75,21 +69,14 @@ class InMemoryAggregateStorage<I> extends AggregateStorage<I> {
         storage.clear();
     }
 
-
     /*
      * Used for sorting by timestamp descending (from newer to older)
      */
     private static class AggregateStorageRecordReverseComparator implements Comparator<AggregateStorageRecord> {
         @Override
         public int compare(AggregateStorageRecord first, AggregateStorageRecord second) {
-            return Timestamps.compare(second.getTimestamp(), first.getTimestamp());
-        }
-    }
-
-    private static class StringComparator implements Comparator<String> {
-        @Override
-        public int compare(String first, String second) {
-            return first.compareTo(second);
+            final int result = Timestamps.compare(second.getTimestamp(), first.getTimestamp());
+            return result;
         }
     }
 }

--- a/server/src/main/proto/spine/server/storage/aggregate_storage.proto
+++ b/server/src/main/proto/spine/server/storage/aggregate_storage.proto
@@ -36,19 +36,16 @@ message AggregateStorageRecord {
     // A timestamp of an event or a snapshot in this record.
     google.protobuf.Timestamp timestamp = 1;
 
-     // string representation of an aggregate id.
-    string aggregate_id = 2;
-
     // A short Protobuf type name of the event.
-    string event_type = 3;
+    string event_type = 2;
 
     // String representation of EventId.
-    string event_id = 4;
+    string event_id = 3;
 
     // The version of the aggregate after the event was applied.
-    int32 version = 5;
+    int32 version = 4;
 
-    reserved 6 to 19;
+    reserved 5 to 19;
 
     oneof kind {
         // Event data and context.
@@ -56,6 +53,20 @@ message AggregateStorageRecord {
 
         // Snapshot of the aggregate.
         spine.server.aggregate.Snapshot snapshot = 21;
+    }
+
+    // Aggregate record identifier.
+    message Id {
+        oneof type {
+            // The string representation of the ID.
+            string string_value = 1;
+
+            // The long representation of the ID.
+            int64 long_value = 2;
+
+            // The integer representation of the ID.
+            int32 int_value = 3;
+        }
     }
 }
 
@@ -70,5 +81,3 @@ message AggregateEvents {
     // Otherwise, records are full history of the aggregate.
     repeated spine.base.EventRecord event_record = 2;
 }
-
-

--- a/server/src/test/java/org/spine3/server/storage/AggregateStorageShould.java
+++ b/server/src/test/java/org/spine3/server/storage/AggregateStorageShould.java
@@ -49,7 +49,7 @@ import static org.spine3.testdata.TestEventRecordFactory.projectCreated;
 @SuppressWarnings("InstanceMethodNamingConvention")
 public abstract class AggregateStorageShould {
 
-    private final ProjectId aggregateId = createProjectId(newUuid());
+    private final ProjectId id = createProjectId(newUuid());
 
     private AggregateStorage<ProjectId> storage;
 
@@ -62,7 +62,7 @@ public abstract class AggregateStorageShould {
 
     @Test
     public void return_iterator_over_empty_collection_if_read_history_from_empty_storage() {
-        final Iterator<AggregateStorageRecord> iterator = storage.historyBackward(aggregateId);
+        final Iterator<AggregateStorageRecord> iterator = storage.historyBackward(id);
 
         assertFalse(iterator.hasNext());
     }
@@ -76,18 +76,48 @@ public abstract class AggregateStorageShould {
     }
 
     @Test(expected = NullPointerException.class)
-    public void throw_exception_if_try_to_write_null_record() {
+    public void throw_exception_if_try_to_write_null_events() {
         // noinspection ConstantConditions
-        storage.write((EventRecord)null);
+        storage.write(id, (AggregateEvents) null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void throw_exception_if_try_to_write_events_by_null_id() {
+        // noinspection ConstantConditions
+        storage.write(null, AggregateEvents.getDefaultInstance());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void throw_exception_if_try_to_write_null_event() {
+        // noinspection ConstantConditions
+        storage.writeEvent(id, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void throw_exception_if_try_to_write_event_record_by_null_id() {
+        // noinspection ConstantConditions
+        storage.writeEvent(null, EventRecord.getDefaultInstance());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void throw_exception_if_try_to_write_null_snapshot() {
+        // noinspection ConstantConditions
+        storage.write(id, (Snapshot) null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void throw_exception_if_try_to_write_snapshot_by_null_id() {
+        // noinspection ConstantConditions
+        storage.write(null, Snapshot.getDefaultInstance());
     }
 
     @Test
-    public void store_and_read_one_record() {
-        final EventRecord expected = projectCreated(aggregateId);
+    public void write_and_read_one_event_record() {
+        final EventRecord expected = projectCreated(id);
 
-        storage.write(expected);
+        storage.writeEvent(id, expected);
 
-        final Iterator<AggregateStorageRecord> iterator = storage.historyBackward(aggregateId);
+        final Iterator<AggregateStorageRecord> iterator = storage.historyBackward(id);
         assertTrue(iterator.hasNext());
         final AggregateStorageRecord actual = iterator.next();
         assertEquals(expected, actual.getEventRecord());
@@ -96,11 +126,11 @@ public abstract class AggregateStorageShould {
 
     @Test
     public void write_and_read_one_record() {
-        final AggregateStorageRecord expected = newAggregateStorageRecord(getCurrentTime(), aggregateId);
+        final AggregateStorageRecord expected = newAggregateStorageRecord(getCurrentTime());
 
-        storage.writeInternal(expected);
+        storage.writeInternal(id, expected);
 
-        final Iterator<AggregateStorageRecord> iterator = storage.historyBackward(aggregateId);
+        final Iterator<AggregateStorageRecord> iterator = storage.historyBackward(id);
         assertTrue(iterator.hasNext());
         final AggregateStorageRecord actual = iterator.next();
         assertEquals(expected, actual);
@@ -109,23 +139,37 @@ public abstract class AggregateStorageShould {
 
     @Test
     public void write_records_and_return_sorted_by_timestamp_descending() {
-        final List<AggregateStorageRecord> records = createSequentialRecords(aggregateId);
+        final List<AggregateStorageRecord> records = createSequentialRecords(id);
 
-        writeAll(records);
+        writeAll(id, records);
 
-        final Iterator<AggregateStorageRecord> iterator = storage.historyBackward(aggregateId);
+        final Iterator<AggregateStorageRecord> iterator = storage.historyBackward(id);
         final List<AggregateStorageRecord> actual = newArrayList(iterator);
         reverse(records); // expected records should be in a reverse order
         assertEquals(records, actual);
     }
 
     @Test
+    public void write_and_read_aggregate_events() {
+        final List<AggregateStorageRecord> records = createSequentialRecords(id);
+        final List<EventRecord> expectedRecords = transform(records, TO_EVENT_RECORD);
+        final AggregateEvents aggregateEvents = AggregateEvents.newBuilder().addAllEventRecord(expectedRecords).build();
+
+        storage.write(id, aggregateEvents);
+
+        final AggregateEvents events = storage.read(id);
+
+        final List<EventRecord> actualRecords = events.getEventRecordList();
+        assertEquals(expectedRecords, actualRecords);
+    }
+
+    @Test
     public void store_and_read_snapshot() {
         final Snapshot expected = newSnapshot(getCurrentTime());
 
-        storage.write(aggregateId, expected);
+        storage.write(id, expected);
 
-        final Iterator<AggregateStorageRecord> iterator = storage.historyBackward(aggregateId);
+        final Iterator<AggregateStorageRecord> iterator = storage.historyBackward(id);
         assertTrue(iterator.hasNext());
         final AggregateStorageRecord actual = iterator.next();
         assertEquals(expected, actual.getSnapshot());
@@ -144,33 +188,25 @@ public abstract class AggregateStorageShould {
         final Timestamp time2 = add(time1, delta);
         final Timestamp time3 = add(time2, delta);
 
-        storage.writeInternal(newAggregateStorageRecord(time1, aggregateId));
-        storage.write(aggregateId, newSnapshot(time2));
+        storage.writeInternal(id, newAggregateStorageRecord(time1));
+        storage.write(id, newSnapshot(time2));
 
         testWriteRecordsAndLoadHistory(time3);
     }
 
     private void testWriteRecordsAndLoadHistory(Timestamp firstRecordTime) {
-        final List<AggregateStorageRecord> records = createSequentialRecords(aggregateId, firstRecordTime);
+        final List<AggregateStorageRecord> records = createSequentialRecords(id, firstRecordTime);
 
-        writeAll(records);
+        writeAll(id, records);
 
-        final AggregateEvents events = storage.read(aggregateId);
+        final AggregateEvents events = storage.read(id);
         final List<EventRecord> expectedEventRecords = transform(records, TO_EVENT_RECORD);
         assertEquals(expectedEventRecords, events.getEventRecordList());
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void throw_exception_if_write_record_without_event_record_or_snapshot_and_load_it() {
-        final AggregateStorageRecord record = AggregateStorageRecord.newBuilder().setAggregateId(aggregateId.getId()).build();
-
-        storage.writeInternal(record);
-        storage.read(aggregateId);
-    }
-
-    private void writeAll(Iterable<AggregateStorageRecord> records) {
+    private void writeAll(ProjectId id, Iterable<AggregateStorageRecord> records) {
         for (AggregateStorageRecord record : records) {
-            storage.writeInternal(record);
+            storage.writeInternal(id, record);
         }
     }
 

--- a/server/src/test/java/org/spine3/testdata/TestAggregateStorageRecordFactory.java
+++ b/server/src/test/java/org/spine3/testdata/TestAggregateStorageRecordFactory.java
@@ -25,7 +25,6 @@ import com.google.protobuf.Timestamp;
 import org.spine3.base.EventRecord;
 import org.spine3.server.storage.AggregateStorageRecord;
 import org.spine3.test.project.ProjectId;
-import org.spine3.test.project.ProjectIdOrBuilder;
 
 import java.util.List;
 
@@ -33,6 +32,8 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.google.protobuf.util.TimeUtil.add;
 import static com.google.protobuf.util.TimeUtil.getCurrentTime;
 import static org.spine3.protobuf.Durations.seconds;
+import static org.spine3.testdata.TestContextFactory.*;
+import static org.spine3.testdata.TestEventRecordFactory.*;
 
 
 /**
@@ -45,23 +46,20 @@ public class TestAggregateStorageRecordFactory {
     private TestAggregateStorageRecordFactory() {}
 
     /**
-     * Creates a new {@link AggregateStorageRecord} with the given timestamp and aggregateId.
+     * Creates a new {@link AggregateStorageRecord} with the given timestamp.
      */
-    public static AggregateStorageRecord newAggregateStorageRecord(Timestamp timestamp, ProjectIdOrBuilder aggregateId) {
-
+    public static AggregateStorageRecord newAggregateStorageRecord(Timestamp timestamp) {
         final AggregateStorageRecord.Builder builder = AggregateStorageRecord.newBuilder()
-                .setAggregateId(aggregateId.getId())
                 .setTimestamp(timestamp);
         return builder.build();
     }
 
     /**
-     * Creates a new {@link AggregateStorageRecord} with the given timestamp, aggregateId and event record.
+     * Creates a new {@link AggregateStorageRecord} with the given timestamp and event record.
      */
-    public static AggregateStorageRecord newAggregateStorageRecord(Timestamp timestamp, ProjectIdOrBuilder aggregateId, EventRecord event) {
-
-        final AggregateStorageRecord.Builder builder = newAggregateStorageRecord(timestamp, aggregateId)
-                .toBuilder()
+    public static AggregateStorageRecord newAggregateStorageRecord(Timestamp timestamp, EventRecord event) {
+        final AggregateStorageRecord.Builder builder = AggregateStorageRecord.newBuilder()
+                .setTimestamp(timestamp)
                 .setEventRecord(event);
         return builder.build();
     }
@@ -79,15 +77,16 @@ public class TestAggregateStorageRecordFactory {
      * @param timestamp1 the timestamp of first record.
      */
     public static List<AggregateStorageRecord> createSequentialRecords(ProjectId id, Timestamp timestamp1) {
-
         final Duration delta = seconds(10);
-
         final Timestamp timestamp2 = add(timestamp1, delta);
         final Timestamp timestamp3 = add(timestamp2, delta);
 
-        final AggregateStorageRecord record1 = newAggregateStorageRecord(timestamp1, id, TestEventRecordFactory.projectCreated(id));
-        final AggregateStorageRecord record2 = newAggregateStorageRecord(timestamp2, id, TestEventRecordFactory.taskAdded(id));
-        final AggregateStorageRecord record3 = newAggregateStorageRecord(timestamp3, id, TestEventRecordFactory.projectStarted(id));
+        final AggregateStorageRecord record1 = newAggregateStorageRecord(timestamp1,
+                projectCreated(id, createEventContext(timestamp1)));
+        final AggregateStorageRecord record2 = newAggregateStorageRecord(timestamp2,
+                taskAdded(id, createEventContext(timestamp2)));
+        final AggregateStorageRecord record3 = newAggregateStorageRecord(timestamp3,
+                projectStarted(id, createEventContext(timestamp3)));
 
         return newArrayList(record1, record2, record3);
     }


### PR DESCRIPTION
Remove string aggregate ID from aggregate storage record (let the client to choose how to store IDs).

Fix and add tests for aggregate storage, fix test factory method.