### PR TITLE
Bump the framework version to 0.9.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
         
-        spineVersion = '0.8.40-SNAPSHOT'
+        spineVersion = '0.9.0'
         
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all
         // the components and change the version of the dependency below to


### PR DESCRIPTION
As long as this PR is merged to `master`, we should create a tag with the same version number. Later, this tag is used as an anchor for the GitHub release.