### PR TITLE
Propagate Entity versions to the Stand

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ buildscript {
     ext {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
-        spineVersion = '0.6.12-SNAPSHOT'
+        spineVersion = '0.6.13-SNAPSHOT'
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all the components and change
         // the version of the dependency below to `spineVersion` defined above.
         spineProtobufPluginVersion = '0.6.6-SNAPSHOT'

--- a/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
@@ -223,7 +223,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
             store(aggregate);
             final Message state = aggregate.getState();
             final Any packedAny = AnyPacker.pack(state);
-            standFunnel.post(aggregateId, packedAny);
+            standFunnel.post(aggregateId, packedAny, aggregate.getVersion());
         } catch (Exception e) {
             commandStatusService.setToError(commandId, e);
         }

--- a/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
+++ b/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
@@ -245,7 +245,7 @@ public abstract class ProjectionRepository<I, P extends Projection<I, M>, M exte
         store(projection);
         final M state = projection.getState();
         final Any packedState = AnyPacker.pack(state);
-        standFunnel.post(id, packedState);
+        standFunnel.post(id, packedState, projection.getVersion());
         final ProjectionStorage<I> storage = projectionStorage();
         final Timestamp eventTime = context.getTimestamp();
         storage.writeLastHandledEventTime(eventTime);

--- a/server/src/main/java/org/spine3/server/stand/Stand.java
+++ b/server/src/main/java/org/spine3/server/stand/Stand.java
@@ -131,10 +131,11 @@ public class Stand implements AutoCloseable {
      *
      * <p>The matching callbacks are executed with the {@link #callbackExecutor}.
      *
-     * @param id          the entity identifier
-     * @param entityState the entity state
+     * @param id            the entity identifier
+     * @param entityState   the entity state
+     * @param entityVersion the version of the entity
      */
-    /* package */ void update(Object id, Any entityState) {
+    /* package */ void update(Object id, Any entityState, int entityVersion) {
         final String typeUrlString = entityState.getTypeUrl();
         final TypeUrl typeUrl = TypeUrl.of(typeUrlString);
 
@@ -146,6 +147,7 @@ public class Stand implements AutoCloseable {
             final EntityStorageRecord record = EntityStorageRecord.newBuilder()
                                                                   .setState(entityState)
                                                                   .setWhenModified(Timestamps.getCurrentTime())
+                                                                  .setVersion(entityVersion)
                                                                   .build();
             storage.write(aggregateStateId, record);
         }
@@ -285,7 +287,7 @@ public class Stand implements AutoCloseable {
      * <p>However, the type of the {@code AggregateRepository} instance is recorded for the postponed processing
      * of updates.
      *
-     * @see #update(Object, Any)
+     * @see #update(Object, Any, int)
      */
     @SuppressWarnings("ChainOfInstanceofChecks")
     public <I, E extends Entity<I, ?>> void registerTypeSupplier(Repository<I, E> repository) {

--- a/server/src/main/java/org/spine3/server/stand/StandFunnel.java
+++ b/server/src/main/java/org/spine3/server/stand/StandFunnel.java
@@ -68,14 +68,15 @@ public class StandFunnel {
      *
      * <p>The state data is posted as {@link Any} to allow transferring over the network.
      *
-     * @param id          the id of an entity
-     * @param entityState the state of an {@code Entity}
+     * @param id            the id of an entity
+     * @param entityState   the state of an {@code Entity}
+     * @param entityVersion the version of an {@code Entity}
      */
-    public void post(final Object id, final Any entityState) {
+    public void post(final Object id, final Any entityState, final int entityVersion) {
         executor.execute(new Runnable() {
             @Override
             public void run() {
-                stand.update(id, entityState);
+                stand.update(id, entityState, entityVersion);
             }
         });
     }

--- a/server/src/test/java/org/spine3/server/SubscriptionServiceShould.java
+++ b/server/src/test/java/org/spine3/server/SubscriptionServiceShould.java
@@ -159,6 +159,7 @@ public class SubscriptionServiceShould {
         assertTrue(observer.isCompleted);
     }
 
+    @SuppressWarnings("ConstantConditions")     // as `null` is intentionally passed as a method param.
     @Test
     public void handle_subscription_process_exceptions_and_call_observer_error_callback() {
         final BoundedContext boundedContext = setupBoundedContextForAggregateRepo();
@@ -203,13 +204,15 @@ public class SubscriptionServiceShould {
         final Message projectState = Project.newBuilder()
                                             .setId(projectId)
                                             .build();
+        final int version = 1;
         boundedContext.getStandFunnel()
-                      .post(projectId, AnyPacker.pack(projectState));
+                      .post(projectId, AnyPacker.pack(projectState), version);
 
         // isCompleted set to false since we don't expect activationObserver::onCompleted to be called.
         activationObserver.verifyState(false);
     }
 
+    @SuppressWarnings("ConstantConditions")     // as `null` is intentionally passed as a method param.
     @Test
     public void handle_activation_process_exceptions_and_call_observer_error_callback() {
         final BoundedContext boundedContext = setupBoundedContextForAggregateRepo();
@@ -258,8 +261,9 @@ public class SubscriptionServiceShould {
         final Message projectState = Project.newBuilder()
                                             .setId(projectId)
                                             .build();
+        final int version = 1;
         boundedContext.getStandFunnel()
-                      .post(projectId, AnyPacker.pack(projectState));
+                      .post(projectId, AnyPacker.pack(projectState), version);
 
         // The update must not be handled by the observer
         verify(activateSubscription, never()).onNext(any(SubscriptionUpdate.class));

--- a/server/src/test/java/org/spine3/server/stand/StandShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandShould.java
@@ -177,7 +177,8 @@ public class StandShould {
 
         final Any someUpdate = AnyPacker.pack(Project.getDefaultInstance());
         final Object someId = new Object();
-        stand.update(someId, someUpdate);
+        final int someVersion = 1;
+        stand.update(someId, someUpdate, someVersion);
 
         verify(executor, times(1)).execute(any(Runnable.class));
     }
@@ -200,10 +201,11 @@ public class StandShould {
         final Customer customerState = customerAggregate.getState();
         final Any packedState = AnyPacker.pack(customerState);
         final TypeUrl customerType = TypeUrl.of(Customer.class);
+        final int stateVersion = 1;
 
         verify(standStorageMock, never()).write(any(AggregateStateId.class), any(EntityStorageRecord.class));
 
-        stand.update(customerId, packedState);
+        stand.update(customerId, packedState, stateVersion);
 
         final AggregateStateId expectedAggregateStateId = AggregateStateId.of(customerId, customerType);
         final EntityStorageRecord expectedRecord = EntityStorageRecord.newBuilder()
@@ -305,7 +307,8 @@ public class StandShould {
         final CustomerId customerId = sampleData.getKey();
         final Customer customer = sampleData.getValue();
         final Any packedState = AnyPacker.pack(customer);
-        stand.update(customerId, packedState);
+        final int stateVersion = 1;
+        stand.update(customerId, packedState, stateVersion);
 
         assertEquals(packedState, memoizeCallback.newEntityState);
     }
@@ -327,7 +330,8 @@ public class StandShould {
         final ProjectId projectId = sampleData.getKey();
         final Project project = sampleData.getValue();
         final Any packedState = AnyPacker.pack(project);
-        stand.update(projectId, packedState);
+        final int stateVersion = 1;
+        stand.update(projectId, packedState, stateVersion);
 
         assertEquals(packedState, memoizeCallback.newEntityState);
     }
@@ -350,7 +354,8 @@ public class StandShould {
         final CustomerId customerId = sampleData.getKey();
         final Customer customer = sampleData.getValue();
         final Any packedState = AnyPacker.pack(customer);
-        stand.update(customerId, packedState);
+        final int stateVersion = 1;
+        stand.update(customerId, packedState, stateVersion);
 
         assertNull(memoizeCallback.newEntityState);
     }
@@ -386,7 +391,8 @@ public class StandShould {
         final CustomerId customerId = sampleData.getKey();
         final Customer customer = sampleData.getValue();
         final Any packedState = AnyPacker.pack(customer);
-        stand.update(customerId, packedState);
+        final int stateVersion = 1;
+        stand.update(customerId, packedState, stateVersion);
 
         for (MemoizeEntityUpdateCallback callback : callbacks) {
             assertEquals(packedState, callback.newEntityState);
@@ -406,7 +412,8 @@ public class StandShould {
         final CustomerId customerId = sampleData.getKey();
         final Customer customer = sampleData.getValue();
         final Any packedState = AnyPacker.pack(customer);
-        stand.update(customerId, packedState);
+        final int stateVersion = 1;
+        stand.update(customerId, packedState, stateVersion);
 
         verify(callback, never()).onStateChanged(any(Any.class));
     }
@@ -434,7 +441,8 @@ public class StandShould {
             final CustomerId customerId = sampleEntry.getKey();
             final Customer customer = sampleEntry.getValue();
             final Any packedState = AnyPacker.pack(customer);
-            stand.update(customerId, packedState);
+            final int stateVersion = 1;
+            stand.update(customerId, packedState, stateVersion);
         }
 
         assertEquals(newHashSet(sampleCustomers.values()), callbackStates);
@@ -466,8 +474,8 @@ public class StandShould {
                                                                               .build());
 
         final Customer sampleCustomer = getSampleCustomer();
-
-        stand.update(sampleCustomer.getId(), AnyPacker.pack(sampleCustomer));
+        final int stateVersion = 1;
+        stand.update(sampleCustomer.getId(), AnyPacker.pack(sampleCustomer), stateVersion);
 
         final Query customerQuery = Queries.readAll(Customer.class);
 
@@ -581,8 +589,8 @@ public class StandShould {
             // Has new ID each time
             final Customer customer = getSampleCustomer();
             customers.add(customer);
-
-            stand.update(customer.getId(), AnyPacker.pack(customer));
+            final int stateVersion = 1;
+            stand.update(customer.getId(), AnyPacker.pack(customer), stateVersion);
         }
 
         final Set<CustomerId> ids = Collections.singleton(customers.get(0)
@@ -609,8 +617,8 @@ public class StandShould {
                                                                               .build());
 
         final Customer sampleCustomer = getSampleCustomer();
-
-        stand.update(sampleCustomer.getId(), AnyPacker.pack(sampleCustomer));
+        final int stateVersion = 1;
+        stand.update(sampleCustomer.getId(), AnyPacker.pack(sampleCustomer), stateVersion);
 
         // FieldMask with invalid type URLs.
         final String[] paths = {"invalid_type_url_example", Project.getDescriptor()
@@ -689,8 +697,8 @@ public class StandShould {
                                                                               .build());
 
         final Customer sampleCustomer = getSampleCustomer();
-
-        stand.update(sampleCustomer.getId(), AnyPacker.pack(sampleCustomer));
+        final int stateVersion = 1;
+        stand.update(sampleCustomer.getId(), AnyPacker.pack(sampleCustomer), stateVersion);
 
         final String[] paths = new String[fieldIndexes.length];
 
@@ -757,14 +765,13 @@ public class StandShould {
         final int querySize = 2;
 
         final Set<CustomerId> ids = new HashSet<>();
-
         for (int i = 0; i < querySize; i++) {
             final Customer customer = getSampleCustomer().toBuilder()
                                                          .setId(CustomerId.newBuilder()
                                                                           .setNumber(i))
                                                          .build();
-
-            stand.update(customer.getId(), AnyPacker.pack(customer));
+            final int stateVersion = 1;
+            stand.update(customer.getId(), AnyPacker.pack(customer), stateVersion);
 
             ids.add(customer.getId());
         }
@@ -967,7 +974,8 @@ public class StandShould {
         for (CustomerId id : sampleCustomers.keySet()) {
             final Customer sampleCustomer = sampleCustomers.get(id);
             final Any customerState = AnyPacker.pack(sampleCustomer);
-            stand.update(id, customerState);
+            final int stateVersion = 1;
+            stand.update(id, customerState, stateVersion);
         }
     }
 


### PR DESCRIPTION
Summary of changes:

* Entity state version is now passed to the `Stand` via `StandFunnel`. That allows to store the version properly in the `StandStorage`.
* Bump Spine version to `0.6.13-SNAPSHOT`.
