### PR TITLE
Protect aggregate state from direct modification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
         
-        spineVersion = '0.8.18-SNAPSHOT'
+        spineVersion = '0.8.19-SNAPSHOT'
         
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all the components and change
         // the version of the dependency below to `spineVersion` defined above.

--- a/server/src/main/java/org/spine3/server/entity/RecordBasedRepository.java
+++ b/server/src/main/java/org/spine3/server/entity/RecordBasedRepository.java
@@ -279,20 +279,18 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
                                               .getIdsList();
         final Class<I> expectedIdClass = getIdClass();
 
-        final Collection<I> result = Collections2.transform(idsList,
-                                                            new EntityIdFunction<>(expectedIdClass));
+        final EntityIdFunction<I> func = new EntityIdFunction<>(expectedIdClass);
+        final Collection<I> result = Collections2.transform(idsList, func);
 
         return result;
     }
 
     /**
-     * Converts the passed entity into {@code EntityStorageRecord} that
-     * stores the entity data.
+     * Converts the passed entity into the record.
      */
     protected EntityRecord toRecord(E entity) {
         final EntityRecord entityRecord = entityConverter().convert(entity);
-        return entityRecord != null ? entityRecord
-                             : EntityRecord.getDefaultInstance();
+        return entityRecord;
     }
 
     private E toEntity(EntityRecord record) {

--- a/server/src/main/java/org/spine3/server/event/enrich/EnrichmentFunction.java
+++ b/server/src/main/java/org/spine3/server/event/enrich/EnrichmentFunction.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
 
 /**
  * {@code EnrichmentFunction} defines how a source message class can be transformed into a target message class.
@@ -57,8 +58,11 @@ abstract class EnrichmentFunction<S, T> implements Function<S, T> {
     EnrichmentFunction(Class<S> eventClass, Class<T> enrichmentClass) {
         this.eventClass = checkNotNull(eventClass);
         this.enrichmentClass = checkNotNull(enrichmentClass);
-        checkArgument(!eventClass.equals(enrichmentClass),
-                      "Event and enrichment class must not be equal. Passed two values of %", eventClass);
+        checkArgument(
+            !eventClass.equals(enrichmentClass),
+            "Event and enrichment class must not be equal. Passed two values of %",
+            eventClass
+        );
     }
 
     Class<S> getEventClass() {
@@ -89,13 +93,13 @@ abstract class EnrichmentFunction<S, T> implements Function<S, T> {
      * definitions. The function internal state in this case is appended with the parsed data, which
      * is later used at runtime.
      *
-     * <p>After the function is activated successfully, the {@link #isActive()} returns {@code true}.
+     * <p>After the function is activated, the {@link #isActive()} returns {@code true}.
      *
      * <p>If an activation cannot be performed flawlessly, the {@code IllegalStateException}
      * should be thrown. In this case {@link #isActive()} should return {@code false}.
      *
-     * @throws IllegalStateException if the function cannot perform the conversion in its current state
-     * or because of the state of its environment
+     * @throws IllegalStateException if the function cannot perform the conversion in its
+     *                               current state or because of the state of its environment
      */
     abstract void activate();
 
@@ -153,8 +157,12 @@ abstract class EnrichmentFunction<S, T> implements Function<S, T> {
      */
     protected void ensureActive() {
         if(!isActive()) {
-            throw new IllegalStateException("The given instance of " + getClass() + " is not active at the moment. " +
-                                                    "Please use `activate()` first.");
+            final String errMsg = format(
+                    "The given instance of %s is not active at the moment. " +
+                    "Please use `activate()` first.",
+                    getClass().getName()
+            );
+            throw new IllegalStateException(errMsg);
         }
     }
 }

--- a/server/src/main/proto/spine/server/entity/entity.proto
+++ b/server/src/main/proto/spine/server/entity/entity.proto
@@ -38,7 +38,6 @@ import "spine/base/version.proto";
 message EntityRecord {
     option (SPI_type) = true;
 
-    //TODO:2017-02-19:alexander.yevsyukov: find usages and fill in this field
     // The ID of the entity.
     google.protobuf.Any entity_id = 1;
 

--- a/server/src/test/java/org/spine3/server/aggregate/AggregateShould.java
+++ b/server/src/test/java/org/spine3/server/aggregate/AggregateShould.java
@@ -517,7 +517,7 @@ public class AggregateShould {
         }
 
         /**
-         * This method attempts to call {@link #setState(Message, Version)} setState()}
+         * This method attempts to call {@link #setState(Message, Version) setState()}
          * directly, which should result in {@link IllegalStateException}.
          */
         void tryToUpdateStateDirectly() {

--- a/server/src/test/java/org/spine3/server/event/enrich/EnrichmentFunctionShould.java
+++ b/server/src/test/java/org/spine3/server/event/enrich/EnrichmentFunctionShould.java
@@ -142,11 +142,14 @@ public class EnrichmentFunctionShould {
         assertNull(fieldEnricher.apply(Tests.<ProjectCreated>nullRef()));
     }
 
-    @SuppressWarnings({"EqualsWithItself",
-            "EqualsBetweenInconvertibleTypes"}) // OK, it's the purpose of the method.
     @Test
     public void have_smart_equals() {
-        new EqualsTester().addEqualityGroup(fieldEnricher)
+        final FieldEnricher<ProjectCreated, ProjectCreated.Enrichment> anotherEnricher =
+                FieldEnricher.newInstance(
+                    ProjectCreated.class,
+                    ProjectCreated.Enrichment.class,
+                    function);
+        new EqualsTester().addEqualityGroup(fieldEnricher, anotherEnricher)
                           .testEquals();
     }
 }


### PR DESCRIPTION
This PR makes the `Aggregate` class reject calls to `setState()` from the derived aggregate classes.

The code modifications of this branch were previously reviewed and merged into the `visibility-on-entity-level` branch. This was done to minimize the amount of code changes for reviewing.

The goal of this PR is to merge into `master after `visiblity-on-entity-level` is merged.