### PR TITLE
Aggregate state double-checking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ allprojects {
     apply plugin: 'idea'
 
     group = 'org.spine3'
-    version = '0.6.4-SNAPSHOT'
+    version = '0.6.5-SNAPSHOT'
 }
 
 ext {

--- a/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
@@ -208,6 +208,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * @param request the request to dispatch
      * @throws IllegalStateException if storage for the repository was not initialized
      */
+    @SuppressWarnings("OverlyBroadCatchBlock")      // the exception handling is the same for all exception types.
     @Override
     @CheckReturnValue
     public void dispatch(Command request) throws IllegalStateException {
@@ -218,7 +219,6 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
         A aggregate = loadAndDispatch(aggregateId, commandId, command, context);
 
         final List<Event> events = aggregate.getUncommittedEvents();
-        //noinspection OverlyBroadCatchBlock
         try {
             store(aggregate);
             final Message state = aggregate.getState();
@@ -231,6 +231,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
         commandStatusService.setOk(commandId);
     }
 
+    @SuppressWarnings("ChainOfInstanceofChecks")        // it's a rare case of handing an exception, so we are OK.
     private A loadAndDispatch(I aggregateId, CommandId commandId, Message command, CommandContext context) {
         final AggregateStorage<I> aggregateStorage = aggregateStorage();
         A aggregate;
@@ -261,7 +262,6 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
                 aggregate.dispatch(command, context);
             } catch (RuntimeException e) {
                 final Throwable cause = e.getCause();
-                //noinspection ChainOfInstanceofChecks
                 if (cause instanceof Exception) {
                     final Exception exception = (Exception) cause;
                     commandStatusService.setToError(commandId, exception);

--- a/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
@@ -278,7 +278,6 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
             eventCountBeforeSave = aggregateStorage.readEventCountAfterLastSnapshot(aggregateId);
         } while (eventCountBeforeDispatch != eventCountBeforeSave);
 
-        checkNotNull(aggregate);
         return aggregate;
     }
 

--- a/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
@@ -161,8 +161,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
     @Nonnull
     @Override
     public A load(I id) throws IllegalStateException {
-        final AggregateStorage<I> aggregateStorage = aggregateStorage();
-        final AggregateEvents aggregateEvents = aggregateStorage.read(id);
+        final AggregateEvents aggregateEvents = aggregateStorage().read(id);
         final Snapshot snapshot = aggregateEvents.getSnapshot();
         final A result = create(id);
         final List<Event> events = aggregateEvents.getEventList();


### PR DESCRIPTION
Summary of changes:

* ensure the event count (after the last snapshot) is the same during the command dispatching. Do not allow to proceed to the `Aggregate` state update until there are no new events from concurrent actors.
* bump framework version to `0.6.5-SNAPSHOT`.