### PR TITLE
Fix Javadocs to have text with class name after FQN.

### DIFF
--- a/client/src/main/java/org/spine3/base/Commands.java
+++ b/client/src/main/java/org/spine3/base/Commands.java
@@ -81,7 +81,8 @@ public class Commands {
      * Creates a new command context with the current time.
      *
      * <p>This method is not supposed to be called from outside the framework.
-     * Commands in client applications should be created by {@link org.spine3.client.CommandFactory#create(Message)},
+     * Commands in client applications should be created by
+     * {@link org.spine3.client.CommandFactory#create(Message) CommandFactory.create(Message)},
      * which creates {@code CommandContext} automatically.
      *
      * @param tenantId   the ID of the tenant or {@code null} for single-tenant applications

--- a/client/src/main/java/org/spine3/base/Identifiers.java
+++ b/client/src/main/java/org/spine3/base/Identifiers.java
@@ -61,10 +61,11 @@ public class Identifiers {
      * The type of the value wrapped into the returned instance is defined by the type
      * of the passed value:
      * <ul>
-     *      <li>For classes implementing {@link com.google.protobuf.Message} — the value of the message itself
-     *      <li>For {@code String} — {@link com.google.protobuf.StringValue}
-     *      <li>For {@code Long} — {@link com.google.protobuf.UInt64Value}
-     *      <li>For {@code Integer} — {@link com.google.protobuf.UInt32Value}
+     *      <li>For classes implementing {@link com.google.protobuf.Message Message} — the value
+     *      of the message itself
+     *      <li>For {@code String} — {@link com.google.protobuf.StringValue StringValue}
+     *      <li>For {@code Long} — {@link com.google.protobuf.UInt64Value UInt64Value}
+     *      <li>For {@code Integer} — {@link com.google.protobuf.UInt32Value UInt32Value}
      * </ul>
      *
      * @param id  the value to wrap
@@ -86,9 +87,9 @@ public class Identifiers {
      *
      * @param any the ID value wrapped into {@code Any}
      * @return <ul>
-     * <li>{@code String} value if {@link com.google.protobuf.StringValue} is unwrapped
-     * <li>{@code Integer} value if {@link com.google.protobuf.UInt32Value} is unwrapped
-     * <li>{@code Long} value if {@link com.google.protobuf.UInt64Value} is unwrapped
+     * <li>{@code String} value if {@link com.google.protobuf.StringValue StringValue} is unwrapped
+     * <li>{@code Integer} value if {@link com.google.protobuf.UInt32Value StringValue} is unwrapped
+     * <li>{@code Long} value if {@link com.google.protobuf.UInt64Value StringValue} is unwrapped
      * <li>unwrapped {@code Message} instance if its type is none of the above
      * </ul>
      */

--- a/client/src/main/java/org/spine3/base/Responses.java
+++ b/client/src/main/java/org/spine3/base/Responses.java
@@ -25,7 +25,7 @@ import com.google.protobuf.Empty;
 import static org.spine3.base.Response.StatusCase.OK;
 
 /**
- * Utilities for working with {@link org.spine3.base.Response} objects.
+ * Utilities for working with {@link org.spine3.base.Response Response} objects.
  *
  * @author Alexander Yevsyukov
  */

--- a/client/src/main/java/org/spine3/protobuf/AnyPacker.java
+++ b/client/src/main/java/org/spine3/protobuf/AnyPacker.java
@@ -86,7 +86,8 @@ public class AnyPacker {
     /**
      * Unwraps {@code Any} value into an instance of the passed class.
      *
-     * <p>If there is no Java class for the type, {@link org.spine3.protobuf.error.UnexpectedTypeException}
+     * <p>If there is no Java class for the type,
+     * {@link org.spine3.protobuf.error.UnexpectedTypeException UnexpectedTypeException}
      * will be thrown.
      *
      * @param any   instance of {@link Any} that should be unwrapped

--- a/client/src/main/java/org/spine3/protobuf/Durations.java
+++ b/client/src/main/java/org/spine3/protobuf/Durations.java
@@ -21,7 +21,7 @@ import static org.spine3.util.Math.safeMultiply;
 
 /**
  * Utility class for working with durations in addition to those available from
- * {@link com.google.protobuf.util.Durations}.
+ * {@link com.google.protobuf.util.Durations Durations}.
  *
  * <p>Use {@code import static org.spine3.protobuf.Durations.*} for compact initialization like this:
  * <pre>
@@ -122,12 +122,14 @@ public class Durations {
         return ofSeconds(seconds);
     }
 
-    /** This method allows for more compact code of creation of {@code Duration} instance with minutes. */
+    /** This method allows for more compact code of creation of
+     * {@code Duration} instance with minutes. */
     public static Duration minutes(long minutes) {
         return ofMinutes(minutes);
     }
 
-    /** This method allows for more compact code of creation of {@code Duration} instance with hours. */
+    /** This method allows for more compact code of creation of
+     * {@code Duration} instance with hours. */
     public static Duration hours(long hours) {
         return ofHours(hours);
     }
@@ -167,7 +169,8 @@ public class Durations {
         return result;
     }
 
-    /** This method allows for more compact code of creation of {@code Duration} instance with hours and minutes. */
+    /** This method allows for more compact code of creation of
+     * {@code Duration} instance with hours and minutes. */
     public static Duration hoursAndMinutes(long hours, long minutes) {
         final Duration result = add(hours(hours), minutes(minutes));
         return result;
@@ -232,7 +235,8 @@ public class Durations {
         return result;
     }
 
-    /** Returns {@code true} of the passed value is greater or equal zero, {@code false} otherwise. */
+    /** Returns {@code true} of the passed value is greater or equal zero,
+     * {@code false} otherwise. */
     public static boolean isPositiveOrZero(Duration value) {
         checkNotNull(value);
         final long millis = toMillis(value);
@@ -240,7 +244,8 @@ public class Durations {
         return result;
     }
 
-    /** Returns {@code true} if the passed value is greater than zero, {@code false} otherwise. */
+    /** Returns {@code true} if the passed value is greater than zero,
+     * {@code false} otherwise. */
     public static boolean isPositive(DurationOrBuilder value) {
         checkNotNull(value);
         final boolean secondsPositive = value.getSeconds() > 0;
@@ -259,7 +264,8 @@ public class Durations {
         return result;
     }
 
-    /** Returns {@code true} if the first argument is greater than the second, {@code false} otherwise. */
+    /** Returns {@code true} if the first argument is greater than the second,
+     * {@code false} otherwise. */
     public static boolean isGreaterThan(Duration value, Duration another) {
         checkNotNull(value);
         checkNotNull(another);
@@ -269,7 +275,8 @@ public class Durations {
         return isGreater;
     }
 
-    /** Returns {@code true} if the first argument is less than the second, {@code false} otherwise. */
+    /** Returns {@code true} if the first argument is less than the second,
+     * {@code false} otherwise. */
     public static boolean isLessThan(Duration value, Duration another) {
         checkNotNull(value);
         checkNotNull(another);

--- a/client/src/main/java/org/spine3/protobuf/KnownTypes.java
+++ b/client/src/main/java/org/spine3/protobuf/KnownTypes.java
@@ -134,7 +134,7 @@ public class KnownTypes {
 
     /**
      * Retrieves a Java class name generated for the Protobuf type by its type url
-     * to be used to parse {@link com.google.protobuf.Message} from {@link Any}.
+     * to be used to parse {@link com.google.protobuf.Message Message} from {@link Any}.
      *
      * @param typeUrl {@link Any} type url
      * @return Java class name
@@ -159,7 +159,8 @@ public class KnownTypes {
         final TypeUrl result = knownTypes.inverse()
                                          .get(className);
         if (result == null) {
-            throw new IllegalStateException("No Protobuf type URL found for the Java class " + className);
+            throw new IllegalStateException("No Protobuf type URL found for the Java class " +
+                                            className);
         }
         return result;
     }
@@ -179,7 +180,8 @@ public class KnownTypes {
      */
     public static Set<TypeUrl> getTypesFromPackage(final String packageName) {
         final Collection<TypeUrl> knownTypeUrls = knownTypes.keySet();
-        final Collection<TypeUrl> resultCollection = Collections2.filter(knownTypeUrls, new Predicate<TypeUrl>() {
+        final Collection<TypeUrl> resultCollection = Collections2.filter(
+                knownTypeUrls, new Predicate<TypeUrl>() {
             @Override
             public boolean apply(@Nullable TypeUrl input) {
                 if (input == null) {
@@ -221,7 +223,8 @@ public class KnownTypes {
             final java.lang.reflect.Method descriptorGetter = clazz.getDeclaredMethod(DESCRIPTOR_GETTER_NAME);
             descriptor = (Descriptors.Descriptor) descriptorGetter.invoke(null);
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            throw new IllegalArgumentException("Type " + typeName + " is not a protobuf Message", e);
+            throw new IllegalArgumentException("Type " + typeName +
+                                               " is not a protobuf Message", e);
         }
         return descriptor;
     }
@@ -382,8 +385,10 @@ public class KnownTypes {
         private void put(TypeUrl typeUrl, ClassName className) {
             if (resultMap.containsKey(typeUrl)) {
                 log().warn("Duplicate key in the {} map: {}. " +
-                                   "It may be caused by the `task.descriptorSetOptions.includeImports` option " +
-                                   "set to `true` in the `build.gradle`.", KnownTypes.class.getName(), typeUrl);
+                           "It may be caused by the " +
+                           "`task.descriptorSetOptions.includeImports` option " +
+                           "set to `true` in the `build.gradle`.", KnownTypes.class.getName(),
+                           typeUrl);
                 return;
             }
             resultMap.put(typeUrl, className);

--- a/client/src/main/java/org/spine3/protobuf/Timestamps.java
+++ b/client/src/main/java/org/spine3/protobuf/Timestamps.java
@@ -223,8 +223,8 @@ public class Timestamps {
      * @param timestamp the timestamp to check if it is between the {@code start} and {@code finish}
      * @param start     the first point in time, must be before the {@code finish} timestamp
      * @param finish    the second point in time, must be after the {@code start} timestamp
-     * @return true if the {@code timestamp} is after the {@code start} and before
-     * the {@code finish} timestamps, false otherwise
+     * @return {@code true} if the {@code timestamp} is after the {@code start} and before
+     * the {@code finish} timestamps, {@code false} otherwise
      */
     public static boolean isBetween(Timestamp timestamp, Timestamp start, Timestamp finish) {
         final boolean isAfterStart = compare(start, timestamp) < 0;
@@ -237,8 +237,8 @@ public class Timestamps {
      *
      * @param timestamp the timestamp to check if it is later then {@code thanTime}
      * @param thanTime  the first point in time which is supposed to be before the {@code timestamp}
-     * @return true if the {@code timestamp} is later than {@code thanTime} timestamp,
-     * false otherwise
+     * @return {@code true} if the {@code timestamp} is later than {@code thanTime} timestamp,
+     * {@code false} otherwise
      */
     public static boolean isLaterThan(Timestamp timestamp, Timestamp thanTime) {
         final boolean isAfter = compare(timestamp, thanTime) > 0;

--- a/client/src/main/java/org/spine3/protobuf/Timestamps.java
+++ b/client/src/main/java/org/spine3/protobuf/Timestamps.java
@@ -34,7 +34,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.protobuf.util.Timestamps.add;
 import static com.google.protobuf.util.Timestamps.fromMillis;
 import static com.google.protobuf.util.Timestamps.subtract;
-import static java.lang.String.*;
+import static java.lang.String.format;
 
 /**
  * Utilities class for working with {@link Timestamp}s in addition to those available from

--- a/client/src/main/java/org/spine3/protobuf/Timestamps.java
+++ b/client/src/main/java/org/spine3/protobuf/Timestamps.java
@@ -34,10 +34,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.protobuf.util.Timestamps.add;
 import static com.google.protobuf.util.Timestamps.fromMillis;
 import static com.google.protobuf.util.Timestamps.subtract;
+import static java.lang.String.*;
 
 /**
  * Utilities class for working with {@link Timestamp}s in addition to those available from
- * {@link com.google.protobuf.util.Timestamps}.
+ * {@link com.google.protobuf.util.Timestamps Timestamps}.
  *
  * @author Mikhail Melnik
  * @author Alexander Yevsyukov
@@ -45,7 +46,7 @@ import static com.google.protobuf.util.Timestamps.subtract;
 public class Timestamps {
 
     /**
-     * The following constants are taken from {@link com.google.protobuf.util.Timestamps}
+     * The following constants are taken from {@link com.google.protobuf.util.Timestamps Timestamps}
      * in order to make them publicly visible to time management utils:
      * <ul>
      *   <li>{@link #TIMESTAMP_SECONDS_MIN}
@@ -117,7 +118,8 @@ public class Timestamps {
     /**
      * Obtains system time.
      *
-     * <p>Unlike {@link #getCurrentTime()} this method <strong>always</strong> uses system time millis.
+     * <p>Unlike {@link #getCurrentTime()} this method <strong>always</strong> uses
+     * system time millis.
      *
      * @return current system time
      */
@@ -215,13 +217,14 @@ public class Timestamps {
     }
 
     /**
-     * Calculates if the {@code timestamp} is between the {@code start} and {@code finish} timestamps.
+     * Calculates if the {@code timestamp} is between the {@code start} and
+     * {@code finish} timestamps.
      *
      * @param timestamp the timestamp to check if it is between the {@code start} and {@code finish}
      * @param start     the first point in time, must be before the {@code finish} timestamp
      * @param finish    the second point in time, must be after the {@code start} timestamp
-     * @return true if the {@code timestamp} is after the {@code start} and before the {@code finish} timestamps,
-     * false otherwise
+     * @return true if the {@code timestamp} is after the {@code start} and before
+     * the {@code finish} timestamps, false otherwise
      */
     public static boolean isBetween(Timestamp timestamp, Timestamp start, Timestamp finish) {
         final boolean isAfterStart = compare(start, timestamp) < 0;
@@ -234,7 +237,8 @@ public class Timestamps {
      *
      * @param timestamp the timestamp to check if it is later then {@code thanTime}
      * @param thanTime  the first point in time which is supposed to be before the {@code timestamp}
-     * @return true if the {@code timestamp} is later than {@code thanTime} timestamp, false otherwise
+     * @return true if the {@code timestamp} is later than {@code thanTime} timestamp,
+     * false otherwise
      */
     public static boolean isLaterThan(Timestamp timestamp, Timestamp thanTime) {
         final boolean isAfter = compare(timestamp, thanTime) > 0;
@@ -270,7 +274,9 @@ public class Timestamps {
      * @return long value
      */
     public static long convertToNanos(TimestampOrBuilder timestamp) {
-        final long nanosFromSeconds = timestamp.getSeconds() * MILLIS_PER_SECOND * NANOS_PER_MILLISECOND;
+        final long nanosFromSeconds = timestamp.getSeconds() *
+                                      MILLIS_PER_SECOND *
+                                      NANOS_PER_MILLISECOND;
         final long totalNanos = nanosFromSeconds + timestamp.getNanos();
         return totalNanos;
     }
@@ -316,7 +322,7 @@ public class Timestamps {
 
     private static void checkPositive(long value) {
         if (value <= 0) {
-            throw new IllegalArgumentException(String.format("value must be positive. Passed: %d", value));
+            throw new IllegalArgumentException(format("value must be positive. Passed: %d", value));
         }
     }
 

--- a/client/src/main/java/org/spine3/protobuf/Values.java
+++ b/client/src/main/java/org/spine3/protobuf/Values.java
@@ -32,7 +32,7 @@ import com.google.protobuf.UInt64Value;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Utility class for working with {@link com.google.protobuf.Message} value wrapper objects.
+ * Utility class for working with {@link com.google.protobuf.Message Message} value wrapper objects.
  *
  * @author Alexander Litus
  */

--- a/client/src/main/java/org/spine3/protobuf/error/UnexpectedTypeException.java
+++ b/client/src/main/java/org/spine3/protobuf/error/UnexpectedTypeException.java
@@ -21,11 +21,12 @@
 package org.spine3.protobuf.error;
 
 /**
- * Exception thrown when the content of {@link com.google.protobuf.Any} does not match one we expect
- * when unpacking.
+ * Exception thrown when the content of {@link com.google.protobuf.Any Any} does not
+ * match one we expect when unpacking.
  *
- * <p>Typically this exception wraps {@link com.google.protobuf.InvalidProtocolBufferException} thrown
- * in unsuccessful call of {@link com.google.protobuf.Any#unpack(Class)}.
+ * <p>Typically this exception wraps
+ * {@link com.google.protobuf.InvalidProtocolBufferException InvalidProtocolBufferException} thrown
+ * in unsuccessful call of {@link com.google.protobuf.Any#unpack(Class) Any.unpack(Class)}.
  *
  * @author Alexander Yevsyukov
  */

--- a/client/src/main/java/org/spine3/protobuf/error/UnknownTypeException.java
+++ b/client/src/main/java/org/spine3/protobuf/error/UnknownTypeException.java
@@ -53,7 +53,8 @@ public class UnknownTypeException extends RuntimeException {
     /**
      * Creates a new instance when only the cause is known.
      *
-     * <p>Use this constructor when propagating {@link com.google.protobuf.InvalidProtocolBufferException}
+     * <p>Use this constructor when propagating
+     * {@link com.google.protobuf.InvalidProtocolBufferException InvalidProtocolBufferException}
      * without knowing which type caused the exception (e.g. when calling {@code JsonFormat.print()}.
      */
     public UnknownTypeException(Throwable cause) {

--- a/client/src/main/java/org/spine3/util/Exceptions.java
+++ b/client/src/main/java/org/spine3/util/Exceptions.java
@@ -24,7 +24,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Utility class for working with exceptions for cases that are not
- * supported by {@link com.google.common.base.Throwables}.
+ * supported by {@link com.google.common.base.Throwables Throwables}.
  *
  * @author Alexander Yevsyukov
  */
@@ -35,8 +35,10 @@ public class Exceptions {
     /**
      * Always throws {@code UnsupportedOperationException} initialized with the passed string.
      *
-     * <p>Use this method in combination with static import for brevity of code for unsupported operations.
-     * The return type is given to keep Java type system happy when called in methods with return type as shown below:
+     * <p>Use this method in combination with static import for brevity of code for
+     * unsupported operations.
+     * The return type is given to keep Java type system happy when called in methods with
+     * return type as shown below:
      *
      * <pre>
      *   import static com.teamdev.commons.Exceptions.unsupported;
@@ -50,7 +52,8 @@ public class Exceptions {
      * @return nothing ever
      * @throws UnsupportedOperationException always
      */
-    public static UnsupportedOperationException unsupported(String message) throws UnsupportedOperationException {
+    public static UnsupportedOperationException unsupported(String message)
+            throws UnsupportedOperationException {
         checkNotNull(message);
         throw new UnsupportedOperationException(message);
     }
@@ -58,8 +61,10 @@ public class Exceptions {
     /**
      * Always throws {@code UnsupportedOperationException}.
      *
-     * <p>Use this method in combination with static import for brevity of code for unsupported operations.
-     * The return type is given to keep Java type system happy when called in methods with return type as shown below:
+     * <p>Use this method in combination with static import for brevity of code for
+     * unsupported operations.
+     * The return type is given to keep Java type system happy when called in methods with
+     * return type as shown below:
      *
      * <pre>
      *   import static com.teamdev.commons.Exceptions.unsupported;

--- a/server/src/main/java/org/spine3/server/BoundedContext.java
+++ b/server/src/main/java/org/spine3/server/BoundedContext.java
@@ -132,7 +132,7 @@ public final class BoundedContext extends IntegrationEventSubscriberGrpc.Integra
      * <li>Closes {@link CommandBus}.
      * <li>Closes {@link EventBus}.
      * <li>Closes {@link CommandStore}.
-     * <li>Closes {@link org.spine3.server.event.EventStore}.
+     * <li>Closes {@link org.spine3.server.event.EventStore EventStore}.
      * <li>Closes {@link Stand}.
      * <li>Shuts down all registered repositories. Each registered repository is:
      *      <ul>

--- a/server/src/main/java/org/spine3/server/aggregate/Aggregate.java
+++ b/server/src/main/java/org/spine3/server/aggregate/Aggregate.java
@@ -192,8 +192,8 @@ public abstract class Aggregate<I, S extends Message, B extends Message.Builder>
     /** Updates the aggregate state and closes the update phase of the aggregate. */
     private void updateState() {
         @SuppressWarnings("unchecked") // It is safe to assume that correct builder type is passed to aggregate,
-         // because otherwise it won't be possible to write the code of applier methods that make
-        // sense to the aggregate.
+         // because otherwise it won't be possible to write the code
+         // of applier methods that make sense to the aggregate.
         final S newState = (S) getBuilder().build();
         setState(newState, getVersion(), whenModified());
 

--- a/server/src/main/java/org/spine3/server/aggregate/Aggregate.java
+++ b/server/src/main/java/org/spine3/server/aggregate/Aggregate.java
@@ -74,7 +74,8 @@ import static org.spine3.util.Exceptions.wrappedCause;
  * the same way as described in {@link CommandHandlingEntity}.
  *
  * <p>Event(s) returned by command handling methods are posted to
- * the {@link org.spine3.server.event.EventBus} automatically by {@link AggregateRepository}.
+ * the {@link org.spine3.server.event.EventBus EventBus} automatically
+ * by {@link AggregateRepository}.
  *
  * <h2>Adding event applier methods</h2>
  *
@@ -182,7 +183,8 @@ public abstract class Aggregate<I, S extends Message, B extends Message.Builder>
     protected B getBuilder() {
         if (this.builder == null) {
             throw new IllegalStateException(
-                    "Builder is not available. Make sure to call getBuilder() only from an event applier method.");
+                    "Builder is not available. Make sure to call getBuilder() " +
+                    "only from an event applier method.");
         }
         return builder;
     }
@@ -190,8 +192,8 @@ public abstract class Aggregate<I, S extends Message, B extends Message.Builder>
     /** Updates the aggregate state and closes the update phase of the aggregate. */
     private void updateState() {
         @SuppressWarnings("unchecked") // It is safe to assume that correct builder type is passed to aggregate,
-         // because otherwise it won't be possible to write the code of applier methods that make sense to the
-         // aggregate.
+         // because otherwise it won't be possible to write the code of applier methods that make
+        // sense to the aggregate.
         final S newState = (S) getBuilder().build();
         setState(newState, getVersion(), whenModified());
 
@@ -273,7 +275,8 @@ public abstract class Aggregate<I, S extends Message, B extends Message.Builder>
      * Applies event messages.
      *
      * @param eventMessages the event message to apply
-     * @param commandContext the context of the command, execution of which produces the passed events
+     * @param commandContext the context of the command, execution of which produces
+     *                       the passed events
      * @throws InvocationTargetException if an exception occurs during event applying
      */
     private void apply(Iterable<? extends Message> eventMessages, CommandContext commandContext)
@@ -288,7 +291,8 @@ public abstract class Aggregate<I, S extends Message, B extends Message.Builder>
         }
     }
 
-    private void apply(Message eventOrMsg, CommandContext commandContext) throws InvocationTargetException {
+    private void apply(Message eventOrMsg, CommandContext commandContext)
+            throws InvocationTargetException {
         final Message eventMsg;
         final EventContext eventContext;
         if (eventOrMsg instanceof Event) {
@@ -319,7 +323,8 @@ public abstract class Aggregate<I, S extends Message, B extends Message.Builder>
      * is dispatched to corresponding applier method.
      *
      * @param eventOrSnapshot an event to apply or a snapshot to use to restore state
-     * @throws MissingEventApplierException if there is no applier method defined for this type of event
+     * @throws MissingEventApplierException if there is no applier method defined for
+     *                                      this type of event
      * @throws InvocationTargetException    if an exception occurred when calling event applier
      */
     private void applyEventOrSnapshot(Message eventOrSnapshot) throws InvocationTargetException {
@@ -341,7 +346,8 @@ public abstract class Aggregate<I, S extends Message, B extends Message.Builder>
         // See if we're in the state update cycle.
         final B builder = this.builder;
 
-        // If the call to restore() is made during a reply (because the snapshot event was encountered)
+        // If the call to restore() is made during a reply
+        // (because the snapshot event was encountered)
         // use the currently initialized builder.
         if (builder != null) {
             builder.clear();

--- a/server/src/main/java/org/spine3/server/aggregate/Apply.java
+++ b/server/src/main/java/org/spine3/server/aggregate/Apply.java
@@ -26,7 +26,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a method of an aggregate as one that modifies the state of the aggregate with data from the passed event.
+ * Marks a method of an aggregate as one that modifies the state of the aggregate with data
+ * from the passed event.
 
  * <p>As we apply the event to the aggregate state, we call such method <i>Event Applier</i>.
  *
@@ -35,7 +36,8 @@ import java.lang.annotation.Target;
  *     <li>is annotated with {@link Apply};
  *     <li>is {@code private};
  *     <li>is {@code void};
- *     <li>accepts an event derived from {@link com.google.protobuf.Message} as the only parameter.
+ *     <li>accepts an event derived from {@link com.google.protobuf.Message Message}
+ *         as the only parameter.
  * </ul>
  *
  * <p>Typically {@link Aggregate#getBuilder()} method is used to get and update an aggregate state.

--- a/server/src/main/java/org/spine3/server/aggregate/storage/package-info.java
+++ b/server/src/main/java/org/spine3/server/aggregate/storage/package-info.java
@@ -20,9 +20,9 @@
 
 /**
  * This package contains classes and interfaces for storing
- * {@link org.spine3.server.aggregate.Aggregate}s.
+ * {@link org.spine3.server.aggregate.Aggregate Aggregate}s.
  *
- * @see org.spine3.server.aggregate.AggregateStorage
+ * @see org.spine3.server.aggregate.AggregateStorage AggregateStorage
  */
 
 @SPI

--- a/server/src/main/java/org/spine3/server/command/Assign.java
+++ b/server/src/main/java/org/spine3/server/command/Assign.java
@@ -32,13 +32,16 @@ import java.lang.annotation.Target;
  * <ul>
  *     <li>is annotated with {@link Assign};
  *     <li>has a default access modifier;
- *     <li>returns an event derived from {@link com.google.protobuf.Message} or a {@link java.util.List} of messages;
- *     <li>accepts a command derived from {@link com.google.protobuf.Message} as a first parameter;
- *     <li>(optional) accepts a {@link org.spine3.base.CommandContext} as the second parameter.
+ *     <li>returns an event derived from {@link com.google.protobuf.Message Message} or
+ *          a {@link java.util.List List} of messages;
+ *     <li>accepts a command derived from {@link com.google.protobuf.Message Message}
+ *          as a first parameter;
+ *     <li>(optional) accepts a {@link org.spine3.base.CommandContext CommandContext}
+ *          as the second parameter.
  * </ul>
  *
- * If the annotation is applied to a method which doesn't satisfy any of these requirements, this method is not
- * considered as a command handler and is not registered for command dispatching.
+ * If the annotation is applied to a method which doesn't satisfy any of these requirements,
+ * this method is not considered as a command handler and is not registered for command dispatching.
  *
  * <p>Objects handing commands are registered using {@link CommandBus#register(CommandHandler)}.
  *

--- a/server/src/main/java/org/spine3/server/command/CommandHandlingEntity.java
+++ b/server/src/main/java/org/spine3/server/command/CommandHandlingEntity.java
@@ -66,7 +66,8 @@ import static org.spine3.util.Exceptions.wrappedCause;
  * <p>The method returns an event message of the specific type, or {@code List} of messages
  * if it produces more than one event.
  *
- * <p>The method may throw one or more throwables derived from {@link org.spine3.base.FailureThrowable}.
+ * <p>The method may throw one or more throwables derived from
+ * {@link org.spine3.base.FailureThrowable FailureThrowable}.
  * Throwing a {@code FailureThrowable} indicates that the passed command cannot be handled
  * because of a {@linkplain org.spine3.base.FailureThrowable#getFailure() business failure}.
  *

--- a/server/src/main/java/org/spine3/server/command/CommandStore.java
+++ b/server/src/main/java/org/spine3/server/command/CommandStore.java
@@ -79,7 +79,7 @@ public class CommandStore implements AutoCloseable {
      * Stores the command with the error status.
      *
      * @param command the command to store
-     * @param exception an exception occurred to convert to {@link org.spine3.base.Error}
+     * @param exception an exception occurred to convert to {@link org.spine3.base.Error Error}
      * @throws IllegalStateException if the storage is closed
      */
     public void store(Command command, Exception exception) {
@@ -91,7 +91,8 @@ public class CommandStore implements AutoCloseable {
      * Stores the command with the error status.
      *
      * @param command the command to store
-     * @param exception the exception occurred, which encloses {@link org.spine3.base.Error} to store
+     * @param exception the exception occurred, which encloses {@link org.spine3.base.Error Error}
+     *                  to store
      * @throws IllegalStateException if the storage is closed
      */
     public void storeWithError(Command command, CommandException exception) {

--- a/server/src/main/java/org/spine3/server/entity/DefaultStateRegistry.java
+++ b/server/src/main/java/org/spine3/server/entity/DefaultStateRegistry.java
@@ -35,7 +35,8 @@ import static com.google.common.collect.Maps.newConcurrentMap;
 class DefaultStateRegistry {
 
     /**
-     * NOTE: The implementation is not customized with {@link com.google.common.collect.MapMaker#makeMap()} options,
+     * NOTE: The implementation is not customized with
+     * {@link com.google.common.collect.MapMaker#makeMap() MapMaker.makeMap()} options,
      * as it is difficult to predict which work best within the real end-user application scenarios.
      **/
     private final Map<Class<? extends Entity>, Message> defaultStates = newConcurrentMap();
@@ -61,7 +62,8 @@ class DefaultStateRegistry {
      */
     void put(Class<? extends Entity> entityClass, Message state) {
         if (contains(entityClass)) {
-            throw new IllegalArgumentException("This class is registered already: " + entityClass.getName());
+            throw new IllegalArgumentException("This class is registered already: " +
+                                               entityClass.getName());
         }
         defaultStates.put(entityClass, state);
     }

--- a/server/src/main/java/org/spine3/server/entity/RecordBasedRepository.java
+++ b/server/src/main/java/org/spine3/server/entity/RecordBasedRepository.java
@@ -247,7 +247,7 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
      *  href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask
      * >FieldMask specs</a>.
      *
-     * <p>At this point only {@link org.spine3.client.EntityIdFilter} is supported.
+     * <p>At this point only {@link org.spine3.client.EntityIdFilter EntityIdFilter} is supported.
      * All other filters are ignored.
      *
      * <p>Filtering by IDs set via {@code EntityIdFilter} is performed

--- a/server/src/main/java/org/spine3/server/entity/idfunc/GetIdByFieldIndex.java
+++ b/server/src/main/java/org/spine3/server/entity/idfunc/GetIdByFieldIndex.java
@@ -32,7 +32,8 @@ import org.spine3.server.error.MissingEntityIdException;
  *
  * @param <I> the type of entity IDs
  * @param <M> the type of messages to get IDs from
- * @param <C> either {@link org.spine3.base.EventContext} or {@link org.spine3.base.CommandContext} type
+ * @param <C> either {@link org.spine3.base.EventContext EventContext} or
+ *            {@link org.spine3.base.CommandContext CommandContext} type
  */
 abstract class GetIdByFieldIndex<I, M extends Message, C extends Message> implements IdFunction<I, M, C> {
 
@@ -50,7 +51,8 @@ abstract class GetIdByFieldIndex<I, M extends Message, C extends Message> implem
     /**
      * {@inheritDoc}
      *
-     * @throws MissingEntityIdException if the field name does not end with the {@link Identifiers#ID_PROPERTY_SUFFIX}.
+     * @throws MissingEntityIdException if the field name does not end with
+     *          the {@link Identifiers#ID_PROPERTY_SUFFIX}.
      * @throws ClassCastException if the field type is invalid
      */
     @Override
@@ -68,8 +70,10 @@ abstract class GetIdByFieldIndex<I, M extends Message, C extends Message> implem
         }
 
         @Override
-        protected RuntimeException createUnavailableFieldException(Message message, String fieldName) {
-            return new MissingEntityIdException(message.getClass().getName(), fieldName, getIndex());
+        protected RuntimeException createUnavailableFieldException(Message message,
+                                                                   String fieldName) {
+            return new MissingEntityIdException(message.getClass().getName(),
+                                                fieldName, getIndex());
         }
 
         @Override

--- a/server/src/main/java/org/spine3/server/entity/idfunc/GetProducerIdFromEvent.java
+++ b/server/src/main/java/org/spine3/server/entity/idfunc/GetProducerIdFromEvent.java
@@ -27,7 +27,8 @@ import org.spine3.base.EventContext;
  * Obtains an event producer ID based on an event {@link Message} and context.
  *
  * <p>An ID must be the first field in event messages (in Protobuf definition).
- * Its name must end with the {@link org.spine3.base.Identifiers#ID_PROPERTY_SUFFIX}.
+ * Its name must end with the
+ * {@link org.spine3.base.Identifiers#ID_PROPERTY_SUFFIX Identifiers.ID_PROPERTY_SUFFIX}.
  *
  * @param <I> the type of target entity IDs
  * @param <M> the type of event messages to get IDs from

--- a/server/src/main/java/org/spine3/server/entity/idfunc/IdFunction.java
+++ b/server/src/main/java/org/spine3/server/entity/idfunc/IdFunction.java
@@ -28,7 +28,8 @@ import org.spine3.server.entity.Entity;
  *
  * @param <I> the type of entity IDs
  * @param <M> the type of messages to get IDs from
- * @param <C> either {@link org.spine3.base.EventContext} or {@link org.spine3.base.CommandContext} type
+ * @param <C> either {@link org.spine3.base.EventContext EventContext} or
+ *          {@link org.spine3.base.CommandContext CommandContext} type
  * @see Entity
  */
 interface IdFunction<I, M extends Message, C extends Message> {
@@ -37,7 +38,8 @@ interface IdFunction<I, M extends Message, C extends Message> {
      * Obtains an entity ID based on the passed event or command message and its context.
      *
      * @param message an event or command message to use to get an ID
-     * @param context either {@link org.spine3.base.EventContext} or {@link org.spine3.base.CommandContext} instance
+     * @param context either {@link org.spine3.base.EventContext EventContext} or
+     *              {@link org.spine3.base.CommandContext CommandContext} instance
      * @return an entity ID
      */
     I apply(M message, C context);

--- a/server/src/main/java/org/spine3/server/entity/idfunc/IdSetFunction.java
+++ b/server/src/main/java/org/spine3/server/entity/idfunc/IdSetFunction.java
@@ -29,7 +29,8 @@ import java.util.Set;
  *
  * @param <I> the type of entity IDs
  * @param <M> the type of messages to get IDs from
- * @param <C> either {@link org.spine3.base.EventContext} or {@link org.spine3.base.CommandContext} type
+ * @param <C> either {@link org.spine3.base.EventContext EventContext} or \
+ *              {@link org.spine3.base.CommandContext CommandContext} type
  * @author Alexander Yevsyukov
  */
 public interface IdSetFunction<I, M extends Message, C extends Message> {
@@ -38,7 +39,8 @@ public interface IdSetFunction<I, M extends Message, C extends Message> {
      * Obtains a set of entity IDs based on the passed event or command message and its context.
      *
      * @param message an event or a command message
-     * @param context either {@link org.spine3.base.EventContext} or {@link org.spine3.base.CommandContext} instance
+     * @param context either {@link org.spine3.base.EventContext EventContext} or
+     *                  {@link org.spine3.base.CommandContext CommandContext} instance
      * @return a set of entity identifiers
      */
     Set<I> apply(M message, C context);

--- a/server/src/main/java/org/spine3/server/error/MissingEntityIdException.java
+++ b/server/src/main/java/org/spine3/server/error/MissingEntityIdException.java
@@ -22,8 +22,9 @@ package org.spine3.server.error;
 import static org.spine3.base.Identifiers.ID_PROPERTY_SUFFIX;
 
 /**
- * This exception is thrown if the corresponding Protobuf command/event message definition does not have
- * an entity ID field whose name ends with the {@link org.spine3.base.Identifiers#ID_PROPERTY_SUFFIX}.
+ * This exception is thrown if the corresponding Protobuf command/event message definition
+ * does not have an entity ID field whose name ends with
+ * the {@link org.spine3.base.Identifiers#ID_PROPERTY_SUFFIX Identifiers.ID_PROPERTY_SUFFIX}.
  *
  * @author Alexander Litus
  */
@@ -35,10 +36,14 @@ public class MissingEntityIdException extends RuntimeException {
         super(createMessage(messageClassName, propertyName, fieldIndex));
     }
 
-    private static String createMessage(String messageClassName, String propertyName, int fieldIndex) {
-        final String message = "The property with the index '" + fieldIndex + "' of the entity message " + messageClassName +
-                " must define an entity ID with the name ending with '" + ID_PROPERTY_SUFFIX +
-                "'. Found property with the name: " + propertyName;
+    private static String createMessage(String messageClassName,
+                                        String propertyName,
+                                        int fieldIndex) {
+        final String message = "The property with the index '" + fieldIndex +
+                               "' of the entity message " + messageClassName +
+                               " must define an entity ID with the name ending with '" +
+                               ID_PROPERTY_SUFFIX +
+                               "'. Found property with the name: " + propertyName;
         return message;
     }
 }

--- a/server/src/main/java/org/spine3/server/event/DispatcherEventDelivery.java
+++ b/server/src/main/java/org/spine3/server/event/DispatcherEventDelivery.java
@@ -46,7 +46,8 @@ public abstract class DispatcherEventDelivery extends EventDelivery<EventDispatc
 
     /**
      * Creates an instance of event executor with a
-     * {@link com.google.common.util.concurrent.MoreExecutors#directExecutor()} used for event dispatching.
+     * {@link com.google.common.util.concurrent.MoreExecutors#directExecutor() MoreExecutors.directExecutor()}
+     * used for event dispatching.
      *
      * @see EventDelivery#EventDelivery()
      */
@@ -65,8 +66,10 @@ public abstract class DispatcherEventDelivery extends EventDelivery<EventDispatc
     }
 
     /**
-     * Obtains a pre-defined instance of the {@code DispatcherEventDelivery}, which does NOT postpone any
-     * event dispatching and uses {@link com.google.common.util.concurrent.MoreExecutors#directExecutor()} for operation.
+     * Obtains a pre-defined instance of the {@code DispatcherEventDelivery}, which does NOT
+     * postpone any event dispatching and uses
+     * {@link com.google.common.util.concurrent.MoreExecutors#directExecutor() MoreExecutors.directExecutor()}
+     * for operation.
      *
      * @return the pre-configured default executor.
      */
@@ -78,8 +81,10 @@ public abstract class DispatcherEventDelivery extends EventDelivery<EventDispatc
     private static final class PredefinedDeliveryStrategies {
 
         /**
-         * A pre-defined instance of the {@code DispatcherEventDelivery}, which does not postpone any event dispatching
-         * and uses {@link com.google.common.util.concurrent.MoreExecutors#directExecutor()} for operation.
+         * A pre-defined instance of the {@code DispatcherEventDelivery}, which does not
+         * postpone any event dispatching and uses
+         * {@link com.google.common.util.concurrent.MoreExecutors#directExecutor() MoreExecutors.directExecutor()}
+         * for operation.
          */
         private static final DispatcherEventDelivery DIRECT_DELIVERY = new DispatcherEventDelivery() {
             @Override

--- a/server/src/main/java/org/spine3/server/event/DispatcherEventDelivery.java
+++ b/server/src/main/java/org/spine3/server/event/DispatcherEventDelivery.java
@@ -81,8 +81,8 @@ public abstract class DispatcherEventDelivery extends EventDelivery<EventDispatc
     private static final class PredefinedDeliveryStrategies {
 
         /**
-         * A pre-defined instance of the {@code DispatcherEventDelivery}, which does not
-         * postpone any event dispatching and uses
+         * A pre-defined instance of the {@code DispatcherEventDelivery},
+         * which does not postpone any event dispatching and uses
          * {@link com.google.common.util.concurrent.MoreExecutors#directExecutor() MoreExecutors.directExecutor()}
          * for operation.
          */

--- a/server/src/main/java/org/spine3/server/event/EventBus.java
+++ b/server/src/main/java/org/spine3/server/event/EventBus.java
@@ -55,7 +55,8 @@ import static com.google.common.base.Preconditions.checkState;
  * <p>To receive event messages a subscriber object should:
  * <ol>
  *    <li>Expose a {@code public} method that accepts an event message as the first parameter
- *        and an {@link org.spine3.base.EventContext} as the second (optional) parameter.
+ *        and an {@link org.spine3.base.EventContext EventContext} as the second
+ *        (optional) parameter.
  *    <li>Mark the method with the {@link Subscribe @Subscribe} annotation.
  *    <li>{@linkplain #subscribe(EventSubscriber) Register} with an instance of
  *    {@code EventBus} directly, or rely on message delivery from an {@link EventDispatcher}.
@@ -152,7 +153,8 @@ public class EventBus implements AutoCloseable {
             @Override
             public Set<EventDispatcher> apply(@Nullable EventClass eventClass) {
                 checkNotNull(eventClass);
-                final Set<EventDispatcher> dispatchers = dispatcherRegistry.getDispatchers(eventClass);
+                final Set<EventDispatcher> dispatchers =
+                        dispatcherRegistry.getDispatchers(eventClass);
                 return dispatchers;
             }
         });
@@ -164,7 +166,8 @@ public class EventBus implements AutoCloseable {
             @Override
             public Set<EventSubscriber> apply(@Nullable EventClass eventClass) {
                 checkNotNull(eventClass);
-                final Set<EventSubscriber> subscribers = subscriberRegistry.getSubscribers(eventClass);
+                final Set<EventSubscriber> subscribers =
+                        subscriberRegistry.getSubscribers(eventClass);
                 return subscribers;
             }
         });
@@ -291,7 +294,8 @@ public class EventBus implements AutoCloseable {
      */
     private int callDispatchers(Event event) {
         final EventClass eventClass = EventClass.of(event);
-        final Collection<EventDispatcher> dispatchers = dispatcherRegistry.getDispatchers(eventClass);
+        final Collection<EventDispatcher> dispatchers =
+                dispatcherRegistry.getDispatchers(eventClass);
         dispatcherEventDelivery.deliver(event);
         return dispatchers.size();
     }
@@ -364,7 +368,9 @@ public class EventBus implements AutoCloseable {
 
         if (enricher == null) {
             enricher = EventEnricher.newBuilder()
-                                    .addFieldEnrichment(eventFieldClass, enrichmentFieldClass, function)
+                                    .addFieldEnrichment(eventFieldClass,
+                                                        enrichmentFieldClass,
+                                                        function)
                                     .build();
         } else {
             enricher.registerFieldEnrichment(eventFieldClass, enrichmentFieldClass, function);

--- a/server/src/main/java/org/spine3/server/event/EventDelivery.java
+++ b/server/src/main/java/org/spine3/server/event/EventDelivery.java
@@ -30,8 +30,8 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 
 /**
- * Base functionality for the routines delivering the {@link org.spine3.base.Event}s to event consumers,
- * such as {@link EventDispatcher}s or {@link EventSubscriber}s.
+ * Base functionality for the routines delivering the {@linkplain org.spine3.base.Event Events}
+ * to event consumers, such as {@link EventDispatcher}s or {@link EventSubscriber}s.
  *
  * @param <C> the type of the consumer
  * @author Alex Tymchenko
@@ -51,7 +51,8 @@ abstract class EventDelivery<C> extends Delivery<Event, C> {
         super();
     }
 
-    /** Used by the instance of {@link EventBus} to inject the knowledge about up-to-date consumers for the event */
+    /** Used by the instance of {@link EventBus} to inject the knowledge about
+     * up-to-date consumers for the event */
     void setConsumerProvider(Function<EventClass, Set<C>> consumerProvider) {
         this.consumerProvider = consumerProvider;
     }

--- a/server/src/main/java/org/spine3/server/event/Subscribe.java
+++ b/server/src/main/java/org/spine3/server/event/Subscribe.java
@@ -33,12 +33,15 @@ import java.lang.annotation.Target;
  *     <li>is annotated with {@link Subscribe};
  *     <li>is {@code public};
  *     <li>returns {@code void};
- *     <li>accepts an event derived from {@link com.google.protobuf.Message} as the first parameter;
- *     <li>(optional) accepts an {@link org.spine3.base.EventContext} as the second parameter.
+ *     <li>accepts an event derived from {@link com.google.protobuf.Message Message}
+ *          as the first parameter;
+ *     <li>(optional) accepts an {@link org.spine3.base.EventContext EventContext}
+ *          as the second parameter.
  * </ul>
  *
- * If the annotation is applied to a method which doesn't satisfy any of these requirements, this method is not
- * considered as an event subscriber and is not registered for event delivery from {@link EventBus}.
+ * If the annotation is applied to a method which doesn't satisfy any of these requirements,
+ * this method is not considered as an event subscriber and is not registered for event delivery
+ * from {@link EventBus}.
  *
  * @author Alexander Yevsyukov
  */

--- a/server/src/main/java/org/spine3/server/event/enrich/EventEnricher.java
+++ b/server/src/main/java/org/spine3/server/event/enrich/EventEnricher.java
@@ -51,6 +51,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Collections2.filter;
 import static com.google.common.collect.FluentIterable.from;
+import static com.google.common.collect.LinkedListMultimap.*;
+import static com.google.common.collect.Multimaps.*;
 import static org.spine3.base.Events.createEvent;
 import static org.spine3.base.Events.getMessage;
 import static org.spine3.base.Events.isEnrichmentEnabled;
@@ -64,10 +66,11 @@ import static org.spine3.protobuf.Messages.toMessageClass;
  * Enterprise Integration pattern.
  *
  * <p>There is one instance of an {@code EventEnricher} per {@code BoundedContext}.
- * This instance is called by an {@link org.spine3.server.event.EventBus} to enrich a new event before it
- * is passed to further processing by dispatchers or handlers.
+ * This instance is called by an {@link org.spine3.server.event.EventBus EventBus} to enrich
+ * a new event before it is passed to further processing by dispatchers or handlers.
  *
- * <p>The event is passed to enrichment <em>after</em> it was passed to the {@link org.spine3.server.event.EventStore}.
+ * <p>The event is passed to enrichment <em>after</em> it was passed to the
+ * {@link org.spine3.server.event.EventStore EventStore}.
  * Therefore events are stored without attached enrichment information.
  *
  * @author Alexander Yevsyukov
@@ -90,8 +93,8 @@ public class EventEnricher {
      * <p>Also adds {@link EventMessageEnricher}s for all enrichments defined in Protobuf.
      */
     EventEnricher(Builder builder) {
-        final LinkedListMultimap<Class<?>, EnrichmentFunction<?, ?>> rawMap = LinkedListMultimap.create();
-        final Multimap<Class<?>, EnrichmentFunction<?, ?>> functionMap = Multimaps.synchronizedMultimap(rawMap);
+        final LinkedListMultimap<Class<?>, EnrichmentFunction<?, ?>> rawMap = create();
+        final Multimap<Class<?>, EnrichmentFunction<?, ?>> functionMap = synchronizedMultimap(rawMap);
         for (EnrichmentFunction<?, ?> function : builder.getFunctions()) {
             functionMap.put(function.getEventClass(), function);
         }

--- a/server/src/main/java/org/spine3/server/event/enrich/EventEnricher.java
+++ b/server/src/main/java/org/spine3/server/event/enrich/EventEnricher.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
@@ -51,8 +50,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Collections2.filter;
 import static com.google.common.collect.FluentIterable.from;
-import static com.google.common.collect.LinkedListMultimap.*;
-import static com.google.common.collect.Multimaps.*;
+import static com.google.common.collect.LinkedListMultimap.create;
+import static com.google.common.collect.Multimaps.synchronizedMultimap;
 import static org.spine3.base.Events.createEvent;
 import static org.spine3.base.Events.getMessage;
 import static org.spine3.base.Events.isEnrichmentEnabled;
@@ -113,9 +112,10 @@ public class EventEnricher {
             final ImmutableCollection<String> eventTypes = enrichmentsMap.get(enrichmentType);
             for (String eventType : eventTypes) {
                 final Class<Message> eventClass = toMessageClass(TypeUrl.of(eventType));
-                final EventMessageEnricher msgEnricher = EventMessageEnricher.newInstance(this,
-                                                                                          eventClass,
-                                                                                          enrichmentClass);
+                final EventMessageEnricher msgEnricher =
+                        EventMessageEnricher.newInstance(this,
+                                                         eventClass,
+                                                         enrichmentClass);
                 functionsMap.put(eventClass, msgEnricher);
             }
         }

--- a/server/src/main/java/org/spine3/server/event/error/EventException.java
+++ b/server/src/main/java/org/spine3/server/event/error/EventException.java
@@ -45,7 +45,8 @@ public abstract class EventException extends RuntimeException {
     /**
      * The event message or the message packed into {@link Any}.
      *
-     * <p>We use {@link GeneratedMessageV3} (not {@code Message}) because it is {@link java.io.Serializable}.
+     * <p>We use {@link GeneratedMessageV3} (not {@code Message}) because
+     * it is {@link java.io.Serializable Serializable}.
      */
     private final GeneratedMessageV3 eventMessage;
 
@@ -66,7 +67,8 @@ public abstract class EventException extends RuntimeException {
         if (eventMessage instanceof GeneratedMessageV3) {
             this.eventMessage = (GeneratedMessageV3) eventMessage;
         } else {
-            // In an unlikely case on encountering a message, which is not `GeneratedMessageV3`, wrap it into `Any`.
+            // In an unlikely case on encountering a message, which is not `GeneratedMessageV3`,
+            // wrap it into `Any`.
             this.eventMessage = AnyPacker.pack(eventMessage);
         }
         this.error = error;

--- a/server/src/main/java/org/spine3/server/integration/IntegrationEventBus.java
+++ b/server/src/main/java/org/spine3/server/integration/IntegrationEventBus.java
@@ -44,14 +44,16 @@ import static org.spine3.server.integration.grpc.IntegrationEventSubscriberGrpc.
  * Allows to register {@link IntegrationEvent} subscribers and deliver events to them.
  *
  * <p>An integration event is sent between loosely coupled parts of a system.
- * Typically such parts would be implemented as {@link org.spine3.server.BoundedContext}s.
+ * Typically such parts would be implemented as
+ * {@link org.spine3.server.BoundedContext BoundedContext}s.
  *
  * @see Subscribe
  * @see EventBus
  */
 public class IntegrationEventBus {
 
-    private final Multimap<EventClass, IntegrationEventSubscriberImplBase> subscribersMap = HashMultimap.create();
+    private final Multimap<EventClass, IntegrationEventSubscriberImplBase> subscribersMap =
+            HashMultimap.create();
 
     private StreamObserver<Response> responseObserver = new DefaultResponseObserver();
 
@@ -60,7 +62,8 @@ public class IntegrationEventBus {
         return instance();
     }
 
-    /** Sets a response observer used in {@link IntegrationEventSubscriberImplBase#notify(IntegrationEvent, StreamObserver)}. */
+    /** Sets a response observer used in
+     * {@link IntegrationEventSubscriberImplBase#notify(IntegrationEvent, StreamObserver)}. */
     public void setResponseObserver(StreamObserver<Response> responseObserver) {
         this.responseObserver = responseObserver;
     }
@@ -78,8 +81,11 @@ public class IntegrationEventBus {
     public void post(IntegrationEvent event) {
         final Message msg = unpack(event.getMessage());
         final EventClass eventClass = EventClass.of(msg);
-        final Collection<IntegrationEventSubscriberImplBase> subscribers = subscribersMap.get(eventClass);
-        checkArgument(!subscribers.isEmpty(), "No integration event subscribers found for event " + msg.getClass().getName());
+        final Collection<IntegrationEventSubscriberImplBase> subscribers =
+                subscribersMap.get(eventClass);
+        checkArgument(!subscribers.isEmpty(),
+                      "No integration event subscribers found for event " +
+                                msg.getClass().getName());
         for (IntegrationEventSubscriberImplBase subscriber : subscribers) {
             subscriber.notify(event, responseObserver);
         }
@@ -88,10 +94,12 @@ public class IntegrationEventBus {
     /**
      * Subscribes the passed object to receive {@link IntegrationEvent}s of the specified classes.
      *
-     * @param subscriber a subscriber to register (typically it is a {@link org.spine3.server.BoundedContext})
+     * @param subscriber a subscriber to register (typically it is a
+     *                  {@link org.spine3.server.BoundedContext BoundedContext})
      * @param eventClasses classes of integration event messages handled by the subscriber
      */
-    public void subscribe(IntegrationEventSubscriberImplBase subscriber, Iterable<Class<? extends Message>> eventClasses) {
+    public void subscribe(IntegrationEventSubscriberImplBase subscriber,
+                          Iterable<Class<? extends Message>> eventClasses) {
         checkNotNull(subscriber);
         for (Class<? extends Message> eventClass : eventClasses) {
             subscribersMap.put(EventClass.of(eventClass), subscriber);
@@ -105,7 +113,8 @@ public class IntegrationEventBus {
      * @param eventClasses classes of integration event messages handled by the subscriber
      */
     @SafeVarargs
-    public final void subscribe(IntegrationEventSubscriberImplBase subscriber, Class<? extends Message>... eventClasses) {
+    public final void subscribe(IntegrationEventSubscriberImplBase subscriber,
+                                Class<? extends Message>... eventClasses) {
         subscribe(subscriber, FluentIterable.from(eventClasses));
     }
 

--- a/server/src/main/java/org/spine3/server/reflect/HandlerMethod.java
+++ b/server/src/main/java/org/spine3/server/reflect/HandlerMethod.java
@@ -41,7 +41,8 @@ import static com.google.common.base.Throwables.throwIfUnchecked;
  *
  * @author Mikhail Melnik
  * @author Alexander Yevsyukov
- * @param <C> the type of the message context or {@link com.google.protobuf.Empty} if a context parameter is never used
+ * @param <C> the type of the message context or {@link com.google.protobuf.Empty Empty} if
+ *           a context parameter is never used
  */
 public abstract class HandlerMethod<C extends Message> {
 

--- a/server/src/main/java/org/spine3/server/stand/AggregateQueryProcessor.java
+++ b/server/src/main/java/org/spine3/server/stand/AggregateQueryProcessor.java
@@ -44,7 +44,7 @@ import java.util.Collection;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Processes the queries targeting {@link org.spine3.server.aggregate.Aggregate} state.
+ * Processes the queries targeting {@link org.spine3.server.aggregate.Aggregate Aggregate} state.
  *
  * @author Alex Tymchenko
  */

--- a/server/src/main/java/org/spine3/server/stand/AggregateStateId.java
+++ b/server/src/main/java/org/spine3/server/stand/AggregateStateId.java
@@ -26,11 +26,12 @@ import org.spine3.protobuf.TypeUrl;
 import javax.annotation.CheckReturnValue;
 
 /**
- * An identifier for the state of a certain {@link org.spine3.server.aggregate.Aggregate}.
+ * An identifier for the state of a certain {@link org.spine3.server.aggregate.Aggregate Aggregate}.
  *
- * <p>{@code Aggregate} state is defined by {@link org.spine3.protobuf.TypeUrl}.
+ * <p>{@code Aggregate} state is defined by {@link org.spine3.protobuf.TypeUrl TypeUrl}.
  *
- * <p>The {@code AggregateStateId} is used to store and access the latest {@code Aggregate} states in a {@link Stand}.
+ * <p>The {@code AggregateStateId} is used to store and access the latest {@code Aggregate}
+ * states in a {@link Stand}.
  *
  * @param <I> the type for IDs of the source aggregate
  * @author Alex Tymchenko

--- a/server/src/main/java/org/spine3/server/stand/EntityQueryProcessor.java
+++ b/server/src/main/java/org/spine3/server/stand/EntityQueryProcessor.java
@@ -32,7 +32,7 @@ import org.spine3.server.entity.Entity;
 import org.spine3.server.entity.RecordBasedRepository;
 
 /**
- * Processes the queries targeting {@link org.spine3.server.entity.Entity} objects.
+ * Processes the queries targeting {@link org.spine3.server.entity.Entity Entity} objects.
  *
  * @author Alex Tymchenko
  */

--- a/server/src/main/java/org/spine3/server/stand/Stand.java
+++ b/server/src/main/java/org/spine3/server/stand/Stand.java
@@ -50,25 +50,28 @@ import java.util.concurrent.Executor;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * A container for storing the lastest {@link org.spine3.server.aggregate.Aggregate} states.
+ * A container for storing the lastest {@link org.spine3.server.aggregate.Aggregate Aggregate} states.
  *
- * <p>Provides an optimal way to access the latest state of published aggregates for read-side services.
- * The aggregate states are delivered to the instance of {@code Stand} through {@link StandFunnel}
- * from {@link AggregateRepository} instances.
+ * <p>Provides an optimal way to access the latest state of published aggregates for read-side
+ * services. The aggregate states are delivered to the instance of {@code Stand} through
+ * {@link StandFunnel} from {@link AggregateRepository} instances.
  *
- * <p>In order to provide a flexibility in defining data access policies, {@code Stand} contains only the states
- * of published aggregates. Please refer to {@link org.spine3.server.aggregate.Aggregate} for publication description.
+ * <p>In order to provide a flexibility in defining data access policies, {@code Stand} contains
+ * only the states of published aggregates. Please refer to
+ * {@link org.spine3.server.aggregate.Aggregate Aggregate} for publication description.
  *
- * <p>Each {@link org.spine3.server.BoundedContext} contains the only instance of {@code Stand}.
+ * <p>Each {@link org.spine3.server.BoundedContext BoundedContext} contains the only instance
+ * of {@code Stand}.
  *
  * @author Alex Tymchenko
  */
 public class Stand implements AutoCloseable {
 
     /**
-     * Persistent storage for the latest {@link org.spine3.server.aggregate.Aggregate} states.
+     * Persistent storage for the latest {@link org.spine3.server.aggregate.Aggregate Aggregate} states.
      *
-     * <p>Any {@code Aggregate} state delivered to this instance of {@code Stand} is persisted to this storage.
+     * <p>Any {@code Aggregate} state delivered to this instance of {@code Stand} is
+     * persisted to this storage.
      */
     private final StandStorage storage;
 
@@ -83,18 +86,21 @@ public class Stand implements AutoCloseable {
     private final Executor callbackExecutor;
 
     /**
-     * The mapping between {@code TypeUrl} instances and repositories providing the entities of this type
+     * The mapping between {@code TypeUrl} instances and repositories providing
+     * the entities of this type
      */
     private final ConcurrentMap<TypeUrl,
-            RecordBasedRepository<?, ? extends Entity, ? extends Message>> typeToRepositoryMap = new ConcurrentHashMap<>();
+            RecordBasedRepository<?, ? extends Entity, ? extends Message>> typeToRepositoryMap =
+            new ConcurrentHashMap<>();
 
     /**
-     * Stores  known {@link org.spine3.server.aggregate.Aggregate} types in order to distinguish them among all
+     * Stores  known {@link org.spine3.server.aggregate.Aggregate Aggregate} types in order to
+     * distinguish them among all
      * instances of {@code TypeUrl}.
      *
-     * <p>Once this instance of {@code Stand} receives an update as {@link Any}, the {@code Aggregate} states
-     * are persisted for further usage. The entities that are not {@code Aggregate} are not persisted,
-     * and only propagated to the registered callbacks.
+     * <p>Once this instance of {@code Stand} receives an update as {@link Any},
+     * the {@code Aggregate} states are persisted for further usage. The entities that are not
+     * {@code Aggregate} are not persisted, and only propagated to the registered callbacks.
      */
     private final Set<TypeUrl> knownAggregateTypes = Sets.newConcurrentHashSet();
 
@@ -115,18 +121,23 @@ public class Stand implements AutoCloseable {
     /**
      * Update the state of an entity inside of the current instance of {@code Stand}.
      *
-     * <p>In case the entity update represents the new {@link org.spine3.server.aggregate.Aggregate} state,
-     * store the new value for the {@code Aggregate} to each of the configured instances of {@link StandStorage}.
+     * <p>In case the entity update represents the new
+     * {@link org.spine3.server.aggregate.Aggregate Aggregate} state,
+     * store the new value for the {@code Aggregate} to each of the configured instances
+     * of {@link StandStorage}.
      *
-     * <p>Each {@code Aggregate } state value is stored as one-to-one to its {@link org.spine3.protobuf.TypeUrl}
-     * obtained via {@link Any#getTypeUrl()}.
+     * <p>Each {@code Aggregate } state value is stored as one-to-one to its
+     * {@link org.spine3.protobuf.TypeUrl TypeUrl} obtained via {@link Any#getTypeUrl()}.
      *
-     * <p>In case {@code Stand} already contains the state for this {@code Aggregate}, the value will be replaced.
+     * <p>In case {@code Stand} already contains the state for this {@code Aggregate}, the value
+     * will be replaced.
      *
-     * <p>The state updates which are not originated from the {@code Aggregate} are not stored in the {@code Stand}.
+     * <p>The state updates which are not originated from the {@code Aggregate} are not stored
+     * in the {@code Stand}.
      *
-     * <p>In any case, the state update is then propagated to the callbacks. The set of matched callbacks
-     * is determined by filtering all the registered callbacks by the entity {@code TypeUrl}.
+     * <p>In any case, the state update is then propagated to the callbacks. The set of matched
+     * callbacks is determined by filtering all the registered callbacks by
+     * the entity {@code TypeUrl}.
      *
      * <p>The matching callbacks are executed with the {@link #callbackExecutor}.
      *
@@ -143,11 +154,12 @@ public class Stand implements AutoCloseable {
         if (isAggregateUpdate) {
             final AggregateStateId aggregateStateId = AggregateStateId.of(id, typeUrl);
 
-            final EntityStorageRecord record = EntityStorageRecord.newBuilder()
-                                                                  .setState(entityState)
-                                                                  .setWhenModified(Timestamps.getCurrentTime())
-                                                                  .setVersion(entityVersion)
-                                                                  .build();
+            final EntityStorageRecord record =
+                    EntityStorageRecord.newBuilder()
+                                       .setState(entityState)
+                                       .setWhenModified(Timestamps.getCurrentTime())
+                                       .setVersion(entityVersion)
+                                       .build();
             storage.write(aggregateStateId, record);
         }
 
@@ -157,8 +169,8 @@ public class Stand implements AutoCloseable {
     /**
      * Subscribe for all further changes of an entity state, which satisfies the {@link Target}.
      *
-     * <p>Once this instance of {@code Stand} receives an update of an entity with the given {@code TypeUrl},
-     * all such callbacks are executed.
+     * <p>Once this instance of {@code Stand} receives an update of an entity with
+     * the given {@code TypeUrl}, all such callbacks are executed.
      *
      * @param target an instance {@link Target}, defining the entity and criteria,
      *               which changes should be propagated to the {@code callback}
@@ -172,8 +184,9 @@ public class Stand implements AutoCloseable {
     /**
      * Activate the subscription created via {@link #subscribe(Target)}.
      *
-     * <p>After the activation, the clients will start receiving the updates via {@code EntityUpdateCallback}
-     * upon the changes in the entities, defined by the {@code Target} attribute used for this subscription.
+     * <p>After the activation, the clients will start receiving the updates via
+     * {@code EntityUpdateCallback} upon the changes in the entities, defined by the {@code Target}
+     * attribute used for this subscription.
      *
      * @param subscription the subscription to activate.
      * @param callback     an instance of {@link EntityUpdateCallback} executed upon entity update.
@@ -186,7 +199,8 @@ public class Stand implements AutoCloseable {
     /**
      * Cancel the {@link Subscription}.
      *
-     * <p>Typically invoked to cancel the previous {@link #activate(Subscription, EntityUpdateCallback)} call.
+     * <p>Typically invoked to cancel the previous
+     * {@link #activate(Subscription, EntityUpdateCallback)} call.
      * <p>After this method is called, the subscribers stop receiving the updates,
      * related to the given {@code Subscription}.
      *
@@ -216,8 +230,8 @@ public class Stand implements AutoCloseable {
     }
 
     /**
-     * Read all {@link org.spine3.server.aggregate.Aggregate} entity types exposed for reading
-     * by this instance of {@code Stand}.
+     * Read all {@link org.spine3.server.aggregate.Aggregate Aggregate} entity types
+     * exposed for reading by this instance of {@code Stand}.
      *
      * <p>Use {@link Stand#registerTypeSupplier(Repository)} to expose an {@code Aggregate} type.
      *
@@ -230,7 +244,8 @@ public class Stand implements AutoCloseable {
     }
 
     /**
-     * Read a particular set of items from the read-side of the application and feed the result into an instance
+     * Read a particular set of items from the read-side of the application and feed the result
+     * into an instance
      *
      * <p>{@link Query} defines the query target and the expected detail level for response.
      *
@@ -277,14 +292,14 @@ public class Stand implements AutoCloseable {
 
     /**
      * Register a supplier for the objects of a certain {@link TypeUrl} to be able
-     * to read them in response to a {@link org.spine3.client.Query}.
+     * to read them in response to a {@link org.spine3.client.Query Query}.
      *
-     * <p>In case the supplier is an instance of {@link AggregateRepository}, the {@code Repository} is not registered
-     * as type supplier, since the {@code Aggregate} reads are performed by accessing
-     * the latest state in the supplied {@code StandStorage}.
+     * <p>In case the supplier is an instance of {@link AggregateRepository}, the {@code Repository}
+     * is not registered as type supplier, since the {@code Aggregate} reads are performed
+     * by accessing the latest state in the supplied {@code StandStorage}.
      *
-     * <p>However, the type of the {@code AggregateRepository} instance is recorded for the postponed processing
-     * of updates.
+     * <p>However, the type of the {@code AggregateRepository} instance is recorded for
+     * the postponed processing of updates.
      *
      * @see #update(Object, Any, int)
      */
@@ -293,7 +308,8 @@ public class Stand implements AutoCloseable {
         final TypeUrl entityType = repository.getEntityStateType();
 
         if (repository instanceof RecordBasedRepository) {
-            typeToRepositoryMap.put(entityType, (RecordBasedRepository<I, E, ? extends Message>) repository);
+            typeToRepositoryMap.put(entityType,
+                                    (RecordBasedRepository<I, E, ? extends Message>) repository);
         }
         if (repository instanceof AggregateRepository) {
             knownAggregateTypes.add(entityType);
@@ -326,12 +342,13 @@ public class Stand implements AutoCloseable {
     }
 
     /**
-     * Factory method which determines a proper {@link QueryProcessor} implementation depending on {@link TypeUrl}
-     * of the incoming {@link Query#getTarget()}.
+     * Factory method which determines a proper {@link QueryProcessor} implementation depending on
+     * {@link TypeUrl} of the incoming {@link Query#getTarget()}.
      *
-     * <p>As {@code Stand} accumulates the read-side updates from various repositories, the {@code Query} processing
-     * varies a lot. The target type of the incoming {@code Query} tells the {@code Stand} about the essence of the
-     * object queried. Thus making it possible to pick a proper strategy for data fetch.
+     * <p>As {@code Stand} accumulates the read-side updates from various repositories,
+     * the {@code Query} processing varies a lot. The target type of the incoming {@code Query}
+     * tells the {@code Stand} about the essence of the object queried. Thus making it possible to
+     * pick a proper strategy for data fetch.
      *
      * @param type the target type of the {@code Query}
      * @return suitable implementation of {@code QueryProcessor}
@@ -339,7 +356,8 @@ public class Stand implements AutoCloseable {
     private QueryProcessor processorFor(TypeUrl type) {
         final QueryProcessor result;
 
-        final RecordBasedRepository<?, ? extends Entity, ? extends Message> repository = typeToRepositoryMap.get(type);
+        final RecordBasedRepository<?, ? extends Entity, ? extends Message> repository =
+                typeToRepositoryMap.get(type);
         if (repository != null) {
 
             // The query target is an {@code Entity}.
@@ -350,7 +368,8 @@ public class Stand implements AutoCloseable {
             result = new AggregateQueryProcessor(storage, type);
         } else {
 
-            // This type points to an objects, that are not exposed via the current instance of {@code Stand}.
+            // This type points to an objects, that are not exposed via the current
+            // instance of {@code Stand}.
             result = NOOP_PROCESSOR;
         }
         return result;
@@ -361,10 +380,11 @@ public class Stand implements AutoCloseable {
         private Executor callbackExecutor;
 
         /**
-         * Set an instance of {@link StandStorage} to be used to persist the latest an Aggregate states.
+         * Set an instance of {@link StandStorage} to be used to persist the latest
+         * an Aggregate states.
          *
-         * <p>If no {@code storage} is assigned, the result of {@link InMemoryStorageFactory#createStandStorage()}
-         * will be set by default.
+         * <p>If no {@code storage} is assigned, the result of
+         * {@link InMemoryStorageFactory#createStandStorage()} will be set by default.
          *
          * @param storage an instance of {@code StandStorage}
          * @return this instance of {@code Builder}
@@ -381,7 +401,8 @@ public class Stand implements AutoCloseable {
         /**
          * Set an {@code Executor} to be used for executing callback methods.
          *
-         * <p>If the {@code Executor} is not set, {@link MoreExecutors#directExecutor()} will be used.
+         * <p>If the {@code Executor} is not set, {@link MoreExecutors#directExecutor()}
+         * will be used.
          *
          * @param callbackExecutor the instance of {@code Executor}
          * @return this instance of {@code Builder}

--- a/server/src/main/java/org/spine3/server/stand/Stand.java
+++ b/server/src/main/java/org/spine3/server/stand/Stand.java
@@ -95,8 +95,7 @@ public class Stand implements AutoCloseable {
 
     /**
      * Stores  known {@link org.spine3.server.aggregate.Aggregate Aggregate} types in order to
-     * distinguish them among all
-     * instances of {@code TypeUrl}.
+     * distinguish them among all instances of {@code TypeUrl}.
      *
      * <p>Once this instance of {@code Stand} receives an update as {@link Any},
      * the {@code Aggregate} states are persisted for further usage. The entities that are not

--- a/server/src/main/java/org/spine3/server/stand/StandStorage.java
+++ b/server/src/main/java/org/spine3/server/stand/StandStorage.java
@@ -27,12 +27,12 @@ import org.spine3.server.storage.EntityStorageRecord;
 import org.spine3.server.storage.RecordStorage;
 
 /**
- * Serves as a storage for the latest {@link org.spine3.server.aggregate.Aggregate} states.
+ * Serves as a storage for the latest {@link org.spine3.server.aggregate.Aggregate Aggregate} states.
  *
  * <p>Used by an instance of {@link Stand} to optimize the {@code Aggregate} state fetch performance.
  *
  * @author Alex Tymchenko
- * @see com.google.protobuf.Any#getTypeUrl()
+ * @see com.google.protobuf.Any#getTypeUrl() Any.getTypeUrl()
  * @see Stand
  */
 @SPI
@@ -46,7 +46,8 @@ public abstract class StandStorage extends RecordStorage<AggregateStateId> {
      * Reads all the state records by the given type.
      *
      * @param type a {@link TypeUrl} instance
-     * @return the state records which {@link com.google.protobuf.Any#getTypeUrl()} equals the argument value
+     * @return the state records which {@link com.google.protobuf.Any#getTypeUrl() Any.getTypeUrl()}
+     *          equals the argument value
      */
     public abstract ImmutableCollection<EntityStorageRecord> readAllByType(TypeUrl type);
 
@@ -54,7 +55,8 @@ public abstract class StandStorage extends RecordStorage<AggregateStateId> {
      * Reads all the state records by the given type.
      *
      * @param type a {@link TypeUrl} instance
-     * @return the state records which {@link com.google.protobuf.Any#getTypeUrl()} equals the argument value
+     * @return the state records which {@link com.google.protobuf.Any#getTypeUrl() Any.getTypeUrl()}
+     *          equals the argument value
      */
     public abstract ImmutableCollection<EntityStorageRecord> readAllByType(TypeUrl type, FieldMask fieldMask);
 }

--- a/server/src/main/java/org/spine3/server/stand/StandUpdateDelivery.java
+++ b/server/src/main/java/org/spine3/server/stand/StandUpdateDelivery.java
@@ -34,8 +34,9 @@ import java.util.Collection;
 import java.util.concurrent.Executor;
 
 /**
- * A base class for the strategies on delivering the {@code Entity} state updates to the {@code Stand} from the
- * sources such as {@link org.spine3.server.aggregate.AggregateRepository} and {@link ProjectionRepository} via {@link StandFunnel}.
+ * A base class for the strategies on delivering the {@code Entity} state updates to
+ * the {@code Stand} from the sources such as {@link org.spine3.server.aggregate.AggregateRepository AggregateRepository}
+ * and {@link ProjectionRepository} via {@link StandFunnel}.
  *
  * @author Alex Tymchenko
  */
@@ -75,8 +76,8 @@ public abstract class StandUpdateDelivery extends Delivery<Entity, Stand> {
     }
 
     /**
-     * Returns an instance of {@code StandUpdateDelivery} which does NOT postpone any state update propagation
-     * and uses the specified {@code executor} for the operation.
+     * Returns an instance of {@code StandUpdateDelivery} which does NOT postpone any state
+     * update propagation and uses the specified {@code executor} for the operation.
      *
      * @param executor an instance of {@code Executor} to use for the delivery
      * @return the instance of {@code StandUpdateDelivery} with the given executor
@@ -99,8 +100,8 @@ public abstract class StandUpdateDelivery extends Delivery<Entity, Stand> {
     private static final class PredefinedDeliveryStrategies {
 
         /**
-         * A pre-defined instance of the {@code StandUpdateDelivery}, which does not postpone any update delivery
-         * and uses a default executor for the operation.
+         * A pre-defined instance of the {@code StandUpdateDelivery}, which does not postpone any
+         * update delivery and uses a default executor for the operation.
          */
         private static final StandUpdateDelivery DIRECT_DELIVERY = new StandUpdateDelivery() {
 

--- a/server/src/main/java/org/spine3/server/storage/EntityField.java
+++ b/server/src/main/java/org/spine3/server/storage/EntityField.java
@@ -53,7 +53,7 @@ public enum EntityField implements StorageField {
 
     /**
      * A field for storing the part of a timestamp representing the amount of nanoseconds which is less then
-     * {@link org.spine3.protobuf.Timestamps#NANOS_PER_SECOND 10^9}.
+     * {@link org.spine3.protobuf.Timestamps#NANOS_PER_SECOND  Timestamps.NANOS_PER_SECOND 10^9}.
      *
      * @see Timestamp#getNanos()
      */

--- a/server/src/main/java/org/spine3/server/storage/Storage.java
+++ b/server/src/main/java/org/spine3/server/storage/Storage.java
@@ -33,11 +33,13 @@ public interface Storage extends AutoCloseable {
     /**
      * Verifies is the storage is multitenant.
      *
-     * <p>A multitenant storage should take into account a current tenant (obtained via {@link org.spine3.server.users.CurrentTenant#get()})
+     * <p>A multitenant storage should take into account a current tenant (obtained via
+     * {@link org.spine3.server.users.CurrentTenant#get() CurrentTenant.get() })
      * when performing operations with the data it stores.
      *
-     * @return {@code true} if the storage was created with multitenancy support, {@code false} otherwise
-     * @see org.spine3.server.users.CurrentTenant#get()
+     * @return {@code true} if the storage was created with multitenancy support,
+     *          {@code false} otherwise
+     * @see org.spine3.server.users.CurrentTenant#get() CurrentTenant.get()
      */
     boolean isMultitenant();
 }

--- a/server/src/main/java/org/spine3/server/storage/StorageFactory.java
+++ b/server/src/main/java/org/spine3/server/storage/StorageFactory.java
@@ -30,8 +30,9 @@ import org.spine3.server.stand.StandStorage;
 
 /**
  * A factory for creating storages used by repositories,
- * {@link org.spine3.server.command.CommandStore}, {@link org.spine3.server.event.EventStore},
- * and {@link org.spine3.server.stand.Stand}.
+ * {@link org.spine3.server.command.CommandStore CommandStore},
+ * {@link org.spine3.server.event.EventStore EventStore},
+ * and {@link org.spine3.server.stand.Stand Stand}.
  *
  * @author Alexander Yevsyukov
  */
@@ -40,7 +41,8 @@ public interface StorageFactory extends AutoCloseable {
     /**
      * Verifies if the storage factory is configured to serve a multitenant application.
      *
-     * @return {@code true} if the factory would produce multitenant storages, {@code false} otherwise
+     * @return {@code true} if the factory would produce multitenant storages,
+     *          {@code false} otherwise
      */
     boolean isMultitenant();
 

--- a/server/src/main/java/org/spine3/server/storage/memory/InMemoryStandStorage.java
+++ b/server/src/main/java/org/spine3/server/storage/memory/InMemoryStandStorage.java
@@ -39,7 +39,7 @@ import static com.google.common.base.Preconditions.checkState;
 /**
  * In-memory implementation of {@link StandStorage}.
  *
- * <p>Uses a {@link java.util.concurrent.ConcurrentMap} for internal storage.
+ * <p>Uses a {@link java.util.concurrent.ConcurrentMap ConcurrentMap} for internal storage.
  *
  * @author Alex Tymchenko
  */

--- a/server/src/main/java/org/spine3/server/validate/FieldValidator.java
+++ b/server/src/main/java/org/spine3/server/validate/FieldValidator.java
@@ -91,7 +91,8 @@ abstract class FieldValidator<V> {
      * Checks if the field value is not set.
      *
      * <p>If the field type is {@link Message}, it must be set to a non-default instance;
-     * if it is {@link String} or {@link com.google.protobuf.ByteString}, it must be set to a non-empty string or array.
+     * if it is {@link String} or {@link com.google.protobuf.ByteString ByteString}, it must be
+     * set to a non-empty string or array.
      *
      * @param value a field value to check
      * @return {@code true} if the field is not set, {@code false} otherwise
@@ -99,7 +100,8 @@ abstract class FieldValidator<V> {
     protected abstract boolean isValueNotSet(V value);
 
     /**
-     * Validates messages according to Spine custom protobuf options and returns validation constraint violations found.
+     * Validates messages according to Spine custom protobuf options and returns validation
+     * constraint violations found.
      *
      * <p>The default implementation calls {@link #validateEntityId()} method if needed.
      *
@@ -125,10 +127,11 @@ abstract class FieldValidator<V> {
      */
     protected void validateEntityId() {
         if (fieldDescriptor.isRepeated()) {
-            final ConstraintViolation violation = ConstraintViolation.newBuilder()
-                                                                     .setMsgFormat(ENTITY_ID_REPEATED_FIELD_MSG)
-                                                                     .setFieldPath(getFieldPath())
-                                                                     .build();
+            final ConstraintViolation violation =
+                    ConstraintViolation.newBuilder()
+                                       .setMsgFormat(ENTITY_ID_REPEATED_FIELD_MSG)
+                                       .setFieldPath(getFieldPath())
+                                       .build();
             addViolation(violation);
             return;
         }
@@ -157,7 +160,8 @@ abstract class FieldValidator<V> {
     /**
      * Checks if the field is required and not set and adds violations found.
      *
-     * <p>If the field is repeated, it must have at least one value set, and all its values must be valid.
+     * <p>If the field is repeated, it must have at least one value set, and all its values
+     * must be valid.
      *
      * <p>It is required to override {@link #isValueNotSet(Object)} method to use this one.
      */

--- a/server/src/main/java/org/spine3/server/validate/NumberFieldValidator.java
+++ b/server/src/main/java/org/spine3/server/validate/NumberFieldValidator.java
@@ -82,7 +82,9 @@ abstract class NumberFieldValidator<V extends Number & Comparable<V>> extends Fi
     protected abstract V getAbs(V number);
 
     /**
-     * Wraps a value to a corresponding message wrapper ({@link com.google.protobuf.DoubleValue}, {@link com.google.protobuf.Int32Value}, etc) and {@link Any}.
+     * Wraps a value to a corresponding message wrapper
+     * ({@link com.google.protobuf.DoubleValue DoubleValue},
+     * {@link com.google.protobuf.Int32Value Int32Value}, etc) and {@link Any}.
      */
     protected abstract Any wrap(V value);
 
@@ -115,10 +117,12 @@ abstract class NumberFieldValidator<V extends Number & Comparable<V>> extends Fi
                                         maxDecimalOpt.getInclusive(), maxDecimalOpt.getValue()));
         }
         if (notFitToMin(value)) {
-            addViolation(newMinOrMaxViolation(value, minOption, minOption.getMsgFormat(), minOption.getValue()));
+            addViolation(newMinOrMaxViolation(value, minOption, minOption.getMsgFormat(),
+                                              minOption.getValue()));
         }
         if (notFitToMax(value)) {
-            addViolation(newMinOrMaxViolation(value, maxOption, maxOption.getMsgFormat(), maxOption.getValue()));
+            addViolation(newMinOrMaxViolation(value, maxOption, maxOption.getMsgFormat(),
+                                              maxOption.getValue()));
         }
     }
 
@@ -181,7 +185,8 @@ abstract class NumberFieldValidator<V extends Number & Comparable<V>> extends Fi
         final String[] parts = PATTERN_DOT.split(String.valueOf(abs));
         final int intDigitsCount = parts[0].length();
         final int fractionDigitsCount = parts[1].length();
-        final boolean isInvalid = (intDigitsCount > intDigitsMax) || (fractionDigitsCount > fractionDigitsMax);
+        final boolean isInvalid = (intDigitsCount > intDigitsMax) ||
+                                  (fractionDigitsCount > fractionDigitsMax);
         if (isInvalid) {
             addViolation(newDigitsViolation(value));
         }
@@ -202,7 +207,8 @@ abstract class NumberFieldValidator<V extends Number & Comparable<V>> extends Fi
         return violation.build();
     }
 
-    private ConstraintViolation newMinOrMaxViolation(V value, Message option, String customMsg, String minOrMax) {
+    private ConstraintViolation newMinOrMaxViolation(V value, Message option,
+                                                     String customMsg, String minOrMax) {
         final String msg = getErrorMsgFormat(option, customMsg);
         final ConstraintViolation.Builder violation = ConstraintViolation.newBuilder()
                 .setMsgFormat(msg)

--- a/server/src/test/java/org/spine3/server/aggregate/Given.java
+++ b/server/src/test/java/org/spine3/server/aggregate/Given.java
@@ -153,7 +153,7 @@ class Given {
 
         /**
          * Creates a new {@link Command} with the given command message, userId and timestamp using default
-         * {@link org.spine3.base.CommandId} instance.
+         * {@link org.spine3.base.CommandId CommandId} instance.
          */
         static org.spine3.base.Command create(Message command, UserId userId, Timestamp when) {
             final CommandContext context = createCommandContext(userId, Commands.generateId(), when);

--- a/server/src/test/java/org/spine3/server/bc/BoundedContextShould.java
+++ b/server/src/test/java/org/spine3/server/bc/BoundedContextShould.java
@@ -116,18 +116,21 @@ public class BoundedContextShould {
 
     @Test
     public void register_AggregateRepository() {
-        final ProjectAggregateRepository repository = new ProjectAggregateRepository(boundedContext);
+        final ProjectAggregateRepository repository =
+                new ProjectAggregateRepository(boundedContext);
         repository.initStorage(storageFactory);
         boundedContext.register(repository);
     }
 
     @Test(expected = IllegalStateException.class)
     public void not_allow_two_aggregate_repositories_with_aggregates_with_the_same_state() {
-        final ProjectAggregateRepository repository = new ProjectAggregateRepository(boundedContext);
+        final ProjectAggregateRepository repository =
+                new ProjectAggregateRepository(boundedContext);
         repository.initStorage(storageFactory);
         boundedContext.register(repository);
 
-        final AnotherProjectAggregateRepository anotherRepo = new AnotherProjectAggregateRepository(boundedContext);
+        final AnotherProjectAggregateRepository anotherRepo =
+                new AnotherProjectAggregateRepository(boundedContext);
         repository.initStorage(storageFactory);
         boundedContext.register(anotherRepo);
     }
@@ -195,14 +198,16 @@ public class BoundedContextShould {
 
     @Test
     public void assign_storage_during_registration_if_repository_does_not_have_storage() {
-        final ProjectAggregateRepository repository = new ProjectAggregateRepository(boundedContext);
+        final ProjectAggregateRepository repository =
+                new ProjectAggregateRepository(boundedContext);
         boundedContext.register(repository);
         assertTrue(repository.storageAssigned());
     }
 
     @Test
     public void not_change_storage_during_registration_if_a_repository_has_one() {
-        final ProjectAggregateRepository repository = new ProjectAggregateRepository(boundedContext);
+        final ProjectAggregateRepository repository =
+                new ProjectAggregateRepository(boundedContext);
         repository.initStorage(storageFactory);
 
         final Repository spy = spy(repository);
@@ -216,12 +221,13 @@ public class BoundedContextShould {
         final BoundedContext boundedContext = newBoundedContext(stand);
         verify(stand, never()).registerTypeSupplier(any(Repository.class));
 
-        final ProjectAggregateRepository repository = new ProjectAggregateRepository(boundedContext);
+        final ProjectAggregateRepository repository =
+                new ProjectAggregateRepository(boundedContext);
         boundedContext.register(repository);
         verify(stand).registerTypeSupplier(eq(repository));
     }
 
-    /** Returns {@link org.mockito.Mockito#any()} matcher for response observer. */
+    /** Returns {@link org.mockito.Mockito#any() Mockito.any()} matcher for response observer. */
     @SuppressWarnings("unchecked")
     private static StreamObserver<Response> anyResponseObserver() {
         return (StreamObserver<Response>) any();
@@ -308,7 +314,8 @@ public class BoundedContextShould {
         }
     }
 
-    private static class ProjectAggregateRepository extends AggregateRepository<ProjectId, ProjectAggregate> {
+    private static class ProjectAggregateRepository
+            extends AggregateRepository<ProjectId, ProjectAggregate> {
         private ProjectAggregateRepository(BoundedContext boundedContext) {
             super(boundedContext);
         }
@@ -354,7 +361,8 @@ public class BoundedContextShould {
         }
     }
 
-    private static class ProjectPmRepo extends ProcessManagerRepository<ProjectId, ProjectProcessManager, Empty> {
+    private static class ProjectPmRepo
+            extends ProcessManagerRepository<ProjectId, ProjectProcessManager, Empty> {
 
         private ProjectPmRepo(BoundedContext boundedContext) {
             super(boundedContext);
@@ -372,11 +380,13 @@ public class BoundedContextShould {
         @SuppressWarnings("UnusedParameters") // OK for test method.
         @Subscribe
         public void on(ProjectCreated event, EventContext context) {
-            // Do nothing. We have the method so that there's one event class exposed by the repository.
+            // Do nothing. We have the method so that there's one event class exposed
+            // by the repository.
         }
     }
 
-    private static class ProjectReportRepository extends ProjectionRepository<ProjectId, ProjectReport, Empty> {
+    private static class ProjectReportRepository
+            extends ProjectionRepository<ProjectId, ProjectReport, Empty> {
         protected ProjectReportRepository(BoundedContext boundedContext) {
             super(boundedContext);
         }

--- a/server/src/test/java/org/spine3/server/event/EventBusShould.java
+++ b/server/src/test/java/org/spine3/server/event/EventBusShould.java
@@ -84,13 +84,15 @@ public class EventBusShould {
     private void setUp(@Nullable EventEnricher enricher) {
         this.storageFactory = InMemoryStorageFactory.getInstance();
         /**
-         * Cannot use {@link com.google.common.util.concurrent.MoreExecutors#directExecutor()}
+         * Cannot use {@link com.google.common.util.concurrent.MoreExecutors#directExecutor() MoreExecutors.directExecutor()}
          * because it's impossible to spy on {@code final} classes.
          */
         this.delegateDispatcherExecutor = spy(directExecutor());
         this.delegateSubscriberExecutor = spy(directExecutor());
-        this.postponedDispatcherDelivery = new PostponedDispatcherEventDelivery(delegateDispatcherExecutor);
-        this.postponedSubscriberDelivery = new PostponedSubscriberEventDelivery(delegateSubscriberExecutor);
+        this.postponedDispatcherDelivery =
+                new PostponedDispatcherEventDelivery(delegateDispatcherExecutor);
+        this.postponedSubscriberDelivery =
+                new PostponedSubscriberEventDelivery(delegateSubscriberExecutor);
         buildEventBus(enricher);
         buildEventBusWithPostponedExecution(enricher);
         this.responseObserver = new TestResponseObserver();
@@ -107,10 +109,11 @@ public class EventBusShould {
     }
 
     private void buildEventBusWithPostponedExecution(@Nullable EventEnricher enricher) {
-        final EventBus.Builder busBuilder = EventBus.newBuilder()
-                                                    .setStorageFactory(storageFactory)
-                                                    .setDispatcherEventDelivery(postponedDispatcherDelivery)
-                                                    .setSubscriberEventDelivery(postponedSubscriberDelivery);
+        final EventBus.Builder busBuilder =
+                EventBus.newBuilder()
+                        .setStorageFactory(storageFactory)
+                        .setDispatcherEventDelivery(postponedDispatcherDelivery)
+                        .setSubscriberEventDelivery(postponedSubscriberDelivery);
 
         if (enricher != null) {
             busBuilder.setEnricher(enricher);
@@ -314,7 +317,8 @@ public class EventBusShould {
     public void assure_that_event_is_valid_and_subscriber_registered() {
         eventBus.subscribe(new ProjectCreatedSubscriber());
 
-        final boolean isValid = eventBus.validate(Given.EventMessage.projectCreated(), responseObserver);
+        final boolean isValid = eventBus.validate(Given.EventMessage.projectCreated(),
+                                                  responseObserver);
         assertTrue(isValid);
         assertResponseIsOk(responseObserver);
     }
@@ -323,7 +327,8 @@ public class EventBusShould {
     public void assure_that_event_is_valid_and_dispatcher_registered() {
         eventBus.register(new BareDispatcher());
 
-        final boolean isValid = eventBus.validate(Given.EventMessage.projectCreated(), responseObserver);
+        final boolean isValid = eventBus.validate(Given.EventMessage.projectCreated(),
+                                                  responseObserver);
         assertTrue(isValid);
         assertResponseIsOk(responseObserver);
     }
@@ -341,7 +346,8 @@ public class EventBusShould {
                                           .build();
         eventBus.subscribe(new ProjectCreatedSubscriber());
 
-        final boolean isValid = eventBus.validate(Given.EventMessage.projectCreated(), responseObserver);
+        final boolean isValid = eventBus.validate(Given.EventMessage.projectCreated(),
+                                                  responseObserver);
 
         assertFalse(isValid);
         assertReturnedExceptionAndNoResponse(InvalidEventException.class, responseObserver);
@@ -349,7 +355,8 @@ public class EventBusShould {
 
     @Test
     public void call_onError_if_event_is_unsupported() {
-        final boolean isValid = eventBus.validate(Given.EventMessage.projectCreated(), responseObserver);
+        final boolean isValid = eventBus.validate(Given.EventMessage.projectCreated(),
+                                                  responseObserver);
 
         assertFalse(isValid);
         assertReturnedExceptionAndNoResponse(UnsupportedEventException.class, responseObserver);
@@ -449,7 +456,9 @@ public class EventBusShould {
             }
         };
         eventBus.addFieldEnrichment(eventFieldClass, enrichmentFieldClass, function);
-        verify(enricher).registerFieldEnrichment(eq(eventFieldClass), eq(enrichmentFieldClass), eq(function));
+        verify(enricher).registerFieldEnrichment(eq(eventFieldClass),
+                                                 eq(enrichmentFieldClass),
+                                                 eq(function));
     }
 
 
@@ -508,8 +517,9 @@ public class EventBusShould {
         @Subscribe
         public void on(ProjectCreated event, EventContext context) {
             methodCalled = true;
-            throw new UnsupportedOperationException("What did you expect from " +
-                                                            FaultySubscriber.class.getSimpleName() + '?');
+            throw new UnsupportedOperationException(
+                    "What did you expect from " +
+                    FaultySubscriber.class.getSimpleName() + '?');
         }
 
         boolean isMethodCalled() {
@@ -517,7 +527,8 @@ public class EventBusShould {
         }
     }
 
-    /** A simple dispatcher class, which only dispatch and does not have own event subscribing methods. */
+    /** A simple dispatcher class, which only dispatch and does not have own event
+     * subscribing methods. */
     private static class BareDispatcher implements EventDispatcher {
 
         private boolean dispatchCalled = false;

--- a/server/src/test/java/org/spine3/server/event/enrich/EnrichmentFunctionShould.java
+++ b/server/src/test/java/org/spine3/server/event/enrich/EnrichmentFunctionShould.java
@@ -142,9 +142,9 @@ public class EnrichmentFunctionShould {
         assertNull(fieldEnricher.apply(Tests.<ProjectCreated>nullRef()));
     }
 
+    @SuppressWarnings("EqualsWithItself")
     @Test
     public void have_smart_equals() {
-        //noinspection EqualsWithItself
         assertTrue(fieldEnricher.equals(fieldEnricher));
         assertFalse(fieldEnricher.equals(Tests.<EnrichmentFunction<ProjectCreated, ProjectCreated.Enrichment>>nullRef()));
     }

--- a/server/src/test/java/org/spine3/server/storage/Given.java
+++ b/server/src/test/java/org/spine3/server/storage/Given.java
@@ -148,8 +148,8 @@ public class Given {
         }
 
         /**
-         * Creates a new {@link Command} with the given command message, userId and timestamp using default
-         * {@link org.spine3.base.CommandId} instance.
+         * Creates a new {@link Command} with the given command message, userId and timestamp using
+         * default {@link org.spine3.base.CommandId CommandId} instance.
          */
         public static org.spine3.base.Command create(Message command, UserId userId, Timestamp when) {
             final CommandContext context = createCommandContext(userId, Commands.generateId(), when);

--- a/server/src/test/java/org/spine3/testdata/TestCommandBusFactory.java
+++ b/server/src/test/java/org/spine3/testdata/TestCommandBusFactory.java
@@ -26,7 +26,7 @@ import org.spine3.server.storage.StorageFactory;
 import org.spine3.server.storage.memory.InMemoryStorageFactory;
 
 /**
- * Creates {@link org.spine3.server.command.CommandBus}s for tests.
+ * Creates {@link org.spine3.server.command.CommandBus CommandBus}s for tests.
  *
  * @author Andrey Lavrov
  */

--- a/server/src/test/java/org/spine3/testdata/TestEventBusFactory.java
+++ b/server/src/test/java/org/spine3/testdata/TestEventBusFactory.java
@@ -28,7 +28,7 @@ import org.spine3.server.storage.StorageFactory;
 import org.spine3.server.storage.memory.InMemoryStorageFactory;
 
 /**
- * Creates {@link org.spine3.server.command.CommandBus}s for tests.
+ * Creates {@link org.spine3.server.command.CommandBus CommandBus}s for tests.
  *
  * @author Andrey Lavrov
  */

--- a/testutil/src/main/java/org/spine3/test/NullToleranceTest.java
+++ b/testutil/src/main/java/org/spine3/test/NullToleranceTest.java
@@ -523,16 +523,18 @@ public class NullToleranceTest {
          * <ul>
          *     <li>an empty string is used for the {@code String};
          *     <li>an empty array is used for the varargs and array parameters;
-         *     <li>the result of the {@link java.util.Collections#emptyList()} call for the types
-         *     derived from {@link List};</li>
-         *     <li>the result of the {@link java.util.Collections#emptySet()} call for the types
-         *     derived from {@link Set};</li>
-         *     <li>the result of the {@link java.util.Collections#emptyMap()} call for the types
-         *     derived from {@link Map};</li>
-         *     <li>the result of the {@link com.google.common.collect.Queues#newPriorityQueue()} call
-         *     for the types derived from {@link Queue};</li>
-         *     <li>the result of the {@link com.google.common.base.Defaults#defaultValue(Class)} call
-         *     is for the primitives and related wrapper types;</li>
+         *     <li>the result of the {@link java.util.Collections#emptyList() Collections.emptyList()}
+         *     call for the types derived from {@link List};</li>
+         *     <li>the result of the {@link java.util.Collections#emptySet() Collections.emptySet()}
+         *     call for the types derived from {@link Set};</li>
+         *     <li>the result of the {@link java.util.Collections#emptyMap() Collections.emptyMap()}
+         *     call for the types derived from {@link Map};</li>
+         *     <li>the result of the
+         *     {@link com.google.common.collect.Queues#newPriorityQueue() Queues.newPriorityQueue()}
+         *     call for the types derived from {@link Queue};</li>
+         *     <li>the result of the
+         *     {@link com.google.common.base.Defaults#defaultValue(Class) Defaults.defaultValue(Class)}
+         *     call is for the primitives and related wrapper types;</li>
          *     <li>the result of {@code getDefaultInstance} call for the types
          *     derived from {@link Message}.</li>
          * </ul>

--- a/testutil/src/main/java/org/spine3/test/Tests.java
+++ b/testutil/src/main/java/org/spine3/test/Tests.java
@@ -219,7 +219,8 @@ public class Tests {
     /**
      * Returns {@code StringObserver} that does nothing.
      *
-     * <p>Use this method when you need to call {@link org.spine3.server.command.CommandBus#post(Command, StreamObserver)}
+     * <p>Use this method when you need to call
+     * {@link org.spine3.server.command.CommandBus#post(Command, StreamObserver) CommandBus.post(Command, StreamObserver)}
      * and observing results is not needed.
      */
     public static StreamObserver<Response> emptyObserver() {

--- a/testutil/src/main/java/org/spine3/test/Verify.java
+++ b/testutil/src/main/java/org/spine3/test/Verify.java
@@ -640,7 +640,7 @@ public final class Verify extends Assert {
         }
     }
 
-    /** Assert the size of the given {@link com.google.common.collect.ImmutableSet}. */
+    /** Assert the size of the given {@link com.google.common.collect.ImmutableSet ImmutableSet}. */
     public static void assertSize(int expectedSize, Collection<?> actualImmutableSet) {
         try {
             assertSize("immutable set", expectedSize, actualImmutableSet);
@@ -649,7 +649,7 @@ public final class Verify extends Assert {
         }
     }
 
-    /** Assert the size of the given {@link com.google.common.collect.ImmutableSet}. */
+    /** Assert the size of the given {@link com.google.common.collect.ImmutableSet ImmutableSet}. */
     public static void assertSize(String immutableSetName,
                                   int expectedSize,
                                   Collection<?> actualImmutableSet) {

--- a/values/src/main/java/org/spine3/net/Urls.java
+++ b/values/src/main/java/org/spine3/net/Urls.java
@@ -39,7 +39,7 @@ public class Urls {
      * Converts {@link Url} with raw data into the instance with structurized record.
      *
      * @param rawUrl {@link Url} with raw String
-     * @return {@link Url} with {@link org.spine3.net.Url.Record} instance
+     * @return {@link Url} with {@link org.spine3.net.Url.Record Url.Record} instance
      * @throws IllegalArgumentException if the argument already has a structurized record
      */
     @SuppressWarnings("TypeMayBeWeakened")
@@ -65,7 +65,7 @@ public class Urls {
      * calling {@link Urls#validate(Url)}.
      *
      * @param rawUrlString raw URL String
-     * @return {@link Url} with {@link org.spine3.net.Url.Record} instance
+     * @return {@link Url} with {@link org.spine3.net.Url.Record Url.Record} instance
      */
     public static Url of(String rawUrlString) {
         checkNotNull(rawUrlString);
@@ -96,7 +96,8 @@ public class Urls {
      *     <li>{@link Url} with raw String is always valid.
      *     <li>{@link Url} with not set value is always invalid.
      *     <li>{@link Url} can not have empty host.
-     *     <li>{@link org.spine3.net.Url.Record.Authorization} can't have password without having login.
+     *     <li>{@link org.spine3.net.Url.Record.Authorization Record.Authorization} can't have
+     *          password without having login.
      * </ul>
      *
      * @param url {@link Url} instance


### PR DESCRIPTION
This is the fix for Javadocs from {@link FQN} to {@link FQN text} format. Also some wrapping for 100 column right margin. 