### PR TITLE
Field masks cleanup 

### DIFF
--- a/server/src/main/java/org/spine3/server/entity/FieldMasks.java
+++ b/server/src/main/java/org/spine3/server/entity/FieldMasks.java
@@ -123,7 +123,7 @@ public class FieldMasks {
         final ProtocolStringList filter = mask.getPathsList();
         final Class<B> builderClass = getBuilderForType(type);
 
-        if (filter.isEmpty() || builderClass == null) {
+        if (builderClass == null) {
             return message;
         }
 

--- a/server/src/test/java/org/spine3/server/entity/FieldMasksShould.java
+++ b/server/src/test/java/org/spine3/server/entity/FieldMasksShould.java
@@ -139,7 +139,7 @@ public class FieldMasksShould {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void fail_to_mask_message_if_passed_type_dees_not_match() {
+    public void fail_to_mask_message_if_passed_type_does_not_match() {
         final FieldMask mask = Given.fieldMask(Project.ID_FIELD_NUMBER);
 
         final Project origin = Given.newProject("some-string");


### PR DESCRIPTION
No coverage improvement can be provided for `FieldMasks` at the moment since `catch` blocks are not to be executed within the standard flow. The only possibility I see for those pieces of code to be run is if the protobuf definitions are compiled improperly.