### PR TITLE
In memory storage cov

### DIFF
--- a/server/src/test/java/org/spine3/server/storage/ProjectionStorageShould.java
+++ b/server/src/test/java/org/spine3/server/storage/ProjectionStorageShould.java
@@ -43,6 +43,7 @@ import static org.junit.Assert.assertNull;
 import static org.spine3.protobuf.Timestamps.getCurrentTime;
 import static org.spine3.test.Tests.assertMatchesMask;
 import static org.spine3.test.Verify.assertContains;
+import static org.spine3.test.Verify.assertEmpty;
 import static org.spine3.test.Verify.assertSize;
 import static org.spine3.testdata.TestEntityStorageRecordFactory.newEntityStorageRecord;
 
@@ -151,6 +152,22 @@ public abstract class ProjectionStorageShould<I> extends AbstractStorageShould<I
             final Project state = AnyPacker.unpack(packedState);
             assertMatchesMask(state, fieldMask);
         }
+    }
+
+    @Test
+    public void retrieve_empty_map_if_store_is_empty() {
+        final Map<I, EntityStorageRecord> noMask = storage.readAll();
+
+        final FieldMask nonEmptyMask = FieldMask.newBuilder()
+                                                .addPaths("invalid_path")
+                                                .build();
+        final Map<I, EntityStorageRecord> masked = storage.readAll(nonEmptyMask);
+
+        assertEmpty(noMask);
+        assertEmpty(masked);
+
+        // Same type
+        assertEquals(noMask, masked);
     }
 
     @Test(expected = NullPointerException.class)

--- a/server/src/test/java/org/spine3/server/storage/ProjectionStorageShould.java
+++ b/server/src/test/java/org/spine3/server/storage/ProjectionStorageShould.java
@@ -172,7 +172,7 @@ public abstract class ProjectionStorageShould<I> extends AbstractStorageShould<I
         assertEquals(noMask, masked);
     }
 
-    @SuppressWarnings("MethodWithMultipleLoops")
+    @SuppressWarnings({"MethodWithMultipleLoops", "BreakStatement"})
     @Test
     public void perform_read_bulk_operations() {
         final int count = 10;
@@ -224,6 +224,7 @@ public abstract class ProjectionStorageShould<I> extends AbstractStorageShould<I
         }
     }
 
+    @SuppressWarnings({"MethodWithMultipleLoops", "BreakStatement"})
     @Test
     public void perform_bulk_read_with_field_mask_operation() {
         final int count = 10;

--- a/server/src/test/java/org/spine3/server/storage/ProjectionStorageShould.java
+++ b/server/src/test/java/org/spine3/server/storage/ProjectionStorageShould.java
@@ -106,7 +106,7 @@ public abstract class ProjectionStorageShould<I> extends AbstractStorageShould<I
         final String projectDescriptor = Project.getDescriptor()
                                                 .getFullName();
         @SuppressWarnings("DuplicateStringLiteralInspection")
-        final FieldMask fieldMask = fields(projectDescriptor + ".id", projectDescriptor + ".name");
+        final FieldMask fieldMask = maskForPaths(projectDescriptor + ".id", projectDescriptor + ".name");
 
         final Map<I, EntityStorageRecord> read = storage.readAll(fieldMask);
         assertSize(ids.size(), read);
@@ -159,7 +159,7 @@ public abstract class ProjectionStorageShould<I> extends AbstractStorageShould<I
 
         final String projectDescriptor = Project.getDescriptor()
                                                 .getFullName();
-        final FieldMask fieldMask = fields(projectDescriptor + ".id", projectDescriptor + ".status");
+        final FieldMask fieldMask = maskForPaths(projectDescriptor + ".id", projectDescriptor + ".status");
 
         final Iterable<EntityStorageRecord> read = storage.readBulk(ids, fieldMask);
         assertSize(ids.size(), read);
@@ -204,7 +204,6 @@ public abstract class ProjectionStorageShould<I> extends AbstractStorageShould<I
                                                                   .build();
             storage.write(id, record);
             ids.add(id);
-
         }
 
         return ids;
@@ -237,7 +236,7 @@ public abstract class ProjectionStorageShould<I> extends AbstractStorageShould<I
         return state;
     }
 
-    private static FieldMask fields(String... paths) {
+    private static FieldMask maskForPaths(String... paths) {
         final FieldMask mask = FieldMask.newBuilder()
                                         .addAllPaths(Arrays.asList(paths))
                                         .build();

--- a/server/src/test/java/org/spine3/server/storage/RecordStorageShould.java
+++ b/server/src/test/java/org/spine3/server/storage/RecordStorageShould.java
@@ -37,7 +37,11 @@ public abstract class RecordStorageShould {
     public void retrieve_empty_map_if_storage_is_empty() {
         final RecordStorage<String> storage = createStorage();
 
-        final Map empty = storage.readAll(FieldMask.getDefaultInstance());
+        final FieldMask nonEmptyFieldMask = FieldMask.newBuilder()
+                                                     .addPaths("invalid-path")
+                                                     .build();
+
+        final Map empty = storage.readAll(nonEmptyFieldMask);
         assertNotNull(empty);
         assertEmpty(empty);
     }

--- a/server/src/test/java/org/spine3/server/storage/RecordStorageShould.java
+++ b/server/src/test/java/org/spine3/server/storage/RecordStorageShould.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.storage;
+
+import com.google.protobuf.FieldMask;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+import static org.spine3.test.Verify.assertEmpty;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public abstract class RecordStorageShould {
+
+    @Test
+    public void retrieve_empty_map_if_storage_is_empty() {
+        final RecordStorage<String> storage = createStorage();
+
+        final Map empty = storage.readAll(FieldMask.getDefaultInstance());
+        assertNotNull(empty);
+        assertEmpty(empty);
+    }
+
+    protected abstract <T> RecordStorage<T> createStorage();
+}

--- a/server/src/test/java/org/spine3/server/storage/memory/InMemoryRecordStorageShould.java
+++ b/server/src/test/java/org/spine3/server/storage/memory/InMemoryRecordStorageShould.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.storage.memory;
+
+import org.spine3.server.storage.RecordStorage;
+import org.spine3.server.storage.RecordStorageShould;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public class InMemoryRecordStorageShould extends RecordStorageShould {
+
+    @Override
+    protected <T> RecordStorage<T> createStorage() {
+        return InMemoryRecordStorage.newInstance(false);
+    }
+}


### PR DESCRIPTION
Fixed coverage:
 - `RecordStorage` (`#readAllInternal` case)
 - `ProjectionStorage`

Both now have __100%__ coverage on both abstract class and in-memory impl.