### PR TITLE
Fix `Commands` null tolerance test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ after_success:
   - chmod +x ./scripts/publish-artifacts.sh
   - ./scripts/publish-artifacts.sh
 
-script: ./gradlew check --debug
+script: ./gradlew check --stacktrace

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ after_success:
   - chmod +x ./scripts/publish-artifacts.sh
   - ./scripts/publish-artifacts.sh
 
-script: ./gradlew check --stacktrace
+script: ./gradlew check --debug

--- a/client/src/main/java/org/spine3/base/Commands.java
+++ b/client/src/main/java/org/spine3/base/Commands.java
@@ -95,6 +95,9 @@ public class Commands {
     public static CommandContext createContext(@Nullable TenantId tenantId,
                                                UserId userId,
                                                ZoneOffset zoneOffset) {
+        checkNotNull(userId);
+        checkNotNull(zoneOffset);
+
         final CommandId commandId = generateId();
         final CommandContext.Builder result = newBuilder()
                 .setActor(userId)
@@ -153,6 +156,7 @@ public class Commands {
      * @return an unpacked message
      */
     public static <M extends Message> M getMessage(Command command) {
+        checkNotNull(command);
         final M result = AnyPacker.unpack(command.getMessage());
         return result;
     }
@@ -161,6 +165,7 @@ public class Commands {
      * Extracts a command ID from the passed {@code Command} instance.
      */
     public static CommandId getId(Command command) {
+        checkNotNull(command);
         final CommandId id = command.getContext()
                                     .getCommandId();
         return id;
@@ -170,6 +175,7 @@ public class Commands {
      * Creates a predicate for filtering commands created after the passed timestamp.
      */
     public static Predicate<Command> wereAfter(final Timestamp from) {
+        checkNotNull(from);
         return new Predicate<Command>() {
             @Override
             public boolean apply(@Nullable Command request) {
@@ -184,6 +190,8 @@ public class Commands {
      * Creates a predicate for filtering commands created withing given timerange.
      */
     public static Predicate<Command> wereWithinPeriod(final Timestamp from, final Timestamp to) {
+        checkNotNull(from);
+        checkNotNull(to);
         return new Predicate<Command>() {
             @Override
             public boolean apply(@Nullable Command request) {
@@ -195,6 +203,7 @@ public class Commands {
     }
 
     private static Timestamp getTimestamp(Command request) {
+        checkNotNull(request);
         final Timestamp result = request.getContext()
                                         .getTimestamp();
         return result;
@@ -206,6 +215,7 @@ public class Commands {
      * @param commands the command list to sort
      */
     public static void sort(List<Command> commands) {
+        checkNotNull(commands);
         Collections.sort(commands, new Comparator<Command>() {
             @Override
             public int compare(Command o1, Command o2) {
@@ -223,6 +233,8 @@ public class Commands {
      * @return {@code true} if the file name ends with the {@link #FILE_NAME_SUFFIX}, {@code false} otherwise
      */
     public static boolean isCommandsFile(FileDescriptor file) {
+        checkNotNull(file);
+
         final String fqn = file.getName();
         final int startIndexOfFileName = fqn.lastIndexOf(FILE_PATH_SEPARATOR) + 1;
         final int endIndexOfFileName = fqn.lastIndexOf(FILE_EXTENSION_SEPARATOR);
@@ -238,6 +250,7 @@ public class Commands {
      * @return {@code true} if the command context has a scheduling option set, {@code false} otherwise
      */
     public static boolean isScheduled(Command command) {
+        checkNotNull(command);
         final Schedule schedule = command.getContext()
                                          .getSchedule();
         final Duration delay = schedule.getDelay();
@@ -257,6 +270,9 @@ public class Commands {
      */
     @Internal
     public static Command setSchedulingTime(Command command, Timestamp schedulingTime) {
+        checkNotNull(command);
+        checkNotNull(schedulingTime);
+
         final Duration delay = command.getContext()
                                       .getSchedule()
                                       .getDelay();
@@ -274,7 +290,11 @@ public class Commands {
      */
     @Internal
     public static Command setSchedule(Command command, Duration delay, Timestamp schedulingTime) {
+        checkNotNull(command);
+        checkNotNull(delay);
+        checkNotNull(schedulingTime);
         checkPositive(schedulingTime, "command scheduling time");
+
         final CommandContext context = command.getContext();
         final Schedule scheduleUpdated = context.getSchedule()
                                                 .toBuilder()

--- a/client/src/test/java/org/spine3/base/CommandsShould.java
+++ b/client/src/test/java/org/spine3/base/CommandsShould.java
@@ -32,6 +32,7 @@ import com.google.protobuf.Timestamp;
 import org.junit.Test;
 import org.spine3.protobuf.AnyPacker;
 import org.spine3.protobuf.Durations;
+import org.spine3.protobuf.Timestamps;
 import org.spine3.test.NullToleranceTest;
 import org.spine3.test.TestCommandFactory;
 import org.spine3.test.commands.TestCommand;
@@ -56,6 +57,8 @@ import static org.spine3.testdata.TestCommandContextFactory.createCommandContext
 
 @SuppressWarnings({"InstanceMethodNamingConvention", "MagicNumber"})
 public class CommandsShould {
+
+    private static final FileDescriptor DEFAULT_FILE_DESCRIPTOR = Any.getDescriptor().getFile();
 
     private final TestCommandFactory commandFactory = TestCommandFactory.newInstance(CommandsShould.class);
     private final StringValue stringValue = newStringValue(newUuid());
@@ -83,6 +86,8 @@ public class CommandsShould {
     public void pass_null_tolerance_test() {
         final boolean passed = NullToleranceTest.newBuilder()
                                                 .setClass(Commands.class)
+                                                .addDefaultValue(DEFAULT_FILE_DESCRIPTOR)
+                                                .addDefaultValue(Timestamps.getCurrentTime()) // to fulfil custom validation
                                                 .build()
                                                 .check();
         assertTrue(passed);

--- a/client/src/test/java/org/spine3/base/CommandsShould.java
+++ b/client/src/test/java/org/spine3/base/CommandsShould.java
@@ -81,10 +81,11 @@ public class CommandsShould {
 
     @Test
     public void pass_null_tolerance_test() {
-        NullToleranceTest.newBuilder()
-                         .setClass(Commands.class)
-                         .build()
-                         .check();
+        final boolean passed = NullToleranceTest.newBuilder()
+                                                .setClass(Commands.class)
+                                                .build()
+                                                .check();
+        assertTrue(passed);
     }
 
     @Test

--- a/testutil/src/main/java/org/spine3/test/NullToleranceTest.java
+++ b/testutil/src/main/java/org/spine3/test/NullToleranceTest.java
@@ -121,11 +121,7 @@ public class NullToleranceTest {
         final Iterable<Method> accessibleMethods = getAccessibleMethods(targetClass);
         final String targetClassName = targetClass.getName();
         for (Method method : accessibleMethods) {
-            final Class[] parameterTypes = method.getParameterTypes();
-            final String methodName = method.getName();
-            final boolean excluded = excludedMethods.contains(methodName);
-            final boolean primitivesOnly = allPrimitiveTypes().containsAll(Arrays.asList(parameterTypes));
-            final boolean skipMethod = excluded || parameterTypes.length == 0 || primitivesOnly;
+            final boolean skipMethod = shouldSkipMethod(method);
             if (skipMethod) {
                 continue;
             }
@@ -138,6 +134,19 @@ public class NullToleranceTest {
 
         }
         return true;
+    }
+
+    @SuppressWarnings("OverlyComplexBooleanExpression") //
+    private boolean shouldSkipMethod(Method method) {
+        final Class[] parameterTypes = method.getParameterTypes();
+        final String methodName = method.getName();
+        final boolean excluded = excludedMethods.contains(methodName);
+        final boolean primitivesOnly = allPrimitiveTypes().containsAll(Arrays.asList(parameterTypes));
+        final boolean syntheticMethod = method.isSynthetic();
+        return excluded
+                || parameterTypes.length == 0
+                || primitivesOnly
+                || syntheticMethod;
     }
 
     /**

--- a/testutil/src/main/java/org/spine3/test/NullToleranceTest.java
+++ b/testutil/src/main/java/org/spine3/test/NullToleranceTest.java
@@ -398,7 +398,11 @@ public class NullToleranceTest {
                 }
             }
 
-            checkState(result != null);
+            checkState(
+                    result != null,
+                    String.format(
+                            "Could not generate a default value for %s type. Please, use NullToleranceTest.Builder#addDefaultValue",
+                            type.getCanonicalName()));
             return result;
         }
 

--- a/testutil/src/main/java/org/spine3/test/NullToleranceTest.java
+++ b/testutil/src/main/java/org/spine3/test/NullToleranceTest.java
@@ -136,7 +136,7 @@ public class NullToleranceTest {
         return true;
     }
 
-    @SuppressWarnings("OverlyComplexBooleanExpression") //
+    @SuppressWarnings("OverlyComplexBooleanExpression")
     private boolean shouldSkipMethod(Method method) {
         final Class[] parameterTypes = method.getParameterTypes();
         final String methodName = method.getName();
@@ -401,7 +401,7 @@ public class NullToleranceTest {
             checkState(
                     result != null,
                     String.format(
-                            "Could not generate a default value for %s type. Please, use NullToleranceTest.Builder#addDefaultValue",
+                            "Could not generate a default value for %s type. Please, use addDefaultValue(I)",
                             type.getCanonicalName()));
             return result;
         }

--- a/testutil/src/test/java/org/spine3/test/NullToleranceTestShould.java
+++ b/testutil/src/test/java/org/spine3/test/NullToleranceTestShould.java
@@ -202,6 +202,15 @@ public class NullToleranceTestShould {
         assertTrue(result);
     }
 
+    @Test
+    public void not_check_synthetic_methods() {
+        final NullToleranceTest nullToleranceTest = NullToleranceTest.newBuilder()
+                                                                     .setClass(ClassWithSyntheticMethods.class)
+                                                                     .build();
+        final boolean result = nullToleranceTest.check();
+        assertTrue(result);
+    }
+
     /*
      * Test utility classes
      ******************************/
@@ -321,5 +330,21 @@ public class NullToleranceTestShould {
             checkNotNull(obj);
             checkNotNull(args);
         }
+    }
+
+    @SuppressWarnings("unused") // accessed via reflection.
+    private static class ClassWithSyntheticMethods {
+
+        private Object withSyntheticAccessor;
+
+        private Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                // Simulate some work
+                if (withSyntheticAccessor == null) {
+                    withSyntheticAccessor = new Object();
+                }
+            }
+        };
     }
 }


### PR DESCRIPTION
The causes of the failure were following:
 - Not checking the test result (`NullToletranceTest` does not _`fail`_ the test but returns a `boolean` value).
 - `Commands` class could not pass the tests by their design.
 - After one failed method checked `false` was returned. The methods order is undefined though, that's why we could not reproduce the problem in our local environments.
 - Not setting default values for the custom parameter types caused an error when trying to get one.

What's done:
 - Check the test result.
 - Fit `Commands` to our requirements.
 - Add an error message for the missing default value case.

Also, I've turned off the checks for `synthetic` methods (`Smth#access$000`), since we declare to check non-private methods only.