### PR TITLE
Make `BoundedContext` final.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
 
-        spineVersion = '0.7.19-SNAPSHOT'
+        spineVersion = '0.7.20-SNAPSHOT'
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all the components and change
         // the version of the dependency below to `spineVersion` defined above.
         spineProtobufPluginVersion = '0.6.6-SNAPSHOT'

--- a/server/src/main/java/org/spine3/server/BoundedContext.java
+++ b/server/src/main/java/org/spine3/server/BoundedContext.java
@@ -67,7 +67,7 @@ import static org.spine3.validate.Validate.checkNameNotEmptyOrBlank;
  * @author Alexander Yevsyukov
  * @author Mikhail Melnik
  */
-public class BoundedContext extends IntegrationEventSubscriberGrpc.IntegrationEventSubscriberImplBase
+public final class BoundedContext extends IntegrationEventSubscriberGrpc.IntegrationEventSubscriberImplBase
         implements AutoCloseable {
 
     /** The default name for a {@code BoundedContext}. */

--- a/server/src/test/java/org/spine3/server/command/CommandBusShould.java
+++ b/server/src/test/java/org/spine3/server/command/CommandBusShould.java
@@ -224,7 +224,10 @@ public class CommandBusShould {
 
     @Test
     public void accept_empty_process_manager_repository_dispatcher() {
-        final ProcessManagerRepoDispatcher pmRepo = new ProcessManagerRepoDispatcher(mock(BoundedContext.class));
+        final BoundedContext boundedContext = BoundedContext.newBuilder()
+                                                            .setStorageFactory(InMemoryStorageFactory.getInstance())
+                                                            .build();
+        final ProcessManagerRepoDispatcher pmRepo = new ProcessManagerRepoDispatcher(boundedContext);
         commandBus.register(pmRepo);
     }
 

--- a/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
@@ -201,7 +201,7 @@ public class StandFunnelShould {
         final Executor executor = isConcurrent ?
                                   Executors.newFixedThreadPool(Given.THREADS_COUNT_IN_POOL_EXECUTOR) :
                                   MoreExecutors.directExecutor();
-        final StandUpdateDelivery delivery = StandUpdateDelivery.immediateDeliveryWithExecutor(executor);
+        final StandUpdateDelivery delivery = spy(StandUpdateDelivery.immediateDeliveryWithExecutor(executor));
 
         final BoundedContext boundedContext = Given.boundedContext(stand, delivery);
 
@@ -210,7 +210,7 @@ public class StandFunnelShould {
         }
 
         // Was called as many times as there are dispatch actions.
-        verify(stand, times(dispatchActions.length)).update(any(Object.class), any(Any.class), anyInt());
+        verify(delivery, times(dispatchActions.length)).deliver(any(Entity.class));
 
         if (isConcurrent) {
             try {

--- a/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
@@ -201,7 +201,7 @@ public class StandFunnelShould {
         final Executor executor = isConcurrent ?
                                   Executors.newFixedThreadPool(Given.THREADS_COUNT_IN_POOL_EXECUTOR) :
                                   MoreExecutors.directExecutor();
-        final StandUpdateDelivery delivery = spy(StandUpdateDelivery.immediateDeliveryWithExecutor(executor));
+        final StandUpdateDelivery delivery = spy(new SpyableStandUpdateDelivery(executor));
 
         final BoundedContext boundedContext = Given.boundedContext(stand, delivery);
 
@@ -314,4 +314,18 @@ public class StandFunnelShould {
         void perform(BoundedContext context);
     }
 
+    /**
+     * A custom {@code StandUpdateDelivery}, which is suitable for {@link org.mockito.Mockito#spy(Object)}.
+     */
+    private static class SpyableStandUpdateDelivery extends StandUpdateDelivery {
+
+        public SpyableStandUpdateDelivery(Executor delegate) {
+            super(delegate);
+        }
+
+        @Override
+        protected boolean shouldPostponeDelivery(Entity deliverable, Stand consumer) {
+            return false;
+        }
+    }
 }

--- a/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
@@ -203,14 +203,14 @@ public class StandFunnelShould {
                                   MoreExecutors.directExecutor();
         final StandUpdateDelivery delivery = StandUpdateDelivery.immediateDeliveryWithExecutor(executor);
 
-        final BoundedContext boundedContext = spy(Given.boundedContext(stand, delivery));
+        final BoundedContext boundedContext = Given.boundedContext(stand, delivery);
 
         for (BoundedContextAction dispatchAction : dispatchActions) {
             dispatchAction.perform(boundedContext);
         }
 
         // Was called as many times as there are dispatch actions.
-        verify(boundedContext, times(dispatchActions.length)).getStandFunnel();
+        verify(stand, times(dispatchActions.length)).update(any(Object.class), any(Any.class), anyInt());
 
         if (isConcurrent) {
             try {

--- a/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandFunnelShould.java
@@ -170,7 +170,7 @@ public class StandFunnelShould {
     }
 
     @Test
-    public void deliver_updates_form_aggregate_repository() {
+    public void deliver_updates_from_aggregate_repository() {
         checkUpdatesDelivery(false, aggregateRepositoryDispatch());
     }
 


### PR DESCRIPTION
Summary of changes:

* `BoundedContext` is now declared as `final` to emphasise it is not designed for subclassing.
* The library version is increased to `0.7.20-SNAPSHOT`.