### PR TITLE
Validating builder API extension

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ buildscript {
 
         // Defines option for the `spine-model-compiler` plugin.
         // Indicates whether the generation of the validating builders is enabled.
-        generateValidatorsOption = false
+        generateValidatingBuildersValue = false
     }
 
     dependencies {

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -34,5 +34,5 @@ apply from: testArtifactsScript
 apply plugin: spineProtobufPluginId
 
 modelCompiler {
-    generateValidators = generateValidatorsOption
+    generateValidatingBuilders = generateValidatingBuildersValue
 }

--- a/client/src/main/java/org/spine3/validate/AbstractValidatingBuilder.java
+++ b/client/src/main/java/org/spine3/validate/AbstractValidatingBuilder.java
@@ -59,15 +59,7 @@ public abstract class AbstractValidatingBuilder<T extends Message> implements Va
         }
     }
 
-    /**
-     * Validates the field according to the protocol buffer message declaration.
-     *
-     * @param descriptor the {@code FieldDescriptor} of the field
-     * @param fieldValue the value of the field
-     * @param fieldName  the name of the field
-     * @param <V>        the type of the field value
-     * @throws ConstraintViolationThrowable if there are some constraint violations
-     */
+    @Override
     public <V> void validate(FieldDescriptor descriptor, V fieldValue, String fieldName)
             throws ConstraintViolationThrowable {
         final FieldPath fieldPath = FieldPath.newBuilder()

--- a/client/src/main/java/org/spine3/validate/ValidatingBuilder.java
+++ b/client/src/main/java/org/spine3/validate/ValidatingBuilder.java
@@ -20,6 +20,7 @@
 
 package org.spine3.validate;
 
+import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
 
 /**
@@ -31,6 +32,19 @@ import com.google.protobuf.Message;
  * @author Illia Shepilov
  */
 public interface ValidatingBuilder<T extends Message> {
+
+    /**
+     * Validates the field according to the protocol buffer message declaration.
+     *
+     * @param descriptor the {@code FieldDescriptor} of the field
+     * @param fieldValue the value of the field
+     * @param fieldName  the name of the field
+     * @param <V>        the type of the field value
+     * @throws ConstraintViolationThrowable if there are some constraint violations
+     */
+    <V> void validate(FieldDescriptor descriptor,
+                      V fieldValue,
+                      String fieldName) throws ConstraintViolationThrowable;
 
     /**
      * Returns constructed and validated {@code Message}.

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -36,5 +36,5 @@ apply from: testArtifactsScript
 apply plugin: spineProtobufPluginId
 
 modelCompiler {
-    generateValidators = generateValidatorsOption
+    generateValidatingBuilders = generateValidatingBuildersValue
 }

--- a/users/build.gradle
+++ b/users/build.gradle
@@ -36,5 +36,5 @@ apply from: testArtifactsScript
 apply plugin: spineProtobufPluginId
 
 modelCompiler {
-    generateValidators = generateValidatorsOption
+    generateValidatingBuilders = generateValidatingBuildersValue
 }

--- a/values/build.gradle
+++ b/values/build.gradle
@@ -28,5 +28,5 @@ apply from: generateDescriptorSetScript
 apply plugin: spineProtobufPluginId
 
 modelCompiler {
-    generateValidators = generateValidatorsOption
+    generateValidatingBuilders = generateValidatingBuildersValue
 }


### PR DESCRIPTION
Summary of changes:
- Renamed the constant defined in the `build.gradle` file.
- Extended the `ValidatingBuilder` API.
