### PR TITLE
Remove public imports

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -198,6 +198,7 @@
       </option>
       <option name="ignoreClassWithParameterization" value="true" />
       <option name="ignoreThrowables" value="true" />
+      <option name="commentsAreContent" value="true" />
     </inspection_tool>
     <inspection_tool class="EmptyDirectory" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="EmptyInitializer" enabled="true" level="WARNING" enabled_by_default="true" />

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ allprojects {
     apply plugin: 'jacoco'
 
     group = 'org.spine3'
-    version = '0.4.5-SNAPSHOT'
+    version = '0.5.0-SNAPSHOT'
 }
 
 project.ext {

--- a/client/src/main/proto/spine/base/error.proto
+++ b/client/src/main/proto/spine/base/error.proto
@@ -26,7 +26,7 @@ option java_multiple_files = true;
 option java_outer_classname = "ErrorProto";
 option java_package = "org.spine3.base";
 
-import public "google/protobuf/struct.proto";
+import "google/protobuf/struct.proto";
 import "spine/validate/constraint_violation.proto";
 
 // Information on a technical error occurred in the system.

--- a/client/src/main/proto/spine/base/field_filter.proto
+++ b/client/src/main/proto/spine/base/field_filter.proto
@@ -26,8 +26,8 @@ option java_multiple_files = true;
 option java_outer_classname = "FieldFilterProto";
 option java_package = "org.spine3.base";
 
-import public "google/protobuf/field_mask.proto";
-import public "google/protobuf/any.proto";
+import "google/protobuf/field_mask.proto";
+import "google/protobuf/any.proto";
 
 // `FieldFilter` specifies accepted values for a field.
 message FieldFilter {

--- a/client/src/main/proto/spine/base/response.proto
+++ b/client/src/main/proto/spine/base/response.proto
@@ -26,9 +26,9 @@ option java_multiple_files = true;
 option java_outer_classname = "ResponseProto";
 option java_package = "org.spine3.base";
 
-import public "google/protobuf/empty.proto";
-import public "spine/base/error.proto";
-import public "spine/base/failure.proto";
+import "google/protobuf/empty.proto";
+import "spine/base/error.proto";
+import "spine/base/failure.proto";
 
 // The result of a call returned by a service.
 //

--- a/client/src/main/proto/spine/client/client.proto
+++ b/client/src/main/proto/spine/client/client.proto
@@ -26,7 +26,7 @@ option java_multiple_files = true;
 option java_outer_classname = "ClientProto";
 option java_package = "org.spine3.client";
 
-import public "spine/base/event.proto";
+import "spine/base/event.proto";
 
 // Version of the code executed on the client.
 message CodeVersion {

--- a/client/src/main/proto/spine/client/query.proto
+++ b/client/src/main/proto/spine/client/query.proto
@@ -26,7 +26,7 @@ option java_multiple_files = true;
 option java_outer_classname = "QueryProto";
 option java_package = "org.spine3.client";
 
-import public "spine/ui/language.proto";
+import "spine/ui/language.proto";
 
 message QueryContext {
 

--- a/server/src/main/java/org/spine3/server/BoundedContext.java
+++ b/server/src/main/java/org/spine3/server/BoundedContext.java
@@ -215,9 +215,7 @@ public class BoundedContext implements IntegrationEventSubscriber, AutoCloseable
     }
 
     /**
-     * Convenience method for obtaining instance of {@link CommandBus}.
-     *
-     * @return instance of {@code CommandDispatcher} used in the application
+     * Obtains instance of {@link CommandBus} of this {@code BoundedContext}.
      */
     @CheckReturnValue
     public CommandBus getCommandBus() {
@@ -225,9 +223,7 @@ public class BoundedContext implements IntegrationEventSubscriber, AutoCloseable
     }
 
     /**
-     * Convenience method for obtaining instance of {@link EventBus}.
-     *
-     * @return instance of {@code EventBus} used in the application
+     * Obtains instance of {@link EventBus} of this {@code BoundedContext}.
      */
     @CheckReturnValue
     public EventBus getEventBus() {

--- a/server/src/main/proto/spine/server/aggregate/snapshot.proto
+++ b/server/src/main/proto/spine/server/aggregate/snapshot.proto
@@ -26,8 +26,8 @@ option java_multiple_files = true;
 option java_outer_classname = "SnapshotProto";
 option java_package = "org.spine3.server.aggregate";
 
-import public "google/protobuf/any.proto";
-import public "google/protobuf/timestamp.proto";
+import "google/protobuf/any.proto";
+import "google/protobuf/timestamp.proto";
 import "spine/annotations.proto";
 
 // Built-in event type for storing aggregate snapshots.

--- a/server/src/main/proto/spine/server/event/event_stream_query.proto
+++ b/server/src/main/proto/spine/server/event/event_stream_query.proto
@@ -26,9 +26,9 @@ option java_multiple_files = true;
 option java_outer_classname = "EventStreamQueryProto";
 option java_package = "org.spine3.server.event";
 
-import public "google/protobuf/timestamp.proto";
+import "google/protobuf/timestamp.proto";
 
-import public "spine/server/event/event_filter.proto";
+import "spine/server/event/event_filter.proto";
 
 // The query specifies event to return from the event store.
 message EventStreamQuery {

--- a/server/src/main/proto/spine/server/storage/aggregate_storage.proto
+++ b/server/src/main/proto/spine/server/storage/aggregate_storage.proto
@@ -28,8 +28,10 @@ option java_generate_equals_and_hash = true;
 
 option (SPI_all) = true;
 
-import public "spine/server/aggregate/snapshot.proto";
-import public "spine/base/event.proto";
+import "google/protobuf/timestamp.proto";
+
+import "spine/server/aggregate/snapshot.proto";
+import "spine/base/event.proto";
 import "spine/annotations.proto";
 
 // A record in the storage of events and snapshots of an aggregate type.

--- a/values/src/main/proto/spine/sharing/sharing.proto
+++ b/values/src/main/proto/spine/sharing/sharing.proto
@@ -26,8 +26,8 @@ option java_multiple_files = true;
 option java_outer_classname = "SharingProto";
 option java_package = "org.spine3.sharing";
 
-import public "spine/users/user_id.proto";
-import public "spine/users/group.proto";
+import "spine/users/user_id.proto";
+import "spine/users/group.proto";
 
 // An object can be shared with a user or a group of users.
 message Subject {

--- a/values/src/main/proto/spine/users/user.proto
+++ b/values/src/main/proto/spine/users/user.proto
@@ -26,9 +26,9 @@ option java_multiple_files = true;
 option java_outer_classname = "UserProto";
 option java_package = "org.spine3.users";
 
-import public "spine/users/user_id.proto";
-import public "spine/net/email_address.proto";
-import public "spine/people/person_name.proto";
+import "spine/users/user_id.proto";
+import "spine/net/email_address.proto";
+import "spine/people/person_name.proto";
 
 // A link to the user's photo.
 message PhotoLink {


### PR DESCRIPTION
Direct imports make dependency analysis much easier.