### PR TITLE
Projection repo catchup performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
 
-        spineVersion = '0.8.1-SNAPSHOT'
+        spineVersion = '0.8.2-SNAPSHOT'
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all the components and change
         // the version of the dependency below to `spineVersion` defined above.
         spineProtobufPluginVersion = '0.7.24-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
 
-        spineVersion = '0.8.2-SNAPSHOT'
+        spineVersion = '0.8.3-SNAPSHOT'
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all the components and change
         // the version of the dependency below to `spineVersion` defined above.
         spineProtobufPluginVersion = '0.7.24-SNAPSHOT'

--- a/client/src/main/proto/spine/enrichment_annotations.proto
+++ b/client/src/main/proto/spine/enrichment_annotations.proto
@@ -144,6 +144,20 @@ extend google.protobuf.FieldOptions {
     //     int32 user_id = 1;
     // }
     //
+    // Also, the multiple arguments are supported. The syntax is:
+    //
+    // message EnrichmentForSeveralEvents {
+    //     option (enrichment) = "EnrichmentForSeveralEvents";
+    //
+    //     int32 user_id = 1 [(by) = "qualifier.One.target_field | qualifier.Two.alternate_target_field"];
+    // }
+    //
+    // Wildcard syntax for the target fields is supported in cases when annotation `enrichment_for` gives a
+    // not ambiguous definition for the target type.
+    //
+    // If using the FQN field names, the `enrichment_for` annotation may be omitted
+    // (the same behavior as with a single-argument `by` annotation).
+    //
     string by = 57125; // NOTE: this field number is used in the `tools` project,
                        // EnrichmentLookupPlugin (update it there on changing).
 }

--- a/server/src/main/java/org/spine3/server/entity/RecordBasedRepository.java
+++ b/server/src/main/java/org/spine3/server/entity/RecordBasedRepository.java
@@ -322,7 +322,7 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
         return entity;
     }
 
-    private EntityStorageRecord toEntityRecord(E entity) {
+    protected EntityStorageRecord toEntityRecord(E entity) {
         final S state = entity.getState();
         final Any stateAny = pack(state);
         final Timestamp whenModified = entity.whenModified();

--- a/server/src/main/java/org/spine3/server/projection/BulkWriteOperation.java
+++ b/server/src/main/java/org/spine3/server/projection/BulkWriteOperation.java
@@ -40,11 +40,11 @@ import static com.google.protobuf.util.Timestamps.add;
  *
  * <p>Acts as an intermediate buffer for the changes to apply.
  *
+ * @author Alex Tymchenko
  * @author Dmytro Dashenkov
  */
 class BulkWriteOperation<I, P extends Projection<I, ?>> implements AutoCloseable {
 
-    private final Duration maximumDuration;
     private final Timestamp expirationTime;
     private final AtomicBoolean active = new AtomicBoolean(false);
 
@@ -54,7 +54,6 @@ class BulkWriteOperation<I, P extends Projection<I, ?>> implements AutoCloseable
     private FlushCallback<P> flushCallback;
 
     BulkWriteOperation(Duration maximumDuration, FlushCallback<P> flushCallback) {
-        this.maximumDuration = maximumDuration;
         this.flushCallback = flushCallback;
         this.expirationTime = add(Timestamps.getCurrentTime(), maximumDuration);
         this.active.set(true);

--- a/server/src/main/java/org/spine3/server/projection/BulkWriteOperation.java
+++ b/server/src/main/java/org/spine3/server/projection/BulkWriteOperation.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.projection;
+
+import com.google.protobuf.Duration;
+import com.google.protobuf.Timestamp;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.spine3.protobuf.Timestamps;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.protobuf.util.Timestamps.add;
+
+/**
+ * Represents a write operation for the storage, designed to modify
+ * multiple items in the {@code Storage} at once.
+ *
+ * <p>Acts as an intermediate buffer for the changes to apply.
+ *
+ * @author Dmytro Dashenkov
+ */
+class BulkWriteOperation<I, P extends Projection<I, ?>> implements AutoCloseable {
+
+    private final Duration maximumDuration;
+    private final Timestamp expirationTime;
+    private final AtomicBoolean active = new AtomicBoolean(false);
+
+    private final Set<P> pendingProjections = Collections.synchronizedSet(new HashSet<P>());
+    private Timestamp lastHandledEventTime = Timestamp.getDefaultInstance();
+
+    private FlushCallback<P> flushCallback;
+
+    BulkWriteOperation(Duration maximumDuration, FlushCallback<P> flushCallback) {
+        this.maximumDuration = maximumDuration;
+        this.flushCallback = flushCallback;
+        this.expirationTime = add(Timestamps.getCurrentTime(), maximumDuration);
+        this.active.set(true);
+    }
+
+    /**
+     * Checks if this operation has been started and is still in progress.
+     *
+     * @return {@code true} if the operation is in progress, {@code false} otherwise
+     */
+    boolean isInProgress() {
+        return active.get();
+    }
+
+    void checkExpiration() {
+        if (!active.get()) {
+            return;
+        }
+
+        final Timestamp currentTime = Timestamps.getCurrentTime();
+        if (Timestamps.compare(currentTime, expirationTime) > 0) {
+            log().warn(
+                    "Completing bulk write operation before all the events are processed. Took at least {} seconds.",
+                    expirationTime.getSeconds());
+            complete();
+        }
+    }
+
+    void writeProjection(P projection) {
+        pendingProjections.add(projection);
+    }
+
+    void writeLastHandledEventTime(Timestamp lastHandledEventTime) {
+        this.lastHandledEventTime = checkNotNull(lastHandledEventTime);
+    }
+
+    void complete() {
+        flushCallback.onFlushResults(pendingProjections, lastHandledEventTime);
+    }
+
+    @Override
+    public void close() {
+        active.set(false);
+        flushCallback = null;
+    }
+
+    interface FlushCallback<P extends Projection<?, ?>> {
+
+        void onFlushResults(Set<P> projections, Timestamp lastHandledEventTime);
+    }
+
+    private static Logger log() {
+        return LoggerSingleton.INSTANCE.logger;
+    }
+
+    private enum LoggerSingleton {
+        INSTANCE;
+        @SuppressWarnings("NonSerializableFieldInSerializableClass")
+        private final Logger logger = LoggerFactory.getLogger(BulkWriteOperation.class);
+    }
+}

--- a/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
+++ b/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
@@ -138,11 +138,12 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S>, S exte
      * <p>If {@code catchUpAfterStorageInit} is set to {@code true}, the {@link #catchUp()} will be called
      * automatically after the {@link #initStorage(StorageFactory)} call is performed.
      *
-     * <p>If the passed {@code catchUpMaxDuration} is not default, the catch-up is performed through a bulk write.
-     * The {@code catchUpMaxDuration} is the time span from the start of the catch-up that is maximum allowed time for
-     * the catch-up to complete. If the catch-up process takes longer then that time, the read will be automatically
-     * finished and all the read records will be flushed to the storage as a bulk.
-     * // TODO:03-02-17:dmytro.dashenkov: Rewrite this part of the doc.
+     * <p>If the passed {@code catchUpMaxDuration} is not default, the repository uses a {@link BulkWriteOperation}
+     * to accumulate the read projections and then save them as a single bulk of records.
+     *
+     * <p>The {@code catchUpMaxDuration} represents the maximum time span for the catch-up to read the events and apply
+     * them to corresponding projections. If the reading process takes longer then this time, the the read will be
+     * automatically finished and all the result projections will be flushed to the storage as a bulk.
      *
      * @param boundedContext          the target {@code BoundedContext}
      * @param catchUpAfterStorageInit whether the automatic catch-up should be performed after storage initialization

--- a/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
+++ b/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
@@ -174,7 +174,7 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S>, S exte
     protected Storage createStorage(StorageFactory factory) {
         final Class<P> projectionClass = getEntityClass();
         final ProjectionStorage<I> projectionStorage = factory.createProjectionStorage(projectionClass);
-        this.recordStorage = projectionStorage.getRecordStorage();
+        this.recordStorage = projectionStorage.recordStorage();
         return projectionStorage;
     }
 

--- a/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
+++ b/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
@@ -357,7 +357,7 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S>, S exte
     }
 
     private boolean isBulkWriteRequired() {
-        return catchUpMaxDuration.equals(
+        return !catchUpMaxDuration.equals(
                 catchUpMaxDuration.getDefaultInstanceForType());
     }
 

--- a/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
+++ b/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
@@ -37,6 +37,7 @@ import org.spine3.server.event.EventFilter;
 import org.spine3.server.event.EventStore;
 import org.spine3.server.event.EventStreamQuery;
 import org.spine3.server.stand.StandFunnel;
+import org.spine3.server.storage.EntityStorageRecord;
 import org.spine3.server.storage.RecordStorage;
 import org.spine3.server.storage.Storage;
 import org.spine3.server.storage.StorageFactory;
@@ -45,6 +46,8 @@ import org.spine3.server.type.EventClass;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -264,10 +267,14 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S>, S exte
     }
 
     private void store(Collection<P> projections) {
-        // TODO:02-02-17:dmytro.dashenkov: Implement bulk store.
+        final RecordStorage<I> storage = recordStorage();
+        final Map<I, EntityStorageRecord> records = new HashMap<>(projections.size());
         for (P projection : projections) {
-            store(projection);
+            final I id = projection.getId();
+            final EntityStorageRecord record = toEntityRecord(projection);
+            records.put(id, record);
         }
+        storage.write(records);
     }
 
     /**

--- a/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
+++ b/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
@@ -96,6 +96,8 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S>, S exte
     /** If {@code true} the projection will {@link #catchUp()} after initialization. */
     private final boolean catchUpAfterStorageInit;
 
+    private final Duration catchUpMaxDuration;
+
     private BulkWriteOperation<I, P> ongoingOperation;
 
     /**
@@ -104,7 +106,7 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S>, S exte
      *
      * <p>NOTE: The {@link #catchUp()} will be called automatically after the {@link #initStorage(StorageFactory)} call
      * is performed. To override this behavior, please use
-     * {@link ProjectionRepository#ProjectionRepository(BoundedContext, boolean)} constructor.
+     * {@link ProjectionRepository#ProjectionRepository(BoundedContext, boolean, Duration)} constructor.
      *
      * @param boundedContext the target {@code BoundedContext}
      */
@@ -117,15 +119,33 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S>, S exte
      *
      * <p>If {@code catchUpAfterStorageInit} is set to {@code true}, the {@link #catchUp()} will be called
      * automatically after the {@link #initStorage(StorageFactory)} call is performed.
-     *
-     * @param boundedContext          the target {@code BoundedContext}
+     *  @param boundedContext          the target {@code BoundedContext}
      * @param catchUpAfterStorageInit whether the automatic catch-up should be performed after storage initialization
      */
     @SuppressWarnings("MethodParameterNamingConvention")
-    protected ProjectionRepository(BoundedContext boundedContext, boolean catchUpAfterStorageInit) {
+    protected ProjectionRepository(BoundedContext boundedContext,
+                                   boolean catchUpAfterStorageInit) {
+        this(boundedContext, catchUpAfterStorageInit, Duration.getDefaultInstance());
+    }
+
+    /**
+     * Creates a {@code ProjectionRepository} for the given {@link BoundedContext} instance.
+     *
+     * <p>If {@code catchUpAfterStorageInit} is set to {@code true}, the {@link #catchUp()} will be called
+     * automatically after the {@link #initStorage(StorageFactory)} call is performed.
+     *
+     * @param boundedContext          the target {@code BoundedContext}
+     * @param catchUpAfterStorageInit whether the automatic catch-up should be performed after storage initialization
+     * @param catchUpMaxDuration      the maximum duration of the catch-up
+     */
+    @SuppressWarnings("MethodParameterNamingConvention")
+    protected ProjectionRepository(BoundedContext boundedContext,
+                                   boolean catchUpAfterStorageInit,
+                                   Duration catchUpMaxDuration) {
         super(boundedContext, EventDispatchingRepository.<I>producerFromContext());
         this.standFunnel = boundedContext.getStandFunnel();
         this.catchUpAfterStorageInit = catchUpAfterStorageInit;
+        this.catchUpMaxDuration = catchUpMaxDuration;
     }
 
     protected Status getStatus() {

--- a/server/src/main/java/org/spine3/server/projection/ProjectionStorage.java
+++ b/server/src/main/java/org/spine3/server/projection/ProjectionStorage.java
@@ -47,20 +47,20 @@ public abstract class ProjectionStorage<I> extends RecordStorage<I> {
 
     @Override
     protected Optional<EntityStorageRecord> readRecord(I id) {
-        final RecordStorage<I> storage = getRecordStorage();
+        final RecordStorage<I> storage = recordStorage();
         final Optional<EntityStorageRecord> record = storage.read(id);
         return record;
     }
 
     @Override
     protected void writeRecord(I id, EntityStorageRecord record) {
-        final RecordStorage<I> storage = getRecordStorage();
+        final RecordStorage<I> storage = recordStorage();
         storage.write(id, record);
     }
 
     @Override
     protected void writeRecords(Map<I, EntityStorageRecord> records) {
-        final RecordStorage<I> storage = getRecordStorage();
+        final RecordStorage<I> storage = recordStorage();
         storage.write(records);
     }
 
@@ -80,5 +80,5 @@ public abstract class ProjectionStorage<I> extends RecordStorage<I> {
     protected abstract Timestamp readLastHandledEventTime();
 
     /** Returns an entity storage implementation. */
-    protected abstract RecordStorage<I> getRecordStorage();
+    protected abstract RecordStorage<I> recordStorage();
 }

--- a/server/src/main/java/org/spine3/server/projection/ProjectionStorage.java
+++ b/server/src/main/java/org/spine3/server/projection/ProjectionStorage.java
@@ -27,6 +27,7 @@ import org.spine3.server.storage.EntityStorageRecord;
 import org.spine3.server.storage.RecordStorage;
 
 import javax.annotation.Nullable;
+import java.util.Map;
 
 /**
  * The storage used by projection repositories for keeping {@link Projection}s
@@ -55,6 +56,12 @@ public abstract class ProjectionStorage<I> extends RecordStorage<I> {
     protected void writeRecord(I id, EntityStorageRecord record) {
         final RecordStorage<I> storage = getRecordStorage();
         storage.write(id, record);
+    }
+
+    @Override
+    protected void writeRecords(Map<I, EntityStorageRecord> records) {
+        final RecordStorage<I> storage = getRecordStorage();
+        storage.write(records);
     }
 
     /**

--- a/server/src/main/java/org/spine3/server/storage/RecordStorage.java
+++ b/server/src/main/java/org/spine3/server/storage/RecordStorage.java
@@ -102,6 +102,21 @@ public abstract class RecordStorage<I> extends AbstractStorage<I, EntityStorageR
     }
 
     /**
+     * Writes a bulk of records into the storage.
+     *
+     * <p>Rewrites it if a record with this ID already exists in the storage.
+     *
+     * @param records an ID to record map with the entries to store
+     * @throws IllegalStateException if the storage is closed
+     */
+    public void write(Map<I, EntityStorageRecord> records) {
+        checkNotNull(records);
+        checkNotClosed();
+
+        writeRecords(records);
+    }
+
+    /**
      * Marks the record with the passed ID as {@code archived}.
      *
      * @param id the ID of the record to mark
@@ -208,4 +223,13 @@ public abstract class RecordStorage<I> extends AbstractStorage<I, EntityStorageR
      * @param record a record to store
      */
     protected abstract void writeRecord(I id, EntityStorageRecord record);
+
+    /**
+     * Writes a bulk of records into the storage.
+     *
+     * <p>Rewrites it if a record with this ID already exists in the storage.
+     *
+     * @param records an ID to record map with the entries to store
+     */
+    protected abstract void writeRecords(Map<I, EntityStorageRecord> records);
 }

--- a/server/src/main/java/org/spine3/server/storage/memory/InMemoryProjectionStorage.java
+++ b/server/src/main/java/org/spine3/server/storage/memory/InMemoryProjectionStorage.java
@@ -64,7 +64,7 @@ class InMemoryProjectionStorage<I> extends ProjectionStorage<I> {
     }
 
     @Override
-    public RecordStorage<I> getRecordStorage() {
+    public RecordStorage<I> recordStorage() {
         return recordStorage;
     }
 
@@ -76,17 +76,17 @@ class InMemoryProjectionStorage<I> extends ProjectionStorage<I> {
 
     @Override
     public boolean markArchived(I id) {
-        return getRecordStorage().markArchived(id);
+        return recordStorage().markArchived(id);
     }
 
     @Override
     public boolean markDeleted(I id) {
-        return getRecordStorage().markDeleted(id);
+        return recordStorage().markDeleted(id);
     }
 
     @Override
     public boolean delete(I id) {
-        return getRecordStorage().delete(id);
+        return recordStorage().delete(id);
     }
 
     @Override

--- a/server/src/main/java/org/spine3/server/storage/memory/InMemoryRecordStorage.java
+++ b/server/src/main/java/org/spine3/server/storage/memory/InMemoryRecordStorage.java
@@ -112,4 +112,11 @@ class InMemoryRecordStorage<I> extends RecordStorage<I> {
         getStorage().put(id, record);
     }
 
+    @Override
+    protected void writeRecords(Map<I, EntityStorageRecord> records) {
+        final TenantRecords<I> storage = getStorage();
+        for (Map.Entry<I, EntityStorageRecord> record : records.entrySet()) {
+            storage.put(record.getKey(), record.getValue());
+        }
+    }
 }

--- a/server/src/main/java/org/spine3/server/storage/memory/InMemoryStandStorage.java
+++ b/server/src/main/java/org/spine3/server/storage/memory/InMemoryStandStorage.java
@@ -135,6 +135,13 @@ class InMemoryStandStorage extends StandStorage {
         recordStorage.write(id, record);
     }
 
+    @Override
+    protected void writeRecords(Map<AggregateStateId, EntityStorageRecord> records) {
+        for (Map.Entry<AggregateStateId, EntityStorageRecord> record : records.entrySet()) {
+            writeRecord(record.getKey(), record.getValue());
+        }
+    }
+
     public static class Builder {
 
         private boolean multitenant;

--- a/server/src/test/java/org/spine3/server/projection/BulkWriteOperationShould.java
+++ b/server/src/test/java/org/spine3/server/projection/BulkWriteOperationShould.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.projection;
+
+import com.google.protobuf.Duration;
+import com.google.protobuf.Message;
+import com.google.protobuf.Timestamp;
+import org.junit.Test;
+import org.spine3.protobuf.Durations;
+import org.spine3.server.projection.BulkWriteOperation.FlushCallback;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public class BulkWriteOperationShould {
+
+    @Test
+    public void initialize_with_proper_delay_and_callback() {
+        final Duration duration = Durations.seconds(60);
+        final BulkWriteOperation operation = new BulkWriteOperation<>(duration, new EmptyCallback());
+        assertNotNull(operation);
+    }
+
+    @Test
+    public void return_own_in_progress_state() {
+        final BulkWriteOperation operation = newOperation();
+        assertTrue(operation.isInProgress());
+        operation.complete();
+        assertFalse(operation.isInProgress());
+    }
+
+    @Test
+    public void do_nothing_if_checked_before_completion_time() {
+        final BulkWriteOperation operation = newOperation();
+        assertTrue(operation.isInProgress());
+        operation.checkExpiration();
+        assertTrue(operation.isInProgress());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void fail_to_complete_twice() {
+        final BulkWriteOperation operation = newOperation();
+        assertTrue(operation.isInProgress());
+
+        operation.complete();
+        assertFalse(operation.isInProgress());
+        operation.complete();
+    }
+
+    @Test
+    public void close_on_complete() {
+        final BulkWriteOperation operationSpy = spy(newOperation());
+
+        operationSpy.complete();
+        verify(operationSpy).close();
+    }
+
+    @Test
+    public void exit_silently_if_cheked_after_completion() {
+        final BulkWriteOperation operation = newOperation();
+        operation.complete();
+        assertFalse(operation.isInProgress());
+        operation.checkExpiration();
+        assertFalse(operation.isInProgress());
+    }
+
+    @Test
+    public void complete_on_timeout() throws InterruptedException {
+        final Duration duration = Durations.nanos(1L);
+        final FlushCallback callback = spy(new EmptyCallback());
+        @SuppressWarnings("unchecked") // Due to `spy` usage
+        final BulkWriteOperation operation = spy(new BulkWriteOperation(duration, callback));
+        assertTrue(operation.isInProgress());
+
+        Thread.sleep(10L);
+
+        operation.checkExpiration();
+        assertFalse(operation.isInProgress());
+        verify(operation).complete();
+        verify(callback).onFlushResults(any(Set.class), any(Timestamp.class));
+    }
+
+    private static BulkWriteOperation newOperation() {
+        final Duration duration = Durations.seconds(42);
+        final BulkWriteOperation operation = new BulkWriteOperation<>(duration, new EmptyCallback());
+        return operation;
+    }
+
+    private static class EmptyCallback implements FlushCallback<Projection<Object, Message>> {
+
+        @Override
+        public void onFlushResults(Set<Projection<Object, Message>> projections, Timestamp lastHandledEventTime) {
+            assertNotNull(projections);
+            assertNotNull(lastHandledEventTime);
+        }
+    }
+}

--- a/server/src/test/java/org/spine3/server/storage/RecordStorageShould.java
+++ b/server/src/test/java/org/spine3/server/storage/RecordStorageShould.java
@@ -222,7 +222,6 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
             final EntityStorageRecord record = newStorageRecord(id);
             expected.put(id, record);
         }
-
         storage.write(expected);
 
         final Collection<EntityStorageRecord> actual = newLinkedList(storage.readMultiple(expected.keySet()));

--- a/server/src/test/java/org/spine3/server/storage/RecordStorageShould.java
+++ b/server/src/test/java/org/spine3/server/storage/RecordStorageShould.java
@@ -225,7 +225,6 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
 
         storage.write(expected);
 
-
         final Collection<EntityStorageRecord> actual = newLinkedList(storage.readMultiple(expected.keySet()));
 
         assertEquals(expected.size(), actual.size());


### PR DESCRIPTION
 - Add `write(Map<>)` method to `EntityRecordStorage`.
 - Write projections in bulk fashion to improve the performance.