### PR TITLE
Migrate to 0.8.13 snapshot tools version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ buildscript {
         // the components and change the version of the dependency below to
         // `spineVersion` defined above.
         spineToolsVersion = '0.8.13-SNAPSHOT'
+
+        // Defines option for the `spine-model-compiler` plugin.
+        // Indicates is needed the generation of the validating builders or not.
+        generateValidatorsOption = false
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ buildscript {
 
         // Defines option for the `spine-model-compiler` plugin.
         // Indicates whether the generation of the validating builders is enabled.
-        generateValidators = false
+        generateValidatorsOption = false
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ buildscript {
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all
         // the components and change the version of the dependency below to
         // `spineVersion` defined above.
-        spineToolsVersion = '0.8.12-SNAPSHOT'
+        spineToolsVersion = '0.8.13-SNAPSHOT'
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,8 @@ buildscript {
         spineToolsVersion = '0.8.13-SNAPSHOT'
 
         // Defines option for the `spine-model-compiler` plugin.
-        // Indicates is needed the generation of the validating builders or not.
-        generateValidatorsOption = false
+        // Indicates whether the generation of the validating builders is enabled.
+        generateValidators = false
     }
 
     dependencies {

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -34,5 +34,5 @@ apply from: testArtifactsScript
 apply plugin: spineProtobufPluginId
 
 modelCompiler {
-    generateValidators = generateValidatorsOption
+    generateValidators = generateValidators
 }

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -32,3 +32,7 @@ apply from: generateDescriptorSetScript
 apply from: testArtifactsScript
 
 apply plugin: spineProtobufPluginId
+
+modelCompiler {
+    generateValidators = false
+}

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -34,5 +34,5 @@ apply from: testArtifactsScript
 apply plugin: spineProtobufPluginId
 
 modelCompiler {
-    generateValidators = false
+    generateValidators = generateValidatorsOption
 }

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -34,5 +34,5 @@ apply from: testArtifactsScript
 apply plugin: spineProtobufPluginId
 
 modelCompiler {
-    generateValidators = generateValidators
+    generateValidators = generateValidatorsOption
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -36,5 +36,5 @@ apply from: testArtifactsScript
 apply plugin: spineProtobufPluginId
 
 modelCompiler {
-    generateValidators = false
+    generateValidators = generateValidatorsOption
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -36,5 +36,5 @@ apply from: testArtifactsScript
 apply plugin: spineProtobufPluginId
 
 modelCompiler {
-    generateValidators = generateValidators
+    generateValidators = generateValidatorsOption
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -36,5 +36,5 @@ apply from: testArtifactsScript
 apply plugin: spineProtobufPluginId
 
 modelCompiler {
-    generateValidators = generateValidatorsOption
+    generateValidators = generateValidators
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -34,3 +34,7 @@ apply from: generateDescriptorSetScript
 apply from: testArtifactsScript
 
 apply plugin: spineProtobufPluginId
+
+modelCompiler {
+    generateValidators = false
+}

--- a/users/build.gradle
+++ b/users/build.gradle
@@ -36,5 +36,5 @@ apply from: testArtifactsScript
 apply plugin: spineProtobufPluginId
 
 modelCompiler {
-    generateValidators = false
+    generateValidators = generateValidatorsOption
 }

--- a/users/build.gradle
+++ b/users/build.gradle
@@ -36,5 +36,5 @@ apply from: testArtifactsScript
 apply plugin: spineProtobufPluginId
 
 modelCompiler {
-    generateValidators = generateValidators
+    generateValidators = generateValidatorsOption
 }

--- a/users/build.gradle
+++ b/users/build.gradle
@@ -36,5 +36,5 @@ apply from: testArtifactsScript
 apply plugin: spineProtobufPluginId
 
 modelCompiler {
-    generateValidators = generateValidatorsOption
+    generateValidators = generateValidators
 }

--- a/users/build.gradle
+++ b/users/build.gradle
@@ -34,3 +34,7 @@ apply from: generateDescriptorSetScript
 apply from: testArtifactsScript
 
 apply plugin: spineProtobufPluginId
+
+modelCompiler {
+    generateValidators = false
+}

--- a/values/build.gradle
+++ b/values/build.gradle
@@ -26,3 +26,7 @@ dependencies {
 apply from: generateDescriptorSetScript
 
 apply plugin: spineProtobufPluginId
+
+modelCompiler {
+    generateValidators = false
+}

--- a/values/build.gradle
+++ b/values/build.gradle
@@ -28,5 +28,5 @@ apply from: generateDescriptorSetScript
 apply plugin: spineProtobufPluginId
 
 modelCompiler {
-    generateValidators = generateValidators
+    generateValidators = generateValidatorsOption
 }

--- a/values/build.gradle
+++ b/values/build.gradle
@@ -28,5 +28,5 @@ apply from: generateDescriptorSetScript
 apply plugin: spineProtobufPluginId
 
 modelCompiler {
-    generateValidators = false
+    generateValidators = generateValidatorsOption
 }

--- a/values/build.gradle
+++ b/values/build.gradle
@@ -28,5 +28,5 @@ apply from: generateDescriptorSetScript
 apply plugin: spineProtobufPluginId
 
 modelCompiler {
-    generateValidators = generateValidatorsOption
+    generateValidators = generateValidators
 }


### PR DESCRIPTION
Summary of changes:
- Migrated to the `0.8.13-SNAPSHOT` tools version.
- Switched off the validating builders generation.