### PR TITLE
ProjectionRepository automatic catch-up.

### DIFF
--- a/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
+++ b/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
@@ -152,7 +152,9 @@ public abstract class ProjectionRepository<I, P extends Projection<I, M>, M exte
         setStatus(Status.STORAGE_ASSIGNED);
 
         if(catchUpAfterStorageInit) {
-            log().debug("Storage assigned. Starting catch-up.");
+            if(log().isDebugEnabled()) {
+                log().debug("Storage assigned. Starting catch-up.");
+            }
             catchUp();
         }
     }

--- a/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
+++ b/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
@@ -153,7 +153,7 @@ public abstract class ProjectionRepository<I, P extends Projection<I, M>, M exte
 
         if(catchUpAfterStorageInit) {
             if(log().isDebugEnabled()) {
-                log().debug("Storage assigned. Starting catch-up.");
+                log().debug("Storage assigned. {} is starting to catch-up", getClass());
             }
             catchUp();
         }

--- a/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
+++ b/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
@@ -91,9 +91,36 @@ public abstract class ProjectionRepository<I, P extends Projection<I, M>, M exte
     /** An instance of {@link StandFunnel} to be informed about state updates */
     private final StandFunnel standFunnel;
 
+    private final boolean catchUpAfterStorageInit;
+
+    /**
+     * Creates a {@code ProjectionRepository} for the given {@link BoundedContext} instance and enables catching up
+     * after the storage initialization.
+     *
+     * <p>NOTE: The {@link #catchUp()} will be called automatically after the {@link #initStorage(StorageFactory)} call
+     * is performed. To override this behavior, please use
+     * {@link ProjectionRepository#ProjectionRepository(BoundedContext, boolean)} constructor.
+     *
+     * @param boundedContext the target {@code BoundedContext}
+     */
     protected ProjectionRepository(BoundedContext boundedContext) {
+        this(boundedContext, true);
+    }
+
+    /**
+     * Creates a {@code ProjectionRepository} for the given {@link BoundedContext} instance.
+     *
+     * <p>If {@code catchUpAfterStorageInit} is set to {@code true}, the {@link #catchUp()} will be called
+     * automatically after the {@link #initStorage(StorageFactory)} call is performed.
+     *
+     * @param boundedContext the target {@code BoundedContext}
+     * @param catchUpAfterStorageInit whether the automatic catch-up should be performed after storage initialization
+     */
+    @SuppressWarnings("MethodParameterNamingConvention")
+    protected ProjectionRepository(BoundedContext boundedContext, boolean catchUpAfterStorageInit) {
         super(boundedContext);
         this.standFunnel = boundedContext.getStandFunnel();
+        this.catchUpAfterStorageInit = catchUpAfterStorageInit;
     }
 
     protected Status getStatus() {
@@ -123,6 +150,11 @@ public abstract class ProjectionRepository<I, P extends Projection<I, M>, M exte
     public void initStorage(StorageFactory factory) {
         super.initStorage(factory);
         setStatus(Status.STORAGE_ASSIGNED);
+
+        if(catchUpAfterStorageInit) {
+            log().debug("Storage assigned. Starting catch-up.");
+            catchUp();
+        }
     }
 
     /** {@inheritDoc} */

--- a/server/src/test/java/org/spine3/server/projection/ProjectionRepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/projection/ProjectionRepositoryShould.java
@@ -84,8 +84,10 @@ public class ProjectionRepositoryShould
     }
 
     /**
-     * As long as {@link TestProjectionRepository#initStorage(StorageFactory)} is called in the `setUp`,
-     * the catch-up should be automatically triggered. The repository should become {@code ONLINE} after the catch-up.
+     * As long as {@link TestProjectionRepository#initStorage(StorageFactory)} is called in {@link #setUp()},
+     * the catch-up should be automatically triggered.
+     *
+     * <p>The repository should become {@code ONLINE} after the catch-up.
      **/
     @Test
     public void become_online_automatically_after_init_storage() {
@@ -93,10 +95,8 @@ public class ProjectionRepositoryShould
     }
 
     /**
-     * As long as {@link ManualCatchupProjectionRepository#initStorage(StorageFactory)} is called in {@link #setUp()},
-     * the catch-up should be automatically triggered.
-     *
-     * <p>The repository should become {@code ONLINE} after the catch-up.
+     * As long as {@code ManualCatchupProjectionRepository} has automatic catch-up disabled, it does not become online
+     * automatically after {@link ManualCatchupProjectionRepository#initStorage(StorageFactory)} is called.
      **/
     @Test
     public void not_become_online_automatically_after_init_storage_if_auto_catch_up_disabled() {

--- a/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
@@ -241,9 +241,7 @@ public class StandFunnelShould {
             public void perform(BoundedContext context) {
                 // Init repository
                 final ProjectionRepository repository = Given.projectionRepo(context);
-
                 repository.initStorage(InMemoryStorageFactory.getInstance());
-                repository.setOnline();
 
                 // Dispatch an update from projection repo
                 repository.dispatch(Given.validEvent());


### PR DESCRIPTION
Summary of changes:
* Turn on automatic catch-up for `ProjectionRepository` instances the storage is initialized. 
* Make this option configurable by introducing an alternative `ProjectionRepository` constructor.
* Add tests for the behaviour changes.