### PR TITLE
Make `StorageFactorySwitch` initialization static

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
 
-        spineVersion = '0.7.22-SNAPSHOT'
+        spineVersion = '0.7.23-SNAPSHOT'
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all the components and change
         // the version of the dependency below to `spineVersion` defined above.
         spineProtobufPluginVersion = '0.6.6-SNAPSHOT'

--- a/server/src/main/java/org/spine3/server/storage/StorageFactorySwitch.java
+++ b/server/src/main/java/org/spine3/server/storage/StorageFactorySwitch.java
@@ -75,12 +75,12 @@ public final class StorageFactorySwitch implements Supplier<StorageFactory> {
     }
 
     /**
-     * Initializes the switch with the suppliers of {@code StorageFactor}ies.
+     * Initializes the current singleton instance with the suppliers.
      *
      * @param productionSupplier the supplier for the production mode
      * @param testsSupplier the supplier for the tests mode.
      *                      If {@code null} is passed {@link InMemoryStorageFactory} will be used
-     * @return this
+     * @return the current singleton instance
      */
     public static StorageFactorySwitch init(Supplier<StorageFactory> productionSupplier,
                                             @Nullable Supplier<StorageFactory> testsSupplier) {

--- a/server/src/main/java/org/spine3/server/storage/StorageFactorySwitch.java
+++ b/server/src/main/java/org/spine3/server/storage/StorageFactorySwitch.java
@@ -82,11 +82,12 @@ public final class StorageFactorySwitch implements Supplier<StorageFactory> {
      *                      If {@code null} is passed {@link InMemoryStorageFactory} will be used
      * @return this
      */
-    public StorageFactorySwitch init(Supplier<StorageFactory> productionSupplier,
-                                     @Nullable Supplier<StorageFactory> testsSupplier) {
-        this.productionSupplier = checkNotNull(productionSupplier);
-        this.testsSupplier = testsSupplier;
-        return this;
+    public static StorageFactorySwitch init(Supplier<StorageFactory> productionSupplier,
+                                            @Nullable Supplier<StorageFactory> testsSupplier) {
+        final StorageFactorySwitch instance = getInstance();
+        instance.productionSupplier = checkNotNull(productionSupplier);
+        instance.testsSupplier = testsSupplier;
+        return instance;
     }
 
     /**

--- a/server/src/test/java/org/spine3/server/storage/StorageFactorySwitchShould.java
+++ b/server/src/test/java/org/spine3/server/storage/StorageFactorySwitchShould.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.spine3.server.storage.StorageFactorySwitch.init;
 import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
 
 /**
@@ -112,7 +113,7 @@ public class StorageFactorySwitchShould {
 
         final StorageFactory custom = mock(StorageFactory.class);
 
-        storageFactorySwitch.init(inMemorySupplier, new Supplier<StorageFactory>() {
+        init(inMemorySupplier, new Supplier<StorageFactory>() {
             @Override
             public StorageFactory get() {
                 return custom;
@@ -146,7 +147,7 @@ public class StorageFactorySwitchShould {
     public void cache_instance_of_StorageFactory_in_testing() {
         final Supplier<StorageFactory> testingSupplier = spy(inMemorySupplier);
 
-        storageFactorySwitch.init(inMemorySupplier, testingSupplier);
+        init(inMemorySupplier, testingSupplier);
 
         Environment.getInstance().setToTests();
 
@@ -160,7 +161,7 @@ public class StorageFactorySwitchShould {
     public void cache_instance_of_StorageFactory_in_production() {
         final Supplier<StorageFactory> productionSupplier = spy(inMemorySupplier);
 
-        storageFactorySwitch.init(productionSupplier, inMemorySupplier);
+        init(productionSupplier, inMemorySupplier);
 
         Environment.getInstance().setToProduction();
 
@@ -172,7 +173,7 @@ public class StorageFactorySwitchShould {
 
     @Test
     public void return_itself_on_init() {
-        final StorageFactorySwitch result = storageFactorySwitch.init(inMemorySupplier, inMemorySupplier);
+        final StorageFactorySwitch result = init(inMemorySupplier, inMemorySupplier);
         assertSame(storageFactorySwitch, result);
     }
 }


### PR DESCRIPTION
This would improve readability when passing it to `BoundedContext.Builder`.