### PR TITLE
Update gRPC version to 1.1.2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
         
-        spineVersion = '0.8.7-SNAPSHOT'
+        spineVersion = '0.8.8-SNAPSHOT'
         
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all the components and change
         // the version of the dependency below to `spineVersion` defined above.
@@ -70,7 +70,7 @@ ext {
     // is updated with new Message types introduced in the new version of Protobuf.
     protobufVersion = '3.2.0'
     protobufDependency = "com.google.protobuf:protoc:${protobufVersion}"
-    gRpcVersion = '1.0.2'
+    gRpcVersion = '1.1.2'
     slf4JVersion = '1.7.21'
     jUnitVersion = '4.12'
 


### PR DESCRIPTION
To keep the framework up-to-date with the most recent libraries, gRPC version has been updated to the latest release.

Summary: 

* Update gRPC version to `1.1.2`.
* Bump Spine version to `0.8.8-SNAPSHOT`.