### PR TITLE
Protect aggregate state

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
         
-        spineVersion = '0.8.19-SNAPSHOT'
+        spineVersion = '0.8.20-SNAPSHOT'
         
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all the components and change
         // the version of the dependency below to `spineVersion` defined above.

--- a/server/src/main/java/org/spine3/server/aggregate/Aggregate.java
+++ b/server/src/main/java/org/spine3/server/aggregate/Aggregate.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
+import org.spine3.Internal;
 import org.spine3.base.CommandClass;
 import org.spine3.base.CommandContext;
 import org.spine3.base.Event;
@@ -185,7 +186,9 @@ public abstract class Aggregate<I, S extends Message, B extends Message.Builder>
         return builder;
     }
 
-    /** Updates the aggregate state and closes the update phase of the aggregate. */
+    /**
+     * Updates the aggregate state and closes the update phase of the aggregate.
+     */
     private void updateState() {
         @SuppressWarnings("unchecked")
          /* It is safe to assume that correct builder type is passed to the aggregate,
@@ -195,6 +198,26 @@ public abstract class Aggregate<I, S extends Message, B extends Message.Builder>
         final Version version = getVersion();
         setState(newState, version);
         this.builder = null;
+    }
+
+    /**
+     * Sets the new state of the aggregate.
+     *
+     * <p>This method is called during the aggregate update phase.
+     * It is not not supposed to be called from outside of this class.
+     *
+     * @param state   the state object to set
+     * @param version the entity version to set
+     * @throws IllegalStateException if the method is called from outside
+     */
+    @Internal
+    @Override
+    protected final void setState(S state, Version version) {
+        if (builder == null) {
+            throw new IllegalStateException(
+                    "setState() is called from outside of the aggregate update phase.");
+        }
+        super.setState(state, version);
     }
 
     /**
@@ -390,7 +413,27 @@ public abstract class Aggregate<I, S extends Message, B extends Message.Builder>
             builder.mergeFrom(stateToRestore);
             initVersion(versionFromSnapshot);
         } else {
+            injectState(stateToRestore, versionFromSnapshot);
+        }
+    }
+
+    /**
+     * Sets the passed state and version.
+     *
+     * <p>The method circumvents the protection in the {@link #setState(Message, Version)
+     * setState()} method by creating a fake builder instance, which is cleared
+     * after the call.
+     */
+    @VisibleForTesting
+    void injectState(S stateToRestore, Version versionFromSnapshot) {
+        try {
+            @SuppressWarnings("unchecked")
+                // The cast is safe as we checked the type on the construction.
+            final B fakeBuilder = (B) getState().newBuilderForType();
+            this.builder = fakeBuilder;
             setState(stateToRestore, versionFromSnapshot);
+        } finally {
+            this.builder = null;
         }
     }
 

--- a/server/src/main/java/org/spine3/server/aggregate/Aggregate.java
+++ b/server/src/main/java/org/spine3/server/aggregate/Aggregate.java
@@ -423,6 +423,9 @@ public abstract class Aggregate<I, S extends Message, B extends Message.Builder>
      * <p>The method circumvents the protection in the {@link #setState(Message, Version)
      * setState()} method by creating a fake builder instance, which is cleared
      * after the call.
+     *
+     * <p>This method has package-private access to be accessible by the
+     * {@code AggregateBuilder} test utility class from the {@code testutil} module.
      */
     @VisibleForTesting
     void injectState(S stateToRestore, Version versionFromSnapshot) {

--- a/testutil/src/main/java/org/spine3/server/aggregate/AggregateBuilder.java
+++ b/testutil/src/main/java/org/spine3/server/aggregate/AggregateBuilder.java
@@ -22,6 +22,7 @@ package org.spine3.server.aggregate;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Message;
+import org.spine3.base.Version;
 import org.spine3.server.entity.EntityBuilder;
 
 /**
@@ -49,5 +50,10 @@ public class AggregateBuilder<A extends Aggregate<I, S, ?>, I, S extends Message
     public AggregateBuilder<A, I, S> setResultClass(Class<A> entityClass) {
         super.setResultClass(entityClass);
         return this;
+    }
+
+    @Override
+    protected void setState(A result, S state, Version version) {
+        result.injectState(state, version);
     }
 }

--- a/testutil/src/main/java/org/spine3/server/entity/EntityBuilder.java
+++ b/testutil/src/main/java/org/spine3/server/entity/EntityBuilder.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
 import org.spine3.base.Identifiers;
+import org.spine3.base.Version;
 import org.spine3.base.Versions;
 import org.spine3.test.ReflectiveBuilder;
 
@@ -117,8 +118,13 @@ public class EntityBuilder<E extends AbstractVersionableEntity<I, S>, I, S exten
         final S state = state(result);
         final Timestamp timestamp = timestamp();
 
-        result.setState(state, Versions.newVersion(version, timestamp));
+        final Version version = Versions.newVersion(this.version, timestamp);
+        setState(result, state, version);
         return result;
+    }
+
+    protected void setState(E result, S state, Version version) {
+        result.setState(state, version);
     }
 
     /**


### PR DESCRIPTION
This PR makes the `Aggregate` class reject calls to `setState()` from the derived aggregate classes.