### PR TITLE
Hide `MethodMap`

### DIFF
--- a/server/src/main/java/org/spine3/server/event/SubscriberRegistry.java
+++ b/server/src/main/java/org/spine3/server/event/SubscriberRegistry.java
@@ -22,6 +22,8 @@ package org.spine3.server.event;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
 import com.google.protobuf.Message;
 import org.spine3.base.EventClass;
 import org.spine3.server.reflect.EventSubscriberMethod;
@@ -42,8 +44,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 class SubscriberRegistry {
 
-    private final HashMultimap<EventClass, EventSubscriber> subscribersByEventClass =
-            HashMultimap.create();
+    private final Multimap<EventClass, EventSubscriber> subscribersByEventClass =
+            Multimaps.synchronizedMultimap(HashMultimap.<EventClass, EventSubscriber>create());
 
     void subscribe(EventSubscriber object) {
         checkNotNull(object);

--- a/server/src/main/java/org/spine3/server/reflect/EventSubscriberMethod.java
+++ b/server/src/main/java/org/spine3/server/reflect/EventSubscriberMethod.java
@@ -87,21 +87,6 @@ public class EventSubscriberMethod extends HandlerMethod<EventContext> {
         return new IllegalStateException(msg);
     }
 
-    /**
-     * Scans for event subscribers the passed target.
-     *
-     * @param target the target to scan
-     * @return immutable map of event subscriber methods
-     */
-    @CheckReturnValue
-    public static MethodMap<EventSubscriberMethod> scan(Object target) {
-        checkNotNull(target);
-
-        final MethodMap<EventSubscriberMethod> result = MethodMap.create(target.getClass(),
-                                                                         factory());
-        return result;
-    }
-
     @CheckReturnValue
     public static ImmutableSet<EventClass> getEventClasses(Class<?> cls) {
         checkNotNull(cls);

--- a/server/src/main/java/org/spine3/server/reflect/MethodMap.java
+++ b/server/src/main/java/org/spine3/server/reflect/MethodMap.java
@@ -41,7 +41,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @param <H> the type of the handler method instances stored in the map
  * @author Alexander Yevsyukov
  */
-public class MethodMap<H extends HandlerMethod> {
+class MethodMap<H extends HandlerMethod> {
 
     private final ImmutableMap<Class<? extends Message>, H> map;
 

--- a/server/src/test/java/org/spine3/server/reflect/EventSubscriberMethodShould.java
+++ b/server/src/test/java/org/spine3/server/reflect/EventSubscriberMethodShould.java
@@ -45,25 +45,7 @@ public class EventSubscriberMethodShould {
         new NullPointerTester()
                 .testAllPublicStaticMethods(EventSubscriberMethod.class);
     }
-
-    @Test
-    public void scan_target_for_subscribers() {
-        final TestEventSubscriber subscriberObject = new ValidSubscriberOneParam();
-
-        final MethodMap<EventSubscriberMethod> subscriberMap =
-                EventSubscriberMethod.scan(subscriberObject);
-
-        assertEquals(1, subscriberMap.values()
-                                     .size());
-
-        @SuppressWarnings("ConstantConditions")
-            // We won't have null because we pass class with method that handles this command.
-        final Method method = subscriberMap.get(ProjectCreated.class)
-                                           .getMethod();
-        assertEquals(subscriberObject.getMethod(),
-                     method);
-    }
-
+    
     @Test
     public void invoke_subscriber_method() throws InvocationTargetException {
         final ValidSubscriberTwoParams subscriberObject = spy(new ValidSubscriberTwoParams());


### PR DESCRIPTION
This PR removes unnecessary method `EventSubscriberMethod.scan()`. `EventSubscriberMethod.getEventClasses()` should be used instead.

As the result the class `MethodMap` was made package-access.