### PR TITLE
Command scheduling as a system property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
         
-        spineVersion = '0.8.38-SNAPSHOT'
+        spineVersion = '0.8.39-SNAPSHOT'
         
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all
         // the components and change the version of the dependency below to

--- a/client/src/main/proto/spine/base/command.proto
+++ b/client/src/main/proto/spine/base/command.proto
@@ -72,8 +72,13 @@ message Command {
     //
     message SystemProperties {
 
-        // If `true` the command was scheduled.
-        bool scheduled = 1;
+        reserved 1 to 10; // for future priority properties.
+
+        // The time when the command was scheduled.
+        // Is set automatically and used only by Spine when re-scheduling a command.
+        google.protobuf.Timestamp scheduling_time = 11 [(internal) = true];
+
+        reserved 12 to 20; // for other scheduling-related properties.
     }
 
     // Service information used by the framework.
@@ -105,10 +110,6 @@ message CommandContext {
         // The delay between the moment of receiving a command at the server
         // and its delivery to the target.
         google.protobuf.Duration delay = 1;
-
-        // The time when the command was scheduled.
-        // Is set automatically and used only by Spine when re-scheduling a command.
-        google.protobuf.Timestamp scheduling_time = 2 [(internal) = true];
 
         //TODO:2016-05-27:alexander.yevsyukov: Have an option for defining schedule at a specific date/time.
         // Name the field `at`;

--- a/client/src/main/proto/spine/base/command.proto
+++ b/client/src/main/proto/spine/base/command.proto
@@ -82,7 +82,7 @@ message Command {
     }
 
     // Service information used by the framework.
-    SystemProperties system_properties = 4;
+    SystemProperties system_properties = 4 [(internal) = true];
 }
 
 // Meta-information about the command and the environment, which generated the command.

--- a/client/src/main/proto/spine/base/command.proto
+++ b/client/src/main/proto/spine/base/command.proto
@@ -68,15 +68,18 @@ message Command {
 
     // Properties that may be set by the framework as the command is delivered and handled.
     //
-    // These properties are not visible to the business logic code of an application.
+    // All fields of this type are reserved for internal framework needs, and are not visible to
+    // the business logic code of an application.
     //
     message SystemProperties {
+
+        option (internal_type) = true;
 
         reserved 1 to 10; // for future priority properties.
 
         // The time when the command was scheduled.
         // Is set automatically and used only by Spine when re-scheduling a command.
-        google.protobuf.Timestamp scheduling_time = 11 [(internal) = true];
+        google.protobuf.Timestamp scheduling_time = 11;
 
         reserved 12 to 20; // for other scheduling-related properties.
     }

--- a/server/src/main/java/org/spine3/server/commandbus/CommandScheduler.java
+++ b/server/src/main/java/org/spine3/server/commandbus/CommandScheduler.java
@@ -115,7 +115,7 @@ public abstract class CommandScheduler implements CommandBusFilter {
         }
         final Command commandUpdated = setSchedulingTime(command, getCurrentTime());
         doSchedule(commandUpdated);
-        markAsScheduled(commandUpdated);
+        rememberAsScheduled(commandUpdated);
     }
 
     /**
@@ -158,7 +158,7 @@ public abstract class CommandScheduler implements CommandBusFilter {
         return isScheduledAlready;
     }
 
-    private static void markAsScheduled(Command command) {
+    private static void rememberAsScheduled(Command command) {
         final CommandId id = command.getId();
         scheduledCommandIds.add(id);
     }
@@ -210,13 +210,18 @@ public abstract class CommandScheduler implements CommandBusFilter {
         final CommandContext.Schedule scheduleUpdated = context.getSchedule()
                                                                .toBuilder()
                                                                .setDelay(delay)
-                                                               .setSchedulingTime(schedulingTime)
                                                                .build();
         final CommandContext contextUpdated = context.toBuilder()
                                                      .setSchedule(scheduleUpdated)
                                                      .build();
+
+        final Command.SystemProperties sysProps = command.getSystemProperties()
+                                                         .toBuilder()
+                                                         .setSchedulingTime(schedulingTime)
+                                                         .build();
         final Command result = command.toBuilder()
                                       .setContext(contextUpdated)
+                                      .setSystemProperties(sysProps)
                                       .build();
         return result;
     }

--- a/server/src/main/java/org/spine3/server/commandbus/Rescheduler.java
+++ b/server/src/main/java/org/spine3/server/commandbus/Rescheduler.java
@@ -137,7 +137,8 @@ class Rescheduler {
     private static Timestamp getTimeToPost(Command command) {
         final CommandContext.Schedule schedule = command.getContext()
                                                         .getSchedule();
-        final Timestamp timeToPost = add(schedule.getSchedulingTime(), schedule.getDelay());
+        final Timestamp timeToPost = add(command.getSystemProperties()
+                                                .getSchedulingTime(), schedule.getDelay());
         return timeToPost;
     }
 

--- a/server/src/test/java/org/spine3/server/commandbus/CommandSchedulingShould.java
+++ b/server/src/test/java/org/spine3/server/commandbus/CommandSchedulingShould.java
@@ -196,25 +196,30 @@ public class CommandSchedulingShould extends AbstractCommandBusTestSuite {
 
     @Test
     public void update_schedule_options() {
-        final Command cmd = requestFactory.command().create(Wrapper.forString(newUuid()));
+        final Command cmd = requestFactory.command()
+                                          .create(Wrapper.forString(newUuid()));
         final Timestamp schedulingTime = getCurrentTime();
         final Duration delay = Durations2.minutes(5);
 
         final Command cmdUpdated = setSchedule(cmd, delay, schedulingTime);
+        final CommandContext.Schedule schedule = cmdUpdated.getContext()
+                                                           .getSchedule();
 
-        final CommandContext.Schedule schedule = cmdUpdated.getContext().getSchedule();
         assertEquals(delay, schedule.getDelay());
-        assertEquals(schedulingTime, schedule.getSchedulingTime());
+        assertEquals(schedulingTime, cmdUpdated.getSystemProperties()
+                                               .getSchedulingTime());
     }
 
     @Test
     public void update_scheduling_time() {
-        final Command cmd = requestFactory.command().create(Wrapper.forString(newUuid()));
+        final Command cmd = requestFactory.command()
+                                          .create(Wrapper.forString(newUuid()));
         final Timestamp schedulingTime = getCurrentTime();
 
         final Command cmdUpdated = CommandScheduler.setSchedulingTime(cmd, schedulingTime);
 
-        assertEquals(schedulingTime, cmdUpdated.getContext().getSchedule().getSchedulingTime());
+        assertEquals(schedulingTime, cmdUpdated.getSystemProperties()
+                                               .getSchedulingTime());
     }
 
     /*

--- a/server/src/test/java/org/spine3/server/commandbus/ExecutorCommandSchedulerShould.java
+++ b/server/src/test/java/org/spine3/server/commandbus/ExecutorCommandSchedulerShould.java
@@ -111,8 +111,7 @@ public class ExecutorCommandSchedulerShould {
     }
 
     private static Timestamp getSchedulingTime(Command cmd) {
-        final Timestamp time = cmd.getContext()
-                                  .getSchedule()
+        final Timestamp time = cmd.getSystemProperties()
                                   .getSchedulingTime();
         return time;
     }


### PR DESCRIPTION
This PR:
 * Moves the `scheduling_time` field into `Command.SystemProperties`.
 * Marks the whole type `SystemProperties` as `internal_type` (which implies that all the fields are `internal`).
 * Marks the `Command.system_properties` field as `internal`.
