### PR TITLE
Add static import on demand for all `String.format()` cases.

### DIFF
--- a/client/src/main/java/org/spine3/protobuf/Values.java
+++ b/client/src/main/java/org/spine3/protobuf/Values.java
@@ -30,6 +30,7 @@ import com.google.protobuf.UInt32Value;
 import com.google.protobuf.UInt64Value;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
 
 /**
  * Utility class for working with {@link com.google.protobuf.Message Message} value wrapper objects.
@@ -59,14 +60,14 @@ public class Values {
      * Creates a new {@code StringValue} wrapping the passed string.
      *
      * @param format a format string
-     * @param args arguments referenced by the format string
+     * @param args   arguments referenced by the format string
      * @return a new {@code StringValue} instance
      * @see String#format(String, Object...)
      */
     public static StringValue newStringValue(String format, Object... args) {
         checkNotNull(format);
         checkNotNull(args);
-        final String msg = String.format(format, args);
+        final String msg = format(format, args);
         return newStringValue(msg);
     }
 

--- a/client/src/main/java/org/spine3/type/UnknownTypeException.java
+++ b/client/src/main/java/org/spine3/type/UnknownTypeException.java
@@ -19,6 +19,8 @@
  */
 package org.spine3.type;
 
+import static java.lang.String.format;
+
 /**
  * Exception that is thrown when unsupported message is obtained
  * or in case when there is no class for given Protobuf message.
@@ -42,7 +44,7 @@ public class UnknownTypeException extends RuntimeException {
     }
 
     private static String makeMsg(String typeName) {
-        return String.format(ERR_MSG_NO_JAVA_CLASS_FOUND, typeName);
+        return format(ERR_MSG_NO_JAVA_CLASS_FOUND, typeName);
     }
 
     /**

--- a/client/src/main/java/org/spine3/validate/ConstraintViolations.java
+++ b/client/src/main/java/org/spine3/validate/ConstraintViolations.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.*;
 import static java.lang.System.lineSeparator;
 
 /**
@@ -57,7 +58,7 @@ public class ConstraintViolations {
 
         final String format = violation.getMsgFormat();
         final List<String> params = violation.getParamList();
-        final String parentViolationFormatted = String.format(format, params.toArray());
+        final String parentViolationFormatted = format(format, params.toArray());
 
         final StringBuilder resultBuilder = new StringBuilder(parentViolationFormatted);
         if (violation.getViolationCount() > 0) {
@@ -103,7 +104,7 @@ public class ConstraintViolations {
         checkNotNull(violation);
 
         final List<String> params = violation.getParamList();
-        final String parentViolationFormatted = String.format(format, params.toArray());
+        final String parentViolationFormatted = format(format, params.toArray());
 
         final StringBuilder resultBuilder = new StringBuilder(parentViolationFormatted);
         if (violation.getViolationCount() > 0) {
@@ -148,9 +149,9 @@ public class ConstraintViolations {
      */
     @Internal
     public abstract static class ExceptionFactory<E extends Exception,
-                                                  M extends Message,
-                                                  C extends MessageClass,
-                                                  R extends ProtocolMessageEnum> {
+            M extends Message,
+            C extends MessageClass,
+            R extends ProtocolMessageEnum> {
 
         private final Iterable<ConstraintViolation> constraintViolations;
         private final M message;
@@ -163,7 +164,7 @@ public class ConstraintViolations {
          * @param constraintViolations constraint violations for the event message
          */
         protected ExceptionFactory(M message,
-                                   Iterable<ConstraintViolation> constraintViolations) {
+                Iterable<ConstraintViolation> constraintViolations) {
             this.constraintViolations = constraintViolations;
             this.message = message;
         }
@@ -197,9 +198,9 @@ public class ConstraintViolations {
         protected abstract E createException(String exceptionMsg, M message, Error error);
 
         private String formatExceptionMessage() {
-            return String.format("%s. Message class: %s. " +
-                                 "See Error.getValidationError() for details.",
-                                 getErrorText(), getMessageClass());
+            return format("%s. Message class: %s. " +
+                                  "See Error.getValidationError() for details.",
+                          getErrorText(), getMessageClass());
         }
 
         private Error createError() {
@@ -211,9 +212,9 @@ public class ConstraintViolations {
             final String typeName = errorCode.getDescriptorForType()
                                              .getFullName();
             final String errorTextTemplate = getErrorText();
-            final String errorText = String.format("%s %s",
-                                                   errorTextTemplate,
-                                                   toText(constraintViolations));
+            final String errorText = format("%s %s",
+                                            errorTextTemplate,
+                                            toText(constraintViolations));
 
             final Error.Builder error = Error.newBuilder()
                                              .setType(typeName)

--- a/client/src/main/java/org/spine3/validate/ConstraintViolations.java
+++ b/client/src/main/java/org/spine3/validate/ConstraintViolations.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static java.lang.String.*;
+import static java.lang.String.format;
 import static java.lang.System.lineSeparator;
 
 /**

--- a/server/src/main/java/org/spine3/server/reflect/DuplicateHandlerMethodException.java
+++ b/server/src/main/java/org/spine3/server/reflect/DuplicateHandlerMethodException.java
@@ -21,6 +21,8 @@ package org.spine3.server.reflect;
 
 import com.google.protobuf.Message;
 
+import static java.lang.String.format;
+
 /**
  * Indicates that more than one handling method for the same message class are present
  * in the declaring class.
@@ -38,7 +40,7 @@ public class DuplicateHandlerMethodException extends RuntimeException {
             String firstMethodName,
             String secondMethodName) {
 
-        super(String.format(
+        super(format(
                 "The %s class defines more than one method for handling the message class %s." +
                         " Methods encountered: %s, %s.",
                 targetClass.getName(), messageClass.getName(),

--- a/server/src/test/java/org/spine3/server/entity/FieldMasksShould.java
+++ b/server/src/test/java/org/spine3/server/entity/FieldMasksShould.java
@@ -36,6 +36,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
+import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -99,7 +100,7 @@ public class FieldMasksShould {
         final Collection<Project> original = new LinkedList<>();
 
         for (int i = 0; i < count; i++) {
-            final Project project = Given.newProject(String.format("project-%s", i));
+            final Project project = Given.newProject(format("project-%s", i));
             original.add(project);
         }
 
@@ -145,7 +146,7 @@ public class FieldMasksShould {
         final int count = 5;
 
         for (int i = 0; i < count; i++) {
-            final Project project = Given.newProject(String.format("test-data--%s", i));
+            final Project project = Given.newProject(format("test-data--%s", i));
             original.add(project);
         }
 
@@ -201,7 +202,7 @@ public class FieldMasksShould {
 
             final Project project = Project.newBuilder()
                                            .setId(projectId)
-                                           .setName(String.format("Test project : %s", id))
+                                           .setName(format("Test project : %s", id))
                                            .addTask(first)
                                            .addTask(second)
                                            .setStatus(Status.CREATED)

--- a/server/src/test/java/org/spine3/server/procman/ProcessManagerRepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/procman/ProcessManagerRepositoryShould.java
@@ -63,6 +63,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Set;
 
+import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -95,7 +96,7 @@ public class ProcessManagerRepositoryShould
     @Override
     protected ProjectId createId(int value) {
         return ProjectId.newBuilder()
-                        .setId(String.format("procman-number-%s", value))
+                        .setId(format("procman-number-%s", value))
                         .build();
     }
 

--- a/server/src/test/java/org/spine3/server/projection/ProjectionRepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/projection/ProjectionRepositoryShould.java
@@ -65,6 +65,8 @@ import java.util.List;
 import java.util.Set;
 
 import static com.google.common.collect.Sets.newHashSet;
+import static java.lang.String.format;
+import static java.lang.String.valueOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -141,7 +143,7 @@ public class ProjectionRepositoryShould
     @Override
     protected ProjectId createId(int i) {
         return ProjectId.newBuilder()
-                        .setId(String.format("test-projection-%s", i))
+                        .setId(format("test-projection-%s", i))
                         .build();
     }
 
@@ -411,14 +413,14 @@ public class ProjectionRepositoryShould
                                                     .getEventStore();
         for (int i = 0; i < eventsCount; i++) {
             final ProjectId projectId = ProjectId.newBuilder()
-                                                 .setId(String.valueOf(i))
+                                                 .setId(valueOf(i))
                                                  .build();
             final Message eventMessage = ProjectCreated.newBuilder()
                                                        .setProjectId(projectId)
                                                        .build();
             final EventContext context = EventContext.newBuilder()
                                                      .setEventId(EventId.newBuilder()
-                                                                        .setUuid(String.valueOf(i)))
+                                                                        .setUuid(valueOf(i)))
                                                      .setProducerId(AnyPacker.pack(projectId))
                                                      .setTimestamp(Timestamps2.getCurrentTime())
                                                      .build();

--- a/server/src/test/java/org/spine3/server/projection/ProjectionStorageShould.java
+++ b/server/src/test/java/org/spine3/server/projection/ProjectionStorageShould.java
@@ -42,6 +42,7 @@ import java.util.Map;
 
 import static com.google.protobuf.util.Durations.fromSeconds;
 import static com.google.protobuf.util.Timestamps.add;
+import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -204,7 +205,7 @@ public abstract class ProjectionStorageShould<I>
 
         for (int i = 0; i < count; i++) {
             final I id = newId();
-            final Project state = Given.project(id.toString(), String.format("project-%d", i));
+            final Project state = Given.project(id.toString(), format("project-%d", i));
             final Any packedState = AnyPacker.pack(state);
 
             final EntityRecord record = EntityRecord.newBuilder()

--- a/server/src/test/java/org/spine3/server/stand/StandStorageShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandStorageShould.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static java.lang.String.format;
 import static org.spine3.test.Tests.assertMatchesMask;
 import static org.spine3.test.Verify.assertContains;
 import static org.spine3.test.Verify.assertSize;
@@ -76,7 +77,7 @@ public abstract class StandStorageShould extends RecordStorageShould<AggregateSt
         final Project project = Project.newBuilder()
                                        .setId((ProjectId) id.getAggregateId())
                                        .setStatus(Project.Status.CREATED)
-                                       .setName(String.format("test-project-%s", id.toString()))
+                                       .setName(format("test-project-%s", id.toString()))
                                        .addTask(Task.getDefaultInstance())
                                        .build();
         return project;

--- a/server/src/test/java/org/spine3/server/storage/memory/InMemoryRecordStorageShould.java
+++ b/server/src/test/java/org/spine3/server/storage/memory/InMemoryRecordStorageShould.java
@@ -28,6 +28,8 @@ import org.spine3.test.storage.Project;
 import org.spine3.test.storage.ProjectId;
 import org.spine3.test.storage.Task;
 
+import static java.lang.String.format;
+
 /**
  * @author Dmytro Dashenkov
  */
@@ -51,7 +53,7 @@ public class InMemoryRecordStorageShould extends RecordStorageShould<ProjectId, 
         final Project project = Project.newBuilder()
                                        .setId(id)
                                        .setStatus(Project.Status.CREATED)
-                                       .setName(String.format("record-storage-test-%s", id.getId()))
+                                       .setName(format("record-storage-test-%s", id.getId()))
                                        .addTask(Task.getDefaultInstance())
                                        .build();
         return project;

--- a/server/src/test/java/org/spine3/server/transport/GrpcContainerShould.java
+++ b/server/src/test/java/org/spine3/server/transport/GrpcContainerShould.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -90,7 +91,7 @@ public class GrpcContainerShould {
         for (int i = 0; i < count; i++) {
             final BindableService mockService = mock(BindableService.class);
             final ServerServiceDefinition mockDefinition = ServerServiceDefinition
-                    .builder(String.format("service-%s", i))
+                    .builder(format("service-%s", i))
                     .build();
             when(mockService.bindService()).thenReturn(mockDefinition);
             definitions.add(mockDefinition);


### PR DESCRIPTION
Our  [Java Code Style](https://github.com/SpineEventEngine/core-java/wiki/Java-Code-Style#fqns-in-javadoc) states that we should use static import for String.format() cases.