### PR TITLE
Fix the package info description of `org.spine3.server.entity`

### DIFF
--- a/server/src/main/java/org/spine3/server/entity/package-info.java
+++ b/server/src/main/java/org/spine3/server/entity/package-info.java
@@ -19,7 +19,7 @@
  */
 
 /**
- * This package contains server-side exceptions related to commands.
+ * This package contains classes and interfaces defining entity-oriented API and base functionality.
  */
 @ParametersAreNonnullByDefault
 package org.spine3.server.entity;


### PR DESCRIPTION
Before this PR the description of the package was irrelevant to its contents.