### PR TITLE
Stringifier expansion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
         
-        spineVersion = '0.8.15-SNAPSHOT'
+        spineVersion = '0.8.17-SNAPSHOT'
         
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all the components and change
         // the version of the dependency below to `spineVersion` defined above.

--- a/client/src/main/java/org/spine3/base/Stringifier.java
+++ b/client/src/main/java/org/spine3/base/Stringifier.java
@@ -23,9 +23,9 @@ package org.spine3.base;
 import com.google.common.base.Converter;
 
 /**
- * An object converting from A to B and reverse.
+ * An object converting from A to {@code String} and reverse.
  *
  * @author Alexander Yevsyukov
  */
-public abstract class Stringifier<A, B> extends Converter<A, B> {
+public abstract class Stringifier<I> extends Converter<I, String> {
 }

--- a/client/src/main/java/org/spine3/base/Stringifier.java
+++ b/client/src/main/java/org/spine3/base/Stringifier.java
@@ -30,6 +30,7 @@ import com.google.common.base.Converter;
  * representations of the same information.
  *
  * @author Alexander Yevsyukov
+ * @author Illia Shepilov
  * @see #convert(Object)
  * @see #reverse()
  */

--- a/client/src/main/java/org/spine3/base/Stringifier.java
+++ b/client/src/main/java/org/spine3/base/Stringifier.java
@@ -20,12 +20,20 @@
 
 package org.spine3.base;
 
-import com.google.common.base.Function;
+import com.google.common.base.Converter;
 
 /**
- * An object converting to {@code String}.
+ * An object converting from A to B and reverse.
  *
  * @author Alexander Yevsyukov
  */
-public interface Stringifier<T> extends Function<T, String> {
+@SuppressWarnings("AbstractMethodOverridesAbstractMethod")
+// To allow calling the methods through the {@code Stringifier} link outside of the package.
+public abstract class Stringifier<A, B> extends Converter<A, B> {
+
+    @Override
+    protected abstract B doForward(A a);
+
+    @Override
+    protected abstract A doBackward(B b);
 }

--- a/client/src/main/java/org/spine3/base/Stringifier.java
+++ b/client/src/main/java/org/spine3/base/Stringifier.java
@@ -28,12 +28,5 @@ import com.google.common.base.Converter;
  * @author Alexander Yevsyukov
  */
 @SuppressWarnings("AbstractMethodOverridesAbstractMethod")
-// To allow calling the methods through the {@code Stringifier} link outside of the package.
 public abstract class Stringifier<A, B> extends Converter<A, B> {
-
-    @Override
-    protected abstract B doForward(A a);
-
-    @Override
-    protected abstract A doBackward(B b);
 }

--- a/client/src/main/java/org/spine3/base/Stringifier.java
+++ b/client/src/main/java/org/spine3/base/Stringifier.java
@@ -27,6 +27,5 @@ import com.google.common.base.Converter;
  *
  * @author Alexander Yevsyukov
  */
-@SuppressWarnings("AbstractMethodOverridesAbstractMethod")
 public abstract class Stringifier<A, B> extends Converter<A, B> {
 }

--- a/client/src/main/java/org/spine3/base/Stringifier.java
+++ b/client/src/main/java/org/spine3/base/Stringifier.java
@@ -23,9 +23,11 @@ package org.spine3.base;
 import com.google.common.base.Converter;
 
 /**
- * An object converting from A to {@code String} and reverse.
+ * Converts an object of the I class to the {@code String} and reverse.
  *
  * @author Alexander Yevsyukov
+ * @see #convert(Object)
+ * @see #reverse()
  */
 public abstract class Stringifier<I> extends Converter<I, String> {
 }

--- a/client/src/main/java/org/spine3/base/Stringifier.java
+++ b/client/src/main/java/org/spine3/base/Stringifier.java
@@ -23,7 +23,11 @@ package org.spine3.base;
 import com.google.common.base.Converter;
 
 /**
- * Converts an object of the I class to the {@code String} and reverse.
+ * Serves as converter from {@code I} to {@code String} with an associated
+ * reverse function from {@code String} to {@code I}.
+ *
+ * <p>It is used for converting back and forth between the different
+ * representations of the same information.
  *
  * @author Alexander Yevsyukov
  * @see #convert(Object)

--- a/client/src/main/java/org/spine3/base/StringifierRegistry.java
+++ b/client/src/main/java/org/spine3/base/StringifierRegistry.java
@@ -64,10 +64,10 @@ class StringifierRegistry {
      * @param <I> the type of the values to convert
      * @return the found {@code Stringifer} or empty {@code Optional}
      */
-    public <I> Optional<Stringifier<I>> get(Class<I> toValueClass) {
-        checkNotNull(toValueClass);
+    public <I> Optional<Stringifier<I>> get(Class<I> valueClass) {
+        checkNotNull(valueClass);
 
-        final Stringifier<?> func = entries.get(toValueClass);
+        final Stringifier<?> func = entries.get(valueClass);
 
         @SuppressWarnings("unchecked") /** The cast is safe as we check the first type when adding.
             @see #register(Class, Stringifier) */

--- a/client/src/main/java/org/spine3/base/StringifierRegistry.java
+++ b/client/src/main/java/org/spine3/base/StringifierRegistry.java
@@ -38,9 +38,9 @@ import static java.util.Collections.synchronizedMap;
  */
 class StringifierRegistry {
 
-    private final Map<Class<?>, Stringifier<?>> entries = synchronizedMap(
+    private final Map<Class<?>, Stringifier<?, ?>> entries = synchronizedMap(
             newHashMap(
-                    ImmutableMap.<Class<?>, Stringifier<?>>builder()
+                    ImmutableMap.<Class<?>, Stringifier<?, ?>>builder()
                             .put(Timestamp.class, new Stringifiers.TimestampIdStringifer())
                             .put(EventId.class, new Stringifiers.EventIdStringifier())
                             .put(CommandId.class, new Stringifiers.CommandIdStringifier())
@@ -52,7 +52,7 @@ class StringifierRegistry {
         // Prevent external instantiation of this singleton class.
     }
 
-    public <I extends Message> void register(Class<I> valueClass, Stringifier<I> converter) {
+    public <I extends Message, B> void register(Class<I> valueClass, Stringifier<I, B> converter) {
         checkNotNull(valueClass);
         checkNotNull(converter);
         entries.put(valueClass, converter);
@@ -61,17 +61,18 @@ class StringifierRegistry {
     /**
      * Obtains a {@code Stringifier} for the passed type.
      *
-     * @param <I> the type of the values to convert
+     * @param <A> the type of the values to convert
+     * @param <B> the type of the values from convert
      * @return the found {@code Stringifer} or empty {@code Optional}
      */
-    public <I> Optional<Stringifier<I>> get(Class<I> valueClass) {
-        checkNotNull(valueClass);
+    public <A, B> Optional<Stringifier<A, B>> get(Class<A> toValueClass) {
+        checkNotNull(toValueClass);
 
-        final Stringifier<?> func = entries.get(valueClass);
+        final Stringifier<?, ?> func = entries.get(toValueClass);
 
         @SuppressWarnings("unchecked") /** The cast is safe as we check the first type when adding.
             @see #register(Class, Stringifier) */
-        final Stringifier<I> result = (Stringifier<I>) func;
+        final Stringifier<A, B> result = (Stringifier<A, B>) func;
         return Optional.fromNullable(result);
     }
 

--- a/client/src/main/java/org/spine3/base/StringifierRegistry.java
+++ b/client/src/main/java/org/spine3/base/StringifierRegistry.java
@@ -75,7 +75,7 @@ class StringifierRegistry {
         return Optional.fromNullable(result);
     }
 
-    public synchronized <I> boolean hasStringiferFor(Class<I> valueClass) {
+    public synchronized <I> boolean hasStringifierFor(Class<I> valueClass) {
         final boolean contains = entries.containsKey(valueClass);
         return contains;
     }

--- a/client/src/main/java/org/spine3/base/StringifierRegistry.java
+++ b/client/src/main/java/org/spine3/base/StringifierRegistry.java
@@ -38,9 +38,9 @@ import static java.util.Collections.synchronizedMap;
  */
 class StringifierRegistry {
 
-    private final Map<Class<?>, Stringifier<?, ?>> entries = synchronizedMap(
+    private final Map<Class<?>, Stringifier<?>> entries = synchronizedMap(
             newHashMap(
-                    ImmutableMap.<Class<?>, Stringifier<?, ?>>builder()
+                    ImmutableMap.<Class<?>, Stringifier<?>>builder()
                             .put(Timestamp.class, new Stringifiers.TimestampIdStringifer())
                             .put(EventId.class, new Stringifiers.EventIdStringifier())
                             .put(CommandId.class, new Stringifiers.CommandIdStringifier())
@@ -52,7 +52,7 @@ class StringifierRegistry {
         // Prevent external instantiation of this singleton class.
     }
 
-    public <I extends Message, B> void register(Class<I> valueClass, Stringifier<I, B> converter) {
+    public <I extends Message> void register(Class<I> valueClass, Stringifier<I> converter) {
         checkNotNull(valueClass);
         checkNotNull(converter);
         entries.put(valueClass, converter);
@@ -61,18 +61,17 @@ class StringifierRegistry {
     /**
      * Obtains a {@code Stringifier} for the passed type.
      *
-     * @param <A> the type of the values to convert
-     * @param <B> the type of the values from convert
+     * @param <I> the type of the values to convert
      * @return the found {@code Stringifer} or empty {@code Optional}
      */
-    public <A, B> Optional<Stringifier<A, B>> get(Class<A> toValueClass) {
+    public <I> Optional<Stringifier<I>> get(Class<I> toValueClass) {
         checkNotNull(toValueClass);
 
-        final Stringifier<?, ?> func = entries.get(toValueClass);
+        final Stringifier<?> func = entries.get(toValueClass);
 
         @SuppressWarnings("unchecked") /** The cast is safe as we check the first type when adding.
             @see #register(Class, Stringifier) */
-        final Stringifier<A, B> result = (Stringifier<A, B>) func;
+        final Stringifier<I> result = (Stringifier<I>) func;
         return Optional.fromNullable(result);
     }
 

--- a/client/src/main/java/org/spine3/base/Stringifiers.java
+++ b/client/src/main/java/org/spine3/base/Stringifiers.java
@@ -167,8 +167,7 @@ public class Stringifiers {
             try {
                 return Timestamps.parse(s);
             } catch (ParseException e) {
-                final ConversionError conversionError = new ConversionError(e.getMessage(),
-                                                                            e.getErrorOffset());
+                final ConversionError conversionError = new ConversionError(e.getMessage());
                 throw new IllegalArgumentException(conversionError);
             }
         }

--- a/client/src/main/java/org/spine3/base/Stringifiers.java
+++ b/client/src/main/java/org/spine3/base/Stringifiers.java
@@ -26,6 +26,7 @@ import com.google.protobuf.MessageOrBuilder;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
 import org.spine3.validate.ConversionError;
+import org.spine3.validate.IllegalConversionArgumentException;
 
 import javax.annotation.Nullable;
 import java.text.ParseException;
@@ -168,7 +169,7 @@ public class Stringifiers {
                 return Timestamps.parse(s);
             } catch (ParseException e) {
                 final ConversionError conversionError = new ConversionError(e.getMessage());
-                throw new IllegalArgumentException(conversionError);
+                throw new IllegalConversionArgumentException(conversionError);
             }
         }
     }

--- a/client/src/main/java/org/spine3/base/Stringifiers.java
+++ b/client/src/main/java/org/spine3/base/Stringifiers.java
@@ -151,7 +151,7 @@ public class Stringifiers {
         return result;
     }
 
-    protected static class TimestampIdStringifer extends Stringifier<Timestamp, String> {
+    protected static class TimestampIdStringifer extends Stringifier<Timestamp> {
 
         @Override
         protected String doForward(Timestamp timestamp) {
@@ -174,7 +174,7 @@ public class Stringifiers {
         }
     }
 
-    static class EventIdStringifier extends Stringifier<EventId, String> {
+    static class EventIdStringifier extends Stringifier<EventId> {
         @Override
         protected String doForward(EventId eventId) {
             final String result = eventId.getUuid();
@@ -190,7 +190,7 @@ public class Stringifiers {
         }
     }
 
-    static class CommandIdStringifier extends Stringifier<CommandId, String> {
+    static class CommandIdStringifier extends Stringifier<CommandId> {
         @Override
         protected String doForward(CommandId commandId) {
             final String result = commandId.getUuid();

--- a/client/src/main/java/org/spine3/base/Stringifiers.java
+++ b/client/src/main/java/org/spine3/base/Stringifiers.java
@@ -41,6 +41,7 @@ import static org.spine3.protobuf.AnyPacker.unpack;
  * Utility class for working with {@code Stringifier}s.
  *
  * @author Alexander Yevsyukov
+ * @author Illia Shepilov
  */
 public class Stringifiers {
 
@@ -174,7 +175,7 @@ public class Stringifiers {
         }
     }
 
-    static class EventIdStringifier extends Stringifier<EventId> {
+    protected static class EventIdStringifier extends Stringifier<EventId> {
         @Override
         protected String doForward(EventId eventId) {
             final String result = eventId.getUuid();
@@ -190,7 +191,7 @@ public class Stringifiers {
         }
     }
 
-    static class CommandIdStringifier extends Stringifier<CommandId> {
+    protected static class CommandIdStringifier extends Stringifier<CommandId> {
         @Override
         protected String doForward(CommandId commandId) {
             final String result = commandId.getUuid();

--- a/client/src/main/java/org/spine3/base/Stringifiers.java
+++ b/client/src/main/java/org/spine3/base/Stringifiers.java
@@ -113,7 +113,7 @@ public class Stringifiers {
         final String result;
         final StringifierRegistry registry = StringifierRegistry.getInstance();
         final Class<? extends Message> msgClass = message.getClass();
-        if (registry.hasStringiferFor(msgClass)) {
+        if (registry.hasStringifierFor(msgClass)) {
             @SuppressWarnings("OptionalGetWithoutIsPresent") // OK as we check for presence above.
             final Stringifier converter = registry.get(msgClass)
                                                   .get();

--- a/client/src/main/java/org/spine3/validate/ConversionError.java
+++ b/client/src/main/java/org/spine3/validate/ConversionError.java
@@ -23,7 +23,7 @@ package org.spine3.validate;
 import java.text.ParseException;
 
 /**
- * Signals that an error has been reached unexpectedly while conversion from one type to another.
+ * Signals that an error has been reached unexpectedly while converting from one type to another.
  *
  * @author Illia Shepilov
  */

--- a/client/src/main/java/org/spine3/validate/ConversionError.java
+++ b/client/src/main/java/org/spine3/validate/ConversionError.java
@@ -29,7 +29,7 @@ package org.spine3.validate;
 // It is OK, because it is not {@code Exception} in usual meaning.
 // It is occurred when input value cannot be converted to desirable type
 // and repeated input is required.
-public class ConversionError extends Throwable {
+public class ConversionError extends Exception {
 
     private static final long serialVersionUID = 1L;
 

--- a/client/src/main/java/org/spine3/validate/ConversionError.java
+++ b/client/src/main/java/org/spine3/validate/ConversionError.java
@@ -36,8 +36,7 @@ public class ConversionError extends ParseException {
     private static final long serialVersionUID = 1L;
 
     /**
-     * Constructs a ParseException with the specified detail message and
-     * offset.
+     * Constructs a ParseException with the specified detail message and offset.
      * A detail message is a String that describes this particular exception.
      *
      * @param s           the detail message

--- a/client/src/main/java/org/spine3/validate/ConversionError.java
+++ b/client/src/main/java/org/spine3/validate/ConversionError.java
@@ -20,8 +20,6 @@
 
 package org.spine3.validate;
 
-import java.text.ParseException;
-
 /**
  * Signals that an error has been reached unexpectedly while converting from one type to another.
  *
@@ -31,18 +29,11 @@ import java.text.ParseException;
 // It is OK, because it is not {@code Exception} in usual meaning.
 // It is occurred when input value cannot be converted to desirable type
 // and repeated input is required.
-public class ConversionError extends ParseException {
+public class ConversionError extends Throwable {
 
     private static final long serialVersionUID = 1L;
 
-    /**
-     * Constructs a ParseException with the specified detail message and offset.
-     * A detail message is a String that describes this particular exception.
-     *
-     * @param s           the detail message
-     * @param errorOffset the position where the error is found while parsing.
-     */
-    public ConversionError(String s, int errorOffset) {
-        super(s, errorOffset);
+    public ConversionError(String message) {
+        super(message);
     }
 }

--- a/client/src/main/java/org/spine3/validate/ConversionError.java
+++ b/client/src/main/java/org/spine3/validate/ConversionError.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.validate;
+
+import java.text.ParseException;
+
+/**
+ * Signals that an error has been reached unexpectedly while conversion from one type to another.
+ *
+ * @author Illia Shepilov
+ */
+@SuppressWarnings("ExceptionClassNameDoesntEndWithException")
+// It is OK, because it is not {@code Exception} in usual meaning.
+// It is occurred when input value cannot be converted to desirable type
+// and repeated input is required.
+public class ConversionError extends ParseException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a ParseException with the specified detail message and
+     * offset.
+     * A detail message is a String that describes this particular exception.
+     *
+     * @param s           the detail message
+     * @param errorOffset the position where the error is found while parsing.
+     */
+    public ConversionError(String s, int errorOffset) {
+        super(s, errorOffset);
+    }
+}

--- a/client/src/main/java/org/spine3/validate/IllegalConversionArgumentException.java
+++ b/client/src/main/java/org/spine3/validate/IllegalConversionArgumentException.java
@@ -22,7 +22,7 @@ package org.spine3.validate;
 
 /**
  * Thrown to indicate that a method has been passed an illegal or
- * inappropriate argument during conversion from one type to another.
+ * inappropriate argument during the conversion from one type to another.
  *
  * @author Illia Shepilov
  * @see ConversionError

--- a/client/src/main/java/org/spine3/validate/IllegalConversionArgumentException.java
+++ b/client/src/main/java/org/spine3/validate/IllegalConversionArgumentException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.validate;
+
+/**
+ * Thrown to indicate that a method has been passed
+ * an illegal or inappropriate argument during conversion.
+ *
+ * @author Illia Shepilov
+ * @see ConversionError
+ */
+public class IllegalConversionArgumentException extends IllegalArgumentException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final ConversionError conversionError;
+
+    public IllegalConversionArgumentException(ConversionError conversionError) {
+        this.conversionError = conversionError;
+    }
+
+    public ConversionError getConversionError() {
+        return conversionError;
+    }
+}

--- a/client/src/main/java/org/spine3/validate/IllegalConversionArgumentException.java
+++ b/client/src/main/java/org/spine3/validate/IllegalConversionArgumentException.java
@@ -21,8 +21,8 @@
 package org.spine3.validate;
 
 /**
- * Thrown to indicate that a method has been passed
- * an illegal or inappropriate argument during conversion.
+ * Thrown to indicate that a method has been passed an illegal or
+ * inappropriate argument during conversion from one type to another.
  *
  * @author Illia Shepilov
  * @see ConversionError
@@ -34,6 +34,7 @@ public class IllegalConversionArgumentException extends IllegalArgumentException
     private final ConversionError conversionError;
 
     public IllegalConversionArgumentException(ConversionError conversionError) {
+        super();
         this.conversionError = conversionError;
     }
 

--- a/client/src/test/java/org/spine3/base/StringifiersShould.java
+++ b/client/src/test/java/org/spine3/base/StringifiersShould.java
@@ -299,7 +299,6 @@ public class StringifiersShould {
                                         .build();
         final EventId actual = new Stringifiers.EventIdStringifier().reverse()
                                                                     .convert(id);
-
         assertEquals(expected, actual);
     }
 

--- a/client/src/test/java/org/spine3/base/StringifiersShould.java
+++ b/client/src/test/java/org/spine3/base/StringifiersShould.java
@@ -25,14 +25,17 @@ import com.google.protobuf.Int32Value;
 import com.google.protobuf.Int64Value;
 import com.google.protobuf.StringValue;
 import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
 import org.junit.Test;
 import org.spine3.protobuf.AnyPacker;
+import org.spine3.protobuf.Timestamps2;
 import org.spine3.test.NullToleranceTest;
 import org.spine3.test.identifiers.IdWithPrimitiveFields;
 import org.spine3.test.identifiers.NestedMessageId;
 import org.spine3.test.identifiers.SeveralFieldsId;
 import org.spine3.test.identifiers.TimestampFieldId;
 
+import java.text.ParseException;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
@@ -263,6 +266,23 @@ public class StringifiersShould {
         assertEquals(expected, actual);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void throw_exception_when_try_to_convert_inappropriate_string_to_timestamp() {
+        final String time = Timestamps2.getCurrentTime()
+                                       .toString();
+        new Stringifiers.TimestampIdStringifer().reverse()
+                                                .convert(time);
+    }
+
+    @Test
+    public void convert_string_to_timestamp() throws ParseException {
+        final String date = "1972-01-01T10:00:20.021-05:00";
+        final Timestamp expected = Timestamps.parse(date);
+        final Timestamp actual = new Stringifiers.TimestampIdStringifer().reverse()
+                                                                         .convert(date);
+        assertEquals(expected, actual);
+    }
+
     @Test
     public void convert_event_id_to_string() {
         final EventId id = Events.generateId();
@@ -272,10 +292,13 @@ public class StringifiersShould {
     }
 
     @Test
-    public void convert_string_to_event_id(){
+    public void convert_string_to_event_id() {
         final String id = newUuid();
-        final EventId expected = EventId.newBuilder().setUuid(id).build();
-        final EventId actual = new Stringifiers.EventIdStringifier().reverse().convert(id);
+        final EventId expected = EventId.newBuilder()
+                                        .setUuid(id)
+                                        .build();
+        final EventId actual = new Stringifiers.EventIdStringifier().reverse()
+                                                                    .convert(id);
 
         assertEquals(expected, actual);
     }

--- a/client/src/test/java/org/spine3/base/StringifiersShould.java
+++ b/client/src/test/java/org/spine3/base/StringifiersShould.java
@@ -33,13 +33,13 @@ import org.spine3.test.identifiers.NestedMessageId;
 import org.spine3.test.identifiers.SeveralFieldsId;
 import org.spine3.test.identifiers.TimestampFieldId;
 
-import javax.annotation.Nullable;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.spine3.base.Identifiers.newUuid;
 import static org.spine3.base.Stringifiers.EMPTY_ID;
 import static org.spine3.base.Stringifiers.NULL_ID;
 import static org.spine3.base.Stringifiers.idToString;
@@ -249,7 +249,18 @@ public class StringifiersShould {
         final String actual = new Stringifiers.CommandIdStringifier().convert(id);
 
         assertEquals(idToString(id), actual);
-        assertEquals(idToString(id), actual);
+    }
+
+    @Test
+    public void convert_string_to_command_id() {
+        final String id = newUuid();
+        final CommandId expected = CommandId.newBuilder()
+                                            .setUuid(id)
+                                            .build();
+        final CommandId actual = new Stringifiers.CommandIdStringifier().reverse()
+                                                                        .convert(id);
+
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -258,6 +269,15 @@ public class StringifiersShould {
         final String actual = new Stringifiers.EventIdStringifier().convert(id);
 
         assertEquals(idToString(id), actual);
+    }
+
+    @Test
+    public void convert_string_to_event_id(){
+        final String id = newUuid();
+        final EventId expected = EventId.newBuilder().setUuid(id).build();
+        final EventId actual = new Stringifiers.EventIdStringifier().reverse().convert(id);
+
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/client/src/test/java/org/spine3/base/StringifiersShould.java
+++ b/client/src/test/java/org/spine3/base/StringifiersShould.java
@@ -38,6 +38,7 @@ import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.spine3.base.Stringifiers.EMPTY_ID;
 import static org.spine3.base.Stringifiers.NULL_ID;
@@ -137,7 +138,9 @@ public class StringifiersShould {
     @Test
     public void convert_to_string_message_id_with_timestamp_field() {
         final Timestamp currentTime = getCurrentTime();
-        final TimestampFieldId id = TimestampFieldId.newBuilder().setId(currentTime).build();
+        final TimestampFieldId id = TimestampFieldId.newBuilder()
+                                                    .setId(currentTime)
+                                                    .build();
         final String expected = toIdString(currentTime);
 
         final String actual = idToString(id);
@@ -148,7 +151,9 @@ public class StringifiersShould {
     @Test
     public void convert_to_string_message_id_with_message_field() {
         final StringValue value = newStringValue(TEST_ID);
-        final NestedMessageId idToConvert = NestedMessageId.newBuilder().setId(value).build();
+        final NestedMessageId idToConvert = NestedMessageId.newBuilder()
+                                                           .setId(value)
+                                                           .build();
 
         final String result = idToString(idToConvert);
 
@@ -169,8 +174,8 @@ public class StringifiersShould {
 
         final String expected =
                 "string=\"" + outerString + '\"' +
-                        " int=" + number +
-                        " message { value=\"" + nestedString + "\" }";
+                " int=" + number +
+                " message { value=\"" + nestedString + "\" }";
 
         final String actual = idToString(idToConvert);
 
@@ -187,54 +192,70 @@ public class StringifiersShould {
         assertEquals(TEST_ID, result);
     }
 
-    private static final Stringifier<IdWithPrimitiveFields> ID_TO_STRING_CONVERTER =
-            new Stringifier<IdWithPrimitiveFields>() {
-        @Override
-        public String apply(@Nullable IdWithPrimitiveFields id) {
-            if (id == null) {
-                return NULL_ID;
-            }
-            return id.getName();
-        }
-    };
+    private static final Stringifier<IdWithPrimitiveFields, String> ID_TO_STRING_CONVERTER =
+            new Stringifier<IdWithPrimitiveFields, String>() {
+                @Override
+                protected String doForward(IdWithPrimitiveFields id) {
+                    return id.getName();
+                }
+
+                @Override
+                protected IdWithPrimitiveFields doBackward(String s) {
+                    return IdWithPrimitiveFields.newBuilder()
+                                                .setName(s)
+                                                .build();
+                }
+            };
 
     @Test
     public void convert_to_string_registered_id_message_type() {
-        StringifierRegistry.getInstance().register(IdWithPrimitiveFields.class, ID_TO_STRING_CONVERTER);
+        StringifierRegistry.getInstance()
+                           .register(IdWithPrimitiveFields.class, ID_TO_STRING_CONVERTER);
 
-        final IdWithPrimitiveFields id = IdWithPrimitiveFields.newBuilder().setName(TEST_ID).build();
+        final IdWithPrimitiveFields id = IdWithPrimitiveFields.newBuilder()
+                                                              .setName(TEST_ID)
+                                                              .build();
         final String result = idToString(id);
 
         assertEquals(TEST_ID, result);
     }
 
-    @SuppressWarnings("OptionalGetWithoutIsPresent") // OK as these are standard Stringifiers we add ourselves.
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    // OK as these are standard Stringifiers we add ourselves.
     @Test
     public void handle_null_in_standard_converters() {
         final StringifierRegistry registry = StringifierRegistry.getInstance();
 
-        assertEquals(NULL_ID, registry.get(Timestamp.class).get().apply(null));
-        assertEquals(NULL_ID, registry.get(EventId.class).get().apply(null));
-        assertEquals(NULL_ID, registry.get(CommandId.class).get().apply(null));
+        assertNull(registry.get(Timestamp.class)
+                           .get()
+                           .convert(null));
+        assertNull(registry.get(EventId.class)
+                           .get()
+                           .convert(null));
+        assertNull(registry.get(CommandId.class)
+                           .get()
+                           .convert(null));
     }
 
     @Test
     public void return_false_on_attempt_to_find_unregistered_type() {
-        assertFalse(StringifierRegistry.getInstance().hasStringiferFor(Random.class));
+        assertFalse(StringifierRegistry.getInstance()
+                                       .hasStringiferFor(Random.class));
     }
 
     @Test
     public void convert_command_id_to_string() {
         final CommandId id = Commands.generateId();
-        final String actual = new Stringifiers.CommandIdStringifier().apply(id);
+        final String actual = new Stringifiers.CommandIdStringifier().convert(id);
 
+        assertEquals(idToString(id), actual);
         assertEquals(idToString(id), actual);
     }
 
     @Test
     public void convert_event_id_to_string() {
         final EventId id = Events.generateId();
-        final String actual = new Stringifiers.EventIdStringifier().apply(id);
+        final String actual = new Stringifiers.EventIdStringifier().convert(id);
 
         assertEquals(idToString(id), actual);
     }

--- a/client/src/test/java/org/spine3/base/StringifiersShould.java
+++ b/client/src/test/java/org/spine3/base/StringifiersShould.java
@@ -243,7 +243,7 @@ public class StringifiersShould {
     @Test
     public void return_false_on_attempt_to_find_unregistered_type() {
         assertFalse(StringifierRegistry.getInstance()
-                                       .hasStringiferFor(Random.class));
+                                       .hasStringifierFor(Random.class));
     }
 
     @Test

--- a/client/src/test/java/org/spine3/base/StringifiersShould.java
+++ b/client/src/test/java/org/spine3/base/StringifiersShould.java
@@ -195,8 +195,8 @@ public class StringifiersShould {
         assertEquals(TEST_ID, result);
     }
 
-    private static final Stringifier<IdWithPrimitiveFields, String> ID_TO_STRING_CONVERTER =
-            new Stringifier<IdWithPrimitiveFields, String>() {
+    private static final Stringifier<IdWithPrimitiveFields> ID_TO_STRING_CONVERTER =
+            new Stringifier<IdWithPrimitiveFields>() {
                 @Override
                 protected String doForward(IdWithPrimitiveFields id) {
                     return id.getName();


### PR DESCRIPTION
Summary of changes:
- `Stringifier` is abstract class from now.
- `Stringifier` extends `com.google.common.base.Converter` and can make reversal conversion from now.
- If `null` is passed to the `convert` method, `null` will be returned.