### PR TITLE
`Failure` propagation improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,12 +33,12 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
         
-        spineVersion = '0.8.39-SNAPSHOT'
+        spineVersion = '0.8.40-SNAPSHOT'
         
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all
         // the components and change the version of the dependency below to
         // `spineVersion` defined above.
-        spineToolsVersion = '0.8.13-SNAPSHOT'
+        spineToolsVersion = '0.8.15-SNAPSHOT'
 
         // Defines option for the `spine-model-compiler` plugin.
         // Indicates whether the generation of the validating builders is enabled.

--- a/client/src/main/java/org/spine3/base/FailureThrowable.java
+++ b/client/src/main/java/org/spine3/base/FailureThrowable.java
@@ -74,7 +74,7 @@ public abstract class FailureThrowable extends Throwable {
     public Failure toFailure(Command command) {
         final Any packedMessage = pack(failureMessage);
         final FailureContext context = createContext(command);
-        final FailureId id = Failures.generateId();
+        final FailureId id = Failures.generateId(command.getId());
         return Failure.newBuilder()
                       .setId(id)
                       .setMessage(packedMessage)

--- a/client/src/main/java/org/spine3/base/FailureThrowable.java
+++ b/client/src/main/java/org/spine3/base/FailureThrowable.java
@@ -48,9 +48,7 @@ public abstract class FailureThrowable extends Throwable {
     /** The moment of creation of this object. */
     private final Timestamp timestamp;
 
-    protected FailureThrowable(GeneratedMessageV3 unused,
-                               CommandContext ignored,
-                               GeneratedMessageV3 failureMessage) {
+    protected FailureThrowable(GeneratedMessageV3 failureMessage) {
         super();
         this.failureMessage = failureMessage;
         this.timestamp = getCurrentTime();

--- a/client/src/main/java/org/spine3/base/Failures.java
+++ b/client/src/main/java/org/spine3/base/Failures.java
@@ -20,6 +20,7 @@
 
 package org.spine3.base;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 
@@ -34,15 +35,25 @@ import static org.spine3.protobuf.Messages.toAny;
  */
 public final class Failures {
 
+    @VisibleForTesting
+    static final String FAILURE_ID_FORMAT = "%s-fail";
+
     private Failures() {
         // Prevent instantiation of this utility class.
     }
 
-    /** Generates a new random UUID-based {@code FailureId}. */
-    public static FailureId generateId() {
-        final String value = Identifiers.newUuid();
+    /**
+     * Generates a {@code FailureId} based upon a {@linkplain CommandId command ID} in a format:
+     *
+     * <pre>{@code <commandId>-fail}</pre>
+     *
+     * @param id the identifier of the {@linkplain Command command}, which processing caused the
+     *           failure
+     **/
+    public static FailureId generateId(CommandId id) {
+        final String idValue = String.format(FAILURE_ID_FORMAT, id.getUuid());
         return FailureId.newBuilder()
-                        .setUuid(value)
+                        .setValue(idValue)
                         .build();
     }
 

--- a/client/src/main/proto/spine/base/failure.proto
+++ b/client/src/main/proto/spine/base/failure.proto
@@ -38,7 +38,13 @@ import "spine/base/version.proto";
 
 // Failure identifier.
 message FailureId {
-    string uuid = 1;
+
+    // The value is based upon the ID of the command, which caused the failure.
+    // It has the following format:
+    //
+    //      `<commandId>-fail`
+    //
+    string value = 1;
 }
 
 // A business failure is a condition in business, which does not allow to

--- a/client/src/test/java/org/spine3/base/FailureThrowableShould.java
+++ b/client/src/test/java/org/spine3/base/FailureThrowableShould.java
@@ -83,7 +83,7 @@ public class FailureThrowableShould {
         protected TestFailure(GeneratedMessageV3 commandMessage,
                               CommandContext context,
                               GeneratedMessageV3 failure) {
-            super(commandMessage, context, failure);
+            super(failure);
         }
 
         private static final long serialVersionUID = 0L;

--- a/client/src/test/java/org/spine3/base/FailuresShould.java
+++ b/client/src/test/java/org/spine3/base/FailuresShould.java
@@ -23,7 +23,8 @@ package org.spine3.base;
 import com.google.common.testing.NullPointerTester;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.spine3.base.Failures.FAILURE_ID_FORMAT;
 import static org.spine3.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
@@ -40,13 +41,16 @@ public class FailuresShould {
     public void pass_null_tolerance_check() {
         new NullPointerTester()
                 .setDefault(Command.class, Command.getDefaultInstance())
+                .setDefault(CommandId.class, CommandId.getDefaultInstance())
                 .testAllPublicStaticMethods(Failures.class);
     }
 
     @Test
-    public void generate_failure_id() {
-        assertFalse(Failures.generateId()
-                            .getUuid()
-                            .isEmpty());
+    public void generate_failure_id_upon_command_id() {
+        final CommandId commandId = Commands.generateId();
+        final FailureId actual = Failures.generateId(commandId);
+
+        final String expected = String.format(FAILURE_ID_FORMAT, commandId.getUuid());
+        assertEquals(expected, actual.getValue());
     }
 }

--- a/server/src/main/java/org/spine3/server/entity/AbstractVersionableEntity.java
+++ b/server/src/main/java/org/spine3/server/entity/AbstractVersionableEntity.java
@@ -22,7 +22,6 @@ package org.spine3.server.entity;
 
 import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
-import org.spine3.base.Command;
 import org.spine3.base.Version;
 import org.spine3.base.Versions;
 import org.spine3.server.entity.failure.CannotModifyArchivedEntity;
@@ -298,34 +297,28 @@ public abstract class AbstractVersionableEntity<I, S extends Message>
     /**
      * Ensures that the entity is not marked as {@code archived}.
      *
-     * @param modification the {@linkplain Command} which execution triggered this check
      * @throws CannotModifyArchivedEntity if the entity in in the archived status
      * @see #getLifecycleFlags()
      * @see LifecycleFlags#getArchived()
      */
-    protected void checkNotArchived(Command modification) throws CannotModifyArchivedEntity {
+    protected void checkNotArchived() throws CannotModifyArchivedEntity {
         if (getLifecycleFlags().getArchived()) {
             final String idStr = idToString(getId());
-            throw new CannotModifyArchivedEntity(modification.getMessage(),
-                                                 modification.getContext(),
-                                                 idStr);
+            throw new CannotModifyArchivedEntity(idStr);
         }
     }
 
     /**
      * Ensures that the entity is not marked as {@code deleted}.
      *
-     * @param modification the {@linkplain Command} which execution triggered this check
      * @throws CannotModifyDeletedEntity if the entity is marked as {@code deleted}
      * @see #getLifecycleFlags()
      * @see LifecycleFlags#getDeleted()
      */
-    protected void checkNotDeleted(Command modification) throws CannotModifyDeletedEntity {
+    protected void checkNotDeleted() throws CannotModifyDeletedEntity {
         if (getLifecycleFlags().getDeleted()) {
             final String idStr = idToString(getId());
-            throw new CannotModifyDeletedEntity(modification.getMessage(),
-                                                modification.getContext(),
-                                                idStr);
+            throw new CannotModifyDeletedEntity(idStr);
         }
     }
 

--- a/server/src/test/java/org/spine3/server/commandbus/AbstractCommandBusTestSuite.java
+++ b/server/src/test/java/org/spine3/server/commandbus/AbstractCommandBusTestSuite.java
@@ -129,6 +129,19 @@ public abstract class AbstractCommandBusTestSuite {
         return invalidCmd;
     }
 
+    protected static Command clearTenantId(Command cmd) {
+        final ActorContext.Builder withNoTenant =
+                ActorContext.newBuilder()
+                            .setTenantId(TenantId.getDefaultInstance());
+        final Command result =
+                cmd.toBuilder()
+                   .setContext(cmd.getContext()
+                                  .toBuilder()
+                                  .setActorContext(withNoTenant))
+                   .build();
+        return result;
+    }
+
     @Before
     public void setUp() {
         final InMemoryStorageFactory storageFactory =

--- a/server/src/test/java/org/spine3/server/commandbus/AbstractCommandBusTestSuite.java
+++ b/server/src/test/java/org/spine3/server/commandbus/AbstractCommandBusTestSuite.java
@@ -132,8 +132,7 @@ public abstract class AbstractCommandBusTestSuite {
     protected static Command clearTenantId(Command cmd) {
         final ActorContext.Builder withNoTenant =
                 ActorContext.newBuilder()
-                            .setTenantId(
-                                    TenantId.getDefaultInstance());
+                            .setTenantId(TenantId.getDefaultInstance());
         final Command result = cmd.toBuilder()
                                   .setContext(cmd.getContext()
                                                  .toBuilder()

--- a/server/src/test/java/org/spine3/server/commandbus/AbstractCommandBusTestSuite.java
+++ b/server/src/test/java/org/spine3/server/commandbus/AbstractCommandBusTestSuite.java
@@ -132,13 +132,13 @@ public abstract class AbstractCommandBusTestSuite {
     protected static Command clearTenantId(Command cmd) {
         final ActorContext.Builder withNoTenant =
                 ActorContext.newBuilder()
-                            .setTenantId(TenantId.getDefaultInstance());
-        final Command result =
-                cmd.toBuilder()
-                   .setContext(cmd.getContext()
-                                  .toBuilder()
-                                  .setActorContext(withNoTenant))
-                   .build();
+                            .setTenantId(
+                                    TenantId.getDefaultInstance());
+        final Command result = cmd.toBuilder()
+                                  .setContext(cmd.getContext()
+                                                 .toBuilder()
+                                                 .setActorContext(withNoTenant))
+                                  .build();
         return result;
     }
 

--- a/server/src/test/java/org/spine3/server/commandbus/CommandStoreShould.java
+++ b/server/src/test/java/org/spine3/server/commandbus/CommandStoreShould.java
@@ -274,9 +274,7 @@ public abstract class CommandStoreShould extends AbstractCommandBusTestSuite {
         private static final long serialVersionUID = 1L;
 
         private TestFailure() {
-            super(Wrapper.forString("some Command message"),
-                  CommandContext.getDefaultInstance(),
-                  Wrapper.forString(TestFailure.class.getName()));
+            super(Wrapper.forString(TestFailure.class.getName()));
         }
     }
 

--- a/server/src/test/java/org/spine3/server/commandbus/SingleTenantCommandBusShould.java
+++ b/server/src/test/java/org/spine3/server/commandbus/SingleTenantCommandBusShould.java
@@ -22,15 +22,29 @@ package org.spine3.server.commandbus;
 
 import io.grpc.stub.StreamObserver;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 import org.spine3.base.Command;
+import org.spine3.base.CommandContext;
+import org.spine3.base.Failure;
 import org.spine3.base.Response;
 import org.spine3.envelope.CommandEnvelope;
+import org.spine3.io.StreamObservers;
+import org.spine3.server.command.Assign;
+import org.spine3.server.command.CommandHandler;
+import org.spine3.server.event.EventBus;
 import org.spine3.test.Tests;
+import org.spine3.test.command.AddTask;
+import org.spine3.test.command.event.TaskAdded;
+import org.spine3.test.failure.InvalidProjectName;
+import org.spine3.test.failure.ProjectId;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.spine3.base.CommandValidationError.INVALID_COMMAND;
 import static org.spine3.base.CommandValidationError.TENANT_INAPPLICABLE;
+import static org.spine3.server.commandbus.Given.Command.addTask;
 import static org.spine3.server.commandbus.Given.Command.createProject;
 import static org.spine3.server.tenant.TenantAwareOperation.isTenantSet;
 
@@ -88,5 +102,42 @@ public class SingleTenantCommandBusShould extends AbstractCommandBusTestSuite {
     public void do_nothing_in_handleDeadMessage() {
         commandBus.handleDeadMessage(Tests.<CommandEnvelope>nullRef(),
                                      Tests.<StreamObserver<Response>>nullRef());
+    }
+
+    @Test
+    public void propagate_failures_to_failure_bus() {
+        final FaultyHandler faultyHandler = new FaultyHandler(eventBus);
+        commandBus.register(faultyHandler);
+
+        final Command addTaskCommand = clearTenantId(addTask());
+        commandBus.post(addTaskCommand, StreamObservers.<Response>noOpObserver());
+
+        final InvalidProjectName failureThrowable = faultyHandler.getThrowable();
+        final Failure expectedFailure = failureThrowable.toFailure(addTaskCommand);
+        verify(failureBus).post(eq(expectedFailure),
+                                ArgumentMatchers.<StreamObserver<Response>>any());
+    }
+
+    /**
+     * A {@code CommandHandler}, which throws a failure upon a command.
+     */
+    private static class FaultyHandler extends CommandHandler {
+
+        private final InvalidProjectName failure =
+                new InvalidProjectName(ProjectId.getDefaultInstance());
+
+        private FaultyHandler(EventBus eventBus) {
+            super(eventBus);
+        }
+
+        @SuppressWarnings("unused")     // does nothing, but throws a failure.
+        @Assign
+        TaskAdded handle(AddTask msg, CommandContext context) throws InvalidProjectName {
+            throw failure;
+        }
+
+        private InvalidProjectName getThrowable() {
+            return failure;
+        }
     }
 }

--- a/server/src/test/java/org/spine3/server/commandstore/StorageShould.java
+++ b/server/src/test/java/org/spine3/server/commandstore/StorageShould.java
@@ -363,7 +363,7 @@ public class StorageShould extends TenantAwareTest {
 
     private static Failure newFailure() {
         final Any packedFailureMessage = pack("newFailure");
-        final FailureId id = Failures.generateId();
+        final FailureId id = Failures.generateId(Commands.generateId());
         return Failure.newBuilder()
                       .setId(id)
                       .setMessage(packedFailureMessage)

--- a/server/src/test/java/org/spine3/server/entity/VisibilityTests.java
+++ b/server/src/test/java/org/spine3/server/entity/VisibilityTests.java
@@ -23,19 +23,14 @@ package org.spine3.server.entity;
 import com.google.protobuf.StringValue;
 import org.junit.Before;
 import org.junit.Test;
-import org.spine3.base.Command;
-import org.spine3.protobuf.Wrapper;
 import org.spine3.server.entity.failure.CannotModifyArchivedEntity;
 import org.spine3.server.entity.failure.CannotModifyDeletedEntity;
-import org.spine3.test.TestActorRequestFactory;
-import org.spine3.time.ZoneOffset;
 
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.spine3.base.Identifiers.newUuid;
 
 /**
  * Tests of working with entity visibility.
@@ -48,7 +43,6 @@ import static org.spine3.base.Identifiers.newUuid;
 public class VisibilityTests {
 
     private AbstractVersionableEntity<Long, StringValue> entity;
-    private Command modificationCommand;
 
     /**
      * A minimal entity class.
@@ -63,10 +57,6 @@ public class VisibilityTests {
     public void setUp() {
         entity = new MiniEntity(ThreadLocalRandom.current()
                                                  .nextLong());
-        final TestActorRequestFactory factory =
-                TestActorRequestFactory.newInstance(newUuid(), ZoneOffset.getDefaultInstance());
-        modificationCommand =
-                factory.command().create(Wrapper.forString("Entity modification command"));
     }
 
     @Test
@@ -138,10 +128,10 @@ public class VisibilityTests {
         entity.setArchived(true);
 
         // This should pass.
-        entity.checkNotDeleted(modificationCommand);
+        entity.checkNotDeleted();
 
         // This should throw.
-        entity.checkNotArchived(modificationCommand);
+        entity.checkNotArchived();
     }
 
     @Test(expected = CannotModifyDeletedEntity.class)
@@ -149,9 +139,9 @@ public class VisibilityTests {
         entity.setDeleted(true);
 
         // This should pass.
-        entity.checkNotArchived(modificationCommand);
+        entity.checkNotArchived();
 
         // This should throw.
-        entity.checkNotDeleted(modificationCommand);
+        entity.checkNotDeleted();
     }
 }


### PR DESCRIPTION
This PR contains the changes related to `FailureThrowable` and `Failure`.

* FailureId is now generated based on `CommandId` of the command, which caused the failure. The format is `<commandId>-fail`.
* All `FailureThrowable`s during the dispatching are now propagated from the `CommandBus` to `FailureBus`.
* The `FailureThrowable` constructor signature has been simplified by removing the unused `Command` message and `CommandContext` parameters.
* The code has been migrated to `tools` version which is compliant with the new `FailureThrowable` ctor.

The framework version is now set to `0.8.40-SNAPSHOT`.