### PR TITLE
Get rid of replaying an empty event list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
         
-        spineVersion = '0.8.31-SNAPSHOT'
+        spineVersion = '0.8.32-SNAPSHOT'
         
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all
         // the components and change the version of the dependency below to

--- a/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
@@ -355,6 +355,18 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
         return result;
     }
 
+    /**
+     * Ensures that the {@link AggregateStateRecord} is valid.
+     *
+     * <p>{@link AggregateStateRecord} is considered valid when one of the following is true:
+     * <ul>
+     *     <li>{@linkplain AggregateStateRecord#getSnapshot() snapshot} is not default;</li>
+     *     <li>{@linkplain AggregateStateRecord#getEventList() event list} is not empty.</li>
+     * </ul>
+     *
+     * @param aggregateStateRecord the record to check
+     * @throws IllegalStateException if the {@link AggregateStateRecord} is not valid
+     */
     private static void checkAggregateStateRecord(AggregateStateRecord aggregateStateRecord) {
         final boolean snapshotIsNotSet =
                 aggregateStateRecord.getSnapshot().equals(Snapshot.getDefaultInstance());

--- a/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
@@ -356,8 +356,11 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
     }
 
     private static void checkAggregateStateRecord(AggregateStateRecord aggregateStateRecord) {
-        if (aggregateStateRecord.getSnapshot() == null || aggregateStateRecord.getEventList()
-                                                                              .isEmpty()) {
+        final boolean snapshotIsNotSet =
+                aggregateStateRecord.getSnapshot().equals(Snapshot.getDefaultInstance());
+
+        if (snapshotIsNotSet && aggregateStateRecord.getEventList()
+                                                    .isEmpty()) {
             throw new IllegalStateException("AggregateStateRecord instance should have either "
                                                     + "snapshot or non-empty event list.");
         }

--- a/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
@@ -77,8 +77,8 @@ import static org.spine3.server.entity.EntityWithLifecycle.Predicates.isEntityVi
  * @author Alexander Yevsyukov
  */
 public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
-        extends Repository<I, A>
-        implements CommandDispatcher {
+                extends Repository<I, A>
+                implements CommandDispatcher {
 
     /** The default number of events to be stored before a next snapshot is made. */
     static final int DEFAULT_SNAPSHOT_TRIGGER = 100;

--- a/server/src/main/java/org/spine3/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/org/spine3/server/aggregate/AggregateStorage.java
@@ -74,6 +74,10 @@ public abstract class AggregateStorage<I>
 
         final Iterator<AggregateEventRecord> historyBackward = historyBackward(aggregateId);
 
+        if (!historyBackward.hasNext()) {
+            return Optional.absent();
+        }
+
         while (historyBackward.hasNext()
                 && snapshot == null) {
 
@@ -91,10 +95,6 @@ public abstract class AggregateStorage<I>
                     throw newIllegalStateException("Event or snapshot missing in record: \"%s\"",
                                                    shortDebugString(record));
             }
-        }
-
-        if (snapshot == null && history.isEmpty()) {
-            return Optional.absent();
         }
 
         final AggregateStateRecord.Builder builder = AggregateStateRecord.newBuilder();

--- a/server/src/main/java/org/spine3/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/org/spine3/server/aggregate/AggregateStorage.java
@@ -56,6 +56,14 @@ public abstract class AggregateStorage<I>
         super(multitenant);
     }
 
+    /**
+     * Reads a {@link AggregateStateRecord} by the passed ID.
+     *
+     * @param aggregateId the ID of the record to read
+     * @return the record instance or {@code Optional.absent()} if either
+     * the aggregate history is empty or there is no record with this ID
+     * @throws IllegalStateException if the storage was closed before
+     */
     @Override
     public Optional<AggregateStateRecord> read(I aggregateId) {
         checkNotClosed();
@@ -83,6 +91,10 @@ public abstract class AggregateStorage<I>
                     throw newIllegalStateException("Event or snapshot missing in record: \"%s\"",
                                                    shortDebugString(record));
             }
+        }
+
+        if (snapshot == null && history.isEmpty()) {
+            return Optional.absent();
         }
 
         final AggregateStateRecord.Builder builder = AggregateStateRecord.newBuilder();

--- a/server/src/main/java/org/spine3/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/org/spine3/server/aggregate/AggregateStorage.java
@@ -57,7 +57,7 @@ public abstract class AggregateStorage<I>
     }
 
     /**
-     * Reads a {@link AggregateStateRecord} by the passed ID.
+     * {@inheritDoc}
      *
      * @param aggregateId the ID of the record to read
      * @return the record instance or {@code Optional.absent()} if either

--- a/server/src/main/java/org/spine3/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/org/spine3/server/aggregate/AggregateStorage.java
@@ -57,11 +57,12 @@ public abstract class AggregateStorage<I>
     }
 
     /**
-     * {@inheritDoc}
+     * Forms and returns an {@link AggregateStateRecord} based on the
+     * {@linkplain #historyBackward(Object) aggregate history}.
      *
-     * @param aggregateId the ID of the record to read
-     * @return the record instance or {@code Optional.absent()} if either
-     * the aggregate history is empty or there is no record with this ID
+     * @param aggregateId the aggregate ID for which to form a record
+     * @return the record instance or {@code Optional.absent()} if the
+     *         {@linkplain #historyBackward(Object) aggregate history} is empty
      * @throws IllegalStateException if the storage was closed before
      */
     @Override

--- a/server/src/test/java/org/spine3/server/aggregate/AggregateCommandEndpointShould.java
+++ b/server/src/test/java/org/spine3/server/aggregate/AggregateCommandEndpointShould.java
@@ -129,7 +129,7 @@ public class AggregateCommandEndpointShould {
         // Change reported event count upon the second invocation and trigger re-dispatch.
         doReturn(0, 1)
                 .when(storage).readEventCountAfterLastSnapshot(projectId);
-        doReturn(Optional.of(AggregateStateRecord.getDefaultInstance()))
+        doReturn(Optional.absent())
                 .when(storage).read(projectId);
         doReturn(storage)
                 .when(repositorySpy).aggregateStorage();

--- a/server/src/test/java/org/spine3/server/aggregate/AggregateRepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/aggregate/AggregateRepositoryShould.java
@@ -20,6 +20,7 @@
 
 package org.spine3.server.aggregate;
 
+import com.google.common.base.Optional;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -118,6 +119,18 @@ public class AggregateRepositoryShould {
         assertTrue(isNotDefault(actual.getState()));
         assertEquals(expected.getId(), actual.getId());
         assertEquals(expected.getState(), actual.getState());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void reject_invalid_AggregateStateRecord_instance() {
+        final ProjectId id = Sample.messageOfType(ProjectId.class);
+        final AggregateStorage<ProjectId> storage = givenAggregateStorageMock();
+
+        doReturn(Optional.of(AggregateStateRecord.getDefaultInstance()))
+                .when(storage)
+                .read(id);
+
+        repositorySpy.loadOrCreate(id);
     }
 
     @Test

--- a/server/src/test/java/org/spine3/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/org/spine3/server/aggregate/AggregateStorageShould.java
@@ -100,20 +100,6 @@ public abstract class AggregateStorageShould
         return Sample.messageOfType(ProjectId.class);
     }
 
-    /**
-     * Overwrites the test behaviour checking that {@code AggregatStorage}
-     * always returns events.
-     */
-    @SuppressWarnings({"OptionalUsedAsFieldOrParameterType",
-            "MethodDoesntCallSuperMethod", "OptionalGetWithoutIsPresent"}) // This is what we want.
-    @Override
-    protected void assertResultForMissingId(Optional<AggregateStateRecord> record) {
-        assertTrue(record.isPresent());
-        assertTrue(record.get()
-                         .getEventList()
-                         .isEmpty());
-    }
-
     @Test
     public void return_iterator_over_empty_collection_if_read_history_from_empty_storage() {
         final Iterator<AggregateEventRecord> iterator = storage.historyBackward(id);

--- a/server/src/test/java/org/spine3/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/org/spine3/server/aggregate/AggregateStorageShould.java
@@ -107,6 +107,13 @@ public abstract class AggregateStorageShould
         assertFalse(iterator.hasNext());
     }
 
+    @Test
+    public void return_absent_AggregateStateRecord_if_read_history_from_empty_storage() {
+        final Optional<AggregateStateRecord> aggregateStateRecord = storage.read(id);
+
+        assertFalse(aggregateStateRecord.isPresent());
+    }
+
     @Test(expected = NullPointerException.class)
     public void throw_exception_if_try_to_read_history_by_null_id() {
         storage.historyBackward(Tests.<ProjectId>nullRef());


### PR DESCRIPTION
Previously `AggregateRepository.loadOrCreate(id)` forced an aggregates with an empty event history to replay an events. Such a behavior was redundant and led to validation of an initial aggregate state. Because an initial aggregate state is not valid, the validation crashed a program. This PR fixes the problem.

Summary:
- `AggregateStorage.read()` now returns an absent `AggregateStateRecord`, if an aggregate history is empty.
- `AggregateRepository` now checks validity of an `AggregateStateRecord` instance.