### PR TITLE
Avoid dependency on JUnit4 from `Tests`

### DIFF
--- a/testutil/src/main/java/org/spine3/test/Tests.java
+++ b/testutil/src/main/java/org/spine3/test/Tests.java
@@ -58,7 +58,8 @@ public class Tests {
      * <p>This method is needed to avoid dependency on JUnit 4.x in projects that use
      * Spine and JUnit5.
      */
-    private static void assertEquals(boolean expected, boolean actual) {
+    @VisibleForTesting
+    static void assertEquals(boolean expected, boolean actual) {
         if (expected != actual) {
             throw new AssertionError();
         }
@@ -71,7 +72,8 @@ public class Tests {
      * <p>This method is needed to avoid dependency on JUnit 4.x in projects that use
      * Spine and JUnit5.
      */
-    private static void assertTrue(boolean condition) {
+    @VisibleForTesting
+    static void assertTrue(boolean condition) {
         if (!condition) {
             throw new AssertionError();
         }

--- a/testutil/src/main/java/org/spine3/test/Tests.java
+++ b/testutil/src/main/java/org/spine3/test/Tests.java
@@ -40,8 +40,6 @@ import java.lang.reflect.Modifier;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Utilities for testing.
@@ -52,6 +50,31 @@ public class Tests {
 
     private Tests() {
         // Prevent instantiation of this utility class.
+    }
+
+    /**
+     * Asserts that two booleans are equal.
+     *
+     * <p>This method is needed to avoid dependency on JUnit 4.x in projects that use
+     * Spine and JUnit5.
+     */
+    private static void assertEquals(boolean expected, boolean actual) {
+        if (expected != actual) {
+            throw new AssertionError();
+        }
+    }
+
+    /**
+     * Asserts that a condition is true. If it isn't it throws an
+     * {@link AssertionError} without a message.
+     *
+     * <p>This method is needed to avoid dependency on JUnit 4.x in projects that use
+     * Spine and JUnit5.
+     */
+    private static void assertTrue(boolean condition) {
+        if (!condition) {
+            throw new AssertionError();
+        }
     }
 
     /**
@@ -142,7 +165,6 @@ public class Tests {
     public static UserId newUserUuid() {
         return newUserId(Identifiers.newUuid());
     }
-
     /**
      * Generates a {@code StringValue} with generated UUID.
      *
@@ -152,6 +174,7 @@ public class Tests {
     public static StringValue newUuidValue() {
         return Values.newStringValue(Identifiers.newUuid());
     }
+
     /**
      * Asserts that the passed message has a field that matches the passed field mask.
      *

--- a/testutil/src/test/java/org/spine3/test/TestsShould.java
+++ b/testutil/src/test/java/org/spine3/test/TestsShould.java
@@ -97,6 +97,32 @@ public class TestsShould {
         emptyObserver.onCompleted();
     }
 
+    @Test(expected = AssertionError.class)
+    public void have_own_assertion_for_boolean() {
+        // This should pass.
+        assertEquals(true, true);
+
+        // This should pass too.
+        assertEquals(false, false);
+
+        // This should fail.
+        Tests.assertEquals(true, false);
+    }
+
+    @SuppressWarnings("ConstantConditions") // The call with `false` should always fail.
+    @Test(expected = AssertionError.class)
+    public void have_own_assertTrue() {
+        // This should pass.
+        Tests.assertTrue(true);
+
+        // This should fail.
+        Tests.assertTrue(false);
+    }
+
+    /*
+     * Test environment classes
+     ***************************/
+
     private static class ClassWithPrivateCtor {
         @SuppressWarnings("RedundantNoArgConstructor") // We need this constructor for our tests.
         private ClassWithPrivateCtor() {}


### PR DESCRIPTION
This PR avoids dependency on JUnit4  recently introduced in the `Tests` class.