### PR TITLE
`Projection.TypeInfo` and tests code cleanup

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -363,7 +363,12 @@
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
     <inspection_tool class="MapReplaceableByEnumMap" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MethodCount" enabled="true" level="INFO" enabled_by_default="true">
+    <inspection_tool class="MethodCount" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Tests" level="TYPO" enabled="true">
+        <option name="m_limit" value="20" />
+        <option name="ignoreGettersAndSetters" value="false" />
+        <option name="ignoreOverridingMethods" value="false" />
+      </scope>
       <option name="m_limit" value="20" />
       <option name="ignoreGettersAndSetters" value="true" />
       <option name="ignoreOverridingMethods" value="true" />

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
         
-        spineVersion = '0.8.15-SNAPSHOT'
+        spineVersion = '0.8.16-SNAPSHOT'
         
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all the components and change
         // the version of the dependency below to `spineVersion` defined above.

--- a/client/src/main/java/org/spine3/io/IoUtil.java
+++ b/client/src/main/java/org/spine3/io/IoUtil.java
@@ -33,6 +33,8 @@ import java.net.URL;
 import java.util.Enumeration;
 import java.util.Properties;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * A utility class working with I/O: streams, resources, etc.
  *
@@ -53,6 +55,8 @@ public class IoUtil {
      * @param propsFilePath the path of the {@code .properties} file to load
      */
     public static ImmutableSet<Properties> loadAllProperties(String propsFilePath) {
+        checkNotNull(propsFilePath);
+
         final ImmutableSet.Builder<Properties> result = ImmutableSet.builder();
         final Enumeration<URL> resources = getResources(propsFilePath);
         if (resources == null) {
@@ -105,6 +109,8 @@ public class IoUtil {
      * <p>Logs each {@link IOException} if it occurs.
      */
     public static void close(Closeable... closeables) {
+        checkNotNull(closeables);
+
         close(FluentIterable.from(closeables));
     }
 
@@ -115,6 +121,8 @@ public class IoUtil {
      */
     @SuppressWarnings("ConstantConditions"/*check for null is ok*/)
     public static <T extends Closeable> void close(Iterable<T> closeables) {
+        checkNotNull(closeables);
+
         try {
             for (T c : closeables) {
                 if (c != null) {

--- a/client/src/test/java/org/spine3/base/CommandsShould.java
+++ b/client/src/test/java/org/spine3/base/CommandsShould.java
@@ -26,8 +26,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Any;
 import com.google.protobuf.BoolValue;
-import com.google.protobuf.DescriptorProtos;
-import com.google.protobuf.Descriptors;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Int64Value;
 import com.google.protobuf.StringValue;
@@ -36,7 +34,6 @@ import org.junit.Test;
 import org.spine3.protobuf.AnyPacker;
 import org.spine3.protobuf.Durations2;
 import org.spine3.protobuf.Timestamps2;
-import org.spine3.test.NullToleranceTest;
 import org.spine3.test.TestCommandFactory;
 import org.spine3.test.Tests;
 import org.spine3.test.commands.TestCommand;
@@ -61,7 +58,7 @@ import static org.spine3.base.Stringifiers.idToString;
 import static org.spine3.protobuf.Durations2.seconds;
 import static org.spine3.protobuf.Timestamps2.getCurrentTime;
 import static org.spine3.protobuf.Values.newStringValue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.spine3.test.Tests.newUserUuid;
 import static org.spine3.test.TimeTests.Past.minutesAgo;
 import static org.spine3.test.TimeTests.Past.secondsAgo;
@@ -78,7 +75,7 @@ public class CommandsShould {
 
     @Test
     public void have_private_ctor() {
-        assertTrue(hasPrivateParameterlessCtor(Commands.class));
+        assertHasPrivateParameterlessCtor(Commands.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/base/ErrorsShould.java
+++ b/client/src/test/java/org/spine3/base/ErrorsShould.java
@@ -25,14 +25,13 @@ import org.spine3.test.NullToleranceTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class ErrorsShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Errors.class));
+        assertHasPrivateParameterlessCtor(Errors.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/base/EventClassShould.java
+++ b/client/src/test/java/org/spine3/base/EventClassShould.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class EventClassShould {
 
     @Test

--- a/client/src/test/java/org/spine3/base/EventPredicatesShould.java
+++ b/client/src/test/java/org/spine3/base/EventPredicatesShould.java
@@ -24,7 +24,6 @@ import com.google.common.base.Predicate;
 import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Timestamp;
 import org.junit.Test;
-import org.spine3.test.Tests;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -33,6 +32,7 @@ import static org.spine3.base.EventPredicates.isBefore;
 import static org.spine3.base.EventPredicates.isBetween;
 import static org.spine3.protobuf.Timestamps2.getCurrentTime;
 import static org.spine3.test.EventTests.newEventContext;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.spine3.test.Tests.newUuidValue;
 import static org.spine3.test.TimeTests.Past.minutesAgo;
 import static org.spine3.test.TimeTests.Past.secondsAgo;
@@ -50,7 +50,7 @@ public class EventPredicatesShould {
 
     @Test
     public void have_private_utility_ctor() {
-        Tests.hasPrivateParameterlessCtor(EventPredicates.class);
+        assertHasPrivateParameterlessCtor(EventPredicates.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/base/EventsShould.java
+++ b/client/src/test/java/org/spine3/base/EventsShould.java
@@ -51,12 +51,11 @@ import static org.spine3.protobuf.AnyPacker.unpack;
 import static org.spine3.protobuf.Values.newBoolValue;
 import static org.spine3.protobuf.Values.newDoubleValue;
 import static org.spine3.protobuf.Values.newStringValue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.spine3.test.TimeTests.Past.minutesAgo;
 import static org.spine3.test.TimeTests.Past.secondsAgo;
 import static org.spine3.validate.Validate.isNotDefault;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class EventsShould {
 
     private final EventContext context = EventTests.newEventContext();
@@ -68,7 +67,7 @@ public class EventsShould {
 
     @Test
     public void have_private_ctor() {
-        assertTrue(hasPrivateParameterlessCtor(Events.class));
+        assertHasPrivateParameterlessCtor(Events.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/base/FailuresShould.java
+++ b/client/src/test/java/org/spine3/base/FailuresShould.java
@@ -22,9 +22,9 @@ package org.spine3.base;
 
 import com.google.common.testing.NullPointerTester;
 import org.junit.Test;
-import org.spine3.test.Tests;
 
 import static org.junit.Assert.assertFalse;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Alexander Yevsyukov
@@ -33,7 +33,7 @@ public class FailuresShould {
 
     @Test
     public void have_utility_ctor() {
-        Tests.hasPrivateParameterlessCtor(Failures.class);
+        assertHasPrivateParameterlessCtor(Failures.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/base/IdentifierShould.java
+++ b/client/src/test/java/org/spine3/base/IdentifierShould.java
@@ -36,7 +36,6 @@ import static org.spine3.protobuf.Values.newStringValue;
 import static org.spine3.protobuf.Values.newUInt64Value;
 import static org.spine3.protobuf.Values.newUIntValue;
 
-@SuppressWarnings({"InstanceMethodNamingConvention", "ClassWithTooManyMethods", "MagicNumber"})
 public class IdentifierShould {
 
     @Test

--- a/client/src/test/java/org/spine3/base/IdentifiersShould.java
+++ b/client/src/test/java/org/spine3/base/IdentifiersShould.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertTrue;
 import static org.spine3.base.Identifiers.idToAny;
 import static org.spine3.base.Identifiers.newUuid;
 import static org.spine3.base.Stringifiers.idToString;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Alexander Litus
@@ -39,7 +39,7 @@ public class IdentifiersShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Identifiers.class));
+        assertHasPrivateParameterlessCtor(Identifiers.class);
     }
 
 

--- a/client/src/test/java/org/spine3/base/IdentifiersShould.java
+++ b/client/src/test/java/org/spine3/base/IdentifiersShould.java
@@ -34,7 +34,6 @@ import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings({"InstanceMethodNamingConvention", "ClassWithTooManyMethods"})
 public class IdentifiersShould {
 
     @Test

--- a/client/src/test/java/org/spine3/base/MessageClassShould.java
+++ b/client/src/test/java/org/spine3/base/MessageClassShould.java
@@ -32,7 +32,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
-@SuppressWarnings({"InstanceMethodNamingConvention", "EmptyClass"})
 public class MessageClassShould {
 
     private static final Class<StringValue> MSG_CLASS = StringValue.class;
@@ -87,7 +86,7 @@ public class MessageClassShould {
 
     private static class TestMessageClass extends MessageClass {
 
-        protected TestMessageClass(Class<? extends Message> value) {
+        private TestMessageClass(Class<? extends Message> value) {
             super(value);
         }
     }

--- a/client/src/test/java/org/spine3/base/QueriesShould.java
+++ b/client/src/test/java/org/spine3/base/QueriesShould.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Alex Tymchenko
@@ -55,12 +55,12 @@ public class QueriesShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Queries.class));
+        assertHasPrivateParameterlessCtor(Queries.class);
     }
 
     @Test
     public void have_private_constructor_of_targets_class() {
-        assertTrue(hasPrivateParameterlessCtor(Queries.Targets.class));
+        assertHasPrivateParameterlessCtor(Queries.Targets.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/base/ResponsesShould.java
+++ b/client/src/test/java/org/spine3/base/ResponsesShould.java
@@ -25,14 +25,13 @@ import org.junit.Test;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class ResponsesShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Responses.class));
+        assertHasPrivateParameterlessCtor(Responses.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/base/StringifiersShould.java
+++ b/client/src/test/java/org/spine3/base/StringifiersShould.java
@@ -47,7 +47,7 @@ import static org.spine3.protobuf.Timestamps2.getCurrentTime;
 import static org.spine3.protobuf.Values.newIntValue;
 import static org.spine3.protobuf.Values.newLongValue;
 import static org.spine3.protobuf.Values.newStringValue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 public class StringifiersShould {
 
@@ -55,7 +55,7 @@ public class StringifiersShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Stringifiers.class));
+        assertHasPrivateParameterlessCtor(Stringifiers.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/base/VersionsShould.java
+++ b/client/src/test/java/org/spine3/base/VersionsShould.java
@@ -24,6 +24,8 @@ import com.google.common.testing.NullPointerTester;
 import org.junit.Test;
 import org.spine3.test.Tests;
 
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
+
 /**
  * @author Alexander Yevsyukov
  */
@@ -31,7 +33,7 @@ public class VersionsShould {
 
     @Test
     public void have_private_utility_ctor() {
-        Tests.hasPrivateParameterlessCtor(Versions.class);
+        assertHasPrivateParameterlessCtor(Versions.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/change/BooleanMismatchShould.java
+++ b/client/src/test/java/org/spine3/change/BooleanMismatchShould.java
@@ -31,7 +31,7 @@ import static org.spine3.change.BooleanMismatch.unpackActual;
 import static org.spine3.change.BooleanMismatch.unpackExpected;
 import static org.spine3.change.BooleanMismatch.unpackNewValue;
 import static org.spine3.change.IntMismatch.of;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 public class BooleanMismatchShould {
 
@@ -39,7 +39,7 @@ public class BooleanMismatchShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(BooleanMismatch.class));
+        assertHasPrivateParameterlessCtor(BooleanMismatch.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/change/ChangesShould.java
+++ b/client/src/test/java/org/spine3/change/ChangesShould.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 @SuppressWarnings({"ConstantConditions" /* We pass `null` to some of the methods to check handling of preconditions */,
         "ResultOfMethodCallIgnored" /* ...when methods throw exceptions */,
@@ -44,7 +44,7 @@ public class ChangesShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Changes.class));
+        assertHasPrivateParameterlessCtor(Changes.class);
     }
 
     @Test(expected = NullPointerException.class)

--- a/client/src/test/java/org/spine3/change/DoubleMismatchShould.java
+++ b/client/src/test/java/org/spine3/change/DoubleMismatchShould.java
@@ -32,7 +32,7 @@ import static org.spine3.change.DoubleMismatch.unexpectedValue;
 import static org.spine3.change.DoubleMismatch.unpackActual;
 import static org.spine3.change.DoubleMismatch.unpackExpected;
 import static org.spine3.change.DoubleMismatch.unpackNewValue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 public class DoubleMismatchShould {
 
@@ -44,7 +44,7 @@ public class DoubleMismatchShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(DoubleMismatch.class));
+        assertHasPrivateParameterlessCtor(DoubleMismatch.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/change/FloatMismatchShould.java
+++ b/client/src/test/java/org/spine3/change/FloatMismatchShould.java
@@ -32,7 +32,7 @@ import static org.spine3.change.FloatMismatch.unexpectedValue;
 import static org.spine3.change.FloatMismatch.unpackActual;
 import static org.spine3.change.FloatMismatch.unpackExpected;
 import static org.spine3.change.FloatMismatch.unpackNewValue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 public class FloatMismatchShould {
 
@@ -44,7 +44,7 @@ public class FloatMismatchShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(FloatMismatch.class));
+        assertHasPrivateParameterlessCtor(FloatMismatch.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/change/IntMismatchShould.java
+++ b/client/src/test/java/org/spine3/change/IntMismatchShould.java
@@ -33,7 +33,7 @@ import static org.spine3.change.IntMismatch.unexpectedValue;
 import static org.spine3.change.IntMismatch.unpackActual;
 import static org.spine3.change.IntMismatch.unpackExpected;
 import static org.spine3.change.IntMismatch.unpackNewValue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 public class IntMismatchShould {
 
@@ -44,7 +44,7 @@ public class IntMismatchShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(IntMismatch.class));
+        assertHasPrivateParameterlessCtor(IntMismatch.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/change/LongMismatchShould.java
+++ b/client/src/test/java/org/spine3/change/LongMismatchShould.java
@@ -32,7 +32,7 @@ import static org.spine3.change.LongMismatch.unexpectedValue;
 import static org.spine3.change.LongMismatch.unpackActual;
 import static org.spine3.change.LongMismatch.unpackExpected;
 import static org.spine3.change.LongMismatch.unpackNewValue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 public class LongMismatchShould {
 
@@ -43,7 +43,7 @@ public class LongMismatchShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(LongMismatch.class));
+        assertHasPrivateParameterlessCtor(LongMismatch.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/change/MessageMismatchShould.java
+++ b/client/src/test/java/org/spine3/change/MessageMismatchShould.java
@@ -33,7 +33,7 @@ import static org.spine3.change.MessageMismatch.unpackActual;
 import static org.spine3.change.MessageMismatch.unpackExpected;
 import static org.spine3.change.MessageMismatch.unpackNewValue;
 import static org.spine3.protobuf.Values.newStringValue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 public class MessageMismatchShould {
 
@@ -45,7 +45,7 @@ public class MessageMismatchShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(MessageMismatch.class));
+        assertHasPrivateParameterlessCtor(MessageMismatch.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/change/PreconditionsShould.java
+++ b/client/src/test/java/org/spine3/change/PreconditionsShould.java
@@ -23,15 +23,14 @@ package org.spine3.change;
 import com.google.protobuf.ByteString;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
 import static org.spine3.change.Preconditions.checkNewValueNotEmpty;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 public class PreconditionsShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Preconditions.class));
+        assertHasPrivateParameterlessCtor(Preconditions.class);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/client/src/test/java/org/spine3/change/StringMismatchShould.java
+++ b/client/src/test/java/org/spine3/change/StringMismatchShould.java
@@ -32,7 +32,7 @@ import static org.spine3.change.StringMismatch.unexpectedValue;
 import static org.spine3.change.StringMismatch.unpackActual;
 import static org.spine3.change.StringMismatch.unpackExpected;
 import static org.spine3.change.StringMismatch.unpackNewValue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 public class StringMismatchShould {
 
@@ -44,7 +44,7 @@ public class StringMismatchShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(StringMismatch.class));
+        assertHasPrivateParameterlessCtor(StringMismatch.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/client/CommandFactoryShould.java
+++ b/client/src/test/java/org/spine3/client/CommandFactoryShould.java
@@ -40,7 +40,6 @@ import static org.junit.Assert.assertTrue;
 import static org.spine3.base.Identifiers.newUuid;
 import static org.spine3.test.Tests.newUserId;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class CommandFactoryShould {
 
     private final UserId actor = newUserId(newUuid());

--- a/client/src/test/java/org/spine3/protobuf/AnyPackerShould.java
+++ b/client/src/test/java/org/spine3/protobuf/AnyPackerShould.java
@@ -33,12 +33,11 @@ import java.util.Iterator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.spine3.base.Identifiers.newUuid;
 import static org.spine3.protobuf.TypeUrl.SPINE_TYPE_URL_PREFIX;
 import static org.spine3.protobuf.TypeUrl.composeTypeUrl;
 import static org.spine3.protobuf.Values.newStringValue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.spine3.test.Tests.newUserId;
 import static org.spine3.test.Tests.newUuidValue;
 
@@ -52,7 +51,7 @@ public class AnyPackerShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(AnyPacker.class));
+        assertHasPrivateParameterlessCtor(AnyPacker.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/protobuf/Durations2Should.java
+++ b/client/src/test/java/org/spine3/protobuf/Durations2Should.java
@@ -46,7 +46,7 @@ import static org.spine3.protobuf.Durations2.seconds;
 import static org.spine3.protobuf.Durations2.toMinutes;
 import static org.spine3.protobuf.Durations2.toNanos;
 import static org.spine3.protobuf.Durations2.toSeconds;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Alexander Yevsyukov
@@ -56,7 +56,7 @@ public class Durations2Should {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Durations2.class));
+        assertHasPrivateParameterlessCtor(Durations2.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/protobuf/KnownTypesShould.java
+++ b/client/src/test/java/org/spine3/protobuf/KnownTypesShould.java
@@ -49,18 +49,17 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.spine3.protobuf.TypeUrl.composeTypeUrl;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.spine3.test.Verify.assertSize;
 
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class KnownTypesShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(KnownTypes.class));
+        assertHasPrivateParameterlessCtor(KnownTypes.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/protobuf/MessageFieldShould.java
+++ b/client/src/test/java/org/spine3/protobuf/MessageFieldShould.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.assertEquals;
 import static org.spine3.base.Identifiers.newUuid;
 import static org.spine3.protobuf.Values.newStringValue;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class MessageFieldShould {
 
     private static final int STR_VALUE_FIELD_INDEX = 0;

--- a/client/src/test/java/org/spine3/protobuf/MessagesShould.java
+++ b/client/src/test/java/org/spine3/protobuf/MessagesShould.java
@@ -45,13 +45,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.spine3.protobuf.Values.newStringValue;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class MessagesShould {
 
     @Test
     public void have_private_utility_ctor() {
-        assertTrue(Tests.hasPrivateParameterlessCtor(Messages.class));
+        assertHasPrivateParameterlessCtor(Messages.class);
     }
 
     @Test(expected = NullPointerException.class)

--- a/client/src/test/java/org/spine3/protobuf/Timestamps2Should.java
+++ b/client/src/test/java/org/spine3/protobuf/Timestamps2Should.java
@@ -42,7 +42,7 @@ import static org.spine3.protobuf.Timestamps2.MILLIS_PER_SECOND;
 import static org.spine3.protobuf.Timestamps2.NANOS_PER_MICROSECOND;
 import static org.spine3.protobuf.Timestamps2.SECONDS_PER_HOUR;
 import static org.spine3.protobuf.Timestamps2.convertToDate;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 public class Timestamps2Should {
 
@@ -52,7 +52,7 @@ public class Timestamps2Should {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Timestamps2.class));
+        assertHasPrivateParameterlessCtor(Timestamps2.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/protobuf/TypeNameShould.java
+++ b/client/src/test/java/org/spine3/protobuf/TypeNameShould.java
@@ -20,34 +20,32 @@
 
 package org.spine3.protobuf;
 
+import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Descriptors;
 import org.junit.Test;
 import org.spine3.base.Command;
-import org.spine3.test.NullToleranceTest;
 
-import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
+/**
+ * Provides only class-level tests.
+ *
+ * <p>Other methods of {@link TypeName} are just over {@link TypeUrl} which are tested by
+ * its own set of tests.
+ */
 public class TypeNameShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(TypeName.class));
+        assertHasPrivateParameterlessCtor(TypeName.class);
     }
 
     @Test
     public void pass_the_null_tolerance_check() {
-        final Descriptors.Descriptor descriptor = Command.getDefaultInstance()
-                                                         .getDescriptorForType();
-        final NullToleranceTest nullToleranceTest = NullToleranceTest.newBuilder()
-                                                                     .setClass(TypeName.class)
-                                                                     .addDefaultValue(descriptor)
-                                                                     .addDefaultValue(Command.class)
-                                                                     .build();
-        final boolean passed = nullToleranceTest.check();
-        assertTrue(passed);
+        new NullPointerTester()
+                .setDefault(Command.class, Command.getDefaultInstance())
+                .setDefault(Descriptors.Descriptor.class, Command.getDefaultInstance()
+                                                                 .getDescriptorForType())
+                .testAllPublicStaticMethods(TypeName.class);
     }
-    /**
-     * Other methods of {@link TypeName} are just over {@link TypeUrl} which are tested by its own set of tests.
-     **/
 }

--- a/client/src/test/java/org/spine3/protobuf/TypeUrlShould.java
+++ b/client/src/test/java/org/spine3/protobuf/TypeUrlShould.java
@@ -43,7 +43,6 @@ import static org.spine3.protobuf.TypeUrl.SPINE_TYPE_URL_PREFIX;
 import static org.spine3.protobuf.TypeUrl.composeTypeUrl;
 import static org.spine3.protobuf.Values.newStringValue;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class TypeUrlShould {
 
     private static final String STRING_VALUE_TYPE_NAME = StringValue.getDescriptor().getFullName();

--- a/client/src/test/java/org/spine3/protobuf/ValuesShould.java
+++ b/client/src/test/java/org/spine3/protobuf/ValuesShould.java
@@ -34,19 +34,18 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.spine3.base.Identifiers.newUuid;
 import static org.spine3.protobuf.AnyPacker.unpack;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class ValuesShould {
 
     public static final double DELTA = 0.01;
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Values.class));
+        assertHasPrivateParameterlessCtor(Values.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/time/ZoneOffsetsShould.java
+++ b/client/src/test/java/org/spine3/time/ZoneOffsetsShould.java
@@ -25,14 +25,12 @@ import org.junit.Test;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.spine3.protobuf.Timestamps2.MINUTES_PER_HOUR;
 import static org.spine3.protobuf.Timestamps2.SECONDS_PER_MINUTE;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.spine3.time.ZoneOffsets.getOffsetInSeconds;
 import static org.spine3.time.ZoneOffsets.toZoneOffset;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class ZoneOffsetsShould {
 
     private static final int MIN_HOURS_OFFSET = -11;
@@ -43,7 +41,7 @@ public class ZoneOffsetsShould {
 
     @Test
     public void has_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(ZoneOffsets.class));
+        assertHasPrivateParameterlessCtor(ZoneOffsets.class);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/util/ExceptionsShould.java
+++ b/client/src/test/java/org/spine3/util/ExceptionsShould.java
@@ -20,22 +20,21 @@
 
 package org.spine3.util;
 
+import com.google.common.testing.NullPointerTester;
 import org.junit.Test;
-import org.spine3.test.NullToleranceTest;
-import org.spine3.test.Tests;
 
-import static org.junit.Assert.assertTrue;
 import static org.spine3.base.Identifiers.newUuid;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings({"InstanceMethodNamingConvention", "ThrowableResultOfMethodCallIgnored"})
+@SuppressWarnings("ThrowableResultOfMethodCallIgnored")
 public class ExceptionsShould {
 
     @Test
     public void have_private_ctor() {
-        assertTrue(Tests.hasPrivateParameterlessCtor(Exceptions.class));
+        assertHasPrivateParameterlessCtor(Exceptions.class);
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -50,11 +49,8 @@ public class ExceptionsShould {
 
     @Test
     public void pass_the_null_tolerance_check() {
-        final NullToleranceTest nullToleranceTest = NullToleranceTest.newBuilder()
-                                                                     .setClass(Exceptions.class)
-                                                                     .addDefaultValue(new RuntimeException("message"))
-                                                                     .build();
-        final boolean passed = nullToleranceTest.check();
-        assertTrue(passed);
+        new NullPointerTester()
+                .setDefault(Exception.class, new RuntimeException(""))
+                .testAllPublicStaticMethods(Exceptions.class);
     }
 }

--- a/client/src/test/java/org/spine3/util/MathShould.java
+++ b/client/src/test/java/org/spine3/util/MathShould.java
@@ -23,15 +23,13 @@ package org.spine3.util;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class MathShould {
 
     @Test
     public void have_private_constructor() throws Exception {
-        assertTrue(hasPrivateParameterlessCtor(Math.class));
+        assertHasPrivateParameterlessCtor(Math.class);
     }
 
     @Test(expected = ArithmeticException.class)

--- a/client/src/test/java/org/spine3/validate/ValidateShould.java
+++ b/client/src/test/java/org/spine3/validate/ValidateShould.java
@@ -35,16 +35,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.spine3.protobuf.Values.newStringValue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.spine3.test.Tests.newUuidValue;
 import static org.spine3.validate.Validate.checkBounds;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class ValidateShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Validate.class));
+        assertHasPrivateParameterlessCtor(Validate.class);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/server/src/main/java/org/spine3/server/entity/Repository.java
+++ b/server/src/main/java/org/spine3/server/entity/Repository.java
@@ -287,10 +287,6 @@ public abstract class Repository<I, E extends Entity<I, ?>>
 
     private static class TypeInfo {
 
-        private TypeInfo() {
-            // Prevent construction from outside.
-        }
-
         private static <E extends Entity<I, ?>, I>
         Class<E> getEntityClass(Class<? extends Repository<I, E>> repositoryClass) {
             final Class<E> result = getGenericParameterType(repositoryClass,

--- a/server/src/main/java/org/spine3/server/projection/Projection.java
+++ b/server/src/main/java/org/spine3/server/projection/Projection.java
@@ -69,13 +69,20 @@ public abstract class Projection<I, M extends Message> extends AbstractVersionab
         }
     }
 
-    /**
-     * Returns the set of event classes handled by the passed {@link Projection} class.
-     *
-     * @param cls the class to inspect
-     * @return immutable set of event classes or an empty set if no events are handled
-     */
-    static ImmutableSet<EventClass> getEventClasses(Class<? extends Projection> cls) {
-        return EventSubscriberMethod.getEventClasses(cls);
+    static class TypeInfo {
+
+        private TypeInfo() {
+            // Prevent instantiation of this utility class.
+        }
+
+        /**
+         * Returns the set of event classes handled by the passed {@link Projection} class.
+         *
+         * @param cls the class to inspect
+         * @return immutable set of event classes or an empty set if no events are handled
+         */
+        static ImmutableSet<EventClass> getEventClasses(Class<? extends Projection> cls) {
+            return EventSubscriberMethod.getEventClasses(cls);
+        }
     }
 }

--- a/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
+++ b/server/src/main/java/org/spine3/server/projection/ProjectionRepository.java
@@ -239,7 +239,7 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S>, S exte
     @Override
     public Set<EventClass> getEventClasses() {
         final Class<? extends Projection> projectionClass = getEntityClass();
-        final Set<EventClass> result = Projection.getEventClasses(projectionClass);
+        final Set<EventClass> result = Projection.TypeInfo.getEventClasses(projectionClass);
         return result;
     }
 

--- a/server/src/main/java/org/spine3/server/reflect/Classes.java
+++ b/server/src/main/java/org/spine3/server/reflect/Classes.java
@@ -29,6 +29,8 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * Utilities for working with classes.
  *
@@ -52,7 +54,7 @@ public class Classes {
      *     <li>The generic parameter must not be a type variable.
      * </ol>
      *
-     * @param clazz the class to check
+     * @param cls the class to check
      * @param paramNumber a zero-based index of the generic parameter in the class declaration
      * @param <T> the generic type
      * @return the class reference for the generic type
@@ -60,11 +62,13 @@ public class Classes {
      *                            parameter of the expected class
      */
     @CheckReturnValue
-    public static <T> Class<T> getGenericParameterType(Class<?> clazz, int paramNumber) {
+    public static <T> Class<T> getGenericParameterType(Class<?> cls, int paramNumber) {
+        checkNotNull(cls);
+
         // We cast here as we assume that the superclasses of the classes
         // we operate with are parametrized too.
         final ParameterizedType genericSuperclass =
-                (ParameterizedType) clazz.getGenericSuperclass();
+                (ParameterizedType) cls.getGenericSuperclass();
 
         final Type[] typeArguments = genericSuperclass.getActualTypeArguments();
         final Type typeArgument = typeArguments[paramNumber];
@@ -104,17 +108,20 @@ public class Classes {
      *
      * <p>The method must match {@code getFieldName} notation, have no argument to be found.
      *
-     * @param clazz     class containing the getter method
+     * @param cls       class containing the getter method
      * @param fieldName field to find a getter for
      * @return {@link Method} instance reflecting the getter method
      * @throws RuntimeException upon reflective failure
      */
-    public static Method getGetterForField(Class<?> clazz, String fieldName)
+    public static Method getGetterForField(Class<?> cls, String fieldName)
             throws NoSuchMethodException {
+        checkNotNull(cls);
+        checkNotNull(fieldName);
+
         @SuppressWarnings("DuplicateStringLiteralInspection")
         final String fieldGetterName = "get" + fieldName.substring(0, 1)
                                                         .toUpperCase() + fieldName.substring(1);
-        final Method fieldGetter = clazz.getMethod(fieldGetterName);
+        final Method fieldGetter = cls.getMethod(fieldGetterName);
         return fieldGetter;
     }
 }

--- a/server/src/test/java/org/spine3/io/IoUtilShould.java
+++ b/server/src/test/java/org/spine3/io/IoUtilShould.java
@@ -20,24 +20,24 @@
 
 package org.spine3.io;
 
+import com.google.common.testing.NullPointerTester;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class IoUtilShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(IoUtil.class));
+        assertHasPrivateParameterlessCtor(IoUtil.class);
     }
 
     @Test
-    public void close_streams() {
-
+    public void pass_null_tolerance_check() {
+        new NullPointerTester()
+                .testAllPublicStaticMethods(IoUtil.class);
     }
 }

--- a/server/src/test/java/org/spine3/server/CommandServiceShould.java
+++ b/server/src/test/java/org/spine3/server/CommandServiceShould.java
@@ -48,7 +48,6 @@ import static org.mockito.Mockito.verify;
 import static org.spine3.testdata.TestBoundedContextFactory.newBoundedContext;
 import static org.spine3.testdata.TestCommandContextFactory.createCommandContext;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class CommandServiceShould {
 
     private CommandService service;

--- a/server/src/test/java/org/spine3/server/StatusesShould.java
+++ b/server/src/test/java/org/spine3/server/StatusesShould.java
@@ -27,13 +27,13 @@ import org.spine3.test.NullToleranceTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 public class StatusesShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Statuses.class));
+        assertHasPrivateParameterlessCtor(Statuses.class);
     }
 
     @Test

--- a/server/src/test/java/org/spine3/server/aggregate/AggregatePartShould.java
+++ b/server/src/test/java/org/spine3/server/aggregate/AggregatePartShould.java
@@ -91,7 +91,7 @@ public class AggregatePartShould {
     }
 
     @Test
-    public void have_TypeInfo() {
+    public void have_TypeInfo_utility_class() {
         assertHasPrivateParameterlessCtor(AggregatePart.TypeInfo.class);
     }
 

--- a/server/src/test/java/org/spine3/server/aggregate/AggregatePartShould.java
+++ b/server/src/test/java/org/spine3/server/aggregate/AggregatePartShould.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.spine3.base.Identifiers.newUuid;
 import static org.spine3.server.aggregate.AggregatePart.create;
 import static org.spine3.server.aggregate.AggregatePart.getConstructor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Illia Shepilov
@@ -87,6 +88,11 @@ public class AggregatePartShould {
         final Constructor<AnAggregatePart> constructor =
                 getConstructor(AnAggregatePart.class);
         assertNotNull(constructor);
+    }
+
+    @Test
+    public void have_TypeInfo() {
+        assertHasPrivateParameterlessCtor(AggregatePart.TypeInfo.class);
     }
 
     /*

--- a/server/src/test/java/org/spine3/server/aggregate/AggregateShould.java
+++ b/server/src/test/java/org/spine3/server/aggregate/AggregateShould.java
@@ -63,6 +63,7 @@ import static org.spine3.protobuf.AnyPacker.unpack;
 import static org.spine3.server.aggregate.Given.Event.projectCreated;
 import static org.spine3.server.aggregate.Given.Event.projectStarted;
 import static org.spine3.server.aggregate.Given.Event.taskAdded;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.spine3.test.Tests.newVersionWithNumber;
 import static org.spine3.test.aggregate.Project.newBuilder;
 import static org.spine3.testdata.TestCommandContextFactory.createCommandContext;
@@ -71,7 +72,7 @@ import static org.spine3.testdata.TestEventContextFactory.createEventContext;
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings({"TypeMayBeWeakened", "ClassWithTooManyMethods"})
+@SuppressWarnings({"TypeMayBeWeakened", "ClassWithTooManyMethods", "OverlyCoupledClass"})
 public class AggregateShould {
 
     private static final ProjectId ID = Sample.messageOfType(ProjectId.class);
@@ -586,6 +587,10 @@ public class AggregateShould {
         new TestAggregateWithIdInteger(100).getBuilder();
     }
 
+    @Test
+    public void have_TypeInfo() {
+        assertHasPrivateParameterlessCtor(Aggregate.TypeInfo.class);
+    }
 
     /*
      * Utility methods.

--- a/server/src/test/java/org/spine3/server/aggregate/AggregateShould.java
+++ b/server/src/test/java/org/spine3/server/aggregate/AggregateShould.java
@@ -503,8 +503,8 @@ public class AggregateShould {
     @SuppressWarnings("unused")
     private static class FaultyAggregate extends Aggregate<ProjectId, Project, Project.Builder> {
 
-        static final String BROKEN_HANDLER = "broken_handler";
-        static final String BROKEN_APPLIER = "broken_applier";
+        private static final String BROKEN_HANDLER = "broken_handler";
+        private static final String BROKEN_APPLIER = "broken_applier";
 
         private final boolean brokenHandler;
         private final boolean brokenApplier;
@@ -539,7 +539,8 @@ public class AggregateShould {
 
     @Test
     public void propagate_RuntimeException_when_handler_throws() {
-        final FaultyAggregate faultyAggregate = new FaultyAggregate(ID, true, false);
+        final FaultyAggregate faultyAggregate =
+                new FaultyAggregate(ID, true, false);
 
         final Command command = Given.Command.createProject();
         try {
@@ -554,7 +555,8 @@ public class AggregateShould {
 
     @Test
     public void propagate_RuntimeException_when_applier_throws() {
-        final FaultyAggregate faultyAggregate = new FaultyAggregate(ID, false, true);
+        final FaultyAggregate faultyAggregate =
+                new FaultyAggregate(ID,false,true);
 
         final Command command = Given.Command.createProject();
         try {
@@ -569,7 +571,8 @@ public class AggregateShould {
 
     @Test
     public void propagate_RuntimeException_when_play_raises_exception() {
-        final FaultyAggregate faultyAggregate = new FaultyAggregate(ID, false, true);
+        final FaultyAggregate faultyAggregate =
+                new FaultyAggregate(ID, false, true);
         try {
             faultyAggregate.play(AggregateStateRecord.newBuilder()
                                                      .addEvent(projectCreated())

--- a/server/src/test/java/org/spine3/server/aggregate/AggregateShould.java
+++ b/server/src/test/java/org/spine3/server/aggregate/AggregateShould.java
@@ -591,7 +591,7 @@ public class AggregateShould {
     }
 
     @Test
-    public void have_TypeInfo() {
+    public void have_TypeInfo_utility_class() {
         assertHasPrivateParameterlessCtor(Aggregate.TypeInfo.class);
     }
 

--- a/server/src/test/java/org/spine3/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/org/spine3/server/aggregate/AggregateStorageShould.java
@@ -55,7 +55,6 @@ import static org.spine3.server.storage.Given.AnEvent.projectCreated;
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings({"InstanceMethodNamingConvention", "ClassWithTooManyMethods"})
 public abstract class AggregateStorageShould
         extends AbstractStorageShould<ProjectId, AggregateStateRecord, AggregateStorage<ProjectId>> {
 

--- a/server/src/test/java/org/spine3/server/bc/BoundedContextBuilderShould.java
+++ b/server/src/test/java/org/spine3/server/bc/BoundedContextBuilderShould.java
@@ -41,8 +41,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-@SuppressWarnings({"InstanceMethodNamingConvention",
-                   "OptionalGetWithoutIsPresent" /* OK as we set right before get(). */})
+@SuppressWarnings("OptionalGetWithoutIsPresent" /* OK as we set right before get(). */)
 public class BoundedContextBuilderShould {
 
     private StorageFactory storageFactory;

--- a/server/src/test/java/org/spine3/server/bc/BoundedContextShould.java
+++ b/server/src/test/java/org/spine3/server/bc/BoundedContextShould.java
@@ -76,7 +76,6 @@ import static org.spine3.testdata.TestBoundedContextFactory.newBoundedContext;
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class BoundedContextShould {
 
     private final TestEventSubscriber subscriber = new TestEventSubscriber();

--- a/server/src/test/java/org/spine3/server/command/CommandBusShouldHandleCommandStatus.java
+++ b/server/src/test/java/org/spine3/server/command/CommandBusShouldHandleCommandStatus.java
@@ -64,7 +64,7 @@ import static org.spine3.protobuf.Values.newStringValue;
 import static org.spine3.server.command.error.CommandExpiredException.commandExpiredError;
 import static org.spine3.test.TimeTests.Past.minutesAgo;
 
-@SuppressWarnings({"InstanceMethodNamingConvention", "ClassWithTooManyMethods", "OverlyCoupledClass"})
+@SuppressWarnings({"ClassWithTooManyMethods", "OverlyCoupledClass"})
 public class CommandBusShouldHandleCommandStatus {
 
     private CommandBus commandBus;

--- a/server/src/test/java/org/spine3/server/command/CommandStorageShould.java
+++ b/server/src/test/java/org/spine3/server/command/CommandStorageShould.java
@@ -66,7 +66,6 @@ import static org.spine3.validate.Validate.isNotDefault;
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings({"InstanceMethodNamingConvention", "ClassWithTooManyMethods"})
 public abstract class CommandStorageShould
         extends AbstractStorageShould<CommandId, CommandRecord, CommandStorage> {
 

--- a/server/src/test/java/org/spine3/server/command/CommandValidatorShould.java
+++ b/server/src/test/java/org/spine3/server/command/CommandValidatorShould.java
@@ -30,6 +30,7 @@ import org.spine3.validate.ConstraintViolation;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.spine3.server.command.Given.CommandMessage.createProjectMessage;
 import static org.spine3.testdata.TestCommandContextFactory.createCommandContext;
 
 /**
@@ -50,7 +51,8 @@ public class CommandValidatorShould {
 
     @Test
     public void validate_command_and_return_violations_if_message_is_NOT_valid() {
-        final Command cmd = Commands.createCommand(CreateProject.getDefaultInstance(), createCommandContext());
+        final Command cmd = Commands.createCommand(CreateProject.getDefaultInstance(),
+                                                   createCommandContext());
 
         final List<ConstraintViolation> violations = validator.validate(cmd);
 
@@ -59,7 +61,8 @@ public class CommandValidatorShould {
 
     @Test
     public void validate_command_and_return_violations_if_context_is_NOT_valid() {
-        final Command cmd = Commands.createCommand(Given.CommandMessage.createProjectMessage(), CommandContext.getDefaultInstance());
+        final Command cmd = Commands.createCommand(createProjectMessage(),
+                                                   CommandContext.getDefaultInstance());
 
         final List<ConstraintViolation> violations = validator.validate(cmd);
 
@@ -75,14 +78,16 @@ public class CommandValidatorShould {
 
     @Test(expected = IllegalArgumentException.class)
     public void check_command_and_throw_exception_if_message_is_NOT_valid() {
-        final Command cmd = Commands.createCommand(CreateProject.getDefaultInstance(), createCommandContext());
+        final Command cmd = Commands.createCommand(CreateProject.getDefaultInstance(),
+                                                   createCommandContext());
 
         CommandValidator.checkCommand(cmd);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void check_command_and_throw_exception_if_context_is_NOT_valid() {
-        final Command cmd = Commands.createCommand(Given.CommandMessage.createProjectMessage(), CommandContext.getDefaultInstance());
+        final Command cmd = Commands.createCommand(createProjectMessage(),
+                                                   CommandContext.getDefaultInstance());
 
         CommandValidator.checkCommand(cmd);
     }

--- a/server/src/test/java/org/spine3/server/command/CommandValidatorShould.java
+++ b/server/src/test/java/org/spine3/server/command/CommandValidatorShould.java
@@ -35,7 +35,6 @@ import static org.spine3.testdata.TestCommandContextFactory.createCommandContext
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class CommandValidatorShould {
 
     private final CommandValidator validator = CommandValidator.getInstance();

--- a/server/src/test/java/org/spine3/server/command/ExecutorCommandSchedulerShould.java
+++ b/server/src/test/java/org/spine3/server/command/ExecutorCommandSchedulerShould.java
@@ -44,7 +44,6 @@ import static org.spine3.testdata.TestCommandContextFactory.createCommandContext
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class ExecutorCommandSchedulerShould {
 
     private static final long DELAY_MS = 1100;

--- a/server/src/test/java/org/spine3/server/entity/EntityShould.java
+++ b/server/src/test/java/org/spine3/server/entity/EntityShould.java
@@ -56,6 +56,7 @@ import static org.spine3.protobuf.Timestamps2.getCurrentTime;
 import static org.spine3.protobuf.Values.newStringValue;
 import static org.spine3.server.entity.AbstractEntity.createEntity;
 import static org.spine3.server.entity.AbstractEntity.getConstructor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.spine3.test.TimeTests.currentTimeSeconds;
 
 /**
@@ -297,6 +298,11 @@ public class EntityShould {
         assertEquals(StringValue.getDefaultInstance(), entity.getState());
         assertFalse(entity.isArchived());
         assertFalse(entity.isDeleted());
+    }
+
+    @Test
+    public void have_TypeInfo() {
+        assertHasPrivateParameterlessCtor(Entity.TypeInfo.class);
     }
 
     private static Matcher<Long> isBetween(final Long lower, final Long higher) {

--- a/server/src/test/java/org/spine3/server/entity/EntityShould.java
+++ b/server/src/test/java/org/spine3/server/entity/EntityShould.java
@@ -301,7 +301,7 @@ public class EntityShould {
     }
 
     @Test
-    public void have_TypeInfo() {
+    public void have_TypeInfo_utility_class() {
         assertHasPrivateParameterlessCtor(Entity.TypeInfo.class);
     }
 

--- a/server/src/test/java/org/spine3/server/entity/FieldMasksShould.java
+++ b/server/src/test/java/org/spine3/server/entity/FieldMasksShould.java
@@ -40,8 +40,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.spine3.test.Tests.assertMatchesMask;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
 import static org.spine3.test.Verify.assertSize;
 
 /**
@@ -51,7 +51,7 @@ public class FieldMasksShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(FieldMasks.class));
+        assertHasPrivateParameterlessCtor(FieldMasks.class);
     }
 
     @Test
@@ -92,7 +92,8 @@ public class FieldMasksShould {
     @SuppressWarnings({"MethodWithMultipleLoops", "ObjectEquality"})
     @Test
     public void apply_mask_to_message_collections() {
-        final FieldMask fieldMask = Given.fieldMask(Project.STATUS_FIELD_NUMBER, Project.TASK_FIELD_NUMBER);
+        final FieldMask fieldMask = Given.fieldMask(Project.STATUS_FIELD_NUMBER,
+                                                    Project.TASK_FIELD_NUMBER);
         final int count = 5;
 
         final Collection<Project> original = new LinkedList<>();
@@ -208,8 +209,8 @@ public class FieldMasksShould {
             return project;
         }
 
-        private static FieldMask fieldMask(int... fieldIndeces) {
-            return FieldMasks.maskOf(TYPE_DESCRIPTOR, fieldIndeces);
+        private static FieldMask fieldMask(int... fieldIndices) {
+            return FieldMasks.maskOf(TYPE_DESCRIPTOR, fieldIndices);
         }
     }
 }

--- a/server/src/test/java/org/spine3/server/entity/GetTargetIdFromCommandShould.java
+++ b/server/src/test/java/org/spine3/server/entity/GetTargetIdFromCommandShould.java
@@ -34,7 +34,6 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class GetTargetIdFromCommandShould {
 
     @Test
@@ -44,6 +43,7 @@ public class GetTargetIdFromCommandShould {
         assertFalse(id.isPresent());
     }
 
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
     @Test
     public void get_ID_from_command_message() {
         final CreateProject msg = Sample.messageOfType(CreateProject.class);

--- a/server/src/test/java/org/spine3/server/entity/GetTargetIdFromCommandShould.java
+++ b/server/src/test/java/org/spine3/server/entity/GetTargetIdFromCommandShould.java
@@ -43,7 +43,7 @@ public class GetTargetIdFromCommandShould {
         assertFalse(id.isPresent());
     }
 
-    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    @SuppressWarnings("OptionalGetWithoutIsPresent") // We call isPresent() in assertion.
     @Test
     public void get_ID_from_command_message() {
         final CreateProject msg = Sample.messageOfType(CreateProject.class);

--- a/server/src/test/java/org/spine3/server/entity/PredicatesShould.java
+++ b/server/src/test/java/org/spine3/server/entity/PredicatesShould.java
@@ -21,11 +21,11 @@
 package org.spine3.server.entity;
 
 import org.junit.Test;
-import org.spine3.test.Tests;
 
 import static org.junit.Assert.assertFalse;
 import static org.spine3.server.entity.Predicates.isEntityVisible;
 import static org.spine3.server.entity.Predicates.isRecordVisible;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Alexander Yevsyukov
@@ -34,7 +34,7 @@ public class PredicatesShould {
 
     @Test
     public void have_private_default_ctor() {
-        Tests.hasPrivateParameterlessCtor(Predicates.class);
+        assertHasPrivateParameterlessCtor(Predicates.class);
     }
 
     @Test

--- a/server/src/test/java/org/spine3/server/entity/RepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/entity/RepositoryShould.java
@@ -60,14 +60,16 @@ public class RepositoryShould {
         new RepoForEntityWithUnsupportedId(boundedContext).getIdClass();
     }
 
-    private static class EntityWithUnsupportedId extends AbstractVersionableEntity<Exception, Project> {
+    private static class EntityWithUnsupportedId
+            extends AbstractVersionableEntity<Exception, Project> {
         protected EntityWithUnsupportedId(Exception id) {
             super(id);
         }
     }
 
     @SuppressWarnings("ReturnOfNull")
-    private static class RepoForEntityWithUnsupportedId extends Repository<Exception, EntityWithUnsupportedId> {
+    private static class RepoForEntityWithUnsupportedId
+            extends Repository<Exception, EntityWithUnsupportedId> {
 
         /**
          * Creates the repository in the passed {@link BoundedContext}.
@@ -117,7 +119,8 @@ public class RepositoryShould {
         }
     }
 
-    private static class EntityWithPrivateConstructor extends AbstractVersionableEntity<ProjectId, Project> {
+    private static class EntityWithPrivateConstructor
+            extends AbstractVersionableEntity<ProjectId, Project> {
         private EntityWithPrivateConstructor(ProjectId id) {
             super(id);
         }
@@ -168,7 +171,8 @@ public class RepositoryShould {
         }
     }
 
-    private static class EntityWithProtectedConstructor extends AbstractVersionableEntity<ProjectId, Project> {
+    private static class EntityWithProtectedConstructor
+            extends AbstractVersionableEntity<ProjectId, Project> {
         protected EntityWithProtectedConstructor(ProjectId id) {
             super(id);
         }
@@ -219,7 +223,8 @@ public class RepositoryShould {
         }
     }
 
-    private static class EntityWithoutRequiredConstructor extends AbstractVersionableEntity<ProjectId, Project> {
+    private static class EntityWithoutRequiredConstructor
+            extends AbstractVersionableEntity<ProjectId, Project> {
         private EntityWithoutRequiredConstructor() {
             super(ProjectId.getDefaultInstance());
         }
@@ -265,7 +270,7 @@ public class RepositoryShould {
     //-----------------------
 
     private static class ProjectEntity extends AbstractVersionableEntity<ProjectId, Project> {
-        public ProjectEntity(ProjectId id) {
+        private ProjectEntity(ProjectId id) {
             super(id);
         }
     }

--- a/server/src/test/java/org/spine3/server/entity/RepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/entity/RepositoryShould.java
@@ -38,7 +38,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.spine3.testdata.TestBoundedContextFactory.newBoundedContext;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class RepositoryShould {
 
     private BoundedContext boundedContext;

--- a/server/src/test/java/org/spine3/server/event/EventBusBuilderShould.java
+++ b/server/src/test/java/org/spine3/server/event/EventBusBuilderShould.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
-@SuppressWarnings({"InstanceMethodNamingConvention", "OptionalGetWithoutIsPresent"})
+@SuppressWarnings("OptionalGetWithoutIsPresent")
 public class EventBusBuilderShould {
 
     private StorageFactory storageFactory;

--- a/server/src/test/java/org/spine3/server/event/EventBusShould.java
+++ b/server/src/test/java/org/spine3/server/event/EventBusShould.java
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-@SuppressWarnings({"InstanceMethodNamingConvention", "ResultOfMethodCallIgnored", "ClassWithTooManyMethods", "OverlyCoupledClass"})
+@SuppressWarnings({"ResultOfMethodCallIgnored", "ClassWithTooManyMethods", "OverlyCoupledClass"})
 public class EventBusShould {
 
     private EventBus eventBus;

--- a/server/src/test/java/org/spine3/server/event/EventStorageShould.java
+++ b/server/src/test/java/org/spine3/server/event/EventStorageShould.java
@@ -58,7 +58,6 @@ import static org.spine3.protobuf.Timestamps2.getCurrentTime;
 import static org.spine3.server.event.Given.AnEventRecord.projectCreated;
 import static org.spine3.server.storage.Given.EventMessage.projectCreated;
 
-@SuppressWarnings({"InstanceMethodNamingConvention", "ClassWithTooManyMethods"})
 public abstract class EventStorageShould extends AbstractStorageShould<EventId, Event, EventStorage> {
 
     /** Small positive delta in seconds or nanoseconds. */

--- a/server/src/test/java/org/spine3/server/event/EventStoreServiceBuilderShould.java
+++ b/server/src/test/java/org/spine3/server/event/EventStoreServiceBuilderShould.java
@@ -31,7 +31,6 @@ import java.util.concurrent.Executor;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class EventStoreServiceBuilderShould {
 
     private EventStore.ServiceBuilder builder;

--- a/server/src/test/java/org/spine3/server/event/enrich/EventEnricherBuilderShould.java
+++ b/server/src/test/java/org/spine3/server/event/enrich/EventEnricherBuilderShould.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-@SuppressWarnings({"InstanceMethodNamingConvention", "ResultOfMethodCallIgnored"})
+@SuppressWarnings("ResultOfMethodCallIgnored")
 public class EventEnricherBuilderShould {
 
     private EventEnricher.Builder builder;

--- a/server/src/test/java/org/spine3/server/event/enrich/EventEnrichmentsMapShould.java
+++ b/server/src/test/java/org/spine3/server/event/enrich/EventEnrichmentsMapShould.java
@@ -57,7 +57,7 @@ import java.util.Collection;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Alexander Litus
@@ -67,7 +67,7 @@ public class EventEnrichmentsMapShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(EventEnrichmentsMap.class));
+        assertHasPrivateParameterlessCtor(EventEnrichmentsMap.class);
     }
 
     @Test
@@ -79,43 +79,53 @@ public class EventEnrichmentsMapShould {
 
     @Test
     public void contain_ProjectCreated_by_ProjectCreatedEnrichment_type() {
-        assertOnlyEventTypeByEnrichmentType(ProjectCreated.Enrichment.class, ProjectCreated.class);
+        assertOnlyEventTypeByEnrichmentType(ProjectCreated.Enrichment.class,
+                                            ProjectCreated.class);
     }
 
     @Test
     public void contain_ProjectCreated_by_ProjectCreatedSeparateEnrichment_type() {
-        assertOnlyEventTypeByEnrichmentType(ProjectCreatedSeparateEnrichment.class, ProjectCreated.class);
+        assertOnlyEventTypeByEnrichmentType(ProjectCreatedSeparateEnrichment.class,
+                                            ProjectCreated.class);
     }
 
     @Test
     public void contain_ProjectCreated_by_ProjectCreatedEnrichmentAnotherPackage_type() {
-        assertOnlyEventTypeByEnrichmentType(ProjectCreatedEnrichmentAnotherPackage.class, ProjectCreated.class);
+        assertOnlyEventTypeByEnrichmentType(ProjectCreatedEnrichmentAnotherPackage.class,
+                                            ProjectCreated.class);
     }
 
     @Test
     public void contain_ProjectCreated_by_ProjectCreatedEnrichmentAnotherPackageFqn_type() {
-        assertOnlyEventTypeByEnrichmentType(ProjectCreatedEnrichmentAnotherPackageFqn.class, ProjectCreated.class);
+        assertOnlyEventTypeByEnrichmentType(ProjectCreatedEnrichmentAnotherPackageFqn.class,
+                                            ProjectCreated.class);
     }
 
     @Test
     public void contain_ProjectCreated_by_ProjectCreatedEnrichmentAnotherPackageFqnAndMsgOpt_type() {
-        assertOnlyEventTypeByEnrichmentType(ProjectCreatedEnrichmentAnotherPackageFqnAndMsgOpt.class, ProjectCreated.class);
+        assertOnlyEventTypeByEnrichmentType(
+                ProjectCreatedEnrichmentAnotherPackageFqnAndMsgOpt.class,
+                ProjectCreated.class);
     }
 
     @Test
     public void contain_ProjectStarted_by_ProjectStartedEnrichment_type() {
-        assertOnlyEventTypeByEnrichmentType(ProjectStarted.Enrichment.class, ProjectStarted.class);
+        assertOnlyEventTypeByEnrichmentType(ProjectStarted.Enrichment.class,
+                                            ProjectStarted.class);
     }
 
     @Test
     public void contain_events_by_EnrichmentForSeveralEvents_type() {
         assertOnlyEventTypeByEnrichmentType(EnrichmentForSeveralEvents.class,
-                                            ProjectStarted.class, ProjectCreated.class, TaskAdded.class);
+                                            ProjectStarted.class,
+                                            ProjectCreated.class,
+                                            TaskAdded.class);
     }
 
     @Test
     public void contain_ProjectCreated_by_EnrichmentByContextFields_type() {
-        assertOnlyEventTypeByEnrichmentType(EnrichmentByContextFields.class, ProjectCreated.class);
+        assertOnlyEventTypeByEnrichmentType(EnrichmentByContextFields.class,
+                                            ProjectCreated.class);
     }
 
     @Test
@@ -162,47 +172,54 @@ public class EventEnrichmentsMapShould {
 
     @Test
     public void contain_enrichments_defined_with_by_with_two_arguments() {
-        assertOnlyEventTypeByEnrichmentType(EnrichmentBoundWithFieldsWithDifferentNames.class,
-                                            SharingRequestApproved.class,
-                                            PermissionGrantedEvent.class);
+        assertOnlyEventTypeByEnrichmentType(
+                EnrichmentBoundWithFieldsWithDifferentNames.class,
+                SharingRequestApproved.class,
+                PermissionGrantedEvent.class);
     }
 
     @Test
     public void contain_enrichments_defined_with_by_with_two_fqn_arguments() {
-        assertOnlyEventTypeByEnrichmentType(EnrichmentBoundThoughFieldFqnWithFieldsWithDifferentNames.class,
-                                            SharingRequestApproved.class,
-                                            PermissionGrantedEvent.class);
+        assertOnlyEventTypeByEnrichmentType(
+                EnrichmentBoundThoughFieldFqnWithFieldsWithDifferentNames.class,
+                SharingRequestApproved.class,
+                PermissionGrantedEvent.class);
     }
 
     @Test
     public void contain_enrichments_defined_with_by_with_multiple_arguments() {
-        assertOnlyEventTypeByEnrichmentType(EnrichmentBoundWithMultipleFieldsWithDifferentNames.class,
-                                            SharingRequestApproved.class,
-                                            PermissionGrantedEvent.class,
-                                            UserDeletedEvent.class);
+        assertOnlyEventTypeByEnrichmentType(
+                EnrichmentBoundWithMultipleFieldsWithDifferentNames.class,
+                SharingRequestApproved.class,
+                PermissionGrantedEvent.class,
+                UserDeletedEvent.class);
     }
 
     @Test
     public void contain_enrichments_defined_with_by_with_multiple_arguments_using_wildcard() {
-        assertOnlyEventTypeByEnrichmentType(EnrichmentBoundWithFieldsWithDifferentNamesOfWildcardTypes.class,
-                                            SharingRequestApproved.class,
-                                            PermissionGrantedEvent.class,
-                                            PermissionRevokedEvent.class);
+        assertOnlyEventTypeByEnrichmentType(
+                EnrichmentBoundWithFieldsWithDifferentNamesOfWildcardTypes.class,
+                SharingRequestApproved.class,
+                PermissionGrantedEvent.class,
+                PermissionRevokedEvent.class);
     }
 
     @Test
     public void contain_enrichments_defined_with_by_containing_separating_spaces() {
-        assertOnlyEventTypeByEnrichmentType(EnrichmentBoundWithFieldsSeparatedWithSpaces.class,
-                                            TaskAdded.class,
-                                            PermissionGrantedEvent.class);
+        assertOnlyEventTypeByEnrichmentType(
+                EnrichmentBoundWithFieldsSeparatedWithSpaces.class,
+                TaskAdded.class,
+                PermissionGrantedEvent.class);
     }
 
     @SafeVarargs
     private static void assertEventTypeByEnrichmentType(
             Class<? extends Message> enrichmentClass,
             Class<? extends Message>... eventClassesExpected) {
-        final Collection<String> eventTypesActual = EventEnrichmentsMap.getInstance()
-                                                                       .get(TypeName.of(enrichmentClass));
+        final Collection<String> eventTypesActual =
+                EventEnrichmentsMap.getInstance()
+                                   .get(TypeName.of(enrichmentClass));
+
         for (Class<? extends Message> expectedClass : FluentIterable.from(eventClassesExpected)) {
             final String expectedTypeName = TypeName.of(expectedClass);
             assertTrue(eventTypesActual.contains(expectedTypeName));
@@ -213,8 +230,9 @@ public class EventEnrichmentsMapShould {
     private static void assertOnlyEventTypeByEnrichmentType(
             Class<? extends Message> enrichmentClass,
             Class<? extends Message>... eventClassesExpected) {
-        final Collection<String> eventTypesActual = EventEnrichmentsMap.getInstance()
-                                                                       .get(TypeName.of(enrichmentClass));
+        final Collection<String> eventTypesActual =
+                EventEnrichmentsMap.getInstance()
+                                   .get(TypeName.of(enrichmentClass));
         assertEquals(eventClassesExpected.length, eventTypesActual.size());
         assertEventTypeByEnrichmentType(enrichmentClass, eventClassesExpected);
     }

--- a/server/src/test/java/org/spine3/server/event/enrich/EventEnrichmentsMapShould.java
+++ b/server/src/test/java/org/spine3/server/event/enrich/EventEnrichmentsMapShould.java
@@ -62,7 +62,7 @@ import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings("ClassWithTooManyMethods")
+@SuppressWarnings({"ClassWithTooManyMethods", "OverlyCoupledClass"})
 public class EventEnrichmentsMapShould {
 
     @Test

--- a/server/src/test/java/org/spine3/server/event/enrich/EventEnrichmentsMapShould.java
+++ b/server/src/test/java/org/spine3/server/event/enrich/EventEnrichmentsMapShould.java
@@ -62,7 +62,7 @@ import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings({"InstanceMethodNamingConvention", "OverlyCoupledClass"}) // Over-coupling is OK for test classes
+@SuppressWarnings("ClassWithTooManyMethods")
 public class EventEnrichmentsMapShould {
 
     @Test

--- a/server/src/test/java/org/spine3/server/event/error/InvalidEventExceptionShould.java
+++ b/server/src/test/java/org/spine3/server/event/error/InvalidEventExceptionShould.java
@@ -32,7 +32,7 @@ import static org.spine3.protobuf.Values.newStringValue;
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings({"InstanceMethodNamingConvention", "ThrowableResultOfMethodCallIgnored"})
+@SuppressWarnings("ThrowableResultOfMethodCallIgnored")
 public class InvalidEventExceptionShould {
 
     @Test

--- a/server/src/test/java/org/spine3/server/event/error/UnsupportedEventExceptionShould.java
+++ b/server/src/test/java/org/spine3/server/event/error/UnsupportedEventExceptionShould.java
@@ -30,7 +30,6 @@ import static org.spine3.protobuf.Values.newStringValue;
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class UnsupportedEventExceptionShould {
 
     @Test

--- a/server/src/test/java/org/spine3/server/integration/IntegrationEventBusShould.java
+++ b/server/src/test/java/org/spine3/server/integration/IntegrationEventBusShould.java
@@ -35,7 +35,6 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class IntegrationEventBusShould {
 
     private IntegrationEventBus eventBus;

--- a/server/src/test/java/org/spine3/server/procman/ProcessManagerShould.java
+++ b/server/src/test/java/org/spine3/server/procman/ProcessManagerShould.java
@@ -328,7 +328,7 @@ public class ProcessManagerShould {
     }
 
     @Test
-    public void have_TypeInfo() {
+    public void have_TypeInfo_utility_class() {
         assertHasPrivateParameterlessCtor(ProcessManager.TypeInfo.class);
     }
 

--- a/server/src/test/java/org/spine3/server/procman/ProcessManagerShould.java
+++ b/server/src/test/java/org/spine3/server/procman/ProcessManagerShould.java
@@ -86,7 +86,10 @@ public class ProcessManagerShould {
     @Before
     public void setUp() {
         final InMemoryStorageFactory storageFactory = InMemoryStorageFactory.getInstance();
-        final CommandStore commandStore = spy(new CommandStore(storageFactory.createCommandStorage()));
+        final CommandStore commandStore = spy(
+                new CommandStore(storageFactory.createCommandStorage())
+        );
+        
         commandBus = spy(CommandBus.newBuilder()
                                    .setCommandStore(commandStore)
                                    .build());

--- a/server/src/test/java/org/spine3/server/procman/ProcessManagerShould.java
+++ b/server/src/test/java/org/spine3/server/procman/ProcessManagerShould.java
@@ -69,6 +69,7 @@ import static org.mockito.Mockito.verify;
 import static org.spine3.base.Commands.getMessage;
 import static org.spine3.protobuf.AnyPacker.unpack;
 import static org.spine3.protobuf.Values.newStringValue;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 @SuppressWarnings("OverlyCoupledClass")
 public class ProcessManagerShould {
@@ -321,6 +322,11 @@ public class ProcessManagerShould {
                     .routeAll();
             return route;
         }
+    }
+
+    @Test
+    public void have_TypeInfo() {
+        assertHasPrivateParameterlessCtor(ProcessManager.TypeInfo.class);
     }
 
     private static class AddTaskDispatcher implements CommandDispatcher {

--- a/server/src/test/java/org/spine3/server/procman/ProcessManagerShould.java
+++ b/server/src/test/java/org/spine3/server/procman/ProcessManagerShould.java
@@ -70,7 +70,7 @@ import static org.spine3.base.Commands.getMessage;
 import static org.spine3.protobuf.AnyPacker.unpack;
 import static org.spine3.protobuf.Values.newStringValue;
 
-@SuppressWarnings({"InstanceMethodNamingConvention", "OverlyCoupledClass"})
+@SuppressWarnings("OverlyCoupledClass")
 public class ProcessManagerShould {
 
     private static final ProjectId ID = Sample.messageOfType(ProjectId.class);

--- a/server/src/test/java/org/spine3/server/projection/ProjectionRepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/projection/ProjectionRepositoryShould.java
@@ -83,9 +83,10 @@ import static org.spine3.testdata.TestEventContextFactory.createEventContext;
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings({"InstanceMethodNamingConvention", "ClassWithTooManyMethods"})
 public class ProjectionRepositoryShould
-        extends RecordBasedRepositoryShould<ProjectionRepositoryShould.TestProjection, ProjectId, Project> {
+        extends RecordBasedRepositoryShould<ProjectionRepositoryShould.TestProjection,
+                                            ProjectId,
+                                            Project> {
 
     private static final ProjectId ID = Sample.messageOfType(ProjectId.class);
 
@@ -496,15 +497,13 @@ public class ProjectionRepositoryShould
     }
 
     /** Stub projection repository. */
-    private static class TestProjectionRepository extends ProjectionRepository<ProjectId, TestProjection, Project> {
-        protected TestProjectionRepository(BoundedContext boundedContext) {
+    private static class TestProjectionRepository
+            extends ProjectionRepository<ProjectId, TestProjection, Project> {
+        private TestProjectionRepository(BoundedContext boundedContext) {
             super(boundedContext);
         }
 
-        protected TestProjectionRepository(BoundedContext boundedContext, Duration catchUpMaxDuration) {
-            super(boundedContext, true, catchUpMaxDuration);
-        }
-
+        @SuppressWarnings("unused")
         @Subscribe
         public void apply(ProjectCreated event, EventContext eventContext) {
             // NOP
@@ -512,15 +511,18 @@ public class ProjectionRepositoryShould
     }
 
     /** Stub projection repository with the disabled automatic catch-up */
-    private static class ManualCatchupProjectionRepository extends ProjectionRepository<ProjectId, TestProjection, Project> {
+    private static class ManualCatchupProjectionRepository
+            extends ProjectionRepository<ProjectId, TestProjection, Project> {
         protected ManualCatchupProjectionRepository(BoundedContext boundedContext) {
             super(boundedContext, false);
         }
 
-        protected ManualCatchupProjectionRepository(BoundedContext boundedContext, Duration catchUpMaxDuration) {
+        protected ManualCatchupProjectionRepository(BoundedContext boundedContext,
+                                                    Duration catchUpMaxDuration) {
             super(boundedContext, false, catchUpMaxDuration);
         }
 
+        @SuppressWarnings("unused")
         @Subscribe
         public void apply(ProjectCreated event, EventContext eventContext) {
             // NOP

--- a/server/src/test/java/org/spine3/server/projection/ProjectionShould.java
+++ b/server/src/test/java/org/spine3/server/projection/ProjectionShould.java
@@ -82,7 +82,7 @@ public class ProjectionShould {
     }
 
     @Test
-    public void have_type_info_utility_class() {
+    public void have_TypeInfo_utility_class() {
         assertHasPrivateParameterlessCtor(Projection.TypeInfo.class);
     }
 

--- a/server/src/test/java/org/spine3/server/projection/ProjectionShould.java
+++ b/server/src/test/java/org/spine3/server/projection/ProjectionShould.java
@@ -38,7 +38,6 @@ import static org.spine3.protobuf.Values.newIntValue;
 import static org.spine3.protobuf.Values.newStringValue;
 import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class ProjectionShould {
 
     private TestProjection projection;

--- a/server/src/test/java/org/spine3/server/projection/ProjectionShould.java
+++ b/server/src/test/java/org/spine3/server/projection/ProjectionShould.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertTrue;
 import static org.spine3.base.Identifiers.newUuid;
 import static org.spine3.protobuf.Values.newIntValue;
 import static org.spine3.protobuf.Values.newStringValue;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 @SuppressWarnings("InstanceMethodNamingConvention")
 public class ProjectionShould {
@@ -73,11 +74,16 @@ public class ProjectionShould {
 
     @Test
     public void return_event_classes_which_it_handles() {
-        final ImmutableSet<EventClass> classes = Projection.getEventClasses(TestProjection.class);
+        final ImmutableSet<EventClass> classes = Projection.TypeInfo.getEventClasses(TestProjection.class);
 
         assertEquals(TestProjection.HANDLING_EVENT_COUNT, classes.size());
         assertTrue(classes.contains(EventClass.of(StringValue.class)));
         assertTrue(classes.contains(EventClass.of(Int32Value.class)));
+    }
+
+    @Test
+    public void have_type_info_utility_class() {
+        assertHasPrivateParameterlessCtor(Projection.TypeInfo.class);
     }
 
     private static class TestProjection extends Projection<String, StringValue> {
@@ -90,14 +96,15 @@ public class ProjectionShould {
         }
 
         @Subscribe
-        public void on(StringValue event, EventContext ignored) {
+        public void on(StringValue event) {
             final StringValue newSate = createNewState("stringState", event.getValue());
             incrementState(newSate);
         }
 
         @Subscribe
         public void on(Int32Value event) {
-            final StringValue newSate = createNewState("integerState", String.valueOf(event.getValue()));
+            final StringValue newSate = createNewState("integerState",
+                                                       String.valueOf(event.getValue()));
             incrementState(newSate);
         }
 

--- a/server/src/test/java/org/spine3/server/projection/ProjectionShould.java
+++ b/server/src/test/java/org/spine3/server/projection/ProjectionShould.java
@@ -73,7 +73,8 @@ public class ProjectionShould {
 
     @Test
     public void return_event_classes_which_it_handles() {
-        final ImmutableSet<EventClass> classes = Projection.TypeInfo.getEventClasses(TestProjection.class);
+        final ImmutableSet<EventClass> classes =
+                Projection.TypeInfo.getEventClasses(TestProjection.class);
 
         assertEquals(TestProjection.HANDLING_EVENT_COUNT, classes.size());
         assertTrue(classes.contains(EventClass.of(StringValue.class)));

--- a/server/src/test/java/org/spine3/server/projection/ProjectionStorageShould.java
+++ b/server/src/test/java/org/spine3/server/projection/ProjectionStorageShould.java
@@ -58,7 +58,6 @@ import static org.spine3.testdata.TestEntityStorageRecordFactory.newEntityStorag
  * @param <I> the type of IDs of storage records
  * @author Alexander Litus
  */
-@SuppressWarnings("InstanceMethodNamingConvention")
 public abstract class ProjectionStorageShould<I>
         extends RecordStorageShould<I, ProjectionStorage<I>> {
 

--- a/server/src/test/java/org/spine3/server/reflect/ClassesShould.java
+++ b/server/src/test/java/org/spine3/server/reflect/ClassesShould.java
@@ -20,15 +20,20 @@
 
 package org.spine3.server.reflect;
 
+import com.google.common.testing.NullPointerTester;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class ClassesShould {
     @Test
     public void have_private_ctor() {
-        assertTrue(hasPrivateParameterlessCtor(Classes.class));
+        assertHasPrivateParameterlessCtor(Classes.class);
+    }
+
+    @Test
+    public void pass_null_tolerance_check() {
+        new NullPointerTester()
+                .testAllPublicStaticMethods(Classes.class);
     }
 }

--- a/server/src/test/java/org/spine3/server/reflect/HandlerMethodShould.java
+++ b/server/src/test/java/org/spine3/server/reflect/HandlerMethodShould.java
@@ -36,7 +36,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class HandlerMethodShould {
 
     private HandlerMethod<EventContext> twoParamMethod;

--- a/server/src/test/java/org/spine3/server/storage/AbstractStorageShould.java
+++ b/server/src/test/java/org/spine3/server/storage/AbstractStorageShould.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.fail;
  * @param <R> the type of records kept in the storage
  * @author Alexander Litus
  */
-@SuppressWarnings({"InstanceMethodNamingConvention", "ClassWithTooManyMethods"})
+@SuppressWarnings("ClassWithTooManyMethods")
 public abstract class AbstractStorageShould<I, R extends Message, S extends AbstractStorage<I, R>> {
 
     private AbstractStorage<I, R> storage;

--- a/server/src/test/java/org/spine3/server/storage/StorageFactorySwitchShould.java
+++ b/server/src/test/java/org/spine3/server/storage/StorageFactorySwitchShould.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.spine3.server.storage.StorageFactorySwitch.init;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Alexander Yevsyukov
@@ -91,7 +91,7 @@ public class StorageFactorySwitchShould {
 
     @Test
     public void have_private_parameterless_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(StorageFactorySwitch.class));
+        assertHasPrivateParameterlessCtor(StorageFactorySwitch.class);
     }
 
     @Test

--- a/server/src/test/java/org/spine3/server/users/CurrentTenantShould.java
+++ b/server/src/test/java/org/spine3/server/users/CurrentTenantShould.java
@@ -28,14 +28,13 @@ import org.spine3.users.TenantId;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class CurrentTenantShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(CurrentTenant.class));
+        assertHasPrivateParameterlessCtor(CurrentTenant.class);
     }
 
     @Test(expected = NullPointerException.class)

--- a/server/src/test/java/org/spine3/server/validate/FieldValidatorFactoryShould.java
+++ b/server/src/test/java/org/spine3/server/validate/FieldValidatorFactoryShould.java
@@ -39,7 +39,6 @@ import static org.spine3.server.validate.FieldValidatorFactory.create;
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class FieldValidatorFactoryShould {
 
     private static final FieldPath FIELD_PATH = FieldPath.getDefaultInstance();

--- a/server/src/test/java/org/spine3/server/validate/FloatFieldValidatorShould.java
+++ b/server/src/test/java/org/spine3/server/validate/FloatFieldValidatorShould.java
@@ -32,7 +32,6 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class FloatFieldValidatorShould {
 
     private static final Float VALUE = 0.5F;

--- a/server/src/test/java/org/spine3/server/validate/IntegerFieldValidatorShould.java
+++ b/server/src/test/java/org/spine3/server/validate/IntegerFieldValidatorShould.java
@@ -32,7 +32,6 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class IntegerFieldValidatorShould {
 
     private static final Integer VALUE = 2;

--- a/server/src/test/java/org/spine3/server/validate/LongFieldValidatorShould.java
+++ b/server/src/test/java/org/spine3/server/validate/LongFieldValidatorShould.java
@@ -32,7 +32,6 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class LongFieldValidatorShould {
 
     private static final Long VALUE = 2L;

--- a/server/src/test/java/org/spine3/server/validate/MessageValidatorShould.java
+++ b/server/src/test/java/org/spine3/server/validate/MessageValidatorShould.java
@@ -85,7 +85,7 @@ import static org.spine3.test.Verify.assertSize;
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings({"InstanceMethodNamingConvention", "ClassWithTooManyMethods", "OverlyCoupledClass", "OverlyComplexClass"})
+@SuppressWarnings({"ClassWithTooManyMethods", "OverlyCoupledClass", "OverlyComplexClass"})
 public class MessageValidatorShould {
 
     private static final double EQUAL_MIN = 16.5;

--- a/server/src/test/java/org/spine3/util/EnvironmentShould.java
+++ b/server/src/test/java/org/spine3/util/EnvironmentShould.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Alexander Yevsyukov
@@ -73,7 +73,7 @@ public class EnvironmentShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Environment.class));
+        assertHasPrivateParameterlessCtor(Environment.class);
     }
 
     @Test

--- a/testutil/src/main/java/org/spine3/test/Tests.java
+++ b/testutil/src/main/java/org/spine3/test/Tests.java
@@ -39,6 +39,7 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Utilities for testing.
@@ -95,6 +96,13 @@ public class Tests {
             return true;
         }
         return true;
+    }
+
+    /**
+     * Asserts that the passed class has private parameter-less constructor.
+     */
+    public static void assertHasPrivateParameterlessCtor(Class<?> targetClass) {
+        assertTrue(hasPrivateParameterlessCtor(targetClass));
     }
 
     /**

--- a/testutil/src/main/java/org/spine3/test/Tests.java
+++ b/testutil/src/main/java/org/spine3/test/Tests.java
@@ -20,6 +20,7 @@
 
 package org.spine3.test;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.Message;
@@ -33,6 +34,7 @@ import org.spine3.protobuf.Timestamps2;
 import org.spine3.protobuf.Values;
 import org.spine3.users.UserId;
 
+import javax.annotation.CheckReturnValue;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.util.List;
@@ -53,7 +55,7 @@ public class Tests {
     }
 
     /**
-     * Verifies if the passed class has private parameter-less constructor and invokes it
+     * Asserts that if the passed class has private parameter-less constructor and invokes it
      * using Reflection.
      *
      * <p>Typically this method is used to add a constructor of a utility class into
@@ -65,12 +67,24 @@ public class Tests {
      *     ...
      *     {@literal @}Test
      *     public void have_private_utility_ctor() {
-     *         assertTrue(hasPrivateParameterlessCtor(MyUtility.class));
+     *         assertHasPrivateParameterlessCtor(MyUtility.class));
      *     }
      * </pre>
-     * @return true if the class has private parameter-less constructor
      */
-    public static boolean hasPrivateParameterlessCtor(Class<?> targetClass) {
+    public static void assertHasPrivateParameterlessCtor(Class<?> targetClass) {
+        assertTrue(hasPrivateParameterlessCtor(targetClass));
+    }
+
+    /**
+     * Verifies if the passed class has private parameter-less constructor and invokes it
+     * using Reflection.
+     *
+     * @return {@code true} if the class has private parameter-less constructor,
+     *         {@code false} otherwise
+     */
+    @CheckReturnValue
+    @VisibleForTesting
+    static boolean hasPrivateParameterlessCtor(Class<?> targetClass) {
         final Constructor constructor;
         try {
             constructor = targetClass.getDeclaredConstructor();
@@ -96,13 +110,6 @@ public class Tests {
             return true;
         }
         return true;
-    }
-
-    /**
-     * Asserts that the passed class has private parameter-less constructor.
-     */
-    public static void assertHasPrivateParameterlessCtor(Class<?> targetClass) {
-        assertTrue(hasPrivateParameterlessCtor(targetClass));
     }
 
     /**

--- a/testutil/src/test/java/org/spine3/test/EventTestsShould.java
+++ b/testutil/src/test/java/org/spine3/test/EventTestsShould.java
@@ -25,6 +25,7 @@ import com.google.protobuf.Timestamp;
 import org.junit.Test;
 
 import static org.spine3.protobuf.Timestamps2.getCurrentTime;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Alexander Yevsyukov
@@ -33,7 +34,7 @@ public class EventTestsShould {
 
     @Test
     public void have_utility_ctor() {
-        Tests.hasPrivateParameterlessCtor(EventTests.class);
+        assertHasPrivateParameterlessCtor(EventTests.class);
     }
 
     @Test

--- a/testutil/src/test/java/org/spine3/test/GivenShould.java
+++ b/testutil/src/test/java/org/spine3/test/GivenShould.java
@@ -34,13 +34,13 @@ import org.spine3.server.projection.Projection;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 public class GivenShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Given.class));
+        assertHasPrivateParameterlessCtor(Given.class);
     }
 
     @Test

--- a/testutil/src/test/java/org/spine3/test/TestsShould.java
+++ b/testutil/src/test/java/org/spine3/test/TestsShould.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
 import static org.spine3.test.Tests.newUserId;
 
@@ -37,27 +38,27 @@ public class TestsShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Tests.class));
+        assertHasPrivateParameterlessCtor(Tests.class);
     }
 
     @Test
     public void return_false_if_no_private_but_public_ctor() {
-        assertFalse(Tests.hasPrivateParameterlessCtor(ClassWithPublicCtor.class));
+        assertFalse(hasPrivateParameterlessCtor(ClassWithPublicCtor.class));
     }
 
     @Test
     public void return_false_if_only_ctor_with_args_found() {
-        assertFalse(Tests.hasPrivateParameterlessCtor(ClassWithCtorWithArgs.class));
+        assertFalse(hasPrivateParameterlessCtor(ClassWithCtorWithArgs.class));
     }
 
     @Test
     public void return_true_if_class_has_private_ctor() {
-        assertTrue(Tests.hasPrivateParameterlessCtor(ClassWithPrivateCtor.class));
+        assertTrue(hasPrivateParameterlessCtor(ClassWithPrivateCtor.class));
     }
 
     @Test
     public void return_true_if_class_has_private_throwing_ctor() {
-        assertTrue(Tests.hasPrivateParameterlessCtor(ClassThrowingExceptionInConstructor.class));
+        assertTrue(hasPrivateParameterlessCtor(ClassThrowingExceptionInConstructor.class));
     }
 
     @Test

--- a/testutil/src/test/java/org/spine3/test/TimeTestsShould.java
+++ b/testutil/src/test/java/org/spine3/test/TimeTestsShould.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.spine3.protobuf.Durations2.fromMinutes;
 import static org.spine3.protobuf.Timestamps2.getCurrentTime;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Alexander Yevsyukov
@@ -39,9 +40,9 @@ public class TimeTestsShould {
 
     @Test
     public void have_private_utility_ctor() {
-        Tests.hasPrivateParameterlessCtor(TimeTests.class);
-        Tests.hasPrivateParameterlessCtor(TimeTests.Future.class);
-        Tests.hasPrivateParameterlessCtor(TimeTests.Past.class);
+        assertHasPrivateParameterlessCtor(TimeTests.class);
+        assertHasPrivateParameterlessCtor(TimeTests.Future.class);
+        assertHasPrivateParameterlessCtor(TimeTests.Past.class);
     }
 
     @Test

--- a/testutil/src/test/java/org/spine3/test/VerifyShould.java
+++ b/testutil/src/test/java/org/spine3/test/VerifyShould.java
@@ -42,8 +42,8 @@ import java.util.concurrent.Callable;
 
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.spine3.test.Verify.assertBefore;
 import static org.spine3.test.Verify.assertClassNonInstantiable;
 import static org.spine3.test.Verify.assertContains;
@@ -94,7 +94,7 @@ public class VerifyShould {
 
     @Test
     public void has_private_ctor() {
-        assertTrue(Tests.hasPrivateParameterlessCtor(Verify.class));
+        assertHasPrivateParameterlessCtor(Verify.class);
     }
 
     @SuppressWarnings({"ThrowCaughtLocally", "ErrorNotRethrown"})

--- a/users/src/main/java/org/spine3/users/UserAccounts.java
+++ b/users/src/main/java/org/spine3/users/UserAccounts.java
@@ -20,6 +20,7 @@
 
 package org.spine3.users;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 
 /**
@@ -27,21 +28,34 @@ import com.google.common.base.Optional;
  */
 public class UserAccounts {
 
-    private static final String GOOGLE_AUTH_PROVIDER_ID = "google.com";
+    @VisibleForTesting
+    static final String GOOGLE_AUTH_PROVIDER_ID = "google.com";
+
+    private static final int DUNBARS_NUMBER = 150;
+
+    private UserAccounts() {
+        // Prevent instantiation of this utility class.
+    }
 
     /**
-     * A suggested congnitive limit to the number of people with whom one can maintain stable
-     * social relationships.
+     * Obtains a suggested congnitive limit to the number of people with whom one can
+     * maintain stable social relationships.
      *
      * <p>This value should be used for calculating the cache size for storing
      * {@code UserAccount} instances.
      *
      * @see <a href="https://en.wikipedia.org/wiki/Dunbar%27s_number">Dunbar's number</a>
      */
-    public static final int DUNBARS_NUMBER = 150;
+    public static int getDunbarsNumber() {
+        return DUNBARS_NUMBER;
+    }
 
-    private UserAccounts() {}
-
+    /**
+     * Obtains Google account ID from the passed {@code UserAccount} instance.
+     *
+     * @return account ID or empty optional if {@code google.com} is not listed
+     * as an identity provider of the passed account
+     */
     public static Optional<String> getGoogleUid(UserAccount account) {
         for (UserInfo userInfo : account.getLinkedIdentityList()) {
             if (userInfo.getProviderId().equals(GOOGLE_AUTH_PROVIDER_ID)) {

--- a/users/src/test/java/org/spine3/users/UserAccountsShould.java
+++ b/users/src/test/java/org/spine3/users/UserAccountsShould.java
@@ -22,10 +22,20 @@ package org.spine3.users;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.spine3.base.Identifiers.newUuid;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
+import static org.spine3.users.UserAccounts.GOOGLE_AUTH_PROVIDER_ID;
+import static org.spine3.users.UserAccounts.getGoogleUid;
 
 public class UserAccountsShould {
+
+    @Test
+    public void have_private_utility_ctor() {
+        assertHasPrivateParameterlessCtor(UserAccounts.class);
+    }
 
     @Test
     public void return_absent_for_google_uid_if_no_linked_account_added() {
@@ -36,6 +46,22 @@ public class UserAccountsShould {
     // Checking the bounds of the constant {@code DUNBARS_NUMBER} value.
     @Test
     public void declare_Dubars_number() {
-        assertTrue(UserAccounts.DUNBARS_NUMBER > 100 && UserAccounts.DUNBARS_NUMBER < 250);
+        assertTrue(UserAccounts.getDunbarsNumber() > 100
+                   && UserAccounts.getDunbarsNumber() < 250);
+    }
+
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    @Test
+    public void obtain_user_google_uid() {
+        final String uid = newUuid(); // In reality Google's user ID has different formant.
+
+        final UserAccount userAccount = UserAccount.newBuilder()
+                                             .addLinkedIdentity(
+                                                     UserInfo.newBuilder()
+                                                             .setProviderId(GOOGLE_AUTH_PROVIDER_ID)
+                                                             .setUid(uid))
+                                             .build();
+
+        assertEquals(uid, getGoogleUid(userAccount).get());
     }
 }

--- a/users/src/test/java/org/spine3/users/UserAccountsShould.java
+++ b/users/src/test/java/org/spine3/users/UserAccountsShould.java
@@ -50,17 +50,17 @@ public class UserAccountsShould {
                    && UserAccounts.getDunbarsNumber() < 250);
     }
 
-    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    @SuppressWarnings("OptionalGetWithoutIsPresent") // No need to check in this test.
     @Test
     public void obtain_user_google_uid() {
         final String uid = newUuid(); // In reality Google's user ID has different formant.
 
-        final UserAccount userAccount = UserAccount.newBuilder()
-                                             .addLinkedIdentity(
-                                                     UserInfo.newBuilder()
-                                                             .setProviderId(GOOGLE_AUTH_PROVIDER_ID)
-                                                             .setUid(uid))
-                                             .build();
+        final UserAccount userAccount =
+                UserAccount.newBuilder()
+                           .addLinkedIdentity(UserInfo.newBuilder()
+                                                      .setProviderId(GOOGLE_AUTH_PROVIDER_ID)
+                                                      .setUid(uid))
+                           .build();
 
         assertEquals(uid, getGoogleUid(userAccount).get());
     }

--- a/values/src/test/java/org/spine3/money/MoneyUtilShould.java
+++ b/values/src/test/java/org/spine3/money/MoneyUtilShould.java
@@ -23,15 +23,13 @@ package org.spine3.money;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class MoneyUtilShould {
 
     @Test
     public void have_private_utility_ctor() {
-        assertTrue(hasPrivateParameterlessCtor(MoneyUtil.class));
+        assertHasPrivateParameterlessCtor(MoneyUtil.class);
     }
 
     @Test

--- a/values/src/test/java/org/spine3/net/QueryParametersShould.java
+++ b/values/src/test/java/org/spine3/net/QueryParametersShould.java
@@ -30,7 +30,7 @@ import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 /**
  * @author Mikhail Mikhaylov
  */
-@SuppressWarnings({"InstanceMethodNamingConvention", "DuplicateStringLiteralInspection"})
+@SuppressWarnings("DuplicateStringLiteralInspection")
 public class QueryParametersShould {
 
     @Test

--- a/values/src/test/java/org/spine3/net/QueryParametersShould.java
+++ b/values/src/test/java/org/spine3/net/QueryParametersShould.java
@@ -24,9 +24,8 @@ import org.junit.Test;
 import org.spine3.net.Url.Record.QueryParameter;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Mikhail Mikhaylov
@@ -74,6 +73,6 @@ public class QueryParametersShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(QueryParameters.class));
+        assertHasPrivateParameterlessCtor(QueryParameters.class);
     }
 }

--- a/values/src/test/java/org/spine3/net/SchemasShould.java
+++ b/values/src/test/java/org/spine3/net/SchemasShould.java
@@ -20,17 +20,15 @@
 
 package org.spine3.net;
 
+import com.google.common.testing.NullPointerTester;
 import org.junit.Test;
-import org.spine3.test.NullToleranceTest;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Mikhail Mikhaylov
  */
-@SuppressWarnings({"InstanceMethodNamingConvention"})
 public class SchemasShould {
 
     @Test
@@ -46,17 +44,13 @@ public class SchemasShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Schemas.class));
+        assertHasPrivateParameterlessCtor(Schemas.class);
     }
 
     @Test
     public void pass_the_null_tolerance_check() {
-        final NullToleranceTest nullToleranceTest =
-                NullToleranceTest.newBuilder()
-                                 .setClass(Schemas.class)
-                                 .addDefaultValue(Url.Record.Schema.UNDEFINED)
-                                 .build();
-        final boolean passed = nullToleranceTest.check();
-        assertTrue(passed);
+        new NullPointerTester()
+                .setDefault(Url.Record.Schema.class, Url.Record.Schema.UNDEFINED)
+                .testAllPublicStaticMethods(Schemas.class);
     }
 }

--- a/values/src/test/java/org/spine3/net/UrlParserShould.java
+++ b/values/src/test/java/org/spine3/net/UrlParserShould.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Mikhail Mikhaylov
  */
-@SuppressWarnings({"InstanceMethodNamingConvention", "DuplicateStringLiteralInspection"})
+@SuppressWarnings("DuplicateStringLiteralInspection")
 public class UrlParserShould {
 
     private static final String HOST = "ulr-parser-should.com";

--- a/values/src/test/java/org/spine3/net/UrlPrinterShould.java
+++ b/values/src/test/java/org/spine3/net/UrlPrinterShould.java
@@ -25,8 +25,7 @@ import org.spine3.net.Url.Record;
 import org.spine3.net.Url.Record.Authorization;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Mikhail Mikhaylov
@@ -135,6 +134,6 @@ public class UrlPrinterShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(UrlPrinter.class));
+        assertHasPrivateParameterlessCtor(UrlPrinter.class);
     }
 }

--- a/values/src/test/java/org/spine3/net/UrlPrinterShould.java
+++ b/values/src/test/java/org/spine3/net/UrlPrinterShould.java
@@ -30,7 +30,7 @@ import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 /**
  * @author Mikhail Mikhaylov
  */
-@SuppressWarnings({"InstanceMethodNamingConvention", "DuplicateStringLiteralInspection"})
+@SuppressWarnings("DuplicateStringLiteralInspection")
 public class UrlPrinterShould {
 
     private static final Authorization AUTH =

--- a/values/src/test/java/org/spine3/net/UrlsShould.java
+++ b/values/src/test/java/org/spine3/net/UrlsShould.java
@@ -32,7 +32,7 @@ import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 /**
  * @author Mikhail Mikhaylov
  */
-@SuppressWarnings({"InstanceMethodNamingConvention", "DuplicateStringLiteralInspection", "LocalVariableNamingConvention"})
+@SuppressWarnings({"DuplicateStringLiteralInspection", "LocalVariableNamingConvention"})
 public class UrlsShould {
 
     @Test

--- a/values/src/test/java/org/spine3/net/UrlsShould.java
+++ b/values/src/test/java/org/spine3/net/UrlsShould.java
@@ -20,15 +20,14 @@
 
 package org.spine3.net;
 
+import com.google.common.testing.NullPointerTester;
 import org.junit.Test;
 import org.spine3.net.Url.Record;
 import org.spine3.net.Url.Record.Authorization;
-import org.spine3.test.NullToleranceTest;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Mikhail Mikhaylov
@@ -116,15 +115,12 @@ public class UrlsShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Urls.class));
+        assertHasPrivateParameterlessCtor(Urls.class);
     }
 
     @Test
     public void pass_the_null_tolerance_check() {
-        final NullToleranceTest nullToleranceTest = NullToleranceTest.newBuilder()
-                                                                     .setClass(Urls.class)
-                                                                     .build();
-        final boolean passed = nullToleranceTest.check();
-        assertTrue(passed);
+        new NullPointerTester()
+                .testAllPublicStaticMethods(Urls.class);
     }
 }

--- a/values/src/test/java/org/spine3/time/CalendarsShould.java
+++ b/values/src/test/java/org/spine3/time/CalendarsShould.java
@@ -26,19 +26,18 @@ import java.util.Calendar;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.spine3.time.Calendars.getHours;
 import static org.spine3.time.Calendars.getMinutes;
 import static org.spine3.time.Calendars.getSeconds;
 import static org.spine3.time.Calendars.getZoneOffset;
 import static org.spine3.time.Calendars.nowAt;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class CalendarsShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Calendars.class));
+        assertHasPrivateParameterlessCtor(Calendars.class);
     }
 
     @Test

--- a/values/src/test/java/org/spine3/time/IntervalsShould.java
+++ b/values/src/test/java/org/spine3/time/IntervalsShould.java
@@ -26,17 +26,16 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Alexander Litus
  */
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class IntervalsShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Intervals.class));
+        assertHasPrivateParameterlessCtor(Intervals.class);
     }
 
     @Test

--- a/values/src/test/java/org/spine3/time/LocalDatesShould.java
+++ b/values/src/test/java/org/spine3/time/LocalDatesShould.java
@@ -27,12 +27,11 @@ import java.util.Calendar;
 import static java.util.Calendar.getInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.spine3.time.Calendars.getDay;
 import static org.spine3.time.Calendars.getMonth;
 import static org.spine3.time.Calendars.getYear;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class LocalDatesShould {
 
     private static final int year = 2014;
@@ -41,7 +40,7 @@ public class LocalDatesShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(LocalDates.class));
+        assertHasPrivateParameterlessCtor(LocalDates.class);
     }
 
     @Test

--- a/values/src/test/java/org/spine3/time/LocalTimesShould.java
+++ b/values/src/test/java/org/spine3/time/LocalTimesShould.java
@@ -26,12 +26,11 @@ import java.util.Calendar;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.spine3.time.Calendars.getHours;
 import static org.spine3.time.Calendars.getMinutes;
 import static org.spine3.time.Calendars.getSeconds;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class LocalTimesShould {
 
     private static final int hours = 9;
@@ -42,7 +41,7 @@ public class LocalTimesShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(LocalTimes.class));
+        assertHasPrivateParameterlessCtor(LocalTimes.class);
     }
 
     @Test

--- a/values/src/test/java/org/spine3/time/OffsetDateTimesShould.java
+++ b/values/src/test/java/org/spine3/time/OffsetDateTimesShould.java
@@ -25,8 +25,7 @@ import org.junit.Test;
 import java.util.Calendar;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.spine3.time.Calendars.getDay;
 import static org.spine3.time.Calendars.getHours;
 import static org.spine3.time.Calendars.getMinutes;
@@ -35,7 +34,6 @@ import static org.spine3.time.Calendars.getSeconds;
 import static org.spine3.time.Calendars.getYear;
 import static org.spine3.time.Calendars.getZoneOffset;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 
 public class OffsetDateTimesShould {
 
@@ -54,7 +52,7 @@ public class OffsetDateTimesShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(OffsetDateTimes.class));
+        assertHasPrivateParameterlessCtor(OffsetDateTimes.class);
     }
 
     @Test

--- a/values/src/test/java/org/spine3/time/OffsetDatesShould.java
+++ b/values/src/test/java/org/spine3/time/OffsetDatesShould.java
@@ -25,15 +25,13 @@ import org.junit.Test;
 import java.util.Calendar;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.spine3.time.Calendars.getDay;
 import static org.spine3.time.Calendars.getMonth;
 import static org.spine3.time.Calendars.getYear;
 import static org.spine3.time.Calendars.getZoneOffset;
 import static org.spine3.time.Calendars.nowAt;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class OffsetDatesShould {
 
     private static final ZoneOffset ZONE_OFFSET = ZoneOffsets.ofHoursMinutes(5, 30);
@@ -44,7 +42,7 @@ public class OffsetDatesShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(OffsetDates.class));
+        assertHasPrivateParameterlessCtor(OffsetDates.class);
     }
 
     @Test

--- a/values/src/test/java/org/spine3/time/OffsetTimesShould.java
+++ b/values/src/test/java/org/spine3/time/OffsetTimesShould.java
@@ -25,14 +25,12 @@ import org.junit.Test;
 import java.util.Calendar;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.spine3.time.Calendars.getHours;
 import static org.spine3.time.Calendars.getMinutes;
 import static org.spine3.time.Calendars.getSeconds;
 import static org.spine3.time.Calendars.getZoneOffset;
 
-@SuppressWarnings("InstanceMethodNamingConvention")
 public class OffsetTimesShould {
 
     private static final int hours = 9;
@@ -45,7 +43,7 @@ public class OffsetTimesShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(OffsetTimes.class));
+        assertHasPrivateParameterlessCtor(OffsetTimes.class);
     }
 
     @Test

--- a/values/src/test/java/org/spine3/time/change/ChangesShould.java
+++ b/values/src/test/java/org/spine3/time/change/ChangesShould.java
@@ -42,7 +42,7 @@ import org.spine3.time.ZoneOffsets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.spine3.test.Tests.hasPrivateParameterlessCtor;
+import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 @SuppressWarnings({"ConstantConditions" /* We pass `null` to some of the methods to check handling of preconditions */,
         "ResultOfMethodCallIgnored" /* ...when methods throw exceptions */,
@@ -51,7 +51,7 @@ public class ChangesShould {
 
     @Test
     public void have_private_constructor() {
-        assertTrue(hasPrivateParameterlessCtor(Changes.class));
+        assertHasPrivateParameterlessCtor(Changes.class);
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
This PR:
* Adds `Projection.TypeInfo`
* Enforces checking of parameterless ctor via `Tests.assertHasParameterlessCtor()`
* Removes redundant warning suppression in tests.
* Add test coverage for `UserAccounts` and `TypeInfo` classes.
