### PR TITLE
Exclude slf4j-jdk14 from the published dependencies. Use it only for tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ project.ext {
     MAVEN_REPOSITORY_URL = 'http://maven.teamdev.com/repository/spine';
     SPINE_PROTOBUF_PLUGIN_VERSION = "1.4.4"
     GRPC_VERSION = '0.14.0'
+    SLF4J_VERSION = '1.7.12'
 }
 
 def repositoryUserName = null;
@@ -73,12 +74,16 @@ subprojects {
     dependencies {
         compile group: 'com.google.guava', name: 'guava', version: '19.0'
         compile group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.0'
-        compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.12'
-        compile group: 'org.slf4j', name: 'slf4j-jdk14', version: '1.7.12'
+
+        //As a Library, we provide logging facade API, not specific logger bindings.
+        //Target apps are free to use any binding they need.
+        compile group: 'org.slf4j', name: 'slf4j-api', version: project.SLF4J_VERSION
 
         compile group: 'com.google.protobuf', name: 'protobuf-java', version: project.PROTOBUF_VERSION
         compile group: 'com.google.protobuf', name: 'protobuf-java-util', version: project.PROTOBUF_VERSION
 
+        //Use jdk14 bindings for test purposes only.
+        testCompile group: 'org.slf4j', name: 'slf4j-jdk14', version: project.SLF4J_VERSION
         testCompile(group: 'junit', name: 'junit', version: '4.12') {
             exclude(module: 'hamcrest-core')
         }


### PR DESCRIPTION
@alexander-yevsyukov PTAL.