### PR TITLE
Thread safety for core singletons.

### DIFF
--- a/client/src/main/java/org/spine3/base/Identifiers.java
+++ b/client/src/main/java/org/spine3/base/Identifiers.java
@@ -43,6 +43,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Maps.newHashMap;
 import static com.google.protobuf.TextFormat.shortDebugString;
+import static java.util.Collections.synchronizedMap;
 import static org.spine3.protobuf.AnyPacker.unpack;
 import static org.spine3.protobuf.Values.newStringValue;
 
@@ -256,12 +257,14 @@ public class Identifiers {
     /** The registry of converters of ID types to string representations. */
     public static class ConverterRegistry {
 
-        private final Map<Class<?>, Function<?, String>> entries = newHashMap(
-                ImmutableMap.<Class<?>, Function<?, String>>builder()
-                        .put(Timestamp.class, new TimestampToStringConverter())
-                        .put(EventId.class, new EventIdToStringConverter())
-                        .put(CommandId.class, new CommandIdToStringConverter())
-                        .build()
+        private final Map<Class<?>, Function<?, String>> entries = synchronizedMap(
+                newHashMap(
+                        ImmutableMap.<Class<?>, Function<?, String>>builder()
+                                .put(Timestamp.class, new TimestampToStringConverter())
+                                .put(EventId.class, new EventIdToStringConverter())
+                                .put(CommandId.class, new CommandIdToStringConverter())
+                                .build()
+                )
         );
 
         private ConverterRegistry() {
@@ -291,7 +294,7 @@ public class Identifiers {
             }
         }
 
-        public <I> boolean containsConverter(I id) {
+        public synchronized  <I> boolean containsConverter(I id) {
             final Class<?> idClass = id.getClass();
             final boolean contains = entries.containsKey(idClass) && (entries.get(idClass) != null);
             return contains;

--- a/server/src/main/java/org/spine3/server/command/CommandValidator.java
+++ b/server/src/main/java/org/spine3/server/command/CommandValidator.java
@@ -51,7 +51,7 @@ public class CommandValidator {
 
     /** Returns a validator instance. */
     public static CommandValidator getInstance() {
-        return LogSingleton.INSTANCE.value;
+        return Singleton.INSTANCE.value;
     }
 
     private CommandValidator() {}
@@ -130,7 +130,7 @@ public class CommandValidator {
         }
     }
 
-    private enum LogSingleton {
+    private enum Singleton {
         INSTANCE;
         @SuppressWarnings("NonSerializableFieldInSerializableClass")
         private final CommandValidator value = new CommandValidator();

--- a/server/src/main/java/org/spine3/server/entity/DefaultStateRegistry.java
+++ b/server/src/main/java/org/spine3/server/entity/DefaultStateRegistry.java
@@ -20,12 +20,13 @@
 
 package org.spine3.server.entity;
 
+import com.google.common.collect.MapMaker;
 import com.google.protobuf.Message;
 
 import javax.annotation.CheckReturnValue;
 import java.util.Map;
 
-import static com.google.common.collect.Maps.newHashMap;
+import static com.google.common.collect.Maps.newConcurrentMap;
 
 /**
  * A wrapper for the map from entity classes to entity default states.
@@ -34,7 +35,11 @@ import static com.google.common.collect.Maps.newHashMap;
  */
 /* package */ class DefaultStateRegistry {
 
-    private final Map<Class<? extends Entity>, Message> defaultStates = newHashMap();
+    /**
+     * NOTE: The implementation is not customized with {@link MapMaker#makeMap()} options,
+     * as it is difficult to predict which work best within the real end-user application scenarios.
+     **/
+    private final Map<Class<? extends Entity>, Message> defaultStates = newConcurrentMap();
 
     /**
      * Specifies if the entity state of this class is already registered.


### PR DESCRIPTION
Summary of changes:

- `ConverterRegistry` and `DefaultStateRegistry` made thread-safe.
- `CommandValidator.LogSingleton` renamed to `... Singleton` to reflect its nature.