### PR TITLE
Rename ID value fields

### DIFF
--- a/client/src/main/java/org/spine3/client/ActorRequestFactory.java
+++ b/client/src/main/java/org/spine3/client/ActorRequestFactory.java
@@ -151,7 +151,7 @@ public class ActorRequestFactory {
         /**
          * The format of all {@linkplain QueryId query identifiers}.
          */
-        private static final String QUERY_ID_FORMAT = "query-%s";
+        private static final String QUERY_ID_FORMAT = "q-%s";
 
         private ForQuery() {
             // Prevent instantiation from the outside.
@@ -283,7 +283,7 @@ public class ActorRequestFactory {
         /**
          * The format of all {@linkplain TopicId topic identifiers}.
          */
-        private static final String TOPIC_ID_FORMAT = "topic-%s";
+        private static final String TOPIC_ID_FORMAT = "t-%s";
 
         private ForTopic() {
             // Prevent instantiation from the outside.

--- a/client/src/main/java/org/spine3/client/ActorRequestFactory.java
+++ b/client/src/main/java/org/spine3/client/ActorRequestFactory.java
@@ -148,11 +148,6 @@ public class ActorRequestFactory {
      */
     public final class ForQuery {
 
-        /**
-         * The format of all {@linkplain QueryId query identifiers}.
-         */
-        private static final String QUERY_ID_FORMAT = "q-%s";
-
         private ForQuery() {
             // Prevent instantiation from the outside.
         }
@@ -261,17 +256,11 @@ public class ActorRequestFactory {
 
             final Query.Builder builder = queryBuilderFor(entityClass, ids, fieldMask);
 
-            builder.setId(newQueryId());
+            builder.setId(Queries.generateId());
             builder.setContext(actorContext());
             return builder.build();
         }
 
-        private QueryId newQueryId() {
-            final String formattedId = format(QUERY_ID_FORMAT, Identifiers.newUuid());
-            return QueryId.newBuilder()
-                          .setUuid(formattedId)
-                          .build();
-        }
     }
 
     /**

--- a/client/src/main/java/org/spine3/client/ActorRequestFactory.java
+++ b/client/src/main/java/org/spine3/client/ActorRequestFactory.java
@@ -27,7 +27,6 @@ import org.spine3.annotations.Internal;
 import org.spine3.base.Command;
 import org.spine3.base.CommandContext;
 import org.spine3.base.Commands;
-import org.spine3.base.Identifiers;
 import org.spine3.time.ZoneOffset;
 import org.spine3.time.ZoneOffsets;
 import org.spine3.users.TenantId;
@@ -39,7 +38,6 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static java.lang.String.format;
 import static org.spine3.client.Queries.queryBuilderFor;
 import static org.spine3.client.Targets.composeTarget;
 import static org.spine3.time.Time.getCurrentTime;
@@ -269,11 +267,6 @@ public class ActorRequestFactory {
      */
     public final class ForTopic {
 
-        /**
-         * The format of all {@linkplain TopicId topic identifiers}.
-         */
-        private static final String TOPIC_ID_FORMAT = "t-%s";
-
         private ForTopic() {
             // Prevent instantiation from the outside.
         }
@@ -321,7 +314,7 @@ public class ActorRequestFactory {
         @Internal
         public Topic forTarget(Target target) {
             checkNotNull(target);
-            final TopicId id = newTopicId();
+            final TopicId id = Topics.generateId();
             return Topic.newBuilder()
                         .setId(id)
                         .setContext(actorContext())
@@ -329,12 +322,6 @@ public class ActorRequestFactory {
                         .build();
         }
 
-        private TopicId newTopicId() {
-            final String formattedId = format(TOPIC_ID_FORMAT, Identifiers.newUuid());
-            return TopicId.newBuilder()
-                          .setUuid(formattedId)
-                          .build();
-        }
     }
 
     /**

--- a/client/src/main/java/org/spine3/client/Queries.java
+++ b/client/src/main/java/org/spine3/client/Queries.java
@@ -22,6 +22,7 @@ package org.spine3.client;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.Message;
 import org.spine3.annotations.Internal;
+import org.spine3.base.Identifiers;
 import org.spine3.type.TypeName;
 import org.spine3.type.TypeUrl;
 
@@ -29,6 +30,7 @@ import javax.annotation.Nullable;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
 import static org.spine3.client.Targets.allOf;
 import static org.spine3.client.Targets.someOf;
 
@@ -41,8 +43,20 @@ import static org.spine3.client.Targets.someOf;
 @Internal
 public final class Queries {
 
+    /**
+     * The format of all {@linkplain QueryId query identifiers}.
+     */
+    private static final String QUERY_ID_FORMAT = "q-%s";
+
     private Queries() {
         // Prevent instantiation of this utility class.
+    }
+
+    public static QueryId generateId() {
+        final String formattedId = format(QUERY_ID_FORMAT, Identifiers.newUuid());
+        return QueryId.newBuilder()
+                      .setValue(formattedId)
+                      .build();
     }
 
     static Query.Builder queryBuilderFor(Class<? extends Message> entityClass,

--- a/client/src/main/java/org/spine3/client/Subscriptions.java
+++ b/client/src/main/java/org/spine3/client/Subscriptions.java
@@ -48,23 +48,22 @@ public final class Subscriptions {
      *
      * @return new subscription identifier.
      */
-    public static SubscriptionId newId() {
+    public static SubscriptionId generateId() {
         final String formattedId = format(SUBSCRIPTION_ID_FORMAT, Identifiers.newUuid());
         return newId(formattedId);
     }
 
     /**
-     * Wraps a given {@code String} as a subscription identifier
+     * Wraps a given {@code String} as a subscription identifier.
      *
-     * <p>Not recommended for a production usage. Use {@linkplain #newId() automatic generation}
+     * <p>Should not be used in production. Use {@linkplain #generateId() automatic generation}
      * instead.
      *
      * @return new subscription identifier.
      */
-    @Internal
     public static SubscriptionId newId(String value) {
         return SubscriptionId.newBuilder()
-                             .setUuid(value)
+                             .setValue(value)
                              .build();
     }
 }

--- a/client/src/main/java/org/spine3/client/Subscriptions.java
+++ b/client/src/main/java/org/spine3/client/Subscriptions.java
@@ -35,7 +35,7 @@ public final class Subscriptions {
     /**
      * The format of all {@linkplain SubscriptionId Subscription identifiers}.
      */
-    private static final String SUBSCRIPTION_ID_FORMAT = "subscription-%s";
+    private static final String SUBSCRIPTION_ID_FORMAT = "s-%s";
 
     private Subscriptions() {
         // prevent instantiation.

--- a/client/src/main/java/org/spine3/client/Topics.java
+++ b/client/src/main/java/org/spine3/client/Topics.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.client;
+
+import org.spine3.base.Identifiers;
+
+import static java.lang.String.format;
+
+/**
+ * Utility class for working with {@link Topic}s.
+ */
+class Topics {
+
+    /**
+     * The format of all {@linkplain TopicId topic identifiers}.
+     */
+    private static final String TOPIC_ID_FORMAT = "t-%s";
+
+    private Topics() {
+        // Prevent instantiation of this utility class.
+    }
+
+    static TopicId generateId() {
+        final String formattedId = format(TOPIC_ID_FORMAT, Identifiers.newUuid());
+        return TopicId.newBuilder()
+                      .setValue(formattedId)
+                      .build();
+    }
+}

--- a/client/src/main/proto/spine/client/query.proto
+++ b/client/src/main/proto/spine/client/query.proto
@@ -44,7 +44,7 @@ message QueryId {
 
     // The value of the ID.
     //
-    // The value starts from the `q-` prefix, then follows a generated UUID value.
+    // Starts with the `q-` prefix followed by a generated UUID value.
     //
     string value = 1;
 }

--- a/client/src/main/proto/spine/client/query.proto
+++ b/client/src/main/proto/spine/client/query.proto
@@ -41,7 +41,12 @@ import "spine/client/actor_context.proto";
 
 // Query identifier.
 message QueryId {
-    string uuid = 1;
+
+    // The value of the ID.
+    //
+    // The value starts from the `q-` prefix, then follows a generated UUID value.
+    //
+    string value = 1;
 }
 
 // Allows clients to form the requests to the read-side through the `QueryService`.

--- a/client/src/main/proto/spine/client/subscription.proto
+++ b/client/src/main/proto/spine/client/subscription.proto
@@ -45,7 +45,7 @@ message TopicId {
 
     // The value of the ID.
     //
-    // Starts with `t-` prefix followed by a generated UUID value.
+    // Starts with the `t-` prefix followed by a generated UUID value.
     //
     string value = 1;
 }
@@ -53,6 +53,7 @@ message TopicId {
 // An object defining a unit of subscription.
 //
 // Defines the target (entities and criteria) of subscription.
+//
 message Topic {
 
     TopicId id = 1 [(required) = true];
@@ -99,7 +100,7 @@ message SubscriptionId {
 
     // The value of the subscription ID.
     //
-    // Starts with the `s-` prefix followed with a generated UUID value.
+    // Starts with the `s-` prefix followed by a generated UUID value.
     //
     string value = 1;
 }
@@ -114,6 +115,7 @@ message Subscription {
     // Unique identifier of the subscription.
     //
     // Must be unique in scope of a bounded context.
+    //
     SubscriptionId id = 1 [(required) = true];
 
     // Represents the original topic for this subscription.

--- a/client/src/main/proto/spine/client/subscription.proto
+++ b/client/src/main/proto/spine/client/subscription.proto
@@ -42,7 +42,12 @@ import "spine/client/actor_context.proto";
 
 // Topic identifier.
 message TopicId {
-    string uuid = 1;
+
+    // The value of the ID.
+    //
+    // Starts with `t-` prefix followed by a generated UUID value.
+    //
+    string value = 1;
 }
 
 // An object defining a unit of subscription.

--- a/client/src/main/proto/spine/client/subscription.proto
+++ b/client/src/main/proto/spine/client/subscription.proto
@@ -91,7 +91,12 @@ message SubscriptionUpdate {
 
 // Subscription identifier.
 message SubscriptionId {
-    string uuid = 1;
+
+    // The value of the subscription ID.
+    //
+    // Starts with the `s-` prefix followed with a generated UUID value.
+    //
+    string value = 1;
 }
 
 // The subscription object.

--- a/client/src/test/java/org/spine3/client/TopicsShould.java
+++ b/client/src/test/java/org/spine3/client/TopicsShould.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.client;
+
+import org.junit.Test;
+import org.spine3.test.Tests;
+
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author Alexander Yeveyukov
+ */
+public class TopicsShould {
+
+    @Test
+    public void have_utility_ctor() {
+        Tests.assertHasPrivateParameterlessCtor(Topics.class);
+    }
+
+    @Test
+    public void generate_id() {
+        assertFalse(Topics.generateId()
+                          .getValue()
+                          .isEmpty());
+    }
+}

--- a/server/src/main/java/org/spine3/server/stand/MultitenantSubscriptionRegistry.java
+++ b/server/src/main/java/org/spine3/server/stand/MultitenantSubscriptionRegistry.java
@@ -150,7 +150,7 @@ final class MultitenantSubscriptionRegistry implements SubscriptionRegistry {
          */
         @Override
         public synchronized Subscription add(Topic topic) {
-            final SubscriptionId subscriptionId = Subscriptions.newId();
+            final SubscriptionId subscriptionId = Subscriptions.generateId();
             final Target target = topic.getTarget();
             final String typeAsString = target
                     .getType();

--- a/server/src/test/java/org/spine3/server/stand/StandShould.java
+++ b/server/src/test/java/org/spine3/server/stand/StandShould.java
@@ -453,7 +453,7 @@ public class StandShould extends TenantAwareTest {
         final Stand stand = Stand.newBuilder()
                                  .build();
         final Subscription inexistentSubscription = Subscription.newBuilder()
-                                                                .setId(Subscriptions.newId())
+                                                                .setId(Subscriptions.generateId())
                                                                 .build();
         stand.cancel(inexistentSubscription, StreamObservers.<Response>noOpObserver());
     }
@@ -979,7 +979,7 @@ public class StandShould extends TenantAwareTest {
         final Topic allCustomersTopic = requestFactory.topic()
                                                       .allOf(Customer.class);
         return Subscription.newBuilder()
-                           .setId(Subscriptions.newId())
+                           .setId(Subscriptions.generateId())
                            .setTopic(allCustomersTopic)
                            .build();
     }

--- a/server/src/test/java/org/spine3/server/tenant/QueryOperationShould.java
+++ b/server/src/test/java/org/spine3/server/tenant/QueryOperationShould.java
@@ -21,12 +21,12 @@
 package org.spine3.server.tenant;
 
 import org.junit.Test;
+import org.spine3.client.Queries;
 import org.spine3.client.Query;
 import org.spine3.client.QueryId;
 import org.spine3.test.Tests;
 
 import static org.junit.Assert.assertEquals;
-import static org.spine3.base.Identifiers.newUuid;
 
 /**
  * @author Alexander Yevsyukov
@@ -61,9 +61,7 @@ public class QueryOperationShould {
 
     @Test
     public void return_query_id() {
-        final QueryId id = QueryId.newBuilder()
-                                     .setUuid(newUuid())
-                                     .build();
+        final QueryId id = Queries.generateId();
         final Query query = Query.newBuilder()
                                  .setId(id)
                                  .build();


### PR DESCRIPTION
This PR renames the fields named `uuid` into `value` to reflect the idea of having type-based prefixes.

The PR also renames generation methods to `generateId()` and move them into corresponding utility classes where appropriate.