### PR TITLE
Pass the `Command` message and context along with `FailureThrowable`.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ buildscript {
         
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all the components and change
         // the version of the dependency below to `spineVersion` defined above.
-        spineProtobufPluginVersion = '0.8.0'
+        spineProtobufPluginVersion = '0.8.1-SNAPSHOT'
     }
     dependencies {
         classpath group: 'com.google.guava', name: 'guava', version: guavaVersion

--- a/client/src/main/java/org/spine3/base/FailureThrowable.java
+++ b/client/src/main/java/org/spine3/base/FailureThrowable.java
@@ -58,11 +58,11 @@ public abstract class FailureThrowable extends Throwable {
     private final Timestamp timestamp;
 
     protected FailureThrowable(GeneratedMessageV3 commandMessage,
-                               CommandContext ctx,
+                               CommandContext commandContext,
                                GeneratedMessageV3 failureMessage) {
         super();
         this.commandMessage = commandMessage;
-        this.commandContext = ctx;
+        this.commandContext = commandContext;
         this.failureMessage = failureMessage;
         this.timestamp = getCurrentTime();
     }

--- a/client/src/main/java/org/spine3/base/FailureThrowable.java
+++ b/client/src/main/java/org/spine3/base/FailureThrowable.java
@@ -38,22 +38,36 @@ public abstract class FailureThrowable extends Throwable {
 
     private static final long serialVersionUID = 0L;
 
-    // We accept GeneratedMessage (instead of Message) because
-    // generated messages implement Serializable.
+    /**
+     * For the {@code failureMessage} and {@code commandMessage} we accept GeneratedMessage
+     * (instead of Message) because generated messages implement Serializable.
+     */
     private final GeneratedMessageV3 failureMessage;
+
+    /**
+     * The message of the {@code Command}, which led to this {@code Failure}.
+     */
+    private final GeneratedMessageV3 commandMessage;
+
+    /**
+     * The context of the {@code Command}, which led to this {@code Failure}.
+     */
+    private final CommandContext commandContext;
 
     /** The moment of creation of this object. */
     private final Timestamp timestamp;
 
-    protected FailureThrowable(GeneratedMessageV3 failureMessage) {
+    protected FailureThrowable(GeneratedMessageV3 commandMessage,
+                               CommandContext ctx,
+                               GeneratedMessageV3 failureMessage) {
         super();
+        this.commandMessage = commandMessage;
+        this.commandContext = ctx;
         this.failureMessage = failureMessage;
         this.timestamp = getCurrentTime();
     }
 
-    //TODO:2017-02-22:alexander.yevsyukov: Rename to getFailureMessage().
-    // This involves modifying failure generation Gradle plug-in in the Tools project.
-    public Message getFailure() {
+    public Message getFailureMessage() {
         return failureMessage;
     }
 
@@ -78,16 +92,13 @@ public abstract class FailureThrowable extends Throwable {
 
     private FailureContext createContext() {
         final String stacktrace = Throwables.getStackTraceAsString(this);
-
-        //TODO:2017-02-22:alexander.yevsyukov: Pass Command to the context
-        // by adding commandMessage and commandContext parameters to
-        // FailureThrowable constructor. This, again, requires extending the Spine model
-        // compiler.
+        final Command command = Commands.createCommand(commandMessage, commandContext);
 
         return FailureContext.newBuilder()
                              .setFailureId(Failures.generateId())
                              .setTimestamp(timestamp)
                              .setStacktrace(stacktrace)
+                             .setCommand(command)
                              .build();
     }
 }

--- a/client/src/test/java/org/spine3/base/FailureThrowableShould.java
+++ b/client/src/test/java/org/spine3/base/FailureThrowableShould.java
@@ -75,6 +75,9 @@ public class FailureThrowableShould {
                                   .isEmpty());
         assertTrue(Timestamps.isValid(failureWrapper.getContext()
                                                     .getTimestamp()));
+        final Command wrappedCommand = failureWrapper.getContext()
+                                                     .getCommand();
+        assertEquals(command, wrappedCommand);
     }
 
     private static class TestFailure extends FailureThrowable {

--- a/client/src/test/java/org/spine3/base/FailureThrowableShould.java
+++ b/client/src/test/java/org/spine3/base/FailureThrowableShould.java
@@ -26,15 +26,14 @@ import com.google.protobuf.util.Timestamps;
 import org.junit.Before;
 import org.junit.Test;
 import org.spine3.protobuf.AnyPacker;
-import org.spine3.protobuf.Timestamps2;
 import org.spine3.test.TestCommandFactory;
-import org.spine3.time.ZoneOffset;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.spine3.base.Identifiers.newUuid;
 import static org.spine3.protobuf.Values.newStringValue;
+import static org.spine3.test.Tests.newUuidValue;
 
 public class FailureThrowableShould {
 
@@ -43,10 +42,8 @@ public class FailureThrowableShould {
     @Before
     public void setUp() {
         final TestCommandFactory commandFactory =
-                TestCommandFactory.newInstance(newUuid(),
-                                               ZoneOffset.getDefaultInstance());
-        this.command = commandFactory.create(newStringValue(newUuid()),
-                                             Timestamps2.getCurrentTime());
+                TestCommandFactory.newInstance(FailureThrowable.class);
+        this.command = commandFactory.create(newUuidValue());
     }
 
     @Test

--- a/server/src/main/java/org/spine3/server/entity/AbstractVersionableEntity.java
+++ b/server/src/main/java/org/spine3/server/entity/AbstractVersionableEntity.java
@@ -283,16 +283,16 @@ public abstract class AbstractVersionableEntity<I, S extends Message>
     /**
      * Ensures that the entity is not marked as {@code archived}.
      *
-     * @param originCommand the {@linkplain Command} which execution triggered this check
+     * @param modification the {@linkplain Command} which execution triggered this check
      * @throws CannotModifyArchivedEntity if the entity in in the archived status
      * @see #getVisibility()
      * @see Visibility#getArchived()
      */
-    protected void checkNotArchived(Command originCommand) throws CannotModifyArchivedEntity {
+    protected void checkNotArchived(Command modification) throws CannotModifyArchivedEntity {
         if (getVisibility().getArchived()) {
             final String idStr = idToString(getId());
-            throw new CannotModifyArchivedEntity(originCommand.getMessage(),
-                                                 originCommand.getContext(),
+            throw new CannotModifyArchivedEntity(modification.getMessage(),
+                                                 modification.getContext(),
                                                  idStr);
         }
     }
@@ -300,16 +300,16 @@ public abstract class AbstractVersionableEntity<I, S extends Message>
     /**
      * Ensures that the entity is not marked as {@code deleted}.
      *
-     * @param originCommand the {@linkplain Command} which execution triggered this check
+     * @param modification the {@linkplain Command} which execution triggered this check
      * @throws CannotModifyDeletedEntity if the entity is marked as {@code deleted}
      * @see #getVisibility()
      * @see Visibility#getDeleted()
      */
-    protected void checkNotDeleted(Command originCommand) throws CannotModifyDeletedEntity {
+    protected void checkNotDeleted(Command modification) throws CannotModifyDeletedEntity {
         if (getVisibility().getDeleted()) {
             final String idStr = idToString(getId());
-            throw new CannotModifyDeletedEntity(originCommand.getMessage(),
-                                                originCommand.getContext(),
+            throw new CannotModifyDeletedEntity(modification.getMessage(),
+                                                modification.getContext(),
                                                 idStr);
         }
     }

--- a/server/src/main/java/org/spine3/server/entity/AbstractVersionableEntity.java
+++ b/server/src/main/java/org/spine3/server/entity/AbstractVersionableEntity.java
@@ -289,7 +289,8 @@ public abstract class AbstractVersionableEntity<I, S extends Message>
     protected void checkNotArchived() throws CannotModifyArchivedEntity {
         if (getVisibility().getArchived()) {
             final String idStr = idToString(getId());
-            throw new CannotModifyArchivedEntity(idStr);
+            //TODO:2/22/17:alex.tymchenko: avoid nulls
+            throw new CannotModifyArchivedEntity(null, null, idStr);
         }
     }
 
@@ -303,7 +304,8 @@ public abstract class AbstractVersionableEntity<I, S extends Message>
     protected void checkNotDeleted() throws CannotModifyDeletedEntity {
         if (getVisibility().getDeleted()) {
             final String idStr = idToString(getId());
-            throw new CannotModifyDeletedEntity(idStr);
+            //TODO:2/22/17:alex.tymchenko: avoid nulls
+            throw new CannotModifyDeletedEntity(null, null, idStr);
         }
     }
 

--- a/server/src/main/java/org/spine3/server/entity/AbstractVersionableEntity.java
+++ b/server/src/main/java/org/spine3/server/entity/AbstractVersionableEntity.java
@@ -22,6 +22,7 @@ package org.spine3.server.entity;
 
 import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
+import org.spine3.base.Command;
 import org.spine3.base.Version;
 import org.spine3.base.Versions;
 import org.spine3.server.entity.failure.CannotModifyArchivedEntity;
@@ -282,30 +283,34 @@ public abstract class AbstractVersionableEntity<I, S extends Message>
     /**
      * Ensures that the entity is not marked as {@code archived}.
      *
+     * @param originCommand the {@linkplain Command} which execution triggered this check
      * @throws CannotModifyArchivedEntity if the entity in in the archived status
      * @see #getVisibility()
      * @see Visibility#getArchived()
      */
-    protected void checkNotArchived() throws CannotModifyArchivedEntity {
+    protected void checkNotArchived(Command originCommand) throws CannotModifyArchivedEntity {
         if (getVisibility().getArchived()) {
             final String idStr = idToString(getId());
-            //TODO:2/22/17:alex.tymchenko: avoid nulls
-            throw new CannotModifyArchivedEntity(null, null, idStr);
+            throw new CannotModifyArchivedEntity(originCommand.getMessage(),
+                                                 originCommand.getContext(),
+                                                 idStr);
         }
     }
 
     /**
      * Ensures that the entity is not marked as {@code deleted}.
      *
+     * @param originCommand the {@linkplain Command} which execution triggered this check
      * @throws CannotModifyDeletedEntity if the entity is marked as {@code deleted}
      * @see #getVisibility()
      * @see Visibility#getDeleted()
      */
-    protected void checkNotDeleted() throws CannotModifyDeletedEntity {
+    protected void checkNotDeleted(Command originCommand) throws CannotModifyDeletedEntity {
         if (getVisibility().getDeleted()) {
             final String idStr = idToString(getId());
-            //TODO:2/22/17:alex.tymchenko: avoid nulls
-            throw new CannotModifyDeletedEntity(null, null, idStr);
+            throw new CannotModifyDeletedEntity(originCommand.getMessage(),
+                                                originCommand.getContext(),
+                                                idStr);
         }
     }
 

--- a/server/src/test/java/org/spine3/server/command/CommandBusShouldHandleCommandStatus.java
+++ b/server/src/test/java/org/spine3/server/command/CommandBusShouldHandleCommandStatus.java
@@ -62,6 +62,7 @@ import static org.spine3.base.Commands.getId;
 import static org.spine3.base.Commands.getMessage;
 import static org.spine3.base.Commands.setSchedule;
 import static org.spine3.base.Identifiers.newUuid;
+import static org.spine3.protobuf.Values.newStringValue;
 import static org.spine3.server.command.error.CommandExpiredException.commandExpiredError;
 import static org.spine3.test.TimeTests.Past.minutesAgo;
 
@@ -221,9 +222,9 @@ public class CommandBusShouldHandleCommandStatus {
         private static final long serialVersionUID = 1L;
 
         private TestFailure() {
-            super(StringValue.newBuilder()
-                             .setValue(TestFailure.class.getName())
-                             .build());
+            super(newStringValue("some Command message"),
+                  CommandContext.getDefaultInstance(),
+                  newStringValue(TestFailure.class.getName()));
         }
     }
 

--- a/server/src/test/java/org/spine3/server/entity/VisibilityTests.java
+++ b/server/src/test/java/org/spine3/server/entity/VisibilityTests.java
@@ -24,9 +24,6 @@ import com.google.protobuf.StringValue;
 import org.junit.Before;
 import org.junit.Test;
 import org.spine3.base.Command;
-import org.spine3.base.Identifiers;
-import org.spine3.client.CommandFactory;
-import org.spine3.protobuf.Values;
 import org.spine3.server.entity.failure.CannotModifyArchivedEntity;
 import org.spine3.server.entity.failure.CannotModifyDeletedEntity;
 import org.spine3.test.TestCommandFactory;
@@ -68,7 +65,7 @@ public class VisibilityTests {
                                                  .nextLong());
         final TestCommandFactory factory =
                 TestCommandFactory.newInstance(newUuid(), ZoneOffset.getDefaultInstance());
-        modificationCommand = factory.create(newStringValue("Entity modification command" ));
+        modificationCommand = factory.create(newStringValue("Entity modification command"));
     }
 
     @Test

--- a/server/src/test/java/org/spine3/server/entity/VisibilityTests.java
+++ b/server/src/test/java/org/spine3/server/entity/VisibilityTests.java
@@ -23,14 +23,22 @@ package org.spine3.server.entity;
 import com.google.protobuf.StringValue;
 import org.junit.Before;
 import org.junit.Test;
+import org.spine3.base.Command;
+import org.spine3.base.Identifiers;
+import org.spine3.client.CommandFactory;
+import org.spine3.protobuf.Values;
 import org.spine3.server.entity.failure.CannotModifyArchivedEntity;
 import org.spine3.server.entity.failure.CannotModifyDeletedEntity;
+import org.spine3.test.TestCommandFactory;
+import org.spine3.time.ZoneOffset;
 
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.spine3.base.Identifiers.newUuid;
+import static org.spine3.protobuf.Values.newStringValue;
 
 /**
  * Tests of working with entity status.
@@ -43,6 +51,7 @@ import static org.junit.Assert.assertTrue;
 public class VisibilityTests {
 
     private AbstractVersionableEntity<Long, StringValue> entity;
+    private Command modificationCommand;
 
     /**
      * A minimal entity class.
@@ -55,7 +64,11 @@ public class VisibilityTests {
 
     @Before
     public void setUp() {
-        entity = new MiniEntity(ThreadLocalRandom.current().nextLong());
+        entity = new MiniEntity(ThreadLocalRandom.current()
+                                                 .nextLong());
+        final TestCommandFactory factory =
+                TestCommandFactory.newInstance(newUuid(), ZoneOffset.getDefaultInstance());
+        modificationCommand = factory.create(newStringValue("Entity modification command" ));
     }
 
     @Test
@@ -127,10 +140,10 @@ public class VisibilityTests {
         entity.setArchived(true);
 
         // This should pass.
-        entity.checkNotDeleted();
+        entity.checkNotDeleted(modificationCommand);
 
         // This should throw.
-        entity.checkNotArchived();
+        entity.checkNotArchived(modificationCommand);
     }
 
     @Test(expected = CannotModifyDeletedEntity.class)
@@ -138,9 +151,9 @@ public class VisibilityTests {
         entity.setDeleted(true);
 
         // This should pass.
-        entity.checkNotArchived();
+        entity.checkNotArchived(modificationCommand);
 
         // This should throw.
-        entity.checkNotDeleted();
+        entity.checkNotDeleted(modificationCommand);
     }
 }


### PR DESCRIPTION
This PR is using the features introduces to the Spine `tools` library in the  [PR #52](https://github.com/SpineEventEngine/tools/pull/52). Please see its detailed description.

The changes in this PR are:
* bump the dependency to the `tools` module to `0.8.1-SNAPSHOT`;
* adjust the codebase according to the new Spine Failure compiler features.