### PR TITLE
Exclude `Patterns.java` from Codacy inspection

### DIFF
--- a/codacy.yaml
+++ b/codacy.yaml
@@ -1,0 +1,3 @@
+---
+exclude_paths:
+- "client/src/main/java/org/spine3/net/Patterns.java"


### PR DESCRIPTION
Because it reports duplicated string warnings for pieces of regexps.