### PR TITLE
Entity state validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
         
-        spineVersion = '0.8.25-SNAPSHOT'
+        spineVersion = '0.8.26-SNAPSHOT'
         
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all
         // the components and change the version of the dependency below to

--- a/server/src/main/java/org/spine3/server/aggregate/Aggregate.java
+++ b/server/src/main/java/org/spine3/server/aggregate/Aggregate.java
@@ -195,7 +195,7 @@ public abstract class Aggregate<I, S extends Message, B extends Message.Builder>
             that make sense to the aggregate. */
         final S newState = (S) getBuilder().build();
         final Version version = getVersion();
-        setState(newState, version);
+        updateState(newState, version);
         this.builder = null;
     }
 
@@ -211,12 +211,12 @@ public abstract class Aggregate<I, S extends Message, B extends Message.Builder>
      */
     @Internal
     @Override
-    protected final void setState(S state, Version version) {
+    protected final void updateState(S state, Version version) {
         if (builder == null) {
             throw new IllegalStateException(
                     "setState() is called from outside of the aggregate update phase.");
         }
-        super.setState(state, version);
+        super.updateState(state, version);
     }
 
     /**
@@ -419,7 +419,7 @@ public abstract class Aggregate<I, S extends Message, B extends Message.Builder>
     /**
      * Sets the passed state and version.
      *
-     * <p>The method circumvents the protection in the {@link #setState(Message, Version)
+     * <p>The method circumvents the protection in the {@link #updateState(Message, Version)
      * setState()} method by creating a fake builder instance, which is cleared
      * after the call.
      *
@@ -433,7 +433,7 @@ public abstract class Aggregate<I, S extends Message, B extends Message.Builder>
                 // The cast is safe as we checked the type on the construction.
             final B fakeBuilder = (B) getState().newBuilderForType();
             this.builder = fakeBuilder;
-            setState(stateToRestore, versionFromSnapshot);
+            updateState(stateToRestore, versionFromSnapshot);
         } finally {
             this.builder = null;
         }

--- a/server/src/main/java/org/spine3/server/entity/AbstractEntity.java
+++ b/server/src/main/java/org/spine3/server/entity/AbstractEntity.java
@@ -21,6 +21,7 @@
 package org.spine3.server.entity;
 
 import com.google.protobuf.Message;
+import org.spine3.base.Stringifiers;
 import org.spine3.protobuf.Messages;
 
 import javax.annotation.CheckReturnValue;
@@ -191,24 +192,38 @@ public abstract class AbstractEntity<I, S extends Message> implements Entity<I, 
      *                if the passed state is not {@linkplain #validate(S) valid}
      */
     protected void updateState(S state) {
-        checkNotNull(state);
         validate(state);
         injectState(state);
     }
 
     /**
-     * Validates the passed state.
+     * Verifies whether the new state is valid.
      *
-     * <p>Does nothing by default. Aggregates may override this method to
-     * specify logic of validating initial or intermediate state.
+     * <p>Default implementation does nothing always returning {@code true}.
+     * Derived classes may provide custom validation logic overriding this method.
      *
-     * @param state a state object to replace the current state
-     * @throws IllegalStateException if the state is not valid
+     * @param newState a state object to replace the current state
+     * @return {@code true} if the new state object is valid, {@code false} otherwise
      */
-    @SuppressWarnings({"NoopMethodInAbstractClass", "UnusedParameters"})
-    // Have this no-op method to prevent enforcing implementation in all sub-classes.
-    protected void validate(S state) throws IllegalStateException {
-        // Do nothing by default.
+    @SuppressWarnings("unused") // OK for this default implementation
+    protected boolean isValid(S newState) {
+        return true;
+    }
+
+    /**
+     * Ensures that the passed new state is valid.
+     *
+     * @param newState a state object to replace the current state
+     * @throws IllegalStateException if the state is not valid
+     * @see #isValid(Message)
+     */
+    protected void validate(S newState) throws IllegalStateException {
+        if (!isValid(newState)) {
+            final String stateStr = Stringifiers.toString(newState);
+            final String errMsg = format("The passed new state (%s) is not valid.",
+                                         stateStr);
+            throw new IllegalStateException(errMsg);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/spine3/server/entity/AbstractEntity.java
+++ b/server/src/main/java/org/spine3/server/entity/AbstractEntity.java
@@ -181,6 +181,36 @@ public abstract class AbstractEntity<I, S extends Message> implements Entity<I, 
         }
     }
 
+    /**
+     * Updates the state of the entity.
+     *
+     * <p>The new state must be {@linkplain #validate(Message) valid}.
+     *
+     * @param state the new state to set
+     * @throws IllegalStateException
+     *                if the passed state is not {@linkplain #validate(S) valid}
+     */
+    protected void updateState(S state) {
+        checkNotNull(state);
+        validate(state);
+        injectState(state);
+    }
+
+    /**
+     * Validates the passed state.
+     *
+     * <p>Does nothing by default. Aggregates may override this method to
+     * specify logic of validating initial or intermediate state.
+     *
+     * @param state a state object to replace the current state
+     * @throws IllegalStateException if the state is not valid
+     */
+    @SuppressWarnings({"NoopMethodInAbstractClass", "UnusedParameters"})
+    // Have this no-op method to prevent enforcing implementation in all sub-classes.
+    protected void validate(S state) throws IllegalStateException {
+        // Do nothing by default.
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/server/src/main/java/org/spine3/server/entity/AbstractEntity.java
+++ b/server/src/main/java/org/spine3/server/entity/AbstractEntity.java
@@ -21,7 +21,6 @@
 package org.spine3.server.entity;
 
 import com.google.protobuf.Message;
-import org.spine3.base.Stringifiers;
 import org.spine3.protobuf.Messages;
 
 import javax.annotation.CheckReturnValue;
@@ -219,9 +218,8 @@ public abstract class AbstractEntity<I, S extends Message> implements Entity<I, 
      */
     protected void validate(S newState) throws IllegalStateException {
         if (!isValid(newState)) {
-            final String stateStr = Stringifiers.toString(newState);
             final String errMsg = format("The passed new state (%s) is not valid.",
-                                         stateStr);
+                                         newState);
             throw new IllegalStateException(errMsg);
         }
     }

--- a/server/src/main/java/org/spine3/server/entity/AbstractEntity.java
+++ b/server/src/main/java/org/spine3/server/entity/AbstractEntity.java
@@ -199,7 +199,7 @@ public abstract class AbstractEntity<I, S extends Message> implements Entity<I, 
      * Verifies whether the new state is valid.
      *
      * <p>Default implementation does nothing always returning {@code true}.
-     * Derived classes may provide custom validation logic overriding this method.
+     * Derived classes may provide custom validation logic by overriding this method.
      *
      * @param newState a state object to replace the current state
      * @return {@code true} if the new state object is valid, {@code false} otherwise

--- a/server/src/main/java/org/spine3/server/entity/AbstractEntity.java
+++ b/server/src/main/java/org/spine3/server/entity/AbstractEntity.java
@@ -204,7 +204,6 @@ public abstract class AbstractEntity<I, S extends Message> implements Entity<I, 
      * @param newState a state object to replace the current state
      * @return {@code true} if the new state object is valid, {@code false} otherwise
      */
-    @SuppressWarnings("unused") // OK for this default implementation
     protected boolean isValid(S newState) {
         return true;
     }

--- a/server/src/main/java/org/spine3/server/entity/AbstractVersionableEntity.java
+++ b/server/src/main/java/org/spine3/server/entity/AbstractVersionableEntity.java
@@ -105,7 +105,11 @@ public abstract class AbstractVersionableEntity<I, S extends Message>
     }
 
     /**
-     * Validates and sets the state.
+     * Updates the state and version of the entity.
+     *
+     * <p>The new state must be {@linkplain #validate(Message) valid}.
+     *
+     * <p>The passed version must have a number not less than the current version of the entity.
      *
      * @param state   the state object to set
      * @param version the entity version to set
@@ -116,25 +120,9 @@ public abstract class AbstractVersionableEntity<I, S extends Message>
      *                version of the entity
      * @see #validate(S)
      */
-    protected void setState(S state, Version version) {
-        validate(state);
-        injectState(state);
+    protected void updateState(S state, Version version) {
+        updateState(state);
         updateVersion(version);
-    }
-
-    /**
-     * Validates the passed state.
-     *
-     * <p>Does nothing by default. Aggregates may override this method to
-     * specify logic of validating initial or intermediate state.
-     *
-     * @param state a state object to replace the current state
-     * @throws IllegalStateException if the state is not valid
-     */
-    @SuppressWarnings({"NoopMethodInAbstractClass", "UnusedParameters"})
-    // Have this no-op method to prevent enforcing implementation in all sub-classes.
-    protected void validate(S state) throws IllegalStateException {
-        // Do nothing by default.
     }
 
     /**
@@ -221,7 +209,7 @@ public abstract class AbstractVersionableEntity<I, S extends Message>
      * @param newState a new state to set
      */
     protected void incrementState(S newState) {
-        setState(newState, incrementedVersion());
+        updateState(newState, incrementedVersion());
     }
 
     /**

--- a/server/src/main/java/org/spine3/server/entity/DefaultEntityStorageConverter.java
+++ b/server/src/main/java/org/spine3/server/entity/DefaultEntityStorageConverter.java
@@ -88,7 +88,7 @@ class DefaultEntityStorageConverter<I, E extends AbstractEntity<I, S>, S extends
         if (entity != null) {
             if (entity instanceof AbstractVersionableEntity) {
                 final AbstractVersionableEntity versionable = (AbstractVersionableEntity) entity;
-                versionable.setState(state, entityRecord.getVersion());
+                versionable.updateState(state, entityRecord.getVersion());
                 versionable.setLifecycleFlags(entityRecord.getLifecycleFlags());
             } else {
                 entity.injectState(state);

--- a/server/src/test/java/org/spine3/server/aggregate/AggregateShould.java
+++ b/server/src/test/java/org/spine3/server/aggregate/AggregateShould.java
@@ -517,11 +517,11 @@ public class AggregateShould {
         }
 
         /**
-         * This method attempts to call {@link #setState(Message, Version) setState()}
+         * This method attempts to call {@link #updateState(Message, Version) setState()}
          * directly, which should result in {@link IllegalStateException}.
          */
         void tryToUpdateStateDirectly() {
-            setState(Project.getDefaultInstance(), Version.getDefaultInstance());
+            updateState(Project.getDefaultInstance(), Version.getDefaultInstance());
         }
 
         @Assign

--- a/server/src/test/java/org/spine3/server/entity/AbstractVersionableEntityShould.java
+++ b/server/src/test/java/org/spine3/server/entity/AbstractVersionableEntityShould.java
@@ -34,7 +34,7 @@ public class AbstractVersionableEntityShould {
     public void have_equals() throws Exception {
         final AvEntity entity = new AvEntity(88L);
         final AvEntity another = new AvEntity(88L);
-        another.setState(entity.getState(), entity.getVersion());
+        another.updateState(entity.getState(), entity.getVersion());
 
         new EqualsTester().addEqualityGroup(entity, another)
                           .addEqualityGroup(new AvEntity(42L))

--- a/server/src/test/java/org/spine3/server/entity/EntityEqualsShould.java
+++ b/server/src/test/java/org/spine3/server/entity/EntityEqualsShould.java
@@ -84,7 +84,7 @@ public class EntityEqualsShould {
     @Test
     public void assure_entities_with_different_states_are_not_equal() {
         final TestEntity another = TestEntity.withStateOf(entity);
-        another.setState(Sample.messageOfType(Project.class), another.getVersion());
+        another.updateState(Sample.messageOfType(Project.class), another.getVersion());
 
         assertNotEquals(entity.getState(), another.getState());
         assertFalse(entity.equals(another));

--- a/server/src/test/java/org/spine3/server/entity/EntityShould.java
+++ b/server/src/test/java/org/spine3/server/entity/EntityShould.java
@@ -160,7 +160,7 @@ public class EntityShould {
     public void have_state() {
         final Version ver = Versions.newVersion(3, getCurrentTime());
 
-        entityNew.setState(state, ver);
+        entityNew.updateState(state, ver);
 
         assertEquals(state, entityNew.getState());
         assertEquals(ver, entityNew.getVersion());
@@ -169,13 +169,13 @@ public class EntityShould {
     @Test
     public void validate_state_when_set_it() {
         final TestEntity spyEntityNew = spy(entityNew);
-        spyEntityNew.setState(state, Versions.create());
+        spyEntityNew.updateState(state, Versions.create());
         verify(spyEntityNew).validate(eq(state));
     }
 
     @Test(expected = NullPointerException.class)
     public void throw_exception_if_try_to_set_null_state() {
-        entityNew.setState(Tests.<Project>nullRef(), Versions.create());
+        entityNew.updateState(Tests.<Project>nullRef(), Versions.create());
     }
 
     private static class BareBonesEntity extends AbstractVersionableEntity<Long, StringValue> {

--- a/testutil/src/main/java/org/spine3/server/entity/EntityBuilder.java
+++ b/testutil/src/main/java/org/spine3/server/entity/EntityBuilder.java
@@ -124,7 +124,7 @@ public class EntityBuilder<E extends AbstractVersionableEntity<I, S>, I, S exten
     }
 
     protected void setState(E result, S state, Version version) {
-        result.setState(state, version);
+        result.updateState(state, version);
     }
 
     /**


### PR DESCRIPTION
This PR simplifies validation state of entities. It is now possible to validate a new state at the level of `AbstractEntity` (previously it was available from `AbstractVersionableEntity`).

Also custom validation can be implemented via overriding `isValid()` method, which returns `boolean`.

The method `setState()` was renamed to `updateState()` to better reflect the nature of the call and highlight the fact of validation.