### PR TITLE
Support for "enrichment" and wildcard "by" options.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ buildscript {
     ext {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
-        spineProtobufPluginVersion = '1.4.10'
+        spineProtobufPluginVersion = '0.6.6-SNAPSHOT'
     }
 
     dependencies {

--- a/client/src/main/proto/spine/event_annotations.proto
+++ b/client/src/main/proto/spine/event_annotations.proto
@@ -85,7 +85,17 @@ extend google.protobuf.MessageOptions {
     // Therefore, if `enrichment` option is used in more than event message, the fields participating
     // in the enrichment process must have the same names.
     //
-    string enrichment = 57126;
+    // In the enrichment message a wildcard `by` option syntax may be used to reference more than a single
+    // target events to enrich.
+    //
+    // For example:
+    //
+    // message EnrichmentForSeveralEvents {
+    //     string str = 1 [(by) = "*.user_id"];
+    // }
+    //
+    string enrichment = 57126; // NOTE: this field number is used in the `tools` project,
+                               // EnrichmentLookupPlugin (update it there on changing).
 }
 
 extend google.protobuf.FieldOptions {
@@ -112,6 +122,28 @@ extend google.protobuf.FieldOptions {
     //
     // message MyEventEnrichment {
     //     string str = 1 [(by) = "MyEvent.user_id"];
+    // }
+    //
+    // If a single enrichment message is used to enrich several events, a wildcard syntax may be used.
+    //
+    // An example:
+    //
+    // message EnrichmentForSeveralEvents {
+    //     string str = 1 [(by) = "*.user_id"];
+    // }
+    //
+    // message EventOne {
+    //
+    //     option (enrichment) = "EnrichmentForSeveralEvents";
+    //
+    //     int32 user_id = 1;
+    // }
+    //
+    // message EventTwo {
+    //
+    //     option (enrichment) = "EnrichmentForSeveralEvents";
+    //
+    //     int32 user_id = 1;
     // }
     //
     string by = 57125; // NOTE: this field number is used in the `tools` project,

--- a/client/src/main/proto/spine/event_annotations.proto
+++ b/client/src/main/proto/spine/event_annotations.proto
@@ -91,7 +91,7 @@ extend google.protobuf.MessageOptions {
     // For example:
     //
     // message EnrichmentForSeveralEvents {
-    //     string str = 1 [(by) = "*.user_id"];
+    //     string username = 1 [(by) = "*.user_id"];
     // }
     //
     string enrichment = 57126; // NOTE: this field number is used in the `tools` project,
@@ -121,7 +121,7 @@ extend google.protobuf.FieldOptions {
     // }
     //
     // message MyEventEnrichment {
-    //     string str = 1 [(by) = "MyEvent.user_id"];
+    //     string username = 1 [(by) = "MyEvent.user_id"];
     // }
     //
     // If a single enrichment message is used to enrich several events, a wildcard syntax may be used.
@@ -129,18 +129,16 @@ extend google.protobuf.FieldOptions {
     // An example:
     //
     // message EnrichmentForSeveralEvents {
-    //     string str = 1 [(by) = "*.user_id"];
+    //     string username = 1 [(by) = "*.user_id"];
     // }
     //
     // message EventOne {
-    //
     //     option (enrichment) = "EnrichmentForSeveralEvents";
     //
     //     int32 user_id = 1;
     // }
     //
     // message EventTwo {
-    //
     //     option (enrichment) = "EnrichmentForSeveralEvents";
     //
     //     int32 user_id = 1;

--- a/server/src/test/java/org/spine3/server/event/Given.java
+++ b/server/src/test/java/org/spine3/server/event/Given.java
@@ -28,8 +28,10 @@ import org.spine3.base.EventContext;
 import org.spine3.base.EventId;
 import org.spine3.server.event.enrich.EventEnricher;
 import org.spine3.test.Tests;
+import org.spine3.test.event.ProjectCompleted;
 import org.spine3.test.event.ProjectCreated;
 import org.spine3.test.event.ProjectId;
+import org.spine3.test.event.ProjectStarred;
 import org.spine3.test.event.ProjectStarted;
 import org.spine3.users.UserId;
 
@@ -63,6 +65,8 @@ public class Given {
         private static final ProjectId DUMMY_PROJECT_ID = AggregateId.newProjectId();
         private static final ProjectCreated PROJECT_CREATED = projectCreated(DUMMY_PROJECT_ID);
         private static final ProjectStarted PROJECT_STARTED = projectStarted(DUMMY_PROJECT_ID);
+        private static final ProjectCompleted PROJECT_COMPLETED = projectCompleted(DUMMY_PROJECT_ID);
+        private static final ProjectStarred PROJECT_STARRED = projectStarred(DUMMY_PROJECT_ID);
 
         private EventMessage() {}
 
@@ -74,6 +78,14 @@ public class Given {
             return PROJECT_STARTED;
         }
 
+        public static ProjectCompleted projectCompleted() {
+            return PROJECT_COMPLETED;
+        }
+
+        public static ProjectStarred projectStarred() {
+            return PROJECT_STARRED;
+        }
+
         public static ProjectCreated projectCreated(ProjectId id) {
             return ProjectCreated.newBuilder()
                                  .setProjectId(id)
@@ -82,6 +94,18 @@ public class Given {
 
         public static ProjectStarted projectStarted(ProjectId id) {
             return ProjectStarted.newBuilder()
+                                 .setProjectId(id)
+                                 .build();
+        }
+
+        public static ProjectCompleted projectCompleted(ProjectId id) {
+            return ProjectCompleted.newBuilder()
+                                   .setProjectId(id)
+                                   .build();
+        }
+
+        public static ProjectStarred projectStarred(ProjectId id) {
+            return ProjectStarred.newBuilder()
                                  .setProjectId(id)
                                  .build();
         }

--- a/server/src/test/proto/spine/test/event/events.proto
+++ b/server/src/test/proto/spine/test/event/events.proto
@@ -87,3 +87,19 @@ message EnrichmentByContextFields {
 
     string by_event_field = 7 [(by) = "project_id"];
 }
+
+message ProjectCompleted {
+    option (enrichment) = "SeparateEnrichmentForMultipleProjectEvents";
+
+    ProjectId project_id = 1;
+}
+
+message ProjectStarred {
+    option (enrichment) = "SeparateEnrichmentForMultipleProjectEvents";
+
+    ProjectId project_id = 1;
+}
+
+message SeparateEnrichmentForMultipleProjectEvents {
+    string project_name = 1 [(by) = "*.project_id"];
+}


### PR DESCRIPTION
Summary of changes:

* Illustrate `enrichment = "TargetEnrichment"` and `(by) = "*.event_id"` options in a core-java test.
* Depend on Spine protobuf-plugin of `0.6.6-SNAPSHOT` version.

NOTE: `core-java` version is NOT increased, so that this PR could be merged to whatever codebase version in `master`.