### PR TITLE
Allow `ProcessManager` have no commands handled

### DIFF
--- a/server/src/main/java/org/spine3/server/command/DispatcherRegistry.java
+++ b/server/src/main/java/org/spine3/server/command/DispatcherRegistry.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.protobuf.Message;
+import org.spine3.server.procman.ProcessManagerRepository;
 import org.spine3.server.reflect.Classes;
 import org.spine3.server.reflect.CommandHandlerMethod;
 import org.spine3.server.type.CommandClass;
@@ -63,6 +64,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
     /**
      * Ensures that the dispatcher forwards at least one command.
      *
+     * <p>Note that {@link org.spine3.server.procman.ProcessManager} is allowed to have no commands handled,
+     * since its business flow may be designed to handle events only.
+     *
      * <p>We pass the {@code dispatcher} and the set as arguments instead of getting the set
      * from the dispatcher because this operation is expensive and
      *
@@ -70,8 +74,16 @@ import static com.google.common.base.Preconditions.checkNotNull;
      * @throws NullPointerException if the dispatcher returns null set
      */
     private static void checkNotEmpty(CommandDispatcher dispatcher, Set<CommandClass> commandClasses) {
-        checkArgument(!commandClasses.isEmpty(),
-                "No command classes are forwarded by this dispatcher: %s", dispatcher);
+
+        /**
+         * Instances of {@link ProcessManagerRepository} are excluded from the check,
+         * as long as {@link org.spine3.server.procman.ProcessManager}s may have no commands handled.
+         */
+        final boolean criterionSatisfied = !commandClasses.isEmpty()
+                || (dispatcher instanceof ProcessManagerRepository);
+
+        checkArgument(criterionSatisfied,
+                      "No command classes are forwarded by this dispatcher: %s", dispatcher);
     }
 
     /**

--- a/server/src/test/java/org/spine3/server/procman/ProcessManagerRepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/procman/ProcessManagerRepositoryShould.java
@@ -254,7 +254,9 @@ public class ProcessManagerRepositoryShould
         }
     }
 
-    /* package */ static class TestProcessManager extends ProcessManager<ProjectId, Project> {
+    // Marked as {@code public} to reuse for {@code CommandBus} dispatcher registration tests as well
+    // with no code duplication.
+    public static class TestProcessManager extends ProcessManager<ProjectId, Project> {
 
         /** The event message we store for inspecting in delivery tests. */
         private static final Multimap<ProjectId, Message> messagesDelivered = HashMultimap.create();


### PR DESCRIPTION
As long as `ProcessManager`s are designed for inter-communication between `Aggregate`s, some flows may be triggered by a business event, not a command. 

However, the framework did not allow to register dispatchers with no command handler methods.

In scope of this PR, we enable `ProcessManager`s registration even with no command handled. We keep registering those in the bus to keep the `CommandDispatcher` processing consistent for all subclasses of `CommandDispatcher`s.