### PR TITLE
gRPC 0.14.0 migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,8 @@ subprojects {
         compile group: 'com.google.protobuf', name: 'protobuf-java', version: project.PROTOBUF_VERSION
         compile group: 'com.google.protobuf', name: 'protobuf-java-util', version: project.PROTOBUF_VERSION
 
+        compile group: 'io.grpc', name: 'grpc-all', version: "$GRPC_VERSION"
+
         testCompile(group: 'junit', name: 'junit', version: '4.12') {
             exclude(module: 'hamcrest-core')
         }
@@ -109,6 +111,11 @@ subprojects {
     }
 
     protobuf {
+        plugins {
+            grpc {
+                artifact = "io.grpc:protoc-gen-grpc-java:$GRPC_VERSION"
+            }
+        }
         generatedFilesBaseDir = GEN_ROOT_DIR
         protoc {
             artifact = project.PROTOBUF_DEPENDENCY

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ project.ext {
     PROTOBUF_DEPENDENCY = "com.google.protobuf:protoc:${project.PROTOBUF_VERSION}";
     MAVEN_REPOSITORY_URL = 'http://maven.teamdev.com/repository/spine';
     SPINE_PROTOBUF_PLUGIN_VERSION = "1.3.3"
+    GRPC_VERSION = '0.14.0'
 }
 
 def repositoryUserName = null;

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -8,7 +8,6 @@ buildscript {
 }
 
 dependencies {
-    compile group: 'io.grpc', name: 'grpc-all', version: "$GRPC_VERSION"
     testCompile project(path: ":testutil", configuration: 'testArtifacts')
 }
 
@@ -26,11 +25,6 @@ sourceSets {
 }
 
 protobuf {
-    plugins {
-        grpc {
-            artifact = "io.grpc:protoc-gen-grpc-java:$GRPC_VERSION"
-        }
-    }
     generateProtoTasks {
         all().each { final task ->
             task.plugins {

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -1,4 +1,3 @@
-
 buildscript {
     configurations.all {
         resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
@@ -9,8 +8,8 @@ buildscript {
 }
 
 dependencies {
-    compile group: 'io.grpc', name: 'grpc-all', version: '0.13.1'
-    testCompile project (path: ":testutil", configuration: 'testArtifacts')
+    compile group: 'io.grpc', name: 'grpc-all', version: "$GRPC_VERSION"
+    testCompile project(path: ":testutil", configuration: 'testArtifacts')
 }
 
 apply plugin: 'org.spine3.tools.protobuf-plugin';
@@ -29,7 +28,7 @@ sourceSets {
 protobuf {
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:0.13.1'
+            artifact = "io.grpc:protoc-gen-grpc-java:$GRPC_VERSION"
         }
     }
     generateProtoTasks {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -8,9 +8,9 @@ buildscript {
 }
 
 dependencies {
-    testCompile project(path: ":client", configuration: 'testArtifacts')
-
     compile project(path: ':client');
+
+    testCompile project(path: ":client", configuration: 'testArtifacts')
 }
 
 apply plugin: 'org.spine3.tools.protobuf-plugin';

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 dependencies {
-    compile group: 'io.grpc', name: 'grpc-all', version: '0.13.1'
+    compile group: 'io.grpc', name: 'grpc-all', version: "$GRPC_VERSION"
     testCompile project(path: ":client", configuration: 'testArtifacts')
 
     compile project(path: ':client');
@@ -30,7 +30,7 @@ sourceSets {
 protobuf {
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:0.13.1'
+            artifact = "io.grpc:protoc-gen-grpc-java:$GRPC_VERSION"
         }
     }
     generateProtoTasks {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -8,7 +8,6 @@ buildscript {
 }
 
 dependencies {
-    compile group: 'io.grpc', name: 'grpc-all', version: "$GRPC_VERSION"
     testCompile project(path: ":client", configuration: 'testArtifacts')
 
     compile project(path: ':client');
@@ -28,11 +27,6 @@ sourceSets {
 }
 
 protobuf {
-    plugins {
-        grpc {
-            artifact = "io.grpc:protoc-gen-grpc-java:$GRPC_VERSION"
-        }
-    }
     generateProtoTasks {
         all().each { final task ->
             task.plugins {


### PR DESCRIPTION
I've moved gRPC dependency to root `build.gradle` file. However, I did not apply gRPC plugin to all subprojects to leave us an ability to enable\disable gRPC code generation. It looks like `grpc {}` block in protobuf task plugins sections in `server` and `client` modules.

Please tell me if we want to move these blocks to root `build.gradle` too.