### PR TITLE
Simplified Field Filter

### DIFF
--- a/client/src/main/proto/spine/base/field_filter.proto
+++ b/client/src/main/proto/spine/base/field_filter.proto
@@ -34,8 +34,11 @@ import "spine/annotations.proto";
 
 // `FieldFilter` specifies accepted values for a field.
 message FieldFilter {
-    // The field specification.
-    google.protobuf.FieldMask field = 1;
+
+    // A symbolic field path.
+    //
+    // Contract is similar to google.protobuf.FieldMask.paths.
+    string field_path = 1;
 
     // Values accepted by the filter.
     repeated google.protobuf.Any value = 2;


### PR DESCRIPTION
Now we use `string field_path` instead of `FildMask field` hence the field must be only one.