### PR TITLE
Make `CommandBus` configurable

### DIFF
--- a/server/src/main/java/org/spine3/server/BoundedContext.java
+++ b/server/src/main/java/org/spine3/server/BoundedContext.java
@@ -484,7 +484,9 @@ public class BoundedContext extends IntegrationEventSubscriberGrpc.IntegrationEv
             if (commandStore == null) {
                 this.commandStore = createCommandStore();
             }
-            final CommandBus commandBus = CommandBus.newInstance(commandStore);
+            final CommandBus commandBus = CommandBus.newBuilder()
+                                                    .setCommandStore(commandStore)
+                                                    .build();
             return commandBus;
         }
 

--- a/server/src/main/java/org/spine3/server/command/CommandBus.java
+++ b/server/src/main/java/org/spine3/server/command/CommandBus.java
@@ -502,8 +502,10 @@ public class CommandBus implements AutoCloseable {
 
         private Builder() {}
 
+        /**
+         * Builds an instance of {@link CommandBus}.
+         */
         public CommandBus build() {
-
             checkNotNull(commandStore, "CommandStore must be set");
 
             if(commandScheduler == null) {

--- a/server/src/main/java/org/spine3/server/command/CommandBus.java
+++ b/server/src/main/java/org/spine3/server/command/CommandBus.java
@@ -433,12 +433,10 @@ public class CommandBus implements AutoCloseable {
          */
         private CommandScheduler commandScheduler;
 
-        @Nullable
         public CommandStore getCommandStore() {
             return commandStore;
         }
 
-        @Nullable
         public CommandScheduler getCommandScheduler() {
             return commandScheduler;
         }

--- a/server/src/test/java/org/spine3/server/aggregate/AggregateRepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/aggregate/AggregateRepositoryShould.java
@@ -96,7 +96,9 @@ public class AggregateRepositoryShould {
         eventBus = mock(EventBus.class);
         commandStore = mock(CommandStore.class);
         doReturn(emptyIterator()).when(commandStore).iterator(any(CommandStatus.class)); // to avoid NPE
-        final CommandBus commandBus = CommandBus.newInstance(commandStore);
+        final CommandBus commandBus = CommandBus.newBuilder()
+                                                .setCommandStore(commandStore)
+                                                .build();
         final BoundedContext boundedContext = newBoundedContext(commandBus, eventBus);
         repository = new TestAggregateRepository(boundedContext);
         repositorySpy = spy(repository);

--- a/server/src/test/java/org/spine3/server/command/CommandBusShould.java
+++ b/server/src/test/java/org/spine3/server/command/CommandBusShould.java
@@ -72,6 +72,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -127,14 +128,37 @@ public class CommandBusShould {
      *********************/
 
     @Test(expected = NullPointerException.class)
-    public void not_accept_null_CommandStore_on_construction() {
-        CommandBus.newInstance(Tests.<CommandStore>nullRef());
+    public void not_accept_null_CommandStore_in_builder() {
+        CommandBus.newBuilder()
+                  .setCommandStore(Tests.<CommandStore>nullRef());
     }
+
+    @Test(expected = NullPointerException.class)
+    public void not_allow_to_omit_setting_CommandStore_in_builder() {
+        CommandBus.newBuilder()
+                  .build();
+    }
+
 
     @Test
     public void create_new_instance() {
-        final CommandBus commandBus = CommandBus.newInstance(commandStore);
+        final CommandBus commandBus = CommandBus.newBuilder()
+                                                .setCommandStore(commandStore)
+                                                .build();
         assertNotNull(commandBus);
+    }
+
+    @Test
+    public void allow_to_specify_command_scheduler_via_builder() {
+        final CommandScheduler expectedScheduler = mock(CommandScheduler.class);
+        final CommandBus commandBus = CommandBus.newBuilder()
+                                                .setCommandStore(commandStore)
+                                                .setCommandScheduler(expectedScheduler)
+                                                .build();
+        assertNotNull(commandBus);
+
+        final CommandScheduler actualScheduler = commandBus.getScheduler();
+        assertEquals(expectedScheduler, actualScheduler);
     }
 
     /*

--- a/server/src/test/java/org/spine3/server/procman/ProcessManagerShould.java
+++ b/server/src/test/java/org/spine3/server/procman/ProcessManagerShould.java
@@ -78,7 +78,9 @@ public class ProcessManagerShould {
     public void setUp() {
         final InMemoryStorageFactory storageFactory = InMemoryStorageFactory.getInstance();
         final CommandStore commandStore = spy(new CommandStore(storageFactory.createCommandStorage()));
-        commandBus = spy(CommandBus.newInstance(commandStore));
+        commandBus = spy(CommandBus.newBuilder()
+                                   .setCommandStore(commandStore)
+                                   .build());
         processManager = new TestProcessManager(ID);
     }
 

--- a/server/src/test/java/org/spine3/testdata/TestCommandBusFactory.java
+++ b/server/src/test/java/org/spine3/testdata/TestCommandBusFactory.java
@@ -46,7 +46,9 @@ public class TestCommandBusFactory {
     /** Creates a new command bus with the given storage factory. */
     public static CommandBus create(StorageFactory storageFactory) {
         final CommandStore store = new CommandStore(storageFactory.createCommandStorage());
-        final CommandBus commandBus = CommandBus.newInstance(store);
+        final CommandBus commandBus = CommandBus.newBuilder()
+                                                .setCommandStore(store)
+                                                .build();
         return commandBus;
     }
 }


### PR DESCRIPTION
Summary of changes:

* Migrate to `Builder`-based approach from `CommandBus#newInstance()`.
* Remove hard-coded thread spawning and replace it with a configuration option.