### PR TITLE
Simplify `valid` option usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ buildscript {
     ext {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
-        spineVersion = '0.7.6-SNAPSHOT'
+        spineVersion = '0.7.8-SNAPSHOT'
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all the components and change
         // the version of the dependency below to `spineVersion` defined above.
         spineProtobufPluginVersion = '0.6.6-SNAPSHOT'

--- a/client/src/main/proto/spine/validate.proto
+++ b/client/src/main/proto/spine/validate.proto
@@ -336,7 +336,7 @@ message PatternOption {
     string msg_format = 3;
 }
 
-// Specifies the message to show is a validated field happens to be invalid.
+// Specifies the message to show if a validated field happens to be invalid.
 // Is applicable only to messages.
 // Repeated fields are supported.
 //

--- a/client/src/main/proto/spine/validate.proto
+++ b/client/src/main/proto/spine/validate.proto
@@ -110,7 +110,7 @@ extend google.protobuf.FieldOptions {
 
     PatternOption pattern = 51108;
 
-    bool valid = 51109;
+    bool validate = 51109;
 
     IfInvalidOption if_invalid = 51110;
 

--- a/client/src/main/proto/spine/validate.proto
+++ b/client/src/main/proto/spine/validate.proto
@@ -110,6 +110,12 @@ extend google.protobuf.FieldOptions {
 
     PatternOption pattern = 51108;
 
+    // The option to indicate that the fields's internal field should be included into the validation.
+    //
+    // The target type of the option is Message.
+    //
+    // Default value is false.
+    //
     bool validate = 51109;
 
     IfInvalidOption if_invalid = 51110;

--- a/client/src/main/proto/spine/validate.proto
+++ b/client/src/main/proto/spine/validate.proto
@@ -110,9 +110,11 @@ extend google.protobuf.FieldOptions {
 
     PatternOption pattern = 51108;
 
-    ValidOption valid = 51109;
+    bool valid = 51109;
 
-    GoesOption goes = 51110;
+    IfInvalidOption if_invalid = 51110;
+
+    GoesOption goes = 51111;
 }
 
 // Defines the error handling for `required` field with no value set.
@@ -334,25 +336,20 @@ message PatternOption {
     string msg_format = 3;
 }
 
-// Specifies if the message field value is validated.
+// Specifies the message to show is a validated field happens to be invalid.
 // Is applicable only to messages.
 // Repeated fields are supported.
 //
 // Example:
-//     MyMessage field = 1 [(valid).value = true];
+//     MyMessage field = 1 [(valid) = true, (if_invalid).msg_format = "The field is invalid."];
 //
-message ValidOption {
+message IfInvalidOption {
 
     // The default error message for the field.
     option (default_message) = "Message must have valid properties.";
 
-    // If it is true, the message's fields are validated.
-    //
-    // The default value is false.
-    bool value = 1;
-
     // A user-defined validation error format message.
-    string msg_format = 2;
+    string msg_format = 1;
 }
 
 // Specifies that a message field can be present only if another field is present.

--- a/client/src/main/proto/spine/validate.proto
+++ b/client/src/main/proto/spine/validate.proto
@@ -116,7 +116,7 @@ extend google.protobuf.FieldOptions {
     //
     // Default value is false.
     //
-    bool validated = 51109;
+    bool valid = 51109;
 
     IfInvalidOption if_invalid = 51110;
 

--- a/client/src/main/proto/spine/validate.proto
+++ b/client/src/main/proto/spine/validate.proto
@@ -116,7 +116,7 @@ extend google.protobuf.FieldOptions {
     //
     // Default value is false.
     //
-    bool validate = 51109;
+    bool validated = 51109;
 
     IfInvalidOption if_invalid = 51110;
 

--- a/server/src/main/java/org/spine3/server/validate/MessageFieldValidator.java
+++ b/server/src/main/java/org/spine3/server/validate/MessageFieldValidator.java
@@ -68,7 +68,7 @@ class MessageFieldValidator extends FieldValidator<Message> {
                           FieldPath rootFieldPath, boolean strict) {
         super(descriptor, fieldValues, rootFieldPath, strict);
         this.timeOption = getFieldOption(ValidationProto.when);
-        this.validateOption = getFieldOption(ValidationProto.validate);
+        this.validateOption = getFieldOption(ValidationProto.validated);
         this.ifInvalidOption = getFieldOption(ValidationProto.ifInvalid);
         this.isFieldTimestamp = isTimestamp();
     }
@@ -95,7 +95,7 @@ class MessageFieldValidator extends FieldValidator<Message> {
     private void validateFieldsOfMessageIfNeeded() {
         if (!validateOption) {
             if (hasCustomInvalidMessage()) {
-                log().warn("'if_invalid' option is set without '(valid) = true'");
+                log().warn("'if_invalid' option is set without '(validate) = true'");
             }
             return;
         }

--- a/server/src/main/java/org/spine3/server/validate/MessageFieldValidator.java
+++ b/server/src/main/java/org/spine3/server/validate/MessageFieldValidator.java
@@ -68,7 +68,7 @@ class MessageFieldValidator extends FieldValidator<Message> {
                           FieldPath rootFieldPath, boolean strict) {
         super(descriptor, fieldValues, rootFieldPath, strict);
         this.timeOption = getFieldOption(ValidationProto.when);
-        this.validateOption = getFieldOption(ValidationProto.validated);
+        this.validateOption = getFieldOption(ValidationProto.valid);
         this.ifInvalidOption = getFieldOption(ValidationProto.ifInvalid);
         this.isFieldTimestamp = isTimestamp();
     }

--- a/server/src/main/java/org/spine3/server/validate/MessageFieldValidator.java
+++ b/server/src/main/java/org/spine3/server/validate/MessageFieldValidator.java
@@ -108,6 +108,9 @@ class MessageFieldValidator extends FieldValidator<Message> {
         }
     }
 
+    /**
+     * @return {@code true} if the option {@code 'if_invalid'} is set to a non-default value.
+     */
     private boolean hasCustomInvalidMessage() {
         final boolean result = isDefault(ifInvalidOption);
         return result;

--- a/server/src/main/java/org/spine3/server/validate/MessageFieldValidator.java
+++ b/server/src/main/java/org/spine3/server/validate/MessageFieldValidator.java
@@ -50,7 +50,7 @@ import static org.spine3.validate.internal.Time.TIME_UNDEFINED;
 class MessageFieldValidator extends FieldValidator<Message> {
 
     private final TimeOption timeOption;
-    private final boolean validOption;
+    private final boolean validateOption;
     private final IfInvalidOption ifInvalidOption;
     private final boolean isFieldTimestamp;
 
@@ -68,7 +68,7 @@ class MessageFieldValidator extends FieldValidator<Message> {
                           FieldPath rootFieldPath, boolean strict) {
         super(descriptor, fieldValues, rootFieldPath, strict);
         this.timeOption = getFieldOption(ValidationProto.when);
-        this.validOption = getFieldOption(ValidationProto.valid);
+        this.validateOption = getFieldOption(ValidationProto.validate);
         this.ifInvalidOption = getFieldOption(ValidationProto.ifInvalid);
         this.isFieldTimestamp = isTimestamp();
     }
@@ -93,7 +93,7 @@ class MessageFieldValidator extends FieldValidator<Message> {
     }
 
     private void validateFieldsOfMessageIfNeeded() {
-        if (!validOption) {
+        if (!validateOption) {
             if (hasCustomInvalidMessage()) {
                 log().warn("'if_invalid' option is set without '(valid) = true'");
             }

--- a/server/src/test/java/org/spine3/server/validate/MessageValidatorShould.java
+++ b/server/src/test/java/org/spine3/server/validate/MessageValidatorShould.java
@@ -43,6 +43,8 @@ import org.spine3.test.validate.msg.DecimalMinIncNumberFieldValue;
 import org.spine3.test.validate.msg.DecimalMinNotIncNumberFieldValue;
 import org.spine3.test.validate.msg.DigitsCountNumberFieldValue;
 import org.spine3.test.validate.msg.EnclosedMessageFieldValue;
+import org.spine3.test.validate.msg.EnclosedMessageFieldValueWithCustomInvalidMessage;
+import org.spine3.test.validate.msg.EnclosedMessageFieldValueWithoutAnnotationFieldValueWithCustomInvalidMessage;
 import org.spine3.test.validate.msg.EnclosedMessageWithoutAnnotationFieldValue;
 import org.spine3.test.validate.msg.EntityIdByteStringFieldValue;
 import org.spine3.test.validate.msg.EntityIdDoubleFieldValue;
@@ -78,6 +80,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.spine3.base.Identifiers.newUuid;
 import static org.spine3.protobuf.Timestamps.getCurrentTime;
+import static org.spine3.test.Verify.assertSize;
 
 /**
  * @author Alexander Litus
@@ -786,6 +789,21 @@ public class MessageValidatorShould {
         assertEquals(NO_VALUE_MSG, violation.getMsgFormat());
         assertFieldPathIs(violation, VALUE);
         assertTrue(violation.getViolationList().isEmpty());
+    }
+
+    @Test
+    public void provide_custom_invalid_field_message_if_specified() {
+        validate(EnclosedMessageFieldValueWithCustomInvalidMessage.getDefaultInstance());
+
+        assertSize(1, violations);
+        final ConstraintViolation violation = firstViolation();
+        assertEquals("Custom error", violation.getMsgFormat());
+    }
+
+    @Test
+    public void ignore_custom_invalid_field_message_if_validation_is_disabled() {
+        validate(EnclosedMessageFieldValueWithoutAnnotationFieldValueWithCustomInvalidMessage.getDefaultInstance());
+        assertIsValid(true);
     }
 
     /*

--- a/server/src/test/proto/spine/test/validate/msg/messages.proto
+++ b/server/src/test/proto/spine/test/validate/msg/messages.proto
@@ -148,7 +148,7 @@ message PatternStringFieldValue {
 // Messages for "valid" option tests.
 
 message EnclosedMessageFieldValue {
-    RequiredStringFieldValue outer_msg_field = 1 [(valid).value = true];
+    RequiredStringFieldValue outer_msg_field = 1 [(validate) = true];
 }
 
 message EnclosedMessageWithoutAnnotationFieldValue {

--- a/server/src/test/proto/spine/test/validate/msg/messages.proto
+++ b/server/src/test/proto/spine/test/validate/msg/messages.proto
@@ -148,7 +148,7 @@ message PatternStringFieldValue {
 // Messages for "validated" option tests.
 
 message EnclosedMessageFieldValue {
-    RequiredStringFieldValue outer_msg_field = 1 [(validated) = true];
+    RequiredStringFieldValue outer_msg_field = 1 [(valid) = true];
 }
 
 message EnclosedMessageWithoutAnnotationFieldValue {

--- a/server/src/test/proto/spine/test/validate/msg/messages.proto
+++ b/server/src/test/proto/spine/test/validate/msg/messages.proto
@@ -145,10 +145,10 @@ message PatternStringFieldValue {
 }
 
 
-// Messages for "valid" option tests.
+// Messages for "validated" option tests.
 
 message EnclosedMessageFieldValue {
-    RequiredStringFieldValue outer_msg_field = 1 [(validate) = true];
+    RequiredStringFieldValue outer_msg_field = 1 [(validated) = true];
 }
 
 message EnclosedMessageWithoutAnnotationFieldValue {

--- a/server/src/test/proto/spine/test/validate/msg/messages.proto
+++ b/server/src/test/proto/spine/test/validate/msg/messages.proto
@@ -154,3 +154,11 @@ message EnclosedMessageFieldValue {
 message EnclosedMessageWithoutAnnotationFieldValue {
     RequiredStringFieldValue outer_msg_field = 1;
 }
+
+message EnclosedMessageFieldValueWithCustomInvalidMessage {
+    RequiredStringFieldValue outer_msg_field = 1 [(valid) = true, (if_invalid).msg_format = "Custom error"];
+}
+
+message EnclosedMessageFieldValueWithoutAnnotationFieldValueWithCustomInvalidMessage {
+    RequiredStringFieldValue outer_msg_field = 1 [(if_invalid).msg_format = "Custom error is redundant in this case"];
+}

--- a/server/src/test/proto/spine/test/validate/msg/messages.proto
+++ b/server/src/test/proto/spine/test/validate/msg/messages.proto
@@ -145,7 +145,7 @@ message PatternStringFieldValue {
 }
 
 
-// Messages for "validated" option tests.
+// Messages for "valid" option tests.
 
 message EnclosedMessageFieldValue {
     RequiredStringFieldValue outer_msg_field = 1 [(valid) = true];


### PR DESCRIPTION
Made the option `boolean` with an adjacent `Message` holding the error message.
