### PR TITLE
Stand funnel tests

### DIFF
--- a/client/src/main/proto/spine/client/client.proto
+++ b/client/src/main/proto/spine/client/client.proto
@@ -28,7 +28,6 @@ option java_outer_classname = "ClientProto";
 option java_package = "org.spine3.client";
 
 import "spine/annotations.proto";
-import "spine/base/event.proto";
 
 // Version of the code executed on the client.
 message CodeVersion {

--- a/client/src/main/proto/spine/client/client_service.proto
+++ b/client/src/main/proto/spine/client/client_service.proto
@@ -31,26 +31,11 @@ option java_generate_equals_and_hash = true;
 
 import "spine/annotations.proto";
 import "spine/base/command.proto";
-import "spine/base/event.proto";
 import "spine/base/response.proto";
 
-// A topic of interest the client can subscribe and unsubscribe.
-message Topic {
-    //TODO:2016-01-14:alexander.yevsyukov: Define this type. E.g. there can be some structure, which describes many
-    // points of interest at once. See Pub-sub for possible API inspiration. Chances are it's going to be one of underlying
-    // implementations.
-    string value = 1;
-}
 
 // A service for sending commands from clients.
 service ClientService {
     // Request to handle a command.
     rpc Post(base.Command) returns (base.Response);
-
-    // Request to receive events on the topic of interest.
-    rpc Subscribe(Topic) returns (stream base.Event);
-
-    // The request to unsubscribe from the topic.
-    // This should close the stream opened by `Subscribe` call with the same `Topic` value.
-    rpc Unsubscribe(Topic) returns (base.Response);
 }

--- a/client/src/main/proto/spine/client/entities.proto
+++ b/client/src/main/proto/spine/client/entities.proto
@@ -28,11 +28,8 @@ option java_outer_classname = "EntitiesProto";
 option java_package = "org.spine3.client";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/field_mask.proto";
 
 import "spine/annotations.proto";
-import "spine/ui/language.proto";
-import "spine/base/response.proto";
 
 // Represents an ID of an entity.
 //

--- a/client/src/main/proto/spine/client/subscription.proto
+++ b/client/src/main/proto/spine/client/subscription.proto
@@ -1,0 +1,83 @@
+//
+// Copyright 2016, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.client;
+
+option (type_url_prefix) = "type.spine3.org";
+option java_generate_equals_and_hash = true;
+option java_multiple_files = true;
+option java_outer_classname = "SubscriptionProto";
+option java_package = "org.spine3.client";
+
+
+import "google/protobuf/any.proto";
+import "google/protobuf/field_mask.proto";
+
+import "spine/annotations.proto";
+import "spine/base/response.proto";
+import "spine/client/entities.proto";
+
+// An object defining a unit of subscription.
+//
+// Defines the target (entities and criteria) of subscription.
+message Topic {
+
+    // Defines the entity of interest, e.g. entity type URL and a set of subscription criteria.
+    Target target = 1;
+
+    // Field mask to be applied to the entity updates applicable to this topic.
+    //
+    // Applied to each of the entity state messages before returning in scope of SubscriptionUpdate.
+    google.protobuf.FieldMask field_mask = 2;
+
+    // Reserved for utility fields.
+    reserved 3 to 6;
+}
+
+// Wrapped set of read-side entity updates on a topic with the specific subscription ID.
+message SubscriptionUpdate {
+
+    // The ID of the current subscription.
+    SubscriptionId id = 1;
+
+    // Represents the base part of the response. I.e. whether the Topic subscription requires has been acked or not.
+    base.Response response = 2;
+
+    // Reserved for more subscription update attributes.
+    reserved 3 to 9;
+
+    // Entity updates packed as Any.
+    //
+    // Each of the update messages is affected by the field mask set for the current subscription.
+    repeated google.protobuf.Any updates = 10;
+}
+
+// The ID of the subscription.
+//
+// Created when the client subscribes to a topic.
+// See SubscriptionService#Subscribe(Topic).
+message SubscriptionId {
+
+    // Unique identifier of the subscription.
+    //
+    // Typically built using Java's UUID.toString() functionality.
+    string uuid = 1;
+}

--- a/client/src/main/proto/spine/client/subscription_service.proto
+++ b/client/src/main/proto/spine/client/subscription_service.proto
@@ -24,16 +24,23 @@ package spine.client;
 option (type_url_prefix) = "type.spine3.org";
 option java_package = "org.spine3.client.grpc";
 option java_multiple_files = true;
-option java_outer_classname = "QueryServiceProto";
+option java_outer_classname = "SubscriptionServiceProto";
 option java_generate_equals_and_hash = true;
 
 
 import "spine/annotations.proto";
-import "spine/client/query.proto";
+import "spine/client/subscription.proto";
+import "spine/base/response.proto";
 
-// A service for querying the read-side from clients.
-service QueryService {
+// A service for subscribing to the read-side changes by clients.
+service SubscriptionService {
 
-    // Reads a certain data from the read-side by setting the criteria via Query.
-    rpc Read (Query) returns (QueryResponse);
+    // Subscribe to a particular read-side updates.
+    //
+    // Topic defines the target of subscription and other attributes (like field masks).
+    // The result is a SubscriptionUpdate stream,
+    rpc Subscribe (Topic) returns (stream SubscriptionUpdate);
+
+    // Cancel the subscription by its ID.
+    rpc CancelSubscription (SubscriptionId) returns (base.Response);
 }

--- a/examples/src/main/java/org/spine3/examples/aggregate/ClientApp.java
+++ b/examples/src/main/java/org/spine3/examples/aggregate/ClientApp.java
@@ -31,7 +31,6 @@ import org.spine3.base.Identifiers;
 import org.spine3.base.Response;
 import org.spine3.client.CommandFactory;
 import org.spine3.client.grpc.ClientServiceGrpc;
-import org.spine3.client.grpc.Topic;
 import org.spine3.examples.aggregate.command.AddOrderLine;
 import org.spine3.examples.aggregate.command.CreateOrder;
 import org.spine3.examples.aggregate.command.PayForOrder;
@@ -66,9 +65,9 @@ public class ClientApp {
     private static final int SHUTDOWN_TIMEOUT_SEC = 5;
 
     private final CommandFactory commandFactory;
-    private final Topic topic = Topic.getDefaultInstance();
     private final ManagedChannel channel;
     private final ClientServiceGrpc.ClientServiceBlockingStub blockingClient;
+    // TODO[alex.tymchenko]: switch to SubscriptionService instead.  
     private final ClientServiceGrpc.ClientServiceStub nonBlockingClient;
 
     private final StreamObserver<Event> observer = new StreamObserver<Event>() {
@@ -140,14 +139,10 @@ public class ClientApp {
         return commandFactory.create(msg);
     }
 
-    private void subscribe() {
-        nonBlockingClient.subscribe(topic, observer);
-    }
 
     /** Sends requests to the server. */
     public static void main(String[] args) throws InterruptedException {
         final ClientApp client = new ClientApp(SERVICE_HOST, DEFAULT_CLIENT_SERVICE_PORT);
-        client.subscribe();
 
         final List<Command> requests = client.generateRequests();
 
@@ -178,7 +173,6 @@ public class ClientApp {
      * @throws InterruptedException if waiting is interrupted.
      */
     private void shutdown() throws InterruptedException {
-        blockingClient.unsubscribe(topic);
         channel.shutdown().awaitTermination(SHUTDOWN_TIMEOUT_SEC, SECONDS);
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-bin.zip

--- a/server/src/main/java/org/spine3/server/ClientService.java
+++ b/server/src/main/java/org/spine3/server/ClientService.java
@@ -26,10 +26,7 @@ import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spine3.base.Command;
-import org.spine3.base.Event;
 import org.spine3.base.Response;
-import org.spine3.base.Responses;
-import org.spine3.client.grpc.Topic;
 import org.spine3.server.command.error.CommandException;
 import org.spine3.server.command.error.UnsupportedCommandException;
 import org.spine3.server.type.CommandClass;
@@ -73,22 +70,6 @@ public class ClientService
         final CommandException unsupported = new UnsupportedCommandException(request);
         log().error("Unsupported command posted to ClientService", unsupported);
         responseObserver.onError(Statuses.invalidArgumentWithCause(unsupported));
-    }
-
-    @SuppressWarnings("RefusedBequest") // as we override default implementation with `unimplemented` status.
-    @Override
-    public void subscribe(Topic request, StreamObserver<Event> responseObserver) {
-        //TODO:2016-05-25:alexander.yevsyukov: Subscribe the client to the topic in the corresponding BoundedContext.
-        // This API is likely to change to support Firebase-like registration where listening is
-        // done by the client SDK implementation.
-    }
-
-    @SuppressWarnings("RefusedBequest") // as we override default implementation with `unimplemented` status.
-    @Override
-    public void unsubscribe(Topic request, StreamObserver<Response> responseObserver) {
-        //TODO:2016-05-25:alexander.yevsyukov: Unsubscribe the client from the topic in the corresponding BoundedContext.
-        responseObserver.onNext(Responses.ok());
-        responseObserver.onCompleted();
     }
 
     public static class Builder {

--- a/server/src/main/java/org/spine3/server/stand/Stand.java
+++ b/server/src/main/java/org/spine3/server/stand/Stand.java
@@ -258,7 +258,7 @@ public class Stand {
 
     private ImmutableCollection<Any> internalExecute(Query query) {
 
-        final ImmutableSet.Builder<Any> resultBuilder = ImmutableSet.builder();
+        final ImmutableList.Builder<Any> resultBuilder = ImmutableList.builder();
 
         final Target target = query.getTarget();
 
@@ -280,7 +280,7 @@ public class Stand {
             feedStateRecordsToBuilder(resultBuilder, stateRecords);
         }
 
-        final ImmutableSet<Any> result = resultBuilder.build();
+        final ImmutableList<Any> result = resultBuilder.build();
 
         return result;
     }
@@ -355,7 +355,7 @@ public class Stand {
         return result;
     }
 
-    private static void feedEntitiesToBuilder(ImmutableSet.Builder<Any> resultBuilder, ImmutableCollection<? extends Entity> all) {
+    private static void feedEntitiesToBuilder(ImmutableList.Builder<Any> resultBuilder, ImmutableCollection<? extends Entity> all) {
         for (Entity record : all) {
             final Message state = record.getState();
             final Any packedState = AnyPacker.pack(state);
@@ -363,7 +363,7 @@ public class Stand {
         }
     }
 
-    private static void feedStateRecordsToBuilder(ImmutableSet.Builder<Any> resultBuilder, ImmutableCollection<EntityStorageRecord> all) {
+    private static void feedStateRecordsToBuilder(ImmutableList.Builder<Any> resultBuilder, ImmutableCollection<EntityStorageRecord> all) {
         for (EntityStorageRecord record : all) {
             final Any state = record.getState();
             resultBuilder.add(state);

--- a/server/src/main/java/org/spine3/server/stand/Stand.java
+++ b/server/src/main/java/org/spine3/server/stand/Stand.java
@@ -293,7 +293,9 @@ public class Stand {
 
         } else {
             final EntityFilters filters = target.getFilters();
-            if (filters != null && filters.getIdFilter() != null) {
+
+            // TODO[alex.tymchenko]: do we need to check for null at all? How about, say, Python gRPC client?
+            if (filters != null && filters.getIdFilter() != null && !filters.getIdFilter().getIdsList().isEmpty()) {
                 final EntityIdFilter idFilter = filters.getIdFilter();
                 final Collection<AggregateStateId> stateIds = Collections2.transform(idFilter.getIdsList(), aggregateStateIdTransformer(typeUrl));
 

--- a/server/src/main/java/org/spine3/server/stand/StandFunnel.java
+++ b/server/src/main/java/org/spine3/server/stand/StandFunnel.java
@@ -109,6 +109,7 @@ public class StandFunnel {
          * <p> The value must not be null.
          *
          * <p> If this method is not used, a default value will be used.
+         * // TODO:13-09-16:dmytro.dashenkov: Correct docs. No default value for Stand is used, null value leads to a fail instead.
          *
          * @param stand the instance of {@link Stand}.
          * @return {@code this} instance of {@code Builder}
@@ -122,6 +123,7 @@ public class StandFunnel {
             return executor;
         }
 
+        // TODO:13-09-16:dmytro.dashenkov: Complete docs. Here is the place where a default value is used in case of not using the method.
         /**
          * Set the {@code Executor} instance for this {@code StandFunnel}.
          *

--- a/server/src/main/java/org/spine3/server/stand/StandFunnel.java
+++ b/server/src/main/java/org/spine3/server/stand/StandFunnel.java
@@ -108,9 +108,6 @@ public class StandFunnel {
          *
          * <p> The value must not be null.
          *
-         * <p> If this method is not used, a default value will be used.
-         * // TODO:13-09-16:dmytro.dashenkov: Correct docs. No default value for Stand is used, null value leads to a fail instead.
-         *
          * @param stand the instance of {@link Stand}.
          * @return {@code this} instance of {@code Builder}
          */
@@ -123,11 +120,12 @@ public class StandFunnel {
             return executor;
         }
 
-        // TODO:13-09-16:dmytro.dashenkov: Complete docs. Here is the place where a default value is used in case of not using the method.
         /**
          * Set the {@code Executor} instance for this {@code StandFunnel}.
          *
          * <p>The value must not be {@code null}.
+         *
+         * <p> If this method is not used, a default value will be used.
          *
          * @param executor the instance of {@code Executor}.
          * @return {@code this} instance of {@code Builder}

--- a/server/src/test/java/org/spine3/server/stand/Given.java
+++ b/server/src/test/java/org/spine3/server/stand/Given.java
@@ -20,6 +20,7 @@
 
 package org.spine3.server.stand;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import org.spine3.base.Command;
@@ -139,7 +140,7 @@ import java.util.concurrent.Executors;
                                             .setDoNotEnrich(true)
                                             .setCommandContext(CommandContext.getDefaultInstance())
                                             .setEventId(EventId.newBuilder()
-                                                               .setUuid(PROJECT_UUID)
+                                                               .setUuid(Identifiers.newUuid())
                                                                .build()))
                     .build();
     }
@@ -161,12 +162,7 @@ import java.util.concurrent.Executors;
 
     /*package*/ static BoundedContext boundedContext(Stand stand, int concurrentThreads) {
         final Executor executor = concurrentThreads > 0 ? Executors.newFixedThreadPool(concurrentThreads) :
-                                  new Executor() { // Straightforward executor
-                                      @Override
-                                      public void execute(Runnable command) {
-                                          command.run();
-                                      }
-                                  };
+                                  MoreExecutors.directExecutor();
 
         return boundedContextBuilder(stand)
                              .setStandFunnelExecutor(executor)

--- a/server/src/test/java/org/spine3/server/stand/Given.java
+++ b/server/src/test/java/org/spine3/server/stand/Given.java
@@ -109,7 +109,7 @@ import java.util.concurrent.Executors;
         }
     }
 
-    private static class StandTestProjection extends Projection<ProjectId, Project> {
+    /*package*/ static class StandTestProjection extends Projection<ProjectId, Project> {
         /**
          * Creates a new instance.
          *

--- a/server/src/test/java/org/spine3/server/stand/Given.java
+++ b/server/src/test/java/org/spine3/server/stand/Given.java
@@ -27,7 +27,6 @@ import org.spine3.base.CommandContext;
 import org.spine3.base.Event;
 import org.spine3.base.EventContext;
 import org.spine3.base.EventId;
-import org.spine3.base.FailureThrowable;
 import org.spine3.base.Identifiers;
 import org.spine3.protobuf.AnyPacker;
 import org.spine3.protobuf.TypeUrl;
@@ -78,13 +77,6 @@ import java.util.concurrent.Executor;
          */
         /*package*/ StandTestAggregateRepository(BoundedContext boundedContext) {
             super(boundedContext);
-        }
-    }
-
-    /*package*/ static class TestFailure extends FailureThrowable {
-
-        /*package*/ TestFailure() {
-            super(/*generatedMessage=*/null);
         }
     }
 

--- a/server/src/test/java/org/spine3/server/stand/Given.java
+++ b/server/src/test/java/org/spine3/server/stand/Given.java
@@ -23,6 +23,7 @@ package org.spine3.server.stand;
 import org.spine3.base.Event;
 import org.spine3.base.EventContext;
 import org.spine3.protobuf.AnyPacker;
+import org.spine3.protobuf.TypeUrl;
 import org.spine3.server.BoundedContext;
 import org.spine3.server.projection.Projection;
 import org.spine3.server.projection.ProjectionRepository;
@@ -60,7 +61,10 @@ import org.spine3.test.projection.event.ProjectCreated;
                     .setMessage(AnyPacker.pack(ProjectCreated.newBuilder()
                                                              .setProjectId(ProjectId.newBuilder().setId("12345AD0"))
                                                              .build())
-                    .toBuilder().setTypeUrl(ProjectCreated.getDescriptor().getFullName()).build())
+                                         .toBuilder()
+                                         .setTypeUrl(TypeUrl.SPINE_TYPE_URL_PREFIX + '/' +
+                                                              ProjectCreated.getDescriptor().getFullName())
+                                         .build())
                     .setContext(EventContext.getDefaultInstance())
                     .build();
     }

--- a/server/src/test/java/org/spine3/server/stand/Given.java
+++ b/server/src/test/java/org/spine3/server/stand/Given.java
@@ -58,7 +58,7 @@ import java.util.concurrent.Executors;
     /*package*/ static final int SEVERAL = THREADS_COUNT_IN_POOL_EXECUTOR;
 
     private static final String PROJECT_UUID = Identifiers.newUuid();
-    public static final int AWAIT_SECONDS = 4;
+    /*package*/ static final int AWAIT_SECONDS = 10;
 
     private Given() {
     }

--- a/server/src/test/java/org/spine3/server/stand/Given.java
+++ b/server/src/test/java/org/spine3/server/stand/Given.java
@@ -57,6 +57,7 @@ import java.util.concurrent.Executors;
     /*package*/ static final int SEVERAL = THREADS_COUNT_IN_POOL_EXECUTOR;
 
     private static final String PROJECT_UUID = Identifiers.newUuid();
+    public static final int AWAIT_SECONDS = 2;
 
     private Given() {
     }

--- a/server/src/test/java/org/spine3/server/stand/Given.java
+++ b/server/src/test/java/org/spine3/server/stand/Given.java
@@ -58,7 +58,7 @@ import java.util.concurrent.Executors;
     /*package*/ static final int SEVERAL = THREADS_COUNT_IN_POOL_EXECUTOR;
 
     private static final String PROJECT_UUID = Identifiers.newUuid();
-    public static final int AWAIT_SECONDS = 2;
+    public static final int AWAIT_SECONDS = 4;
 
     private Given() {
     }

--- a/server/src/test/java/org/spine3/server/stand/Given.java
+++ b/server/src/test/java/org/spine3/server/stand/Given.java
@@ -58,7 +58,7 @@ import java.util.concurrent.Executors;
     /*package*/ static final int SEVERAL = THREADS_COUNT_IN_POOL_EXECUTOR;
 
     private static final String PROJECT_UUID = Identifiers.newUuid();
-    /*package*/ static final int AWAIT_SECONDS = 10;
+    /*package*/ static final int AWAIT_SECONDS = 6;
 
     private Given() {
     }

--- a/server/src/test/java/org/spine3/server/stand/Given.java
+++ b/server/src/test/java/org/spine3/server/stand/Given.java
@@ -128,7 +128,7 @@ import java.util.concurrent.Executors;
         }
     }
 
-     /*package*/ static Event validEvent() {
+    /*package*/ static Event validEvent() {
         return Event.newBuilder()
                     .setMessage(AnyPacker.pack(ProjectCreated.newBuilder()
                                                              .setProjectId(ProjectId.newBuilder().setId("12345AD0"))

--- a/server/src/test/java/org/spine3/server/stand/Given.java
+++ b/server/src/test/java/org/spine3/server/stand/Given.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.stand;
+
+import org.spine3.base.Event;
+import org.spine3.base.EventContext;
+import org.spine3.protobuf.AnyPacker;
+import org.spine3.server.BoundedContext;
+import org.spine3.server.projection.Projection;
+import org.spine3.server.projection.ProjectionRepository;
+import org.spine3.test.projection.Project;
+import org.spine3.test.projection.ProjectId;
+import org.spine3.test.projection.event.ProjectCreated;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+/*package*/ class Given {
+
+    /*package*/static class StandTestProjectionRepository extends ProjectionRepository<ProjectId, StandTestProjection, Project> {
+        /*package*/ StandTestProjectionRepository(BoundedContext boundedContext) {
+            super(boundedContext);
+        }
+    }
+
+    private static class StandTestProjection extends Projection<ProjectId, Project> {
+        /**
+         * Creates a new instance.
+         *
+         * Required to be public.
+         *
+         * @param id the ID for the new instance
+         * @throws IllegalArgumentException if the ID is not of one of the supported types
+         */
+        public StandTestProjection(ProjectId id) {
+            super(id);
+        }
+    }
+
+    /*package*/ static Event validEvent() {
+        return Event.newBuilder()
+                    .setMessage(AnyPacker.pack(ProjectCreated.newBuilder()
+                                                             .setProjectId(ProjectId.newBuilder().setId("12345AD0"))
+                                                             .build())
+                    .toBuilder().setTypeUrl(ProjectCreated.getDescriptor().getFullName()).build())
+                    .setContext(EventContext.getDefaultInstance())
+                    .build();
+    }
+}

--- a/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
@@ -168,6 +168,7 @@ public class StandFunnelShould {
     @Test
     public void deliver_updates_through_several_threads() throws InterruptedException {
         final int threadsCount = 10;
+        final int threadExecuteionMaxAwaitSeconds = 2;
 
         final Map<String, Object> threadInvakationRegistry = new ConcurrentHashMap<>(threadsCount);
 
@@ -197,7 +198,7 @@ public class StandFunnelShould {
             processes.execute(task);
         }
 
-        processes.awaitTermination(10, TimeUnit.SECONDS);
+        processes.awaitTermination(threadExecuteionMaxAwaitSeconds, TimeUnit.SECONDS);
 
         Assert.assertEquals(threadInvakationRegistry.size(), threadsCount);
 

--- a/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
@@ -174,7 +174,7 @@ public class StandFunnelShould {
         final Random random = new SecureRandom();
 
         for (int i = 0; i < result.length; i++) {
-            result[i] = random.nextBoolean() ? aggregateRepositoryDispatch() : projectionRepositoryDispatch();
+            result[i] = (i % 2 == 0) ? aggregateRepositoryDispatch() : projectionRepositoryDispatch();
         }
 
         return result;

--- a/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
@@ -166,7 +166,7 @@ public class StandFunnelShould {
      * - deliver the updates from several projection and aggregate repositories.
      */
 
-    @Test
+    //@Test
     public void deliver_updates_from_projection_repository() throws Exception {
         final BoundedContext boundedContext = mock(BoundedContext.class);
         final Stand stand = mock(Stand.class);

--- a/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
@@ -31,6 +31,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -89,14 +91,16 @@ public class StandFunnelShould {
 
     @Test
     public void deliver_mock_updates_to_stand() {
-        final Stand stand = spy(TestStandFactory.create());
+        final Object id = new Object();
+        final Any state = Any.getDefaultInstance();
+
+        final Stand stand = mock(Stand.class);
+        doNothing().when(stand).update(id, state);
 
         final StandFunnel funnel = StandFunnel.newBuilder()
                                               .setStand(stand)
                                               .build();
 
-        final Object id = new Object();
-        final Any state = Any.getDefaultInstance();
         funnel.post(id, state);
 
         verify(stand).update(id, state);
@@ -131,20 +135,11 @@ public class StandFunnelShould {
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test(expected = NullPointerException.class)
-    public void fail_to_initialize_with_null_stand() {
+    public void fail_to_initialize_with_inproper_stand() {
         @SuppressWarnings("ConstantConditions")
         final StandFunnel.Builder builder = StandFunnel.newBuilder().setStand(null);
 
         builder.build();
-    }
-
-    @SuppressWarnings("ResultOfMethodCallIgnored")
-    @Test(expected = NullPointerException.class)
-    public void fail_to_initialize_with_importer_stand() {
-        // TODO:13-09-16:dmytro.dashenkov: Implement.
-//        @SuppressWarnings("ConstantConditions")
-//        final StandFunnel.Builder builder = StandFunnel.newBuilder().setStand(null);
-//        builder.build();
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
@@ -161,6 +156,11 @@ public class StandFunnelShould {
      * - deliver updates from aggregate repo on update;
      * - deliver the updates from several projection and aggregate repositories.
      */
+
+    @Test
+    public void deliver_updates_from_projection_repo() {
+
+    }
 
 
 }

--- a/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
@@ -87,6 +87,21 @@ public class StandFunnelShould {
         Assert.assertNotNull(emptyExecutorFunnel);
     }
 
+    @Test
+    public void deliver_mock_updates_to_stand() {
+        final Stand stand = spy(TestStandFactory.create());
+
+        final StandFunnel funnel = StandFunnel.newBuilder()
+                                              .setStand(stand)
+                                              .build();
+
+        final Object id = new Object();
+        final Any state = Any.getDefaultInstance();
+        funnel.post(id, state);
+
+        verify(stand).update(id, state);
+    }
+
 
     @Test
     public void use_executor_from_builder() {
@@ -114,9 +129,23 @@ public class StandFunnelShould {
 
     // **** Negative scenarios (unit) ****
 
-    /**
-     * - Fail to initialise with improper stand.
-     */
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test(expected = NullPointerException.class)
+    public void fail_to_initialize_with_null_stand() {
+        @SuppressWarnings("ConstantConditions")
+        final StandFunnel.Builder builder = StandFunnel.newBuilder().setStand(null);
+
+        builder.build();
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test(expected = NullPointerException.class)
+    public void fail_to_initialize_with_importer_stand() {
+        // TODO:13-09-16:dmytro.dashenkov: Implement.
+//        @SuppressWarnings("ConstantConditions")
+//        final StandFunnel.Builder builder = StandFunnel.newBuilder().setStand(null);
+//        builder.build();
+    }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test(expected = IllegalStateException.class)

--- a/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 import org.spine3.testdata.TestStandFactory;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
@@ -40,7 +42,6 @@ public class StandFunnelShould {
     // **** Positive scenarios (unit) ****
 
     /**
-     * - Initialize properly with various Builder options;
      * - deliver mock updates to the stand (invoke proper methods with particular arguments) - test the delivery only.
      */
 
@@ -51,6 +52,39 @@ public class StandFunnelShould {
                                                        .setStand(stand);
         final StandFunnel standFunnel = builder.build();
         Assert.assertNotNull(standFunnel);
+    }
+
+    @Test
+    public void initialize_properly_with_various_builder_options() {
+        final Stand stand = TestStandFactory.create();
+        final Executor executor = Executors.newSingleThreadExecutor(new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                return Thread.currentThread();
+            }
+        });
+
+        final StandFunnel blockingFunnel = StandFunnel.newBuilder()
+                                                      .setStand(stand)
+                                                      .setExecutor(executor)
+                                                      .build();
+        Assert.assertNotNull(blockingFunnel);
+
+        final StandFunnel funnelForBusyStand = StandFunnel.newBuilder()
+                                                          .setStand(stand)
+                                                          .setExecutor(Executors.newSingleThreadExecutor())
+                                                          .build();
+        Assert.assertNotNull(funnelForBusyStand);
+
+
+        final StandFunnel emptyExecutorFunnel = StandFunnel.newBuilder()
+                                                           .setStand(TestStandFactory.create())
+                                                           .setExecutor(new Executor() {
+                                                               @Override
+                                                               public void execute(Runnable neverCalled) { }
+                                                           })
+                                                           .build();
+        Assert.assertNotNull(emptyExecutorFunnel);
     }
 
 

--- a/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
@@ -26,6 +26,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.spine3.server.BoundedContext;
+import org.spine3.server.projection.ProjectionRepository;
 import org.spine3.server.storage.memory.InMemoryStorageFactory;
 import org.spine3.testdata.TestStandFactory;
 
@@ -42,7 +43,6 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Alex Tymchenko
@@ -166,22 +166,21 @@ public class StandFunnelShould {
      * - deliver the updates from several projection and aggregate repositories.
      */
 
-    //@Test
+    @Test
     public void deliver_updates_from_projection_repository() throws Exception {
-        final BoundedContext boundedContext = mock(BoundedContext.class);
         final Stand stand = mock(Stand.class);
-        when(boundedContext.getStandFunnel()).thenReturn(StandFunnel.newBuilder()
-                                                                    .setStand(stand)
-                                                                    .setExecutor(new Executor() {
-                                                                        @Override
-                                                                        public void execute(Runnable command) {
-                                                                            command.run();
-                                                                        }
-                                                                    })
-                                                                    .build());
-
+        final BoundedContext boundedContext = spy(BoundedContext.newBuilder()
+                                                                .setStand(stand)
+                                                                .setStorageFactory(InMemoryStorageFactory.getInstance())
+                                                                .setStandFunnelExecutor(new Executor() { // Straightforward executor
+                                                                    @Override
+                                                                    public void execute(Runnable command) {
+                                                                        command.run();
+                                                                    }
+                                                                })
+                                                                .build());
         // Init repository
-        final Given.StandTestProjectionRepository repository = new Given.StandTestProjectionRepository(boundedContext);
+        final ProjectionRepository repository = Given.repo(boundedContext);
 
         stand.registerTypeSupplier(repository);
         repository.initStorage(InMemoryStorageFactory.getInstance());

--- a/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
@@ -214,10 +214,21 @@ public class StandFunnelShould {
             dispatchAction.perform(boundedContext);
         }
 
-
-        // Was called ONCE
+        // Was called as much times as there are dispatch actions.
         verify(boundedContext, times(dispatchActions.length)).getStandFunnel();
+
+        if (isMultiThread) {
+            await(Given.AWAIT_SECONDS);
+        }
+
         verify(stand, times(dispatchActions.length)).update(ArgumentMatchers.any(), any(Any.class));
+    }
+
+    private static void await(int seconds) {
+        try {
+            Thread.sleep(seconds);
+        } catch (InterruptedException ignore) {
+        }
     }
 
     private static BoundedContextAction aggregateRepositoryDispatch() {
@@ -256,13 +267,12 @@ public class StandFunnelShould {
     }
 
 
-
     @SuppressWarnings("MethodWithMultipleLoops")
     @Test
     public void deliver_updates_through_several_threads() throws InterruptedException {
         final int threadsCount = Given.THREADS_COUNT_IN_POOL_EXECUTOR;
         @SuppressWarnings("LocalVariableNamingConvention") // Too long variable name
-        final int threadExecutionMaxAwaitSeconds = 2;
+        final int threadExecutionMaxAwaitSeconds = Given.AWAIT_SECONDS;
 
         final Map<String, Object> threadInvocationRegistry = new ConcurrentHashMap<>(threadsCount);
 

--- a/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Alex Tymchenko

--- a/server/src/test/java/org/spine3/server/stand/StandShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandShould.java
@@ -45,15 +45,12 @@ import org.spine3.protobuf.AnyPacker;
 import org.spine3.protobuf.TypeUrl;
 import org.spine3.server.BoundedContext;
 import org.spine3.server.Given;
-import org.spine3.server.projection.Projection;
-import org.spine3.server.projection.ProjectionRepository;
-import org.spine3.server.storage.EntityStorageRecord;
 import org.spine3.server.stand.Given.StandTestProjectionRepository;
+import org.spine3.server.storage.EntityStorageRecord;
 import org.spine3.server.storage.StandStorage;
 import org.spine3.test.clientservice.customer.Customer;
 import org.spine3.test.clientservice.customer.CustomerId;
 import org.spine3.test.projection.Project;
-import org.spine3.test.projection.ProjectId;
 
 import javax.annotation.Nullable;
 import java.util.Collection;

--- a/server/src/test/java/org/spine3/server/stand/StandShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandShould.java
@@ -44,7 +44,9 @@ import org.spine3.client.Target;
 import org.spine3.protobuf.AnyPacker;
 import org.spine3.protobuf.TypeUrl;
 import org.spine3.server.BoundedContext;
-import org.spine3.server.Given;
+import org.spine3.server.Given.CustomerAggregate;
+import org.spine3.server.Given.CustomerAggregateRepository;
+import org.spine3.server.projection.ProjectionRepository;
 import org.spine3.server.stand.Given.StandTestProjectionRepository;
 import org.spine3.server.storage.EntityStorageRecord;
 import org.spine3.server.stand.Given.StandTestProjectionRepository;
@@ -52,6 +54,7 @@ import org.spine3.server.storage.StandStorage;
 import org.spine3.test.clientservice.customer.Customer;
 import org.spine3.test.clientservice.customer.CustomerId;
 import org.spine3.test.projection.Project;
+import org.spine3.test.projection.ProjectId;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -139,7 +142,7 @@ public class StandShould {
 
         checkTypesEmpty(stand);
 
-        final Given.CustomerAggregateRepository customerAggregateRepo = new Given.CustomerAggregateRepository(boundedContext);
+        final CustomerAggregateRepository customerAggregateRepo = new CustomerAggregateRepository(boundedContext);
         stand.registerTypeSupplier(customerAggregateRepo);
 
         final Descriptors.Descriptor customerEntityDescriptor = Customer.getDescriptor();
@@ -147,7 +150,7 @@ public class StandShould {
         checkHasExactlyOne(stand.getKnownAggregateTypes(), customerEntityDescriptor);
 
         @SuppressWarnings("LocalVariableNamingConvention")
-        final Given.CustomerAggregateRepository anotherCustomerAggregateRepo = new Given.CustomerAggregateRepository(boundedContext);
+        final CustomerAggregateRepository anotherCustomerAggregateRepo = new CustomerAggregateRepository(boundedContext);
         stand.registerTypeSupplier(anotherCustomerAggregateRepo);
         checkHasExactlyOne(stand.getAvailableTypes(), customerEntityDescriptor);
         checkHasExactlyOne(stand.getKnownAggregateTypes(), customerEntityDescriptor);
@@ -184,7 +187,7 @@ public class StandShould {
         assertNotNull(stand);
 
         final BoundedContext boundedContext = newBoundedContext(stand);
-        final Given.CustomerAggregateRepository customerAggregateRepo = new Given.CustomerAggregateRepository(boundedContext);
+        final CustomerAggregateRepository customerAggregateRepo = new CustomerAggregateRepository(boundedContext);
         stand.registerTypeSupplier(customerAggregateRepo);
 
 
@@ -192,7 +195,7 @@ public class StandShould {
         final CustomerId customerId = CustomerId.newBuilder()
                                                 .setNumber(numericIdValue)
                                                 .build();
-        final Given.CustomerAggregate customerAggregate = customerAggregateRepo.create(customerId);
+        final CustomerAggregate customerAggregate = customerAggregateRepo.create(customerId);
         final Customer customerState = customerAggregate.getState();
         final Any packedState = AnyPacker.pack(customerState);
         final TypeUrl customerType = TypeUrl.of(Customer.class);
@@ -498,10 +501,10 @@ public class StandShould {
             StandTestProjectionRepository projectionRepository) {
 
         final Set<ProjectId> projectIds = sampleProjects.keySet();
-        final ImmutableCollection<StandTestProjection> allResults = toProjectionCollection(projectIds);
+        final ImmutableCollection<org.spine3.server.stand.Given.StandTestProjection> allResults = toProjectionCollection(projectIds);
 
         for (ProjectId projectId : projectIds) {
-            when(projectionRepository.find(eq(projectId))).thenReturn(new StandTestProjection(projectId));
+            when(projectionRepository.find(eq(projectId))).thenReturn(new Given.StandTestProjection(projectId));
         }
 
         final Iterable<ProjectId> matchingIds = argThat(projectionIdsIterableMatcher(projectIds));
@@ -537,16 +540,16 @@ public class StandShould {
         };
     }
 
-    private static ImmutableCollection<StandTestProjection> toProjectionCollection(Collection<ProjectId> values) {
-        final Collection<StandTestProjection> transformed = Collections2.transform(values, new Function<ProjectId, StandTestProjection>() {
+    private static ImmutableCollection<Given.StandTestProjection> toProjectionCollection(Collection<ProjectId> values) {
+        final Collection<Given.StandTestProjection> transformed = Collections2.transform(values, new Function<ProjectId, Given.StandTestProjection>() {
             @Nullable
             @Override
-            public StandTestProjection apply(@Nullable ProjectId input) {
+            public Given.StandTestProjection apply(@Nullable ProjectId input) {
                 checkNotNull(input);
-                return new StandTestProjection(input);
+                return new Given.StandTestProjection(input);
             }
         });
-        final ImmutableList<StandTestProjection> result = ImmutableList.copyOf(transformed);
+        final ImmutableList<Given.StandTestProjection> result = ImmutableList.copyOf(transformed);
         return result;
     }
 
@@ -662,7 +665,7 @@ public class StandShould {
         assertNotNull(stand);
 
         final BoundedContext boundedContext = newBoundedContext(stand);
-        final Given.CustomerAggregateRepository customerAggregateRepo = new Given.CustomerAggregateRepository(boundedContext);
+        final org.spine3.server.Given.CustomerAggregateRepository customerAggregateRepo = new org.spine3.server.Given.CustomerAggregateRepository(boundedContext);
         stand.registerTypeSupplier(customerAggregateRepo);
         return stand;
     }

--- a/server/src/test/java/org/spine3/server/stand/StandShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandShould.java
@@ -222,6 +222,32 @@ public class StandShould {
     }
 
     @Test
+    public void return_empty_list_to_unknown_type_reading() {
+
+        final Stand stand = Stand.newBuilder()
+                                 .build();
+
+        checkTypesEmpty(stand);
+
+        // Customer type was NOT registered.
+        final TypeUrl customerType = TypeUrl.of(Customer.class);
+        final Target customerTarget = Target.newBuilder()
+                                            .setIncludeAll(true)
+                                            .setType(customerType.getTypeName())
+                                            .build();
+        final Query readAllCustomers = Query.newBuilder()
+                                            .setTarget(customerTarget)
+                                            .build();
+
+        final MemoizeQueryResponseObserver responseObserver = new MemoizeQueryResponseObserver();
+        stand.execute(readAllCustomers, responseObserver);
+
+        final List<Any> messageList = checkAndGetMessageList(responseObserver);
+
+        assertTrue("Query returned a non-empty response message list for an unknown type", messageList.isEmpty());
+    }
+
+    @Test
     public void return_empty_list_for_aggregate_read_by_ids_on_empty_stand_storage() {
 
         final TypeUrl customerType = TypeUrl.of(Customer.class);

--- a/server/src/test/java/org/spine3/server/stand/StandShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandShould.java
@@ -48,6 +48,7 @@ import org.spine3.server.Given;
 import org.spine3.server.projection.Projection;
 import org.spine3.server.projection.ProjectionRepository;
 import org.spine3.server.storage.EntityStorageRecord;
+import org.spine3.server.stand.Given.StandTestProjectionRepository;
 import org.spine3.server.storage.StandStorage;
 import org.spine3.test.clientservice.customer.Customer;
 import org.spine3.test.clientservice.customer.CustomerId;
@@ -720,26 +721,6 @@ public class StandShould {
 
 
     // ***** Inner classes used for tests. *****
-
-    private static class StandTestProjection extends Projection<ProjectId, Project> {
-        /**
-         * Creates a new instance.
-         *
-         * @param id the ID for the new instance
-         * @throws IllegalArgumentException if the ID is not of one of the supported types
-         */
-        public StandTestProjection(ProjectId id) {
-            super(id);
-        }
-    }
-
-
-    private static class StandTestProjectionRepository extends ProjectionRepository<ProjectId, StandTestProjection, Project> {
-        protected StandTestProjectionRepository(BoundedContext boundedContext) {
-            super(boundedContext);
-        }
-    }
-
 
     /**
      * A {@link StreamObserver} storing the state of {@link Query} execution.

--- a/server/src/test/java/org/spine3/server/stand/StandShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandShould.java
@@ -47,6 +47,7 @@ import org.spine3.server.BoundedContext;
 import org.spine3.server.Given;
 import org.spine3.server.stand.Given.StandTestProjectionRepository;
 import org.spine3.server.storage.EntityStorageRecord;
+import org.spine3.server.stand.Given.StandTestProjectionRepository;
 import org.spine3.server.storage.StandStorage;
 import org.spine3.test.clientservice.customer.Customer;
 import org.spine3.test.clientservice.customer.CustomerId;

--- a/server/src/test/java/org/spine3/testdata/TestStandFactory.java
+++ b/server/src/test/java/org/spine3/testdata/TestStandFactory.java
@@ -21,6 +21,7 @@
  */
 package org.spine3.testdata;
 
+import org.mockito.Mockito;
 import org.spine3.server.stand.Stand;
 
 /**
@@ -37,5 +38,9 @@ public class TestStandFactory {
         final Stand stand = Stand.newBuilder()
                                  .build();
         return stand;
+    }
+
+    public static Stand createMock() {
+        return Mockito.mock(Stand.class);
     }
 }

--- a/server/src/test/java/org/spine3/testdata/TestStandFactory.java
+++ b/server/src/test/java/org/spine3/testdata/TestStandFactory.java
@@ -22,13 +22,13 @@
 package org.spine3.testdata;
 
 import org.spine3.server.stand.Stand;
-import org.spine3.server.storage.memory.InMemoryStandStorage;
 
 /**
  * Creates stands for tests.
  *
  * @author Alex Tymchenko
  */
+@SuppressWarnings("UtilityClass")
 public class TestStandFactory {
 
     private TestStandFactory() {}


### PR DESCRIPTION
Added `Given` util class for stand tests.
Added stand funnel tests covering:
 - Creation with various arguments.
 - Updates delivery from projection/aggregate repository into a stand.
 - Concurrent processing behavior.