### PR TITLE
Allow dynamic configuration of the `EventEnricher`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ buildscript {
     ext {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
-        spineVersion = '0.7.14-SNAPSHOT'
+        spineVersion = '0.7.16-SNAPSHOT'
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all the components and change
         // the version of the dependency below to `spineVersion` defined above.
         spineProtobufPluginVersion = '0.6.6-SNAPSHOT'

--- a/server/src/main/java/org/spine3/server/event/enrich/EnrichmentFunction.java
+++ b/server/src/main/java/org/spine3/server/event/enrich/EnrichmentFunction.java
@@ -84,7 +84,15 @@ abstract class EnrichmentFunction<S, T> implements Function<S, T> {
      *
      * <p>During the activation the internal state of the function may be adjusted.
      *
+     * <p>A typical example of such an adjustment would be parsing and validation of the relations
+     * between {@code eventClass} and {@code enrichmentClass} from the corresponding {@code .proto}
+     * definitions. The function internal state in this case is appended with the parsed data, which
+     * is later used at runtime.
+     *
      * <p>After the function is activated successfully, the {@link #isActive()} returns {@code true}.
+     *
+     * <p>If an activation cannot be performed flawlessly, the {@code IllegalStateException}
+     * should be thrown. In this case {@link #isActive()} should return {@code false}.
      *
      * @throws IllegalStateException if the function cannot perform the conversion in its current state
      * or because of the state of its environment

--- a/server/src/main/java/org/spine3/server/event/enrich/EnrichmentFunction.java
+++ b/server/src/main/java/org/spine3/server/event/enrich/EnrichmentFunction.java
@@ -86,6 +86,8 @@ abstract class EnrichmentFunction<S, T> implements Function<S, T> {
      */
     abstract void validate();
 
+    //TODO:24-Jan-2017:alex.tymchenko: think of creating `isValid` instead or in addition.
+
     @Override
     public int hashCode() {
         return Objects.hash(eventClass, enrichmentClass);

--- a/server/src/main/java/org/spine3/server/event/enrich/EnrichmentFunction.java
+++ b/server/src/main/java/org/spine3/server/event/enrich/EnrichmentFunction.java
@@ -154,7 +154,7 @@ abstract class EnrichmentFunction<S, T> implements Function<S, T> {
     protected void ensureActive() {
         if(!isActive()) {
             throw new IllegalStateException("The given instance of " + getClass() + " is not active at the moment. " +
-                                                    "Please use `#activate()` first.");
+                                                    "Please use `activate()` first.");
         }
     }
 }

--- a/server/src/main/java/org/spine3/server/event/enrich/EventEnricher.java
+++ b/server/src/main/java/org/spine3/server/event/enrich/EventEnricher.java
@@ -51,6 +51,7 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Collections2.filter;
 import static com.google.common.collect.FluentIterable.from;
 import static org.spine3.base.Events.createEvent;
 import static org.spine3.base.Events.getMessage;
@@ -181,8 +182,10 @@ public class EventEnricher {
         private Action(EventEnricher parent, Message eventMessage, EventContext eventContext) {
             this.eventMessage = eventMessage;
             this.eventContext = eventContext;
-            this.availableFunctions = parent.functions.get(EventClass.of(eventMessage)
-                                                                     .value());
+            final Class<? extends Message> eventClass = EventClass.of(eventMessage)
+                                                             .value();
+            final Collection<EnrichmentFunction<?, ?>> functionsPerClass = parent.functions.get(eventClass);
+            this.availableFunctions = filter(functionsPerClass, EnrichmentFunction.activeOnly());
         }
 
         private Event perform() {
@@ -436,7 +439,7 @@ public class EventEnricher {
     /** Performs validation by validating its functions. */
     private static void validate(Multimap<Class<?>, EnrichmentFunction<?, ?>> fnRegistry) {
         for (EnrichmentFunction<?, ?> func : fnRegistry.values()) {
-            func.validate();
+            func.activate();
         }
     }
 }

--- a/server/src/main/java/org/spine3/server/event/enrich/EventEnricher.java
+++ b/server/src/main/java/org/spine3/server/event/enrich/EventEnricher.java
@@ -250,9 +250,9 @@ public class EventEnricher {
      */
     Optional<EnrichmentFunction<?, ?>> functionFor(Class<?> eventFieldClass,
                                                    Class<?> enrichmentFieldClass) {
-        final Optional<EnrichmentFunction<?, ?>> result =
-                from(functions.values())
-                        .firstMatch(SupportsFieldConversion.of(eventFieldClass, enrichmentFieldClass));
+        final Optional<EnrichmentFunction<?, ?>> result = from(functions.values())
+                                                         .firstMatch(SupportsFieldConversion.of(eventFieldClass,
+                                                                                                enrichmentFieldClass));
         return result;
     }
 

--- a/server/src/main/java/org/spine3/server/event/enrich/EventMessageEnricher.java
+++ b/server/src/main/java/org/spine3/server/event/enrich/EventMessageEnricher.java
@@ -86,12 +86,13 @@ class EventMessageEnricher<S extends Message, T extends Message> extends Enrichm
                                                                              getEventClass(),
                                                                              getEnrichmentClass());
         final ImmutableMultimap.Builder<Class<?>, EnrichmentFunction> map = ImmutableMultimap.builder();
-        final List<EnrichmentFunction<?, ?>> fieldFunctions = referenceValidator.validate();
+        final ReferenceValidator.Result validationResult = referenceValidator.validate();
+        final List<EnrichmentFunction<?, ?>> fieldFunctions = validationResult.getFunctions();
         for (EnrichmentFunction<?, ?> fieldFunction : fieldFunctions) {
             map.put(fieldFunction.getEventClass(), fieldFunction);
         }
         this.fieldFunctions = map.build();
-        this.fieldMap = referenceValidator.fieldMap();
+        this.fieldMap = validationResult.getFieldMap();
 
         markActive();
     }

--- a/server/src/main/java/org/spine3/server/event/enrich/EventMessageEnricher.java
+++ b/server/src/main/java/org/spine3/server/event/enrich/EventMessageEnricher.java
@@ -104,6 +104,8 @@ class EventMessageEnricher<S extends Message, T extends Message> extends Enrichm
 
     @Override
     public T apply(@Nullable S eventMsg) {
+        ensureActive();
+
         checkNotNull(eventMsg);
         verifyOwnState();
 

--- a/server/src/main/java/org/spine3/server/event/enrich/EventMessageEnricher.java
+++ b/server/src/main/java/org/spine3/server/event/enrich/EventMessageEnricher.java
@@ -86,7 +86,7 @@ class EventMessageEnricher<S extends Message, T extends Message> extends Enrichm
                                                                              getEventClass(),
                                                                              getEnrichmentClass());
         final ImmutableMultimap.Builder<Class<?>, EnrichmentFunction> map = ImmutableMultimap.builder();
-        final ReferenceValidator.Result validationResult = referenceValidator.validate();
+        final ReferenceValidator.ValidationResult validationResult = referenceValidator.validate();
         final List<EnrichmentFunction<?, ?>> fieldFunctions = validationResult.getFunctions();
         for (EnrichmentFunction<?, ?> fieldFunction : fieldFunctions) {
             map.put(fieldFunction.getEventClass(), fieldFunction);

--- a/server/src/main/java/org/spine3/server/event/enrich/FieldEnricher.java
+++ b/server/src/main/java/org/spine3/server/event/enrich/FieldEnricher.java
@@ -58,14 +58,18 @@ class FieldEnricher<S, T> extends EnrichmentFunction<S, T> {
         return result;
     }
 
+    /**
+     * Do nothing. Field enrichment relies only on the aggregated function.
+     */
     @Override
-    void activate() {
-        // Do nothing. Field enrichment relies only on the aggregated function.
-    }
+    void activate() {}
 
+    /**
+     * The instances of {@code FieldEnricher} are always active,
+     * as no special actions are required for the activation.
+     */
     @Override
     boolean isActive() {
-        // It is always active, as no special actions are required to activate.
         return true;
     }
 

--- a/server/src/main/java/org/spine3/server/event/enrich/FieldEnricher.java
+++ b/server/src/main/java/org/spine3/server/event/enrich/FieldEnricher.java
@@ -59,8 +59,14 @@ class FieldEnricher<S, T> extends EnrichmentFunction<S, T> {
     }
 
     @Override
-    void validate() {
+    void activate() {
         // Do nothing. Field enrichment relies only on the aggregated function.
+    }
+
+    @Override
+    boolean isActive() {
+        // It is always active, as no special actions are required to activate.
+        return true;
     }
 
     @Override
@@ -71,6 +77,7 @@ class FieldEnricher<S, T> extends EnrichmentFunction<S, T> {
     @Override
     @Nullable
     public T apply(@Nullable S message) {
+        ensureActive();
         if (message == null) {
             return null;
         }

--- a/server/src/main/java/org/spine3/server/event/enrich/ReferenceValidator.java
+++ b/server/src/main/java/org/spine3/server/event/enrich/ReferenceValidator.java
@@ -71,9 +71,9 @@ class ReferenceValidator {
     /**
      * Returns those fields and functions, that may be used for the enrichment at the moment.
      *
-     * @return a {@link Result} data transfer object, containing the valid fields and functions.
+     * @return a {@code ValidationResult} data transfer object, containing the valid fields and functions.
      */
-    Result validate() {
+    ValidationResult validate() {
         final ImmutableList.Builder<EnrichmentFunction<?, ?>> functions = ImmutableList.builder();
         final ImmutableMultimap.Builder<FieldDescriptor, FieldDescriptor> fields = ImmutableMultimap.builder();
         for (FieldDescriptor enrichmentField : enrichmentDescriptor.getFields()) {
@@ -86,7 +86,7 @@ class ReferenceValidator {
         }
         final ImmutableMultimap<FieldDescriptor, FieldDescriptor> fieldMap = fields.build();
         final ImmutableList<EnrichmentFunction<?, ?>> functionList = functions.build();
-        final Result result = new Result(functionList, fieldMap);
+        final ValidationResult result = new ValidationResult(functionList, fieldMap);
         return result;
     }
 
@@ -168,12 +168,12 @@ class ReferenceValidator {
     /**
      * A wrapper DTO for the validation result.
      */
-    static class Result {
+    static class ValidationResult {
         private final ImmutableList<EnrichmentFunction<?, ?>> functions;
         private final ImmutableMultimap<FieldDescriptor, FieldDescriptor> fieldMap;
 
-        private Result(ImmutableList<EnrichmentFunction<?, ?>> functions,
-                       ImmutableMultimap<FieldDescriptor, FieldDescriptor> fieldMap) {
+        private ValidationResult(ImmutableList<EnrichmentFunction<?, ?>> functions,
+                                 ImmutableMultimap<FieldDescriptor, FieldDescriptor> fieldMap) {
             this.functions = functions;
             this.fieldMap = fieldMap;
         }

--- a/server/src/main/java/org/spine3/server/event/enrich/ReferenceValidator.java
+++ b/server/src/main/java/org/spine3/server/event/enrich/ReferenceValidator.java
@@ -160,7 +160,8 @@ class ReferenceValidator {
     private static void logNoFunction(Class<?> sourceFieldClass, Class<?> targetFieldClass) {
         // Using `DEBUG` level to avoid polluting the `stderr`.
         if (log().isDebugEnabled()) {
-            log().debug("There is no enrichment function for translating {} into {}", sourceFieldClass, targetFieldClass);
+            log().debug("There is no enrichment function for translating {} into {}",
+                        sourceFieldClass, targetFieldClass);
         }
     }
 

--- a/server/src/main/java/org/spine3/server/event/enrich/ReferenceValidator.java
+++ b/server/src/main/java/org/spine3/server/event/enrich/ReferenceValidator.java
@@ -38,7 +38,7 @@ import static com.google.protobuf.Descriptors.FieldDescriptor;
 import static java.lang.String.format;
 
 /**
- * Performs validation analzing which of fields annotated in the enrichment message
+ * Performs validation analyzing which of fields annotated in the enrichment message
  * can be initialized with the translation functions supplied in the parent enricher.
  *
  * <p>As long as the new enrichment functions may be appended to the parent enricher at runtime,

--- a/server/src/test/java/org/spine3/server/event/EventBusShould.java
+++ b/server/src/test/java/org/spine3/server/event/EventBusShould.java
@@ -20,6 +20,7 @@
 
 package org.spine3.server.event;
 
+import com.google.common.base.Function;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.Message;
@@ -39,6 +40,8 @@ import org.spine3.server.storage.memory.InMemoryStorageFactory;
 import org.spine3.server.type.EventClass;
 import org.spine3.server.validate.MessageValidator;
 import org.spine3.test.event.ProjectCreated;
+import org.spine3.test.event.ProjectId;
+import org.spine3.test.projection.Project;
 import org.spine3.validate.ConstraintViolation;
 
 import javax.annotation.Nullable;
@@ -47,6 +50,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.newHashMap;
 import static org.junit.Assert.assertEquals;
@@ -54,6 +58,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -61,7 +66,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-@SuppressWarnings({"InstanceMethodNamingConvention", "ResultOfMethodCallIgnored"})
+@SuppressWarnings({"InstanceMethodNamingConvention", "ResultOfMethodCallIgnored", "ClassWithTooManyMethods"})
 public class EventBusShould {
 
     private EventBus eventBus;
@@ -140,7 +145,6 @@ public class EventBusShould {
     @Test(expected = IllegalArgumentException.class)
     public void reject_object_with_no_subscriber_methods() {
         // Pass just String instance.
-        //noinspection EmptyClass
         eventBus.subscribe(new EventSubscriber() {
         });
     }
@@ -408,6 +412,65 @@ public class EventBusShould {
         eventBus.post(Given.Event.projectCreated());
 
         verify(enricher, never()).enrich(any(Event.class));
+    }
+
+    @Test
+    public void allow_enrichment_configuration_at_runtime_if_enricher_not_set_previously() {
+        setUp(null);
+        assertNull(eventBus.getEnricher());
+
+        final Class<ProjectId> eventFieldClass = ProjectId.class;
+        final Class<String> enrichmentFieldClass = String.class;
+        final Function<ProjectId, String> function = new Function<ProjectId, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nullable ProjectId input) {
+                checkNotNull(input);
+                return input.toString();
+            }
+        };
+        eventBus.addFieldEnrichment(eventFieldClass, enrichmentFieldClass, function);
+        final EventEnricher enricher = eventBus.getEnricher();
+        assertNull(enricher);
+    }
+
+    @Test
+    public void allow_enrichment_configuration_at_runtime_if_enricher_previously_set() {
+        final EventEnricher enricher = mock(EventEnricher.class);
+        setUp(enricher);
+
+        final Class<ProjectId> eventFieldClass = ProjectId.class;
+        final Class<String> enrichmentFieldClass = String.class;
+        final Function<ProjectId, String> function = new Function<ProjectId, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nullable ProjectId input) {
+                checkNotNull(input);
+                return input.toString();
+            }
+        };
+        eventBus.addFieldEnrichment(eventFieldClass, enrichmentFieldClass, function);
+        verify(enricher).registerFieldEnrichment(eq(eventFieldClass), eq(enrichmentFieldClass), eq(function));
+    }
+
+
+
+    @SuppressWarnings("ConstantConditions")
+    @Test(expected = NullPointerException.class)
+    public void not_accept_null_eventFieldClass_passed_as_field_enrichment_configuration_param() {
+        eventBus.addFieldEnrichment(null, String.class, mock(Function.class));
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test(expected = NullPointerException.class)
+    public void not_accept_null_enrichmentFieldClass_passed_as_field_enrichment_configuration_param() {
+        eventBus.addFieldEnrichment(ProjectId.class, null, mock(Function.class));
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test(expected = NullPointerException.class)
+    public void not_accept_null_function_passed_as_field_enrichment_configuration_param() {
+        eventBus.addFieldEnrichment(ProjectId.class, String.class, null);
     }
 
     private static void assertResponseIsOk(TestResponseObserver responseObserver) {

--- a/server/src/test/java/org/spine3/server/event/EventBusShould.java
+++ b/server/src/test/java/org/spine3/server/event/EventBusShould.java
@@ -431,7 +431,7 @@ public class EventBusShould {
         };
         eventBus.addFieldEnrichment(eventFieldClass, enrichmentFieldClass, function);
         final EventEnricher enricher = eventBus.getEnricher();
-        assertNull(enricher);
+        assertNotNull(enricher);
     }
 
     @Test

--- a/server/src/test/java/org/spine3/server/event/Given.java
+++ b/server/src/test/java/org/spine3/server/event/Given.java
@@ -184,7 +184,7 @@ public class Given {
             }
         }
 
-        public static class GetProjectMaxMembersCount implements Function<ProjectId, Integer> {
+        public static class GetProjectMaxMemberCount implements Function<ProjectId, Integer> {
             @Nullable
             @Override
             public Integer apply(@Nullable ProjectId input) {

--- a/server/src/test/java/org/spine3/server/event/Given.java
+++ b/server/src/test/java/org/spine3/server/event/Given.java
@@ -184,6 +184,17 @@ public class Given {
             }
         }
 
+        public static class GetProjectMaxMembersCount implements Function<ProjectId, Integer> {
+            @Nullable
+            @Override
+            public Integer apply(@Nullable ProjectId input) {
+                if (input == null) {
+                    return 0;
+                }
+                return input.hashCode();
+            }
+        }
+
         private static final Function<EventId, String> EVENT_ID_TO_STRING =
                 new Function<EventId, String>() {
                     @Nullable

--- a/server/src/test/java/org/spine3/server/event/enrich/EventEnricherBuilderShould.java
+++ b/server/src/test/java/org/spine3/server/event/enrich/EventEnricherBuilderShould.java
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.spine3.protobuf.Values;
 import org.spine3.server.event.Given;
-import org.spine3.server.event.enrich.EventEnricher.Builder.SameTransition;
+import org.spine3.server.event.enrich.EventEnricher.SameTransition;
 import org.spine3.test.Tests;
 import org.spine3.test.event.ProjectId;
 import org.spine3.users.UserId;
@@ -120,17 +120,19 @@ public class EventEnricherBuilderShould {
         builder.addFieldEnrichment(Timestamp.class, StringValue.class, function);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void throw_exception_if_no_enrichment_functions_registered() {
-        EventEnricher.newBuilder()
-                     .build();
+    @Test
+    public void allow_registering_no_functions() {
+        final EventEnricher enricher = EventEnricher.newBuilder()
+                                                 .build();
+        assertNotNull(enricher);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void throw_exception_if_not_all_needed_functions_registered() {
+    @Test
+    public void allow_registering_just_some_of_expected_functions() {
         builder.addFieldEnrichment(ProjectId.class, UserId.class, new Given.Enrichment.GetProjectOwnerId());
         builder.addFieldEnrichment(ProjectId.class, String.class, new Given.Enrichment.GetProjectName());
-        builder.build();
+        final EventEnricher enricher = builder.build();
+        assertNotNull(enricher);
     }
 
     @Test

--- a/server/src/test/java/org/spine3/server/event/enrich/EventEnricherShould.java
+++ b/server/src/test/java/org/spine3/server/event/enrich/EventEnricherShould.java
@@ -140,7 +140,7 @@ public class EventEnricherShould {
 
     @Test
     public void enrich_event_if_function_added_at_runtime() {
-        final Given.Enrichment.GetProjectMaxMembersCount function = new Given.Enrichment.GetProjectMaxMembersCount();
+        final Given.Enrichment.GetProjectMaxMemberCount function = new Given.Enrichment.GetProjectMaxMemberCount();
         enricher.registerFieldEnrichment(ProjectId.class, Integer.class,function);
 
         final ProjectCreated msg = Given.EventMessage.projectCreated();
@@ -150,7 +150,7 @@ public class EventEnricherShould {
 
         @SuppressWarnings("ConstantConditions")     // the `function` was specially implemented to return non-null ints.
         final int expectedValue = function.apply(projectId);
-        assertEquals(expectedValue, subscriber.projectCreatedDynamicEnrichment.getMaxMembersCount());
+        assertEquals(expectedValue, subscriber.projectCreatedDynamicEnrichment.getMaxMemberCount());
     }
 
     @Test

--- a/server/src/test/java/org/spine3/server/event/enrich/EventEnricherShould.java
+++ b/server/src/test/java/org/spine3/server/event/enrich/EventEnricherShould.java
@@ -21,7 +21,6 @@
 package org.spine3.server.event.enrich;
 
 import com.google.common.base.Function;
-import com.google.protobuf.Int32Value;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
 import org.junit.After;

--- a/server/src/test/java/org/spine3/server/event/enrich/EventMessageEnricherShould.java
+++ b/server/src/test/java/org/spine3/server/event/enrich/EventMessageEnricherShould.java
@@ -26,6 +26,7 @@ import org.spine3.server.event.Given;
 import org.spine3.test.event.ProjectCreated;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * @author Alexander Litus
@@ -43,14 +44,19 @@ public class EventMessageEnricherShould {
                 ProjectCreated.Enrichment.class);
     }
 
+    @Test
+    public void be_inactive_when_created() {
+        assertFalse(enricher.isActive());
+    }
+
     @Test(expected = NullPointerException.class)
     public void throw_NPE_if_pass_null() {
         enricher.activate();
         enricher.apply(null);
     }
 
-    @Test(expected = NullPointerException.class)
-    public void throw_NPE_if_validate_not_called_before_apply() {
+    @Test(expected = IllegalStateException.class)
+    public void throw_ISE_if_activate_not_called_before_apply() {
         enricher.apply(ProjectCreated.getDefaultInstance());
     }
 

--- a/server/src/test/java/org/spine3/server/event/enrich/EventMessageEnricherShould.java
+++ b/server/src/test/java/org/spine3/server/event/enrich/EventMessageEnricherShould.java
@@ -45,7 +45,7 @@ public class EventMessageEnricherShould {
 
     @Test(expected = NullPointerException.class)
     public void throw_NPE_if_pass_null() {
-        enricher.validate();
+        enricher.activate();
         enricher.apply(null);
     }
 

--- a/server/src/test/proto/spine/test/event/events.proto
+++ b/server/src/test/proto/spine/test/event/events.proto
@@ -48,6 +48,12 @@ message ProjectCreatedSeparateEnrichment {
     string project_name = 1 [(by) = "project_id"];
 }
 
+message ProjectCreatedDynamicallyConfiguredEnrichment {
+    option (enrichment_for) = "ProjectCreated";
+
+    int32 max_members_count = 1 [(by) = "project_id"];
+}
+
 message TaskAdded {
     ProjectId project_id = 1;
 

--- a/server/src/test/proto/spine/test/event/events.proto
+++ b/server/src/test/proto/spine/test/event/events.proto
@@ -51,7 +51,7 @@ message ProjectCreatedSeparateEnrichment {
 message ProjectCreatedDynamicallyConfiguredEnrichment {
     option (enrichment_for) = "ProjectCreated";
 
-    int32 max_members_count = 1 [(by) = "project_id"];
+    int32 max_member_count = 1 [(by) = "project_id"];
 }
 
 message TaskAdded {


### PR DESCRIPTION
Before this PR the instance of `EventEnricher` must have been fully initialized by the moment of the `BoundedContext` creation. That made it hard to use the `AggregateRepository` instances in the enrichment functions, since `AggregateRepository` required the `BoundedContext`. There was a circular dependency:

`EventEnricher` (wants) —> `AggregateRepo` (needs) —> `BoundedContext` (requires) —> `EventEnricher`.

In order to break the circle, I made it possible to append the new enrichment functions at runtime.

Summary of changes:

* Allowed to append the enrichment functions at runtime via `boundedContext.getEventBus().addFieldEnrichment(...)`.
* Some API and documentation improvements made to `org.spine3.server.event.enrich.*` classes.
* Spine version increased and now is `0.7.16-SNAPSHOT`.
