### PR TITLE
Supply the storage record with a proper `EventContext` instance.

### DIFF
--- a/server/src/test/java/org/spine3/server/storage/EventStorageShould.java
+++ b/server/src/test/java/org/spine3/server/storage/EventStorageShould.java
@@ -192,8 +192,12 @@ public abstract class EventStorageShould extends AbstractStorageShould<EventId, 
         final EventId eventId = EventId.newBuilder()
                                        .setUuid(Identifiers.newUuid())
                                        .build();
+        final Any eventProducerId = AnyPacker.pack(uid);
+        final EventContext context = EventContext.newBuilder()
+                                                 .setProducerId(eventProducerId)
+                                                 .build();
         final EventStorageRecord record = EventStorageRecord.newBuilder()
-                                                            .setContext(EventContext.getDefaultInstance())
+                                                            .setContext(context)
                                                             .setEventId(eventId.getUuid())
                                                             .setEventType(TypeUrl.of(ProjectCreated.class)
                                                                                  .value())


### PR DESCRIPTION
Summary of changes:

* The default event context was used for `EventStorage` tests previously.
* `GCD` implementation requires proper event producer set for the `EventStorageRecord`'s event context.
* Proper event context with a valid `producerId` was set to allow `GCD` tests pass.