### PR TITLE
Get rid of `Tuple`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
         
-        spineVersion = '0.8.18-SNAPSHOT'
+        spineVersion = '0.8.19-SNAPSHOT'
         
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all the components and change
         // the version of the dependency below to `spineVersion` defined above.

--- a/server/src/main/java/org/spine3/server/entity/DefaultEntityFactory.java
+++ b/server/src/main/java/org/spine3/server/entity/DefaultEntityFactory.java
@@ -33,14 +33,15 @@ import static org.spine3.server.entity.AbstractEntity.getConstructor;
  * @param <E> the type of entities to create
  * @author Alexander Yevsyukov
  */
-public class DefaultEntityFactory<I, E extends AbstractEntity<I, ?>> implements EntityFactory<I, E> {
+class DefaultEntityFactory<I, E extends AbstractEntity<I, ?>>
+        implements EntityFactory<I, E> {
 
     private final Repository<I, E> repository;
 
     /** The constructor for creating entity instances. */
     private final Constructor<E> entityConstructor;
 
-    public DefaultEntityFactory(Repository<I, E> repository) {
+    DefaultEntityFactory(Repository<I, E> repository) {
         this.repository = repository;
         this.entityConstructor = getEntityConstructor();
         this.entityConstructor.setAccessible(true);

--- a/server/src/main/java/org/spine3/server/entity/DefaultEntityStorageConverter.java
+++ b/server/src/main/java/org/spine3/server/entity/DefaultEntityStorageConverter.java
@@ -25,6 +25,8 @@ import com.google.protobuf.FieldMask;
 import com.google.protobuf.Message;
 import org.spine3.protobuf.TypeUrl;
 
+import static org.spine3.base.Identifiers.idFromAny;
+import static org.spine3.base.Identifiers.idToAny;
 import static org.spine3.protobuf.AnyPacker.pack;
 import static org.spine3.protobuf.AnyPacker.unpack;
 
@@ -58,9 +60,11 @@ class DefaultEntityStorageConverter<I, E extends AbstractEntity<I, S>, S extends
 
     @Override
     protected Tuple<I> doForward(E entity) {
+        final Any entityId = idToAny(entity.getId());
         final Any stateAny = pack(entity.getState());
         final EntityRecord.Builder builder =
                 EntityRecord.newBuilder()
+                            .setEntityId(entityId)
                             .setState(stateAny);
 
         if (entity instanceof AbstractVersionableEntity) {
@@ -76,19 +80,19 @@ class DefaultEntityStorageConverter<I, E extends AbstractEntity<I, S>, S extends
     @Override
     @SuppressWarnings("unchecked")
     protected E doBackward(Tuple<I> tuple) {
-        final Message unpacked = unpack(tuple.getState()
-                                             .getState());
+        final EntityRecord entityRecord = tuple.getState();
+        final Message unpacked = unpack(entityRecord.getState());
         final TypeUrl entityStateType = repository.getEntityStateType();
         final S state = (S) FieldMasks.applyMask(fieldMask, unpacked, entityStateType);
 
-        final E entity = repository.create(tuple.getId());
+        final I id = (I) idFromAny(entityRecord.getEntityId());
+        final E entity = repository.create(id);
 
-        final EntityRecord record = tuple.getState();
         if (entity != null) {
             if (entity instanceof AbstractVersionableEntity) {
                 final AbstractVersionableEntity versionable = (AbstractVersionableEntity) entity;
-                versionable.setState(state, record.getVersion());
-                versionable.setLifecycleFlags(record.getLifecycleFlags());
+                versionable.setState(state, entityRecord.getVersion());
+                versionable.setLifecycleFlags(entityRecord.getLifecycleFlags());
             } else {
                 entity.injectState(state);
             }

--- a/server/src/main/java/org/spine3/server/entity/DefaultEntityStorageConverter.java
+++ b/server/src/main/java/org/spine3/server/entity/DefaultEntityStorageConverter.java
@@ -34,7 +34,6 @@ import static org.spine3.protobuf.AnyPacker.unpack;
  * Default implementation of {@code EntityStorageConverter} for {@code AbstractVersionableEntity}.
  *
  * @author Alexander Yevsyukov
- * @see Tuple
  */
 class DefaultEntityStorageConverter<I, E extends AbstractEntity<I, S>, S extends Message>
         extends EntityStorageConverter<I, E, S> {
@@ -59,7 +58,7 @@ class DefaultEntityStorageConverter<I, E extends AbstractEntity<I, S>, S extends
     }
 
     @Override
-    protected Tuple<I> doForward(E entity) {
+    protected EntityRecord doForward(E entity) {
         final Any entityId = idToAny(entity.getId());
         final Any stateAny = pack(entity.getState());
         final EntityRecord.Builder builder =
@@ -73,14 +72,12 @@ class DefaultEntityStorageConverter<I, E extends AbstractEntity<I, S>, S extends
                    .setLifecycleFlags(versionable.getLifecycleFlags());
         }
 
-        final Tuple<I> result = tuple(entity.getId(), builder.build());
-        return result;
+        return builder.build();
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    protected E doBackward(Tuple<I> tuple) {
-        final EntityRecord entityRecord = tuple.getState();
+    protected E doBackward(EntityRecord entityRecord) {
         final Message unpacked = unpack(entityRecord.getState());
         final TypeUrl entityStateType = repository.getEntityStateType();
         final S state = (S) FieldMasks.applyMask(fieldMask, unpacked, entityStateType);

--- a/server/src/main/java/org/spine3/server/entity/EntityStorageConverter.java
+++ b/server/src/main/java/org/spine3/server/entity/EntityStorageConverter.java
@@ -30,10 +30,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * An abstract base for converters of entities into {@link EntityRecord}.
  *
  * @author Alexander Yevsyukov
- * @see Tuple
  */
 public abstract class EntityStorageConverter<I, E extends Entity<I, S>, S extends Message>
-        extends Converter<E, EntityStorageConverter.Tuple<I>> {
+        extends Converter<E, EntityRecord> {
 
     private final FieldMask fieldMask;
 
@@ -53,26 +52,4 @@ public abstract class EntityStorageConverter<I, E extends Entity<I, S>, S extend
      * Creates a copy of this converter modified with the passed filed mask.
      */
     public abstract EntityStorageConverter<I, E, S> withFieldMask(FieldMask fieldMask);
-
-    /**
-     * Creates new tuple of entity ID and corresponding storage record.
-     */
-    public static <I> Tuple<I> tuple(I id, EntityRecord record) {
-        return new Tuple<>(id, record);
-    }
-
-    /**
-     * The tuple of an entity ID and a storage record.
-     *
-     * <p>This data structure is needed for passing entity information to the reverse
-     * conversion.
-     *
-     * @param <I> type of the entity ID
-     */
-    public static class Tuple<I> extends AbstractEntity<I, EntityRecord> {
-        private Tuple(I id, EntityRecord record) {
-            super(id);
-            injectState(record);
-        }
-    }
 }

--- a/server/src/main/java/org/spine3/server/entity/RecordBasedRepository.java
+++ b/server/src/main/java/org/spine3/server/entity/RecordBasedRepository.java
@@ -279,20 +279,18 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
                                               .getIdsList();
         final Class<I> expectedIdClass = getIdClass();
 
-        final Collection<I> result = Collections2.transform(idsList,
-                                                            new EntityIdFunction<>(expectedIdClass));
+        final EntityIdFunction<I> func = new EntityIdFunction<>(expectedIdClass);
+        final Collection<I> result = Collections2.transform(idsList, func);
 
         return result;
     }
 
     /**
-     * Converts the passed entity into {@code EntityStorageRecord} that
-     * stores the entity data.
+     * Converts the passed entity into the record.
      */
     protected EntityRecord toRecord(E entity) {
         final EntityRecord entityRecord = entityConverter().convert(entity);
-        return entityRecord != null ? entityRecord
-                             : EntityRecord.getDefaultInstance();
+        return entityRecord;
     }
 
     private E toEntity(EntityRecord record) {

--- a/server/src/main/java/org/spine3/server/event/enrich/EnrichmentFunction.java
+++ b/server/src/main/java/org/spine3/server/event/enrich/EnrichmentFunction.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
 
 /**
  * {@code EnrichmentFunction} defines how a source message class can be transformed into a target message class.
@@ -57,8 +58,11 @@ abstract class EnrichmentFunction<S, T> implements Function<S, T> {
     EnrichmentFunction(Class<S> eventClass, Class<T> enrichmentClass) {
         this.eventClass = checkNotNull(eventClass);
         this.enrichmentClass = checkNotNull(enrichmentClass);
-        checkArgument(!eventClass.equals(enrichmentClass),
-                      "Event and enrichment class must not be equal. Passed two values of %", eventClass);
+        checkArgument(
+            !eventClass.equals(enrichmentClass),
+            "Event and enrichment class must not be equal. Passed two values of %",
+            eventClass
+        );
     }
 
     Class<S> getEventClass() {
@@ -89,13 +93,13 @@ abstract class EnrichmentFunction<S, T> implements Function<S, T> {
      * definitions. The function internal state in this case is appended with the parsed data, which
      * is later used at runtime.
      *
-     * <p>After the function is activated successfully, the {@link #isActive()} returns {@code true}.
+     * <p>After the function is activated, the {@link #isActive()} returns {@code true}.
      *
      * <p>If an activation cannot be performed flawlessly, the {@code IllegalStateException}
      * should be thrown. In this case {@link #isActive()} should return {@code false}.
      *
-     * @throws IllegalStateException if the function cannot perform the conversion in its current state
-     * or because of the state of its environment
+     * @throws IllegalStateException if the function cannot perform the conversion in its
+     *                               current state or because of the state of its environment
      */
     abstract void activate();
 
@@ -153,8 +157,12 @@ abstract class EnrichmentFunction<S, T> implements Function<S, T> {
      */
     protected void ensureActive() {
         if(!isActive()) {
-            throw new IllegalStateException("The given instance of " + getClass() + " is not active at the moment. " +
-                                                    "Please use `activate()` first.");
+            final String errMsg = format(
+                    "The given instance of %s is not active at the moment. " +
+                    "Please use `activate()` first.",
+                    getClass().getName()
+            );
+            throw new IllegalStateException(errMsg);
         }
     }
 }

--- a/server/src/main/proto/spine/server/entity/entity.proto
+++ b/server/src/main/proto/spine/server/entity/entity.proto
@@ -38,7 +38,6 @@ import "spine/base/version.proto";
 message EntityRecord {
     option (SPI_type) = true;
 
-    //TODO:2017-02-19:alexander.yevsyukov: find usages and fill in this field
     // The ID of the entity.
     google.protobuf.Any entity_id = 1;
 

--- a/server/src/test/java/org/spine3/server/entity/DefaultEntityStorageConverterShould.java
+++ b/server/src/test/java/org/spine3/server/entity/DefaultEntityStorageConverterShould.java
@@ -78,7 +78,7 @@ public class DefaultEntityStorageConverterShould {
         final EntityStorageConverter<Long, TestEntity, StringValue> converter = forAllFields(
                 repository);
 
-        final EntityStorageConverter.Tuple<Long> out = converter.convert(entity);
+        final EntityRecord out = converter.convert(entity);
         final TestEntity back = converter.reverse()
                                          .convert(out);
         assertEquals(entity, back);

--- a/server/src/test/java/org/spine3/server/event/enrich/EnrichmentFunctionShould.java
+++ b/server/src/test/java/org/spine3/server/event/enrich/EnrichmentFunctionShould.java
@@ -142,11 +142,14 @@ public class EnrichmentFunctionShould {
         assertNull(fieldEnricher.apply(Tests.<ProjectCreated>nullRef()));
     }
 
-    @SuppressWarnings({"EqualsWithItself",
-            "EqualsBetweenInconvertibleTypes"}) // OK, it's the purpose of the method.
     @Test
     public void have_smart_equals() {
-        new EqualsTester().addEqualityGroup(fieldEnricher)
+        final FieldEnricher<ProjectCreated, ProjectCreated.Enrichment> anotherEnricher =
+                FieldEnricher.newInstance(
+                    ProjectCreated.class,
+                    ProjectCreated.Enrichment.class,
+                    function);
+        new EqualsTester().addEqualityGroup(fieldEnricher, anotherEnricher)
                           .testEquals();
     }
 }


### PR DESCRIPTION
This PR utilizes recently introduced `EntityRecord.entity_id` field for symmetry of conversion between an `Entity` and `EntityRecord`.

As the result we no longer need the `Tuple` class that hold an ID together with an `EntityRecord`.

This PR is based on #372. 