### PR TITLE
Expose `FailureBus` from the `BoundedContext` instance 

### DIFF
--- a/server/src/main/java/org/spine3/server/BoundedContext.java
+++ b/server/src/main/java/org/spine3/server/BoundedContext.java
@@ -42,6 +42,7 @@ import org.spine3.server.entity.Repository;
 import org.spine3.server.entity.VersionableEntity;
 import org.spine3.server.event.EventBus;
 import org.spine3.server.event.EventDispatcher;
+import org.spine3.server.failure.FailureBus;
 import org.spine3.server.integration.IntegrationEvent;
 import org.spine3.server.integration.grpc.IntegrationEventSubscriberGrpc;
 import org.spine3.server.procman.ProcessManagerRepository;
@@ -328,6 +329,12 @@ public final class BoundedContext
     @CheckReturnValue
     public EventBus getEventBus() {
         return this.eventBus;
+    }
+
+    /** Obtains instance of {@link FailureBus} of this {@code BoundedContext}. */
+    @CheckReturnValue
+    public FailureBus getFailureBus() {
+        return this.commandBus.failureBus();
     }
 
     /** Obtains instance of {@link StandFunnel} of this {@code BoundedContext}. */

--- a/server/src/main/java/org/spine3/server/commandbus/CommandBus.java
+++ b/server/src/main/java/org/spine3/server/commandbus/CommandBus.java
@@ -24,6 +24,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import io.grpc.stub.StreamObserver;
+import org.spine3.annotations.Internal;
 import org.spine3.base.Command;
 import org.spine3.base.Identifiers;
 import org.spine3.base.Response;
@@ -132,8 +133,15 @@ public class CommandBus extends Bus<Command, CommandEnvelope, CommandClass, Comm
         return scheduler;
     }
 
-    @VisibleForTesting
-    FailureBus failureBus() {
+    /**
+     * Exposes the {@code FailureBus} instance for this {@code CommandBus}.
+     *
+     * <p>This method is designed for internal use only. Client code should use
+     * {@link org.spine3.server.BoundedContext#getFailureBus() BoundedContext.getFailureBus()}
+     * instead.
+     */
+    @Internal
+    public FailureBus failureBus() {
         return this.failureBus;
     }
 

--- a/server/src/test/java/org/spine3/server/bc/BoundedContextShould.java
+++ b/server/src/test/java/org/spine3/server/bc/BoundedContextShould.java
@@ -117,6 +117,11 @@ public class BoundedContextShould {
     }
 
     @Test
+    public void return_FailureBus() {
+        assertNotNull(boundedContext.getFailureBus());
+    }
+
+    @Test
     public void return_CommandDispatcher() {
         assertNotNull(boundedContext.getCommandBus());
     }


### PR DESCRIPTION
Before this PR it was very hard to register custom `FailureDispatcher`s in an application, since the `FailureBus` instance was private to `CommandBus`.

As of these changes it became possible as simple as this:
```
final BoundedContext bc = ...;

bc.getFailureBus().register(myCustomFailureDispatcher);
```

Also, the `BoundedContext` now exposes all types of `Bus`es, i.e. `EventBus`, `CommandBus`, and now `FailureBus`, bringing more consistency into API.