### PR TITLE
Projection Repo Catch Up performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
         
-        spineVersion = '0.8.40-SNAPSHOT'
+        spineVersion = '0.8.41-SNAPSHOT'
         
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all
         // the components and change the version of the dependency below to

--- a/server/src/main/java/org/spine3/server/entity/RecordBasedRepository.java
+++ b/server/src/main/java/org/spine3/server/entity/RecordBasedRepository.java
@@ -23,6 +23,7 @@ package org.spine3.server.entity;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableCollection;
@@ -132,6 +133,15 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
         }
         final E entity = toEntity(record);
         return Optional.of(entity);
+    }
+
+    @Override
+    public Iterator<E> iterator(Predicate<E> filter) {
+        final Iterable<E> allEntities = loadAll();
+        final Iterator<E> result = FluentIterable.from(allEntities)
+                                                 .filter(filter)
+                                                 .iterator();
+        return result;
     }
 
     /**

--- a/server/src/test/java/org/spine3/server/entity/RepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/entity/RepositoryShould.java
@@ -25,7 +25,6 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.spine3.server.BoundedContext;
 import org.spine3.server.storage.RecordStorage;
@@ -255,26 +254,5 @@ public class RepositoryShould {
     private void createAndStore(String entityId) {
         ProjectEntity entity = repository.create(createId(entityId));
         repository.store(entity);
-    }
-
-    @Ignore
-    // TODO:2017-05-03:dmytro.dashenkov: This test is still valid for the non-record-based repos.
-    @Test(expected = IllegalStateException.class)
-    public void throw_ISE_if_unable_to_load_entity_by_id_from_storage_index() {
-        createAndStoreEntities();
-
-        // Store a troublesome entity, which cannot be loaded.
-        final TenantAwareOperation op = new TenantAwareOperation(tenantId) {
-            @Override
-            public void run() {
-                createAndStore(TestRepo.troublesome.getId());
-            }
-        };
-        op.execute();
-
-        final Iterator<ProjectEntity> iterator = getIterator(tenantId);
-
-        // This should iterate through all.
-        Lists.newArrayList(iterator);
     }
 }

--- a/server/src/test/java/org/spine3/server/entity/RepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/entity/RepositoryShould.java
@@ -25,6 +25,7 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.spine3.server.BoundedContext;
 import org.spine3.server.storage.RecordStorage;
@@ -256,6 +257,8 @@ public class RepositoryShould {
         repository.store(entity);
     }
 
+    @Ignore
+    // TODO:2017-05-03:dmytro.dashenkov: This test is still valid for the non-record-based repos.
     @Test(expected = IllegalStateException.class)
     public void throw_ISE_if_unable_to_load_entity_by_id_from_storage_index() {
         createAndStoreEntities();


### PR DESCRIPTION
The Catch-Up process in the `ProjectionRepository` uses `Repository.iterator`.

Currently, `Repository.iterator` uses `Storage.index` to get the instances of desired entities. The issue is that the Storage index is, in fact, an `Iterator` of the Storage IDs. When the Repository iterates over the index it first reads all the entities from the Storage and transforms them into the ID and then iterates over these IDs and fetches each entity separately.

The fix is following: the `RecordBasedRepository` overrides the `iterator` method implementation by using the advantage of `RecordStorage.readAll` operation.

This fix should get version `0.8.41-SNAPSHOT`.