### PR TITLE
0.7.0 release and new artifact ID 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ buildscript {
     ext {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
-        spineVersion = '0.6.16-SNAPSHOT'
+        spineVersion = '0.7.0'
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all the components and change
         // the version of the dependency below to `spineVersion` defined above.
         spineProtobufPluginVersion = '0.6.6-SNAPSHOT'

--- a/scripts/publish.gradle
+++ b/scripts/publish.gradle
@@ -59,11 +59,31 @@ projectsToPublish.each {
     project(":$it") { final currentProject ->
         apply plugin: 'maven-publish'
 
+        // Artifact IDs are composed as "spine-<project.name>-core". Example:
+        //
+        //      "spine-server-core"
+        //
+        // That helps to distinguish resulting JARs in the final assembly, such as WAR package.
+        // In addition, "-core" suffix serves as a type marker, helping to identify them among similar modules.
+        //
+        // Example:
+        //
+        //      "spine-server-core" (core Spine functionality for back-end)
+        //  vs.
+        //      "spine-server-gae" (Google AppEngine-based functionality for back-end)
+        //
+        // However, the artifact IDs for "users" and "values" domains do not have "-core" suffix,
+        // as they do not require any additional identification.
+        //
+        final boolean shouldAddSuffix = !currentProject.name.equals("users") && !currentProject.name.equals("values")
+        final String artifactIdSuffix = shouldAddSuffix ? "-core" : ""
+        final String artifactIdForPublishing = "spine-${currentProject.name}" + artifactIdSuffix
+
         publishing {
             publications {
                 mavenJava(MavenPublication) {
                     groupId = "${group}"
-                    artifactId = "${currentProject.name}"
+                    artifactId = "${artifactIdForPublishing}"
                     version = "${currentProject.version}"
 
                     from components.java


### PR DESCRIPTION
Bump Spine version to `0.7.0`.

BREAKING CHANGES [Publishing]: 
* rename artifact IDs to `spine-<project.name>-core` for `server`, `client` and `testutil`;
* rename artifact IDs to `spine-<project.name>` for `users` and `values`.