### PR TITLE
Method predicate improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
         
-        spineVersion = '0.8.13-SNAPSHOT'
+        spineVersion = '0.8.14-SNAPSHOT'
         
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all the components and change
         // the version of the dependency below to `spineVersion` defined above.

--- a/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
@@ -31,7 +31,6 @@ import org.spine3.base.CommandEnvelope;
 import org.spine3.base.Event;
 import org.spine3.server.BoundedContext;
 import org.spine3.server.command.CommandDispatcher;
-import org.spine3.server.command.CommandHandlingEntity;
 import org.spine3.server.entity.AbstractEntity;
 import org.spine3.server.entity.Entity;
 import org.spine3.server.entity.Predicates;
@@ -40,6 +39,7 @@ import org.spine3.server.entity.Visibility;
 import org.spine3.server.entity.idfunc.GetTargetIdFromCommand;
 import org.spine3.server.entity.idfunc.IdCommandFunction;
 import org.spine3.server.event.EventBus;
+import org.spine3.server.reflect.CommandHandlerMethod;
 import org.spine3.server.stand.StandFunnel;
 import org.spine3.server.storage.Storage;
 import org.spine3.server.storage.StorageFactory;
@@ -156,7 +156,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
     public Set<CommandClass> getMessageClasses() {
         if (messageClasses == null) {
             messageClasses = ImmutableSet.copyOf(
-                    CommandHandlingEntity.getCommandClasses(getAggregateClass()));
+                    CommandHandlerMethod.getCommandClasses(getAggregateClass()));
         }
         return messageClasses;
     }

--- a/server/src/main/java/org/spine3/server/aggregate/EventApplierMethod.java
+++ b/server/src/main/java/org/spine3/server/aggregate/EventApplierMethod.java
@@ -24,6 +24,7 @@ import com.google.common.base.Predicate;
 import com.google.protobuf.Empty;
 import com.google.protobuf.Message;
 import org.spine3.server.reflect.HandlerMethod;
+import org.spine3.server.reflect.HandlerMethodPredicate;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -98,7 +99,7 @@ class EventApplierMethod extends HandlerMethod<Empty> {
     }
 
     /** The predicate for filtering event applier methods. */
-    private static class FilterPredicate extends HandlerMethod.FilterPredicate {
+    private static class FilterPredicate extends HandlerMethodPredicate {
 
         private static final int NUMBER_OF_PARAMS = 1;
         private static final int EVENT_PARAM_INDEX = 0;

--- a/server/src/main/java/org/spine3/server/aggregate/EventApplierMethod.java
+++ b/server/src/main/java/org/spine3/server/aggregate/EventApplierMethod.java
@@ -50,10 +50,18 @@ class EventApplierMethod extends HandlerMethod<Empty> {
     }
 
     /**
-     * Invokes {@link HandlerMethod#invoke(Object, Message, Message)} passing the default message as the context parameter
-     * as event appliers do not have this parameter.
+     * Invokes the applier method.
+     *
+     * <p>The method {@linkplain HandlerMethod#invoke(Object, Message, Message) delegates}
+     * the invocation passing {@linkplain Empty#getDefaultInstance() empty message}
+     * as the context parameter because event appliers do not have a context parameter.
+     * Such redirection is correct because {@linkplain #getParamCount()} the number of parameters}
+     * is set to one during instance construction.
+     *
+     * @throws InvocationTargetException if the method call results in an exception
      */
-    protected <R> R invoke(Object aggregate, Message message) throws InvocationTargetException {
+    protected <R> R invoke(Object aggregate, Message message)
+            throws InvocationTargetException {
         // Make this method visible to Aggregate class.
         return invoke(aggregate, message, Empty.getDefaultInstance());
     }
@@ -89,8 +97,8 @@ class EventApplierMethod extends HandlerMethod<Empty> {
 
         private enum Singleton {
             INSTANCE;
-            @SuppressWarnings({"NonSerializableFieldInSerializableClass", "UnnecessarilyQualifiedInnerClassAccess"})
-            private final EventApplierMethod.Factory value = new EventApplierMethod.Factory(); // use the FQN
+            @SuppressWarnings("NonSerializableFieldInSerializableClass")
+            private final EventApplierMethod.Factory value = new EventApplierMethod.Factory();
         }
 
         private static Factory instance() {
@@ -99,10 +107,14 @@ class EventApplierMethod extends HandlerMethod<Empty> {
     }
 
     /** The predicate for filtering event applier methods. */
-    private static class FilterPredicate extends HandlerMethodPredicate {
+    private static class FilterPredicate extends HandlerMethodPredicate<Empty> {
 
         private static final int NUMBER_OF_PARAMS = 1;
         private static final int EVENT_PARAM_INDEX = 0;
+
+        private FilterPredicate() {
+            super(Apply.class, Empty.class);
+        }
 
         @SuppressWarnings("MethodDoesntCallSuperMethod") // because we override the checking.
         @Override
@@ -118,20 +130,9 @@ class EventApplierMethod extends HandlerMethod<Empty> {
         }
 
         @Override
-        protected boolean isAnnotatedCorrectly(Method method) {
-            final boolean isAnnotated = method.isAnnotationPresent(Apply.class);
-            return isAnnotated;
-        }
-
-        @Override
         protected boolean isReturnTypeCorrect(Method method) {
             final boolean isVoid = Void.TYPE.equals(method.getReturnType());
             return isVoid;
-        }
-
-        @Override
-        protected Class<? extends Message> getContextClass() {
-            return Empty.class;
         }
     }
 }

--- a/server/src/main/java/org/spine3/server/aggregate/EventApplierMethod.java
+++ b/server/src/main/java/org/spine3/server/aggregate/EventApplierMethod.java
@@ -118,7 +118,7 @@ class EventApplierMethod extends HandlerMethod<Empty> {
 
         @SuppressWarnings("MethodDoesntCallSuperMethod") // because we override the checking.
         @Override
-        protected boolean acceptsCorrectParams(Method method) {
+        protected boolean verifyParams(Method method) {
             final Class<?>[] parameterTypes = method.getParameterTypes();
             final boolean paramCountIsValid = parameterTypes.length == NUMBER_OF_PARAMS;
             if (!paramCountIsValid) {
@@ -130,7 +130,7 @@ class EventApplierMethod extends HandlerMethod<Empty> {
         }
 
         @Override
-        protected boolean isReturnTypeCorrect(Method method) {
+        protected boolean verifyReturnType(Method method) {
             final boolean isVoid = Void.TYPE.equals(method.getReturnType());
             return isVoid;
         }

--- a/server/src/main/java/org/spine3/server/command/CommandHandler.java
+++ b/server/src/main/java/org/spine3/server/command/CommandHandler.java
@@ -28,6 +28,7 @@ import org.spine3.base.CommandContext;
 import org.spine3.base.CommandEnvelope;
 import org.spine3.base.Event;
 import org.spine3.server.event.EventBus;
+import org.spine3.server.reflect.CommandHandlerMethod;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -94,7 +95,7 @@ public abstract class CommandHandler extends CommandHandlingEntity<String, Empty
     @Override
     public Set<CommandClass> getMessageClasses() {
         if (commandClasses == null) {
-            commandClasses = ImmutableSet.copyOf(getCommandClasses(getClass()));
+            commandClasses = ImmutableSet.copyOf(CommandHandlerMethod.getCommandClasses(getClass()));
         }
         return commandClasses;
     }

--- a/server/src/main/java/org/spine3/server/command/CommandHandlingEntity.java
+++ b/server/src/main/java/org/spine3/server/command/CommandHandlingEntity.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
-import org.spine3.base.CommandClass;
 import org.spine3.base.CommandContext;
 import org.spine3.base.Event;
 import org.spine3.base.EventContext;
@@ -44,13 +43,11 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.spine3.base.Events.generateId;
 import static org.spine3.base.Identifiers.idToAny;
 import static org.spine3.protobuf.Timestamps2.getCurrentTime;
-import static org.spine3.server.reflect.Classes.getHandledMessageClasses;
 import static org.spine3.util.Exceptions.wrappedCause;
 
 /**
@@ -134,18 +131,6 @@ public abstract class CommandHandlingEntity<I, S extends Message>
                                       Message event,
                                       CommandContext commandContext) {
         // Do nothing.
-    }
-
-    /**
-     * Returns the set of the command classes handled by the passed class.
-     *
-     * @param clazz the class of objects that handle commands
-     * @return immutable set of command classes
-     */
-    public static Set<CommandClass> getCommandClasses(Class<? extends CommandHandlingEntity> clazz) {
-        final Set<CommandClass> result = CommandClass.setOf(
-                getHandledMessageClasses(clazz, CommandHandlerMethod.PREDICATE));
-        return result;
     }
 
     /**

--- a/server/src/main/java/org/spine3/server/procman/ProcessManagerRepository.java
+++ b/server/src/main/java/org/spine3/server/procman/ProcessManagerRepository.java
@@ -33,10 +33,10 @@ import org.spine3.base.Events;
 import org.spine3.server.BoundedContext;
 import org.spine3.server.command.CommandBus;
 import org.spine3.server.command.CommandDispatcher;
-import org.spine3.server.command.CommandHandlingEntity;
 import org.spine3.server.entity.EventDispatchingRepository;
 import org.spine3.server.entity.idfunc.GetTargetIdFromCommand;
 import org.spine3.server.event.EventBus;
+import org.spine3.server.reflect.CommandHandlerMethod;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
@@ -79,7 +79,7 @@ public abstract class ProcessManagerRepository<I,
     public Set<CommandClass> getMessageClasses() {
         if (commandClasses == null) {
             final Class<? extends ProcessManager> pmClass = getEntityClass();
-            commandClasses = CommandHandlingEntity.getCommandClasses(pmClass);
+            commandClasses = CommandHandlerMethod.getCommandClasses(pmClass);
         }
         return commandClasses;
     }

--- a/server/src/main/java/org/spine3/server/reflect/CommandHandlerMethod.java
+++ b/server/src/main/java/org/spine3/server/reflect/CommandHandlerMethod.java
@@ -177,12 +177,10 @@ public class CommandHandlerMethod extends HandlerMethod<CommandContext> {
      *
      * <p>See {@link Assign} annotation for more info about such methods.
      */
-    private static class FilterPredicate extends HandlerMethodPredicate {
+    private static class FilterPredicate extends HandlerMethodPredicate<CommandContext> {
 
-        @Override
-        protected boolean isAnnotatedCorrectly(Method method) {
-            final boolean isAnnotated = method.isAnnotationPresent(Assign.class);
-            return isAnnotated;
+        private FilterPredicate() {
+            super(Assign.class, CommandContext.class);
         }
 
         @Override
@@ -194,11 +192,6 @@ public class CommandHandlerMethod extends HandlerMethod<CommandContext> {
             }
             final boolean isList = List.class.isAssignableFrom(returnType);
             return isList;
-        }
-
-        @Override
-        protected Class<? extends Message> getContextClass() {
-            return CommandContext.class;
         }
     }
 }

--- a/server/src/main/java/org/spine3/server/reflect/CommandHandlerMethod.java
+++ b/server/src/main/java/org/spine3/server/reflect/CommandHandlerMethod.java
@@ -177,7 +177,7 @@ public class CommandHandlerMethod extends HandlerMethod<CommandContext> {
      *
      * <p>See {@link Assign} annotation for more info about such methods.
      */
-    private static class FilterPredicate extends HandlerMethod.FilterPredicate {
+    private static class FilterPredicate extends HandlerMethodPredicate {
 
         @Override
         protected boolean isAnnotatedCorrectly(Method method) {

--- a/server/src/main/java/org/spine3/server/reflect/CommandHandlerMethod.java
+++ b/server/src/main/java/org/spine3/server/reflect/CommandHandlerMethod.java
@@ -22,6 +22,7 @@ package org.spine3.server.reflect;
 
 import com.google.common.base.Predicate;
 import com.google.protobuf.Message;
+import org.spine3.base.CommandClass;
 import org.spine3.base.CommandContext;
 import org.spine3.server.command.Assign;
 import org.spine3.server.command.CommandHandler;
@@ -32,9 +33,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.List;
+import java.util.Set;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.spine3.server.reflect.Classes.getHandledMessageClasses;
 
 /**
  * The wrapper for a command handler method.
@@ -44,7 +47,7 @@ import static java.util.Collections.singletonList;
 public class CommandHandlerMethod extends HandlerMethod<CommandContext> {
 
     /** The instance of the predicate to filter command handler methods of a class. */
-    public static final Predicate<Method> PREDICATE = new FilterPredicate();
+    static final Predicate<Method> PREDICATE = new FilterPredicate();
 
     /**
      * Creates a new instance to wrap {@code method} on {@code target}.
@@ -53,6 +56,19 @@ public class CommandHandlerMethod extends HandlerMethod<CommandContext> {
      */
     public CommandHandlerMethod(Method method) {
         super(method);
+    }
+
+    /**
+     * Returns the set of the command classes handled by the passed class.
+     *
+     * @param cls the class of objects that handle commands
+     * @return immutable set of command classes
+     */
+    @CheckReturnValue
+    public static Set<CommandClass> getCommandClasses(Class<?> cls) {
+        final Set<CommandClass> result = CommandClass.setOf(
+                getHandledMessageClasses(cls, PREDICATE));
+        return result;
     }
 
     /**
@@ -103,7 +119,7 @@ public class CommandHandlerMethod extends HandlerMethod<CommandContext> {
      * @return immutable map
      */
     @CheckReturnValue
-    public static MethodMap<CommandHandlerMethod> scan(CommandHandler object) {
+    static MethodMap<CommandHandlerMethod> scan(CommandHandler object) {
         final MethodMap<CommandHandlerMethod> handlers = MethodMap.create(object.getClass(),
                                                                           factory());
         return handlers;
@@ -148,7 +164,7 @@ public class CommandHandlerMethod extends HandlerMethod<CommandContext> {
         private enum Singleton {
             INSTANCE;
             @SuppressWarnings("NonSerializableFieldInSerializableClass")
-            private final CommandHandlerMethod.Factory value = new CommandHandlerMethod.Factory();
+            private final Factory value = new Factory();
         }
 
         private static Factory instance() {

--- a/server/src/main/java/org/spine3/server/reflect/CommandHandlerMethod.java
+++ b/server/src/main/java/org/spine3/server/reflect/CommandHandlerMethod.java
@@ -184,7 +184,7 @@ public class CommandHandlerMethod extends HandlerMethod<CommandContext> {
         }
 
         @Override
-        protected boolean isReturnTypeCorrect(Method method) {
+        protected boolean verifyReturnType(Method method) {
             final Class<?> returnType = method.getReturnType();
             final boolean isMessage = Message.class.isAssignableFrom(returnType);
             if (isMessage) {

--- a/server/src/main/java/org/spine3/server/reflect/EventSubscriberMethod.java
+++ b/server/src/main/java/org/spine3/server/reflect/EventSubscriberMethod.java
@@ -106,7 +106,7 @@ public class EventSubscriberMethod extends HandlerMethod<EventContext> {
      *
      * <p>Please see {@link Subscribe} annotation for more information.
      */
-    private static class FilterPredicate extends HandlerMethod.FilterPredicate {
+    private static class FilterPredicate extends HandlerMethodPredicate {
 
         @Override
         protected boolean isAnnotatedCorrectly(Method method) {

--- a/server/src/main/java/org/spine3/server/reflect/EventSubscriberMethod.java
+++ b/server/src/main/java/org/spine3/server/reflect/EventSubscriberMethod.java
@@ -112,7 +112,7 @@ public class EventSubscriberMethod extends HandlerMethod<EventContext> {
         }
 
         @Override
-        protected boolean isReturnTypeCorrect(Method method) {
+        protected boolean verifyReturnType(Method method) {
             final boolean isVoid = Void.TYPE.equals(method.getReturnType());
             return isVoid;
         }

--- a/server/src/main/java/org/spine3/server/reflect/EventSubscriberMethod.java
+++ b/server/src/main/java/org/spine3/server/reflect/EventSubscriberMethod.java
@@ -21,7 +21,6 @@
 package org.spine3.server.reflect;
 
 import com.google.common.base.Predicate;
-import com.google.protobuf.Message;
 import org.spine3.base.EventContext;
 import org.spine3.server.event.Subscribe;
 
@@ -92,8 +91,8 @@ public class EventSubscriberMethod extends HandlerMethod<EventContext> {
 
         private enum Singleton {
             INSTANCE;
-            @SuppressWarnings({"NonSerializableFieldInSerializableClass", "UnnecessarilyQualifiedInnerClassAccess"})
-            private final EventSubscriberMethod.Factory value = new EventSubscriberMethod.Factory(); // use the FQN
+            @SuppressWarnings("NonSerializableFieldInSerializableClass")
+            private final EventSubscriberMethod.Factory value = new EventSubscriberMethod.Factory();
         }
 
         private static Factory instance() {
@@ -106,23 +105,16 @@ public class EventSubscriberMethod extends HandlerMethod<EventContext> {
      *
      * <p>Please see {@link Subscribe} annotation for more information.
      */
-    private static class FilterPredicate extends HandlerMethodPredicate {
+    private static class FilterPredicate extends HandlerMethodPredicate<EventContext> {
 
-        @Override
-        protected boolean isAnnotatedCorrectly(Method method) {
-            final boolean isAnnotated = method.isAnnotationPresent(Subscribe.class);
-            return isAnnotated;
+        private FilterPredicate() {
+            super(Subscribe.class, EventContext.class);
         }
 
         @Override
         protected boolean isReturnTypeCorrect(Method method) {
             final boolean isVoid = Void.TYPE.equals(method.getReturnType());
             return isVoid;
-        }
-
-        @Override
-        protected Class<? extends Message> getContextClass() {
-            return EventContext.class;
         }
     }
 }

--- a/server/src/main/java/org/spine3/server/reflect/HandlerMethod.java
+++ b/server/src/main/java/org/spine3/server/reflect/HandlerMethod.java
@@ -39,10 +39,10 @@ import static com.google.common.base.Throwables.throwIfUnchecked;
  * <p>Two message handlers are equivalent when they refer to the same method on the
  * same object (not class).
  *
+ * @param <C> the type of the message context or {@link com.google.protobuf.Empty Empty} if
+ *            a context parameter is never used
  * @author Mikhail Melnik
  * @author Alexander Yevsyukov
- * @param <C> the type of the message context or {@link com.google.protobuf.Empty Empty} if
- *           a context parameter is never used
  */
 public abstract class HandlerMethod<C extends Message> {
 
@@ -68,15 +68,19 @@ public abstract class HandlerMethod<C extends Message> {
         return method;
     }
 
+    private int getModifiers() {
+        return method.getModifiers();
+    }
+
     /** Returns {@code true} if the method is declared {@code public}, {@code false} otherwise. */
     protected boolean isPublic() {
-        final boolean result = Modifier.isPublic(getMethod().getModifiers());
+        final boolean result = Modifier.isPublic(getModifiers());
         return result;
     }
 
     /** Returns {@code true} if the method is declared {@code private}, {@code false} otherwise. */
     protected boolean isPrivate() {
-        final boolean result = Modifier.isPrivate(getMethod().getModifiers());
+        final boolean result = Modifier.isPrivate(getModifiers());
         return result;
     }
 

--- a/server/src/main/java/org/spine3/server/reflect/HandlerMethod.java
+++ b/server/src/main/java/org/spine3/server/reflect/HandlerMethod.java
@@ -92,10 +92,12 @@ public abstract class HandlerMethod<C extends Message> {
      * @param target  the target object on which call the method
      * @param message the message to handle   @return the result of message handling
      * @param context the context of the message
-     * @throws InvocationTargetException if the wrapped method throws any {@link Throwable} that is not an {@link Error}.
+     * @throws InvocationTargetException if the wrapped method throws any {@link Throwable} that
+     *                                   is not an {@link Error}.
      *                                   {@code Error} instances are propagated as-is.
      */
-    public <R> R invoke(Object target, Message message, C context) throws InvocationTargetException {
+    public <R> R invoke(Object target, Message message, C context)
+            throws InvocationTargetException {
         checkNotNull(message);
         checkNotNull(context);
         try {
@@ -213,51 +215,6 @@ public abstract class HandlerMethod<C extends Message> {
          * @see HandlerMethod#warnOnWrongModifier(String, Method)
          */
         void checkAccessModifier(Method method);
-    }
-
-    /** The predicate class allowing to filter message handler methods. */
-    protected abstract static class FilterPredicate implements Predicate<Method> {
-
-        @Override
-        public boolean apply(@Nullable Method method) {
-            checkNotNull(method);
-            return isHandler(method);
-        }
-
-        /** Checks if the passed method is a handler. */
-        protected boolean isHandler(Method method) {
-            final boolean isHandler = isAnnotatedCorrectly(method)
-                    && acceptsCorrectParams(method)
-                    && isReturnTypeCorrect(method);
-            return isHandler;
-        }
-
-        /** Returns {@code true} if the method is annotated correctly, {@code false} otherwise. */
-        protected abstract boolean isAnnotatedCorrectly(Method method);
-
-        /** Returns {@code true} if the method return type is correct, {@code false} otherwise. */
-        protected abstract boolean isReturnTypeCorrect(Method method);
-
-        /** Returns the context parameter type. */
-        protected abstract Class<? extends Message> getContextClass();
-
-        /** Returns {@code true} if the method parameters are correct, {@code false} otherwise. */
-        protected boolean acceptsCorrectParams(Method method) {
-            final Class<?>[] paramTypes = method.getParameterTypes();
-            final int paramCount = paramTypes.length;
-            final boolean isParamCountCorrect = (paramCount == 1) || (paramCount == 2);
-            if (!isParamCountCorrect) {
-                return false;
-            }
-            final boolean isFirstParamMsg = Message.class.isAssignableFrom(paramTypes[0]);
-            if (paramCount == 1) {
-                return isFirstParamMsg;
-            } else {
-                final Class<? extends Message> contextClass = getContextClass();
-                final boolean paramsCorrect = isFirstParamMsg && contextClass.equals(paramTypes[1]);
-                return paramsCorrect;
-            }
-        }
     }
 
     private enum LogSingleton {

--- a/server/src/main/java/org/spine3/server/reflect/HandlerMethod.java
+++ b/server/src/main/java/org/spine3/server/reflect/HandlerMethod.java
@@ -186,7 +186,8 @@ public abstract class HandlerMethod<C extends Message> {
      */
     static Class<? extends Message> getFirstParamType(Method handler) {
         @SuppressWarnings("unchecked") /* we always expect first param as {@link Message} */
-        final Class<? extends Message> result = (Class<? extends Message>) handler.getParameterTypes()[0];
+        final Class<? extends Message> result =
+                (Class<? extends Message>) handler.getParameterTypes()[0];
         return result;
     }
 

--- a/server/src/main/java/org/spine3/server/reflect/HandlerMethodPredicate.java
+++ b/server/src/main/java/org/spine3/server/reflect/HandlerMethodPredicate.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.reflect;
+
+import com.google.protobuf.Message;
+
+import java.lang.reflect.Method;
+
+/**
+ * The predicate for filtering message handling methods.
+ *
+ * @author Alexander Yevsyukov
+ */
+public abstract class HandlerMethodPredicate extends MethodPredicate {
+
+    /**
+     * Returns the context parameter class.
+     */
+    protected abstract Class<? extends Message> getContextClass();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean acceptsCorrectParams(Method method) {
+        final Class<?>[] paramTypes = method.getParameterTypes();
+        final int paramCount = paramTypes.length;
+        final boolean isParamCountCorrect = (paramCount == 1) || (paramCount == 2);
+        if (!isParamCountCorrect) {
+            return false;
+        }
+        final boolean isFirstParamMsg = Message.class.isAssignableFrom(paramTypes[0]);
+        if (paramCount == 1) {
+            return isFirstParamMsg;
+        } else {
+            final Class<? extends Message> contextClass = getContextClass();
+            final boolean paramsCorrect = isFirstParamMsg && contextClass.equals(paramTypes[1]);
+            return paramsCorrect;
+        }
+    }
+}

--- a/server/src/main/java/org/spine3/server/reflect/HandlerMethodPredicate.java
+++ b/server/src/main/java/org/spine3/server/reflect/HandlerMethodPredicate.java
@@ -55,7 +55,7 @@ public abstract class HandlerMethodPredicate<C extends Message> extends MethodPr
     }
 
     @Override
-    protected boolean isAnnotatedCorrectly(Method method) {
+    protected boolean verifyAnnotation(Method method) {
         final boolean isAnnotated = method.isAnnotationPresent(getAnnotationClass());
         return isAnnotated;
     }
@@ -64,7 +64,7 @@ public abstract class HandlerMethodPredicate<C extends Message> extends MethodPr
      * {@inheritDoc}
      */
     @Override
-    protected boolean acceptsCorrectParams(Method method) {
+    protected boolean verifyParams(Method method) {
         final Class<?>[] paramTypes = method.getParameterTypes();
         final int paramCount = paramTypes.length;
         final boolean isParamCountCorrect = (paramCount == 1) || (paramCount == 2);

--- a/server/src/main/java/org/spine3/server/reflect/HandlerMethodPredicate.java
+++ b/server/src/main/java/org/spine3/server/reflect/HandlerMethodPredicate.java
@@ -28,7 +28,8 @@ import java.lang.reflect.Method;
 /**
  * The predicate for filtering message handling methods.
  *
- * @param <C> the type of message context
+ * @param <C> the type of message context or {@link com.google.protobuf.Empty Empty} if
+ *            a context parameter is never used
  * @author Alexander Yevsyukov
  */
 public abstract class HandlerMethodPredicate<C extends Message> extends MethodPredicate {

--- a/server/src/main/java/org/spine3/server/reflect/HandlerMethodPredicate.java
+++ b/server/src/main/java/org/spine3/server/reflect/HandlerMethodPredicate.java
@@ -22,19 +22,42 @@ package org.spine3.server.reflect;
 
 import com.google.protobuf.Message;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
 /**
  * The predicate for filtering message handling methods.
  *
+ * @param <C> the type of message context
  * @author Alexander Yevsyukov
  */
-public abstract class HandlerMethodPredicate extends MethodPredicate {
+public abstract class HandlerMethodPredicate<C extends Message> extends MethodPredicate {
+
+    private final Class<? extends Annotation> annotationClass;
+    private final Class<C> contextClass;
+
+    protected HandlerMethodPredicate(Class<? extends Annotation> annotationClass,
+                                     Class<C> contextClass) {
+        this.annotationClass = annotationClass;
+        this.contextClass = contextClass;
+    }
 
     /**
      * Returns the context parameter class.
      */
-    protected abstract Class<? extends Message> getContextClass();
+    protected Class<C> getContextClass() {
+        return contextClass;
+    }
+
+    protected Class<? extends Annotation> getAnnotationClass() {
+        return annotationClass;
+    }
+
+    @Override
+    protected boolean isAnnotatedCorrectly(Method method) {
+        final boolean isAnnotated = method.isAnnotationPresent(getAnnotationClass());
+        return isAnnotated;
+    }
 
     /**
      * {@inheritDoc}

--- a/server/src/main/java/org/spine3/server/reflect/MethodPredicate.java
+++ b/server/src/main/java/org/spine3/server/reflect/MethodPredicate.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.reflect;
+
+import com.google.common.base.Predicate;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Method;
+
+/**
+ * A filter for methods by annotation, method parameters, and return type.
+ *
+ * @author Alexander Yevsyukov
+ */
+public abstract class MethodPredicate implements Predicate<Method> {
+
+    @Override
+    public boolean apply(@Nullable Method method) {
+        if (method == null) {
+            return false;
+        }
+        final boolean result = isAnnotatedCorrectly(method)
+                               && acceptsCorrectParams(method)
+                               && isReturnTypeCorrect(method);
+        return result;
+    }
+
+    /**
+     * Returns {@code true} if the method is annotated correctly, {@code false} otherwise.
+     */
+    protected abstract boolean isAnnotatedCorrectly(Method method);
+
+    /**
+     * Returns {@code true} if the method return type is correct, {@code false} otherwise.
+     */
+    protected abstract boolean isReturnTypeCorrect(Method method);
+
+    /**
+     * Returns {@code true} if the method parameters are correct, {@code false} otherwise.
+     */
+    protected abstract boolean acceptsCorrectParams(Method method);
+}

--- a/server/src/main/java/org/spine3/server/reflect/MethodPredicate.java
+++ b/server/src/main/java/org/spine3/server/reflect/MethodPredicate.java
@@ -37,24 +37,24 @@ public abstract class MethodPredicate implements Predicate<Method> {
         if (method == null) {
             return false;
         }
-        final boolean result = isAnnotatedCorrectly(method)
-                               && acceptsCorrectParams(method)
-                               && isReturnTypeCorrect(method);
+        final boolean result = verifyAnnotation(method)
+                               && verifyParams(method)
+                               && verifyReturnType(method);
         return result;
     }
 
     /**
      * Returns {@code true} if the method is annotated correctly, {@code false} otherwise.
      */
-    protected abstract boolean isAnnotatedCorrectly(Method method);
+    protected abstract boolean verifyAnnotation(Method method);
 
     /**
      * Returns {@code true} if the method return type is correct, {@code false} otherwise.
      */
-    protected abstract boolean isReturnTypeCorrect(Method method);
+    protected abstract boolean verifyReturnType(Method method);
 
     /**
      * Returns {@code true} if the method parameters are correct, {@code false} otherwise.
      */
-    protected abstract boolean acceptsCorrectParams(Method method);
+    protected abstract boolean verifyParams(Method method);
 }

--- a/server/src/main/java/org/spine3/server/reflect/MethodRegistry.java
+++ b/server/src/main/java/org/spine3/server/reflect/MethodRegistry.java
@@ -55,8 +55,9 @@ public class MethodRegistry {
                                               HandlerMethod.Factory<H> factory) {
 
         final Key<?, H> key = new Key<>(targetClass, factory.getMethodClass());
-        @SuppressWarnings("unchecked") /* We can cast as the map type is the same as one of the passed factory,
-                                          which is used in creating the entry in the `if` block below. */
+        @SuppressWarnings("unchecked")
+            /* We can cast as the map type is the same as one of the passed factory,
+               which is used in creating the entry in the `if` block below. */
         MethodMap<H> methods = items.get(key);
         if (methods == null) {
             methods = MethodMap.create(targetClass, factory);

--- a/server/src/test/java/org/spine3/server/aggregate/AggregateRepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/aggregate/AggregateRepositoryShould.java
@@ -58,7 +58,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.spine3.server.command.CommandHandlingEntity.getCommandClasses;
+import static org.spine3.server.reflect.CommandHandlerMethod.getCommandClasses;
 import static org.spine3.testdata.TestCommandContextFactory.createCommandContext;
 import static org.spine3.validate.Validate.isDefault;
 import static org.spine3.validate.Validate.isNotDefault;

--- a/server/src/test/java/org/spine3/server/aggregate/AggregateShould.java
+++ b/server/src/test/java/org/spine3/server/aggregate/AggregateShould.java
@@ -62,7 +62,7 @@ import static org.spine3.protobuf.AnyPacker.unpack;
 import static org.spine3.server.aggregate.Given.Event.projectCreated;
 import static org.spine3.server.aggregate.Given.Event.projectStarted;
 import static org.spine3.server.aggregate.Given.Event.taskAdded;
-import static org.spine3.server.command.CommandHandlingEntity.getCommandClasses;
+import static org.spine3.server.reflect.CommandHandlerMethod.getCommandClasses;
 import static org.spine3.test.Tests.newVersionWithNumber;
 import static org.spine3.test.aggregate.Project.newBuilder;
 import static org.spine3.testdata.TestCommandContextFactory.createCommandContext;

--- a/testutil/src/main/java/org/spine3/test/Verify.java
+++ b/testutil/src/main/java/org/spine3/test/Verify.java
@@ -10,6 +10,7 @@
 
 package org.spine3.test;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.Multimap;
@@ -56,7 +57,9 @@ public final class Verify extends Assert {
     @SuppressWarnings("AccessOfSystemProperties")
     private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
-    private static final String PARAM_MAP = "map";
+    @VisibleForTesting
+    static final String PARAM_MAP = "map";
+
     private static final String PARAM_MULTIMAP = "multimap";
     private static final String PARAM_COLLECTION = "collection";
     private static final String PARAM_ARRAY = "array";

--- a/testutil/src/test/java/org/spine3/test/VerifyShould.java
+++ b/testutil/src/test/java/org/spine3/test/VerifyShould.java
@@ -44,14 +44,46 @@ import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.spine3.test.Verify.*;
+import static org.spine3.test.Verify.assertBefore;
+import static org.spine3.test.Verify.assertClassNonInstantiable;
+import static org.spine3.test.Verify.assertContains;
+import static org.spine3.test.Verify.assertContainsAll;
+import static org.spine3.test.Verify.assertContainsEntry;
+import static org.spine3.test.Verify.assertContainsKey;
+import static org.spine3.test.Verify.assertContainsKeyValue;
+import static org.spine3.test.Verify.assertEmpty;
+import static org.spine3.test.Verify.assertEndsWith;
+import static org.spine3.test.Verify.assertEqualsAndHashCode;
+import static org.spine3.test.Verify.assertError;
+import static org.spine3.test.Verify.assertInstanceOf;
+import static org.spine3.test.Verify.assertItemAtIndex;
+import static org.spine3.test.Verify.assertIterableEmpty;
+import static org.spine3.test.Verify.assertIterableNotEmpty;
+import static org.spine3.test.Verify.assertMapsEqual;
+import static org.spine3.test.Verify.assertNegative;
+import static org.spine3.test.Verify.assertNotContains;
+import static org.spine3.test.Verify.assertNotContainsKey;
+import static org.spine3.test.Verify.assertNotEmpty;
+import static org.spine3.test.Verify.assertNotEquals;
+import static org.spine3.test.Verify.assertNotInstanceOf;
+import static org.spine3.test.Verify.assertPositive;
+import static org.spine3.test.Verify.assertSetsEqual;
+import static org.spine3.test.Verify.assertShallowClone;
+import static org.spine3.test.Verify.assertSize;
+import static org.spine3.test.Verify.assertStartsWith;
+import static org.spine3.test.Verify.assertThrows;
+import static org.spine3.test.Verify.assertThrowsWithCause;
+import static org.spine3.test.Verify.assertZero;
+import static org.spine3.test.Verify.denyContainsKey;
+import static org.spine3.test.Verify.mangledException;
 
 @SuppressWarnings({"ClassWithTooManyMethods", "OverlyComplexClass"})
 public class VerifyShould {
 
     private static final String EMPTY_STRING = "";
     private static final String NON_EMPTY_STRING = "Non-empty string";
-    private static final String MAP_NAME = "map";
+
+    private static final String MAP_NAME = Verify.PARAM_MAP;
 
     @Test
     public void extend_Assert_class() {


### PR DESCRIPTION
This PR improves hierarchy of `MethodPredicate` classes. Namely:

- `MethodPredicate` is introduced as a generic predicate for methods
- `HandlerMethodPredicate` is introduced as a specific filter for handler methods
- Context class and annotation class are passed as constructor parameters