### PR TITLE
Common tests for EntityRepository

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -11,6 +11,7 @@
           <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>
         <codeStyleSettings language="JAVA">
+          <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
           <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
           <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
           <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -11,6 +11,8 @@
           <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>
         <codeStyleSettings language="JAVA">
+          <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+          <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
           <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
           <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
           <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />

--- a/client/src/main/proto/spine/client/query.proto
+++ b/client/src/main/proto/spine/client/query.proto
@@ -45,8 +45,8 @@ message QueryContext {
 
 // The main abstraction over the read-side API.
 //
-// Allows clients to form the requests to the read-side through the QueryService.
-// Query execution typically results in a QueryResponse object.
+// Allows clients to form the requests to the read-side through the `QueryService`.
+// `Query` execution typically results in a QueryResponse object.
 message Query {
 
     // Defines the entity of interest, e.g. entity type URL and a set of fetch criteria.
@@ -59,18 +59,18 @@ message Query {
     reserved 3 to 6;
 }
 
-// The result of Query processing in the read-side implementation.
+// The result of `Query` processing.
 //
 // Contains the actual processing results and other response attributes.
 // Used as a result of {@code QueryService#Read(Query)} gRPC method call.
 message QueryResponse {
 
-    // Represents the base part of the response. I.e. whether the Query has been acked or not.
+    // Represents the base part of the response. I.e. whether the `Query` has been acked or not.
     base.Response response = 1;
 
     // Reserved for more query response attributes, e.g. to describe paginated response etc.
     reserved 2 to 4;
 
-    // Entity states (each packed as Any) returned to the API user as a result of Query execution.
+    // Entity states (each packed as `Any`) returned to the API user as a result of Query execution.
     repeated google.protobuf.Any messages = 5;
 }

--- a/client/src/test/java/org/spine3/base/QueriesShould.java
+++ b/client/src/test/java/org/spine3/base/QueriesShould.java
@@ -1,0 +1,39 @@
+/*
+ *
+ * Copyright 2016, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+package org.spine3.base;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.spine3.test.Tests.hasPrivateUtilityConstructor;
+
+/**
+ * @author Alex Tymchenko
+ */
+public class QueriesShould {
+
+    @Test
+    public void have_private_constructor() {
+        assertTrue(hasPrivateUtilityConstructor(Queries.class));
+    }
+
+}

--- a/client/src/test/proto/spine/test/queries_should.proto
+++ b/client/src/test/proto/spine/test/queries_should.proto
@@ -1,0 +1,50 @@
+//
+// Copyright 2016, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.test.queries;
+
+option (type_url_prefix) = "type.spine3.org";
+option java_package="org.spine3.test.queries";
+option java_multiple_files = true;
+option java_outer_classname = "QueriesShouldProto";
+
+
+import "spine/annotations.proto";
+
+// Only for usage in `QueriesShould` class.
+
+// Simple ID for tests.
+message TestEntityId {
+
+    // Numeric value wrapped into this ID.
+    int32 value = 1;
+}
+
+// Test entity used as a `Target` for queries.
+message TestEntity {
+
+    // Entity ID.
+    TestEntityId id = 1;
+
+    string first_field = 2;
+
+    bool second_field = 3;
+}

--- a/server/src/main/java/org/spine3/server/QueryService.java
+++ b/server/src/main/java/org/spine3/server/QueryService.java
@@ -91,7 +91,6 @@ public class QueryService extends QueryServiceGrpc.QueryServiceImplBase {
             return this;
         }
 
-
         @SuppressWarnings("ReturnOfCollectionOrArrayField") // the collection returned is immutable
         public ImmutableMap<TypeUrl, BoundedContext> getBoundedContextMap() {
             return typeToContextMap;
@@ -120,7 +119,7 @@ public class QueryService extends QueryServiceGrpc.QueryServiceImplBase {
         }
 
         private static void addBoundedContext(ImmutableMap.Builder<TypeUrl, BoundedContext> mapBuilder,
-                BoundedContext boundedContext) {
+                                              BoundedContext boundedContext) {
 
             final ImmutableSet<TypeUrl> availableTypes = boundedContext.getStand()
                                                                        .getAvailableTypes();

--- a/server/src/main/java/org/spine3/server/SubscriptionService.java
+++ b/server/src/main/java/org/spine3/server/SubscriptionService.java
@@ -119,8 +119,8 @@ public class SubscriptionService extends SubscriptionServiceGrpc.SubscriptionSer
 
         final BoundedContext boundedContext = selectBoundedContext(subscription);
         try {
-            boundedContext.getStand()
-                          .cancel(subscription);
+            final Stand stand = boundedContext.getStand();
+            stand.cancel(subscription);
             responseObserver.onNext(Responses.ok());
         } catch (@SuppressWarnings("OverlyBroadCatchBlock") Exception e) {
             log().error("Error processing cancel subscription request", e);
@@ -191,8 +191,8 @@ public class SubscriptionService extends SubscriptionServiceGrpc.SubscriptionSer
         private static void addBoundedContext(ImmutableMap.Builder<TypeUrl, BoundedContext> mapBuilder,
                                               BoundedContext boundedContext) {
 
-            final ImmutableSet<TypeUrl> availableTypes = boundedContext.getStand()
-                                                                       .getAvailableTypes();
+            final Stand stand = boundedContext.getStand();
+            final ImmutableSet<TypeUrl> availableTypes = stand.getAvailableTypes();
             for (TypeUrl availableType : availableTypes) {
                 mapBuilder.put(availableType, boundedContext);
             }

--- a/server/src/main/java/org/spine3/server/entity/EntityRepository.java
+++ b/server/src/main/java/org/spine3/server/entity/EntityRepository.java
@@ -159,6 +159,11 @@ public abstract class EntityRepository<I, E extends Entity<I, M>, M extends Mess
         while (idIterator.hasNext() && recordIterator.hasNext()) {
             final I id = idIterator.next();
             final EntityStorageRecord record = recordIterator.next();
+
+            if (record == null) { // Record is nullable here since RecordStorage::findBulk returns an Iterable that may contain nulls.
+                continue;
+            }
+
             final E entity = toEntity(id, record, fieldMask);
             entities.add(entity);
         }

--- a/server/src/main/java/org/spine3/server/entity/EntityRepository.java
+++ b/server/src/main/java/org/spine3/server/entity/EntityRepository.java
@@ -109,25 +109,9 @@ public abstract class EntityRepository<I, E extends Entity<I, M>, M extends Mess
     }
 
     /**
-     * Finds the entity with the passed ID.
-     *
-     * <p>As opposed to {@link #load(Object)}, the invocation of this method never leads to creation of a new entity.
-     *
-     * <p>NOTE: The storage must be assigned before calling this method.
-     *
-     * @param id the id of the entity to find.
-     * @return the entity or {@code null} if there's no entity with such id
-     */
-    @CheckReturnValue
-    @Nullable
-    public E find(I id) {
-        return this.load(id);
-    }
-
-    /**
      * Finds all the entities in this repository with IDs, contained within the passed {@code ids} values.
      *
-     * <p>Provides a convenience wrapper around multiple invocations of {@link #find(Object)}. Descendants may
+     * <p>Provides a convenience wrapper around multiple invocations of {@link #load(Object)}. Descendants may
      * optimize the execution of this method, choosing the most suitable way for the particular storage engine used.
      *
      * <p>The result only contains those entities which IDs are contained inside the passed {@code ids}.
@@ -137,8 +121,6 @@ public abstract class EntityRepository<I, E extends Entity<I, M>, M extends Mess
      *
      * <p>In case IDs contain duplicates, the result may also contain duplicates, depending on particular
      * implementation.
-     *
-     * <p>Similar to {@link #find(Object)}, the invocation of this method never leads to creation of new objects.
      *
      * <p>NOTE: The storage must be assigned before calling this method.
      *

--- a/server/src/main/java/org/spine3/server/entity/EntityRepository.java
+++ b/server/src/main/java/org/spine3/server/entity/EntityRepository.java
@@ -203,6 +203,8 @@ public abstract class EntityRepository<I, E extends Entity<I, M>, M extends Mess
      *
      * <p>At this point only {@link org.spine3.client.EntityIdFilter} is supported. All other filters are ignored.
      *
+     * <p>Filtering by IDs set via {@code EntityIdFilter} is performed in the same way as by {@link #loadAll(Iterable)}.
+     *
      * <p>NOTE: The storage must be assigned before calling this method.
      *
      * @param filters   entity filters
@@ -210,7 +212,7 @@ public abstract class EntityRepository<I, E extends Entity<I, M>, M extends Mess
      * @return all the entities in this repository passed the filters.
      */
     @CheckReturnValue
-    public ImmutableCollection<E> findAll(EntityFilters filters, FieldMask fieldMask) {
+    public ImmutableCollection<E> find(EntityFilters filters, FieldMask fieldMask) {
         final List<EntityId> idsList = filters.getIdFilter()
                                               .getIdsList();
         final Class<I> expectedIdClass = getIdClass();

--- a/server/src/main/java/org/spine3/server/entity/EntityRepository.java
+++ b/server/src/main/java/org/spine3/server/entity/EntityRepository.java
@@ -109,7 +109,7 @@ public abstract class EntityRepository<I, E extends Entity<I, M>, M extends Mess
     }
 
     /**
-     * Finds all the entities in this repository with IDs, contained within the passed {@code ids} values.
+     * Loads all the entities in this repository with IDs, contained within the passed {@code ids} values.
      *
      * <p>Provides a convenience wrapper around multiple invocations of {@link #load(Object)}. Descendants may
      * optimize the execution of this method, choosing the most suitable way for the particular storage engine used.
@@ -133,7 +133,7 @@ public abstract class EntityRepository<I, E extends Entity<I, M>, M extends Mess
     }
 
     /**
-     * Finds all the entities in this repository by their IDs and applies the {@link FieldMask} to each of them.
+     * Loads all the entities in this repository by their IDs and applies the {@link FieldMask} to each of them.
      *
      * <p>Acts in the same way as {@link #loadAll(Iterable)}, with the {@code FieldMask} applied to the results.
      *
@@ -166,6 +166,14 @@ public abstract class EntityRepository<I, E extends Entity<I, M>, M extends Mess
         return ImmutableList.copyOf(entities);
     }
 
+    /**
+     * Loads all the entities in this repository.
+     *
+     * <p>NOTE: The storage must be assigned before calling this method.
+     *
+     * @return all the entities in this repository
+     * @see #loadAll(Iterable)
+     */
     @CheckReturnValue
     public ImmutableCollection<E> loadAll() {
         final RecordStorage<I> storage = recordStorage();

--- a/server/src/main/java/org/spine3/server/entity/EntityRepository.java
+++ b/server/src/main/java/org/spine3/server/entity/EntityRepository.java
@@ -155,7 +155,7 @@ public abstract class EntityRepository<I, E extends Entity<I, M>, M extends Mess
      *
      * <p>Acts in the same way as {@link #findBulk(Iterable)}, with the {@code FieldMask} applied to the results.
      *
-     * <p>Field mask must be applied according to
+     * <p>Field mask is applied according to
      * <a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask>FieldMask specs</a>.
      *
      * <p>NOTE: The storage must be assigned before calling this method.
@@ -206,7 +206,10 @@ public abstract class EntityRepository<I, E extends Entity<I, M>, M extends Mess
     }
 
     /**
-     * Find all the entities passing the given filters.
+     * Finds all the entities passing the given filters and applies the given {@link FieldMask} to the results.
+     *
+     * <p>Field mask is applied according to
+     * <a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask>FieldMask specs</a>.
      *
      * <p>At this point only {@link org.spine3.client.EntityIdFilter} is supported. All other filters are ignored.
      *

--- a/server/src/main/java/org/spine3/server/entity/EntityRepository.java
+++ b/server/src/main/java/org/spine3/server/entity/EntityRepository.java
@@ -167,7 +167,7 @@ public abstract class EntityRepository<I, E extends Entity<I, M>, M extends Mess
     }
 
     @CheckReturnValue
-    public ImmutableCollection<E> findAll() {
+    public ImmutableCollection<E> loadAll() {
         final RecordStorage<I> storage = recordStorage();
         final Map<I, EntityStorageRecord> recordMap = storage.readAll();
 

--- a/server/src/main/java/org/spine3/server/entity/EntityRepository.java
+++ b/server/src/main/java/org/spine3/server/entity/EntityRepository.java
@@ -127,11 +127,23 @@ public abstract class EntityRepository<I, E extends Entity<I, M>, M extends Mess
     /**
      * Finds all the entities in this repository with IDs, contained within the passed {@code ids} values.
      *
-     * <p>Same as calling <pre>{@code findBulk(id, FieldMask.getDefaultInstance());}</pre>
+     * <p>Provides a convenience wrapper around multiple invocations of {@link #find(Object)}. Descendants may
+     * optimize the execution of this method, choosing the most suitable way for the particular storage engine used.
+     *
+     * <p>The result only contains those entities which IDs are contained inside the passed {@code ids}.
+     * The resulting collection is always returned with no {@code null} values.
+     *
+     * <p>The order of objects in the result is not guaranteed to be the same as the order of IDs passed as argument.
+     *
+     * <p>In case IDs contain duplicates, the result may also contain duplicates, depending on particular
+     * implementation.
+     *
+     * <p>Similar to {@link #find(Object)}, the invocation of this method never leads to creation of new objects.
+     *
+     * <p>NOTE: The storage must be assigned before calling this method.
      *
      * @param ids entity IDs to search for
-     * @return all the entities in this repository with the IDs contained in the given {@code ids}
-     * @see #findBulk(Iterable, FieldMask)
+     * @return all the entities in this repository with the IDs matching the given {@code Iterable}
      */
     @CheckReturnValue
     public ImmutableCollection<E> findBulk(Iterable<I> ids) {
@@ -139,26 +151,19 @@ public abstract class EntityRepository<I, E extends Entity<I, M>, M extends Mess
     }
 
     /**
-     * Finds all the entities in this repository with IDs, contained within the passed {@code Iterable}.
+     * Finds all the entities in this repository by their IDs and applies the {@link FieldMask} to each of them.
      *
-     * <p>Provides a convenience wrapper around multiple invocations of {@link #find(Object)}. Descendants may
-     * optimize the execution of this method, choosing the most suitable way for the particular storage engine used.
+     * <p>Acts in the same way as {@link #findBulk(Iterable)}, with the {@code FieldMask} applied to the results.
      *
-     * <p>The order of resulting objects in the {@link Iterable} is not guaranteed to be the same as the order
-     * of IDs passed as argument.
-     *
-     * <p>The instance of {@code Iterable} is always returned with no {@code null} values.
-     *
-     * <p>In case IDs contain duplicates, the resulting {@code Iterable} may also contain duplicates, depending
-     * on particular implementation.
-     *
-     * <p>Similar to {@link #find(Object)}, the invocation of this method never leads to creation of new objects.
+     * <p>Field mask must be applied according to
+     * <a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask>FieldMask specs</a>.
      *
      * <p>NOTE: The storage must be assigned before calling this method.
      *
      * @param ids       entity IDs to search for
      * @param fieldMask mask to apply on entities
-     * @return all the entities in this repository with the IDs matching the given {@code Iterable}
+     * @return all the entities in this repository with the IDs contained in the given {@code ids}
+     * @see #findBulk(Iterable)
      */
     @CheckReturnValue
     public ImmutableCollection<E> findBulk(Iterable<I> ids, FieldMask fieldMask) {

--- a/server/src/main/java/org/spine3/server/entity/EntityRepository.java
+++ b/server/src/main/java/org/spine3/server/entity/EntityRepository.java
@@ -128,14 +128,14 @@ public abstract class EntityRepository<I, E extends Entity<I, M>, M extends Mess
      * @return all the entities in this repository with the IDs matching the given {@code Iterable}
      */
     @CheckReturnValue
-    public ImmutableCollection<E> findBulk(Iterable<I> ids) {
-        return findBulk(ids, FieldMask.getDefaultInstance());
+    public ImmutableCollection<E> loadAll(Iterable<I> ids) {
+        return loadAll(ids, FieldMask.getDefaultInstance());
     }
 
     /**
      * Finds all the entities in this repository by their IDs and applies the {@link FieldMask} to each of them.
      *
-     * <p>Acts in the same way as {@link #findBulk(Iterable)}, with the {@code FieldMask} applied to the results.
+     * <p>Acts in the same way as {@link #loadAll(Iterable)}, with the {@code FieldMask} applied to the results.
      *
      * <p>Field mask is applied according to
      * <a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask>FieldMask specs</a>.
@@ -145,10 +145,10 @@ public abstract class EntityRepository<I, E extends Entity<I, M>, M extends Mess
      * @param ids       entity IDs to search for
      * @param fieldMask mask to apply on entities
      * @return all the entities in this repository with the IDs contained in the given {@code ids}
-     * @see #findBulk(Iterable)
+     * @see #loadAll(Iterable)
      */
     @CheckReturnValue
-    public ImmutableCollection<E> findBulk(Iterable<I> ids, FieldMask fieldMask) {
+    public ImmutableCollection<E> loadAll(Iterable<I> ids, FieldMask fieldMask) {
         final RecordStorage<I> storage = recordStorage();
         final Iterable<EntityStorageRecord> entityStorageRecords = storage.readBulk(ids);
 
@@ -230,7 +230,7 @@ public abstract class EntityRepository<I, E extends Entity<I, M>, M extends Mess
             }
         });
 
-        final ImmutableCollection<E> result = findBulk(domainIds, fieldMask);
+        final ImmutableCollection<E> result = loadAll(domainIds, fieldMask);
         return result;
     }
 

--- a/server/src/main/java/org/spine3/server/stand/Stand.java
+++ b/server/src/main/java/org/spine3/server/stand/Stand.java
@@ -70,6 +70,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Maps.newHashMap;
 
 /**
  * A container for storing the lastest {@link org.spine3.server.aggregate.Aggregate} states.
@@ -522,8 +523,8 @@ public class Stand implements AutoCloseable {
      * <p>Responsible for {@link Subscription} object instantiation.
      */
     private static final class StandSubscriptionRegistry {
-        private final Map<TypeUrl, Set<SubscriptionRecord>> typeToAttrs = new HashMap<>();
-        private final Map<Subscription, SubscriptionRecord> subscriptionToAttrs = new HashMap<>();
+        private final Map<TypeUrl, Set<SubscriptionRecord>> typeToAttrs = newHashMap();
+        private final Map<Subscription, SubscriptionRecord> subscriptionToAttrs = newHashMap();
 
         private synchronized void activate(Subscription subscription, StandUpdateCallback callback) {
             if (!subscriptionToAttrs.containsKey(subscription)) {

--- a/server/src/main/java/org/spine3/server/stand/Stand.java
+++ b/server/src/main/java/org/spine3/server/stand/Stand.java
@@ -382,7 +382,7 @@ public class Stand implements AutoCloseable {
         final FieldMask fieldMask = query.getFieldMask();
 
         if (target.getIncludeAll() && fieldMask.getPathsList().isEmpty()) {
-            result = repository.findAll();
+            result = repository.loadAll();
         } else {
             final EntityFilters filters = target.getFilters();
             result = repository.findAll(filters, fieldMask);

--- a/server/src/main/java/org/spine3/server/stand/Stand.java
+++ b/server/src/main/java/org/spine3/server/stand/Stand.java
@@ -385,7 +385,7 @@ public class Stand implements AutoCloseable {
             result = repository.loadAll();
         } else {
             final EntityFilters filters = target.getFilters();
-            result = repository.findAll(filters, fieldMask);
+            result = repository.find(filters, fieldMask);
         }
         return result;
     }

--- a/server/src/main/java/org/spine3/server/storage/BulkStorageOperationsMixin.java
+++ b/server/src/main/java/org/spine3/server/storage/BulkStorageOperationsMixin.java
@@ -42,15 +42,19 @@ import java.util.Map;
      *
      * <p>The size of {@link Iterable} returned is always the same as the size of given IDs.
      *
-     * <p>In case there is no record for a particular ID, {@code null} will be present in the result.
+     * <p>In case there is no record for a particular ID, {@code null} will be present in the result instead.
+     * In this way {@code readBulk()} callees are able to track the absenсe of a certain element by comparing
+     * the input IDs and resulting {@code Iterable}.
+     *
+     * <p>E.g. {@code readBulk( Lists.newArrayList(idPresentInStorage, idNonPresentInStorage) )} will return
+     * an {@code Iterable} with two elements, first of which is non-null and the second is null.
      *
      * @param ids record IDs of interest
      * @return the {@link Iterable} containing the records matching the given IDs
      * @throws IllegalStateException if the storage was closed before
      */
     @CheckReturnValue
-    Iterable<R>
-    readBulk(Iterable<I> ids);
+    Iterable<R> readBulk(Iterable<I> ids);
 
 
     /**

--- a/server/src/main/java/org/spine3/server/storage/memory/InMemoryRecordStorage.java
+++ b/server/src/main/java/org/spine3/server/storage/memory/InMemoryRecordStorage.java
@@ -88,10 +88,10 @@ import static com.google.common.collect.Maps.newHashMap;
 
                     matchingRecord.setState(processed);
 
-                    result.add(matchingRecord.build());
-                } else {
-                    result.add(null);
-                }
+                    result.add(matchingRecord.build()); }
+//                } else {
+//                    result.add(null);
+//                }
             }
         }
         return result;
@@ -99,7 +99,7 @@ import static com.google.common.collect.Maps.newHashMap;
 
     @Override
     protected Iterable<EntityStorageRecord> readBulkInternal(Iterable<I> ids) {
-        return readBulkInternal(ids, null);
+        return readBulkInternal(ids, FieldMask.getDefaultInstance());
     }
 
     @Override

--- a/server/src/main/java/org/spine3/server/storage/memory/InMemoryRecordStorage.java
+++ b/server/src/main/java/org/spine3/server/storage/memory/InMemoryRecordStorage.java
@@ -72,8 +72,12 @@ import static com.google.common.collect.Maps.newHashMap;
 
         TypeUrl typeUrl = null;
 
-        for (I recordId : storage.keySet()) {
-            for (I givenId : givenIds) {
+        int resultExpectedSize = 0;
+
+        for (I givenId : givenIds) {
+            resultExpectedSize++;
+
+            for (I recordId : storage.keySet()) {
                 if (recordId.equals(givenId)) {
                     final EntityStorageRecord.Builder matchingRecord = storage.get(recordId).toBuilder();
                     final Any state = matchingRecord.getState();
@@ -88,10 +92,14 @@ import static com.google.common.collect.Maps.newHashMap;
 
                     matchingRecord.setState(processed);
 
-                    result.add(matchingRecord.build()); }
-//                } else {
-//                    result.add(null);
-//                }
+                    result.add(matchingRecord.build());
+                }
+            }
+
+            // If no record was found
+            if (result.size() < resultExpectedSize) {
+                result.add(null);
+                resultExpectedSize++;
             }
         }
         return result;

--- a/server/src/test/java/org/spine3/server/CommandServiceShould.java
+++ b/server/src/test/java/org/spine3/server/CommandServiceShould.java
@@ -98,15 +98,17 @@ public class CommandServiceShould {
     @Test
     public void never_retrieve_removed_bounded_contexts_from_builder() {
         final CommandService.Builder builder = CommandService.newBuilder()
-                .addBoundedContext(projectsContext)
-                .addBoundedContext(customersContext)
-                .removeBoundedContext(projectsContext);
+                                                             .addBoundedContext(projectsContext)
+                                                             .addBoundedContext(customersContext)
+                                                             .removeBoundedContext(projectsContext);
 
         final CommandService service = builder.build(); // Creates BoundedContext map
         assertNotNull(service);
 
-        assertTrue(builder.getBoundedContextMap().containsValue(customersContext));
-        assertFalse(builder.getBoundedContextMap().containsValue(projectsContext));
+        assertTrue(builder.getBoundedContextMap()
+                          .containsValue(customersContext));
+        assertFalse(builder.getBoundedContextMap()
+                           .containsValue(projectsContext));
     }
 
     private void verifyPostsCommand(Command cmd, CommandBus commandBus) {
@@ -132,8 +134,8 @@ public class CommandServiceShould {
     @Test
     public void deploy_to_grpc_container() throws IOException {
         final GrpcContainer grpcContainer = GrpcContainer.newBuilder()
-                                                 .addService(service)
-                                                 .build();
+                                                         .addService(service)
+                                                         .build();
         try {
             assertTrue(grpcContainer.isScheduledForDeployment(service));
 
@@ -143,7 +145,7 @@ public class CommandServiceShould {
             grpcContainer.shutdown();
             assertFalse(grpcContainer.isLive(service));
         } finally {
-            if(!grpcContainer.isShutdown()) {
+            if (!grpcContainer.isShutdown()) {
                 grpcContainer.shutdown();
             }
         }

--- a/server/src/test/java/org/spine3/server/QueryServiceShould.java
+++ b/server/src/test/java/org/spine3/server/QueryServiceShould.java
@@ -142,7 +142,7 @@ public class QueryServiceShould {
 
     @Test
     public void return_error_if_query_failed_to_execute() {
-        when(projectDetailsRepository.findAll()).thenThrow(RuntimeException.class);
+        when(projectDetailsRepository.loadAll()).thenThrow(RuntimeException.class);
         final Query query = Given.Query.readAllProjects();
         service.read(query, responseObserver);
         checkFailureResponse(responseObserver);

--- a/server/src/test/java/org/spine3/server/entity/AbstractEntityRepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/entity/AbstractEntityRepositoryShould.java
@@ -51,7 +51,7 @@ public abstract class AbstractEntityRepositoryShould<E extends Entity<?, ?>> {
 
         repo.store(entity);
 
-        final Entity<?, ?> found = repo.find(entity.getId());
+        final Entity<?, ?> found = repo.load(entity.getId());
 
         assertEquals(found, entity);
     }
@@ -73,7 +73,7 @@ public abstract class AbstractEntityRepositoryShould<E extends Entity<?, ?>> {
             ids.add(entities.get(i).getId());
         }
 
-        final Collection<E> found = repo.findBulk(ids);
+        final Collection<E> found = repo.loadAll(ids);
 
         assertSize(ids.size(), found);
 
@@ -103,7 +103,7 @@ public abstract class AbstractEntityRepositoryShould<E extends Entity<?, ?>> {
 
         ids.add(sideEntity.getId());
 
-        final Collection<E> found = repo.findBulk(ids);
+        final Collection<E> found = repo.loadAll(ids);
 
         assertSize(ids.size() - 1, found); // Check we've found all existing items
 
@@ -112,8 +112,7 @@ public abstract class AbstractEntityRepositoryShould<E extends Entity<?, ?>> {
         }
     }
 
-
-    @SuppressWarnings({ "MethodWithMultipleLoops", "unchecked"})
+    @SuppressWarnings({"MethodWithMultipleLoops", "unchecked"})
     @Test
     public void retrieve_all_records_with_entity_filters_and_field_mask_applied() {
         final EntityRepository<?, E, ?> repo = repository();
@@ -128,22 +127,31 @@ public abstract class AbstractEntityRepositoryShould<E extends Entity<?, ?>> {
         final List<EntityId> ids = new LinkedList<>();
         for (int i = 0; i < count / 2; i++) {
             final EntityId id = EntityId.newBuilder()
-                                        .setId(AnyPacker.pack((Message) entities.get(i).getId()))
+                                        .setId(AnyPacker.pack((Message) entities.get(i)
+                                                                                .getId()))
                                         .build();
             ids.add(id);
         }
 
-        final EntityIdFilter filter = EntityIdFilter.newBuilder().addAllIds(ids).build();
+        final EntityIdFilter filter = EntityIdFilter.newBuilder()
+                                                    .addAllIds(ids)
+                                                    .build();
         final EntityFilters filters = EntityFilters.newBuilder()
-                .setIdFilter(filter)
-                .build();
+                                                   .setIdFilter(filter)
+                                                   .build();
 
-        final String firstFieldName = entities.get(0).getState().getDescriptorForType().getFields().get(0).getFullName();
+        final String firstFieldName = entities.get(0)
+                                              .getState()
+                                              .getDescriptorForType()
+                                              .getFields()
+                                              .get(0)
+                                              .getFullName();
 
         final FieldMask firstFieldOnly = FieldMask.newBuilder()
-                .addPaths(firstFieldName).build();
+                                                  .addPaths(firstFieldName)
+                                                  .build();
 
-        final Iterable<E> readEntities = repo.findAll(filters, firstFieldOnly);
+        final Iterable<E> readEntities = repo.find(filters, firstFieldOnly);
 
         assertSize(ids.size(), readEntities);
 
@@ -152,13 +160,15 @@ public abstract class AbstractEntityRepositoryShould<E extends Entity<?, ?>> {
         }
     }
 
-
     private void assertMatches(E entity, FieldMask fieldMask) {
         final Message state = entity.getState();
         final List<String> paths = fieldMask.getPathsList();
 
-        for (Descriptors.FieldDescriptor field : state.getDescriptorForType().getFields()) {
-            if (field.isRepeated()) continue;
+        for (Descriptors.FieldDescriptor field : state.getDescriptorForType()
+                                                      .getFields()) {
+            if (field.isRepeated()) {
+                continue;
+            }
 
             assertEquals(state.hasField(field), paths.contains(field.getFullName()));
         }

--- a/server/src/test/java/org/spine3/server/entity/AbstractEntityRepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/entity/AbstractEntityRepositoryShould.java
@@ -69,6 +69,8 @@ public abstract class AbstractEntityRepositoryShould<E extends Entity<?, ?>> {
         }
 
         final List ids = new LinkedList<>();
+
+        // Find some of the records (half of them in this case)
         for (int i = 0; i < count / 2; i++) {
             ids.add(entities.get(i).getId());
         }
@@ -125,6 +127,8 @@ public abstract class AbstractEntityRepositoryShould<E extends Entity<?, ?>> {
         }
 
         final List<EntityId> ids = new LinkedList<>();
+
+        // Find some of the records (half of them in this case)
         for (int i = 0; i < count / 2; i++) {
             final EntityId id = EntityId.newBuilder()
                                         .setId(AnyPacker.pack((Message) entities.get(i)
@@ -160,7 +164,7 @@ public abstract class AbstractEntityRepositoryShould<E extends Entity<?, ?>> {
         }
     }
 
-    private void assertMatches(E entity, FieldMask fieldMask) {
+    private static <E extends Entity<?, ?>> void assertMatches(E entity, FieldMask fieldMask) {
         final Message state = entity.getState();
         final List<String> paths = fieldMask.getPathsList();
 

--- a/server/src/test/java/org/spine3/server/entity/AbstractEntityRepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/entity/AbstractEntityRepositoryShould.java
@@ -68,7 +68,37 @@ public abstract class AbstractEntityRepositoryShould<E extends Entity<?, ?>> {
 
         final Collection<E> found = repo.findBulk(ids);
 
-        assertSize(count / 2, found);
+        assertSize(ids.size(), found);
+
+        for (E entity : found) {
+            assertContains(entity, entities);
+        }
+    }
+
+    @SuppressWarnings({"MethodWithMultipleLoops", "unchecked"})
+    @Test
+    public void handle_wrong_passed_ids() {
+        final EntityRepository<?, E, ?> repo = repository();
+
+        final int count = 10;
+        final List<E> entities = entities(count);
+
+        for (E entity : entities) {
+            repo.store(entity);
+        }
+
+        final List ids = new LinkedList<>();
+        for (int i = 0; i < count; i++) {
+            ids.add(entities.get(i).getId());
+        }
+
+        final Entity<?, ?> sideEntity = entity();
+
+        ids.add(sideEntity.getId());
+
+        final Collection<E> found = repo.findBulk(ids);
+
+        assertSize(ids.size() - 1, found); // Check we've found all existing items
 
         for (E entity : found) {
             assertContains(entity, entities);

--- a/server/src/test/java/org/spine3/server/entity/AbstractEntityRepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/entity/AbstractEntityRepositoryShould.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.entity;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.spine3.test.Verify.assertContains;
+import static org.spine3.test.Verify.assertSize;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public abstract class AbstractEntityRepositoryShould<E extends Entity<?, ?>> {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void find_single_entity_by_id() {
+        final EntityRepository repo = repository();
+
+        final E entity = entity();
+
+        repo.store(entity);
+
+        final Entity<?, ?> found = repo.find(entity.getId());
+
+        assertEquals(found, entity);
+    }
+
+    @SuppressWarnings({"MethodWithMultipleLoops", "unchecked"})
+    @Test
+    public void find_multiple_entities_by_ids() {
+        final EntityRepository<?, E, ?> repo = repository();
+
+        final int count = 10;
+        final List<E> entities = entities(count);
+
+        for (E entity : entities) {
+            repo.store(entity);
+        }
+
+        final List ids = new LinkedList<>();
+        for (int i = 0; i < count / 2; i++) {
+            ids.add(entities.get(i).getId());
+        }
+
+        final Collection<E> found = repo.findBulk(ids);
+
+        assertSize(count / 2, found);
+
+        for (E entity : found) {
+            assertContains(entity, entities);
+        }
+    }
+
+    protected abstract EntityRepository<?, E, ?> repository();
+
+    protected abstract E entity();
+
+    protected abstract List<E> entities(int count);
+}

--- a/server/src/test/java/org/spine3/server/procman/ProcessManagerRepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/procman/ProcessManagerRepositoryShould.java
@@ -38,6 +38,8 @@ import org.spine3.base.Events;
 import org.spine3.server.BoundedContext;
 import org.spine3.server.command.Assign;
 import org.spine3.server.command.CommandDispatcher;
+import org.spine3.server.entity.AbstractEntityRepositoryShould;
+import org.spine3.server.entity.EntityRepository;
 import org.spine3.server.entity.IdFunction;
 import org.spine3.server.event.EventBus;
 import org.spine3.server.event.GetProducerIdFromEvent;
@@ -59,6 +61,8 @@ import org.spine3.testdata.TestEventBusFactory;
 
 import javax.annotation.Nonnull;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -74,7 +78,7 @@ import static org.spine3.testdata.TestCommandContextFactory.createCommandContext
  * @author Alexander Litus
  */
 @SuppressWarnings("InstanceMethodNamingConvention")
-public class ProcessManagerRepositoryShould {
+public class ProcessManagerRepositoryShould extends AbstractEntityRepositoryShould<ProcessManagerRepositoryShould.TestProcessManager> {
 
     private static final ProjectId ID = Given.AggregateId.newProjectId();
 
@@ -205,6 +209,36 @@ public class ProcessManagerRepositoryShould {
         assertTrue(eventClasses.contains(EventClass.of(ProjectStarted.class)));
     }
 
+    @Override
+    protected EntityRepository<?, TestProcessManager, ?> repository() {
+        final TestProcessManagerRepository repo = new TestProcessManagerRepository(
+                TestBoundedContextFactory.newBoundedContext());
+
+        repo.initStorage(InMemoryStorageFactory.getInstance());
+
+        return repo;
+    }
+
+    @Override
+    protected TestProcessManager entity() {
+        final ProjectId id = ProjectId.newBuilder().setId("123-id").build();
+        return new TestProcessManager(id);
+    }
+
+    @Override
+    protected List<TestProcessManager> entities(int count) {
+        final List<TestProcessManager> procmans = new ArrayList<>();
+
+        for (int i = 0; i < count; i++) {
+            final ProjectId id = ProjectId.newBuilder().setId(String.format("procman-number-%s", i)).build();
+
+            procmans.add(new TestProcessManager(id));
+        }
+
+        return procmans;
+    }
+
+
     private static class TestProcessManagerRepository
             extends ProcessManagerRepository<ProjectId, TestProcessManager, Project> {
 
@@ -218,7 +252,7 @@ public class ProcessManagerRepositoryShould {
         }
     }
 
-    private static class TestProcessManager extends ProcessManager<ProjectId, Project> {
+    /* package */ static class TestProcessManager extends ProcessManager<ProjectId, Project> {
 
         /** The event message we store for inspecting in delivery tests. */
         private static final Multimap<ProjectId, Message> messagesDelivered = HashMultimap.create();

--- a/server/src/test/java/org/spine3/server/projection/ProjectionRepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/projection/ProjectionRepositoryShould.java
@@ -30,6 +30,8 @@ import org.spine3.base.Event;
 import org.spine3.base.EventContext;
 import org.spine3.base.Events;
 import org.spine3.server.BoundedContext;
+import org.spine3.server.entity.AbstractEntityRepositoryShould;
+import org.spine3.server.entity.EntityRepository;
 import org.spine3.server.event.EventStore;
 import org.spine3.server.event.Subscribe;
 import org.spine3.server.storage.RecordStorage;
@@ -41,6 +43,8 @@ import org.spine3.test.projection.event.ProjectCreated;
 import org.spine3.test.projection.event.ProjectStarted;
 import org.spine3.test.projection.event.TaskAdded;
 
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -59,7 +63,7 @@ import static org.spine3.testdata.TestEventContextFactory.createEventContext;
  * @author Alexander Litus
  */
 @SuppressWarnings("InstanceMethodNamingConvention")
-public class ProjectionRepositoryShould {
+public class ProjectionRepositoryShould extends AbstractEntityRepositoryShould<ProjectionRepositoryShould.TestProjection> {
 
     private static final ProjectId ID = Given.AggregateId.newProjectId();
 
@@ -207,8 +211,33 @@ public class ProjectionRepositoryShould {
         assertTrue(TestProjection.processed(Events.getMessage(projectStartedEvent)));
     }
 
+    @Override
+    protected EntityRepository<?, TestProjection, ?> repository() {
+        return repository;
+    }
+
+    @Override
+    protected TestProjection entity() {
+        final TestProjection projection = new TestProjection(ProjectId.newBuilder().setId("single-test-projection").build());
+        return projection;
+    }
+
+    @Override
+    protected List<TestProjection> entities(int count) {
+        final List<TestProjection> projections = new LinkedList<>();
+
+        for (int i = 0; i < count; i++) {
+            final TestProjection projection = new TestProjection(
+                    ProjectId.newBuilder().setId(String.format("test-projection-%s", i)).build());
+
+            projections.add(projection);
+        }
+
+        return projections;
+    }
+
     /** The projection stub used in tests. */
-    private static class TestProjection extends Projection<ProjectId, Project> {
+    /* package */ static class TestProjection extends Projection<ProjectId, Project> {
 
         /** The event message history we store for inspecting in delivery tests. */
         private static final Multimap<ProjectId, Message> eventMessagesDelivered = HashMultimap.create();

--- a/server/src/test/java/org/spine3/server/stand/StandShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandShould.java
@@ -838,7 +838,7 @@ public class StandShould {
 
         final Iterable<ProjectId> matchingIds = argThat(projectionIdsIterableMatcher(projectIds));
 
-        when(projectionRepository.findBulk(matchingIds, any(FieldMask.class))).thenReturn(allResults);
+        when(projectionRepository.loadAll(matchingIds, any(FieldMask.class))).thenReturn(allResults);
 
         when(projectionRepository.findAll()).thenReturn(allResults);
 

--- a/server/src/test/java/org/spine3/server/stand/StandShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandShould.java
@@ -833,7 +833,7 @@ public class StandShould {
         final ImmutableCollection<Given.StandTestProjection> allResults = toProjectionCollection(projectIds);
 
         for (ProjectId projectId : projectIds) {
-            when(projectionRepository.find(eq(projectId))).thenReturn(new StandTestProjection(projectId));
+            when(projectionRepository.load(eq(projectId))).thenReturn(new StandTestProjection(projectId));
         }
 
         final Iterable<ProjectId> matchingIds = argThat(projectionIdsIterableMatcher(projectIds));

--- a/server/src/test/java/org/spine3/server/stand/StandShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandShould.java
@@ -843,7 +843,7 @@ public class StandShould {
         when(projectionRepository.loadAll()).thenReturn(allResults);
 
         final EntityFilters matchingFilter = argThat(entityFilterMatcher(projectIds));
-        when(projectionRepository.findAll(matchingFilter, any(FieldMask.class))).thenReturn(allResults);
+        when(projectionRepository.find(matchingFilter, any(FieldMask.class))).thenReturn(allResults);
     }
 
     @SuppressWarnings("OverlyComplexAnonymousInnerClass")

--- a/server/src/test/java/org/spine3/server/stand/StandShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandShould.java
@@ -840,7 +840,7 @@ public class StandShould {
 
         when(projectionRepository.loadAll(matchingIds, any(FieldMask.class))).thenReturn(allResults);
 
-        when(projectionRepository.findAll()).thenReturn(allResults);
+        when(projectionRepository.loadAll()).thenReturn(allResults);
 
         final EntityFilters matchingFilter = argThat(entityFilterMatcher(projectIds));
         when(projectionRepository.findAll(matchingFilter, any(FieldMask.class))).thenReturn(allResults);


### PR DESCRIPTION
Common tests for `EntityRepository`:
 - `load(id)`
 - `loadAll(ids)`
 - `find(EntityFilters, FieldMask)`

Fixed issue with returning multiple `null` values from `InMemoryEntityRepository`.