### PR TITLE
Entity visibility control

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
         
-        spineVersion = '0.9.2-SNAPSHOT'
+        spineVersion = '0.9.3-SNAPSHOT'
         
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all
         // the components and change the version of the dependency below to

--- a/client/src/main/java/org/spine3/option/EntityOptions.java
+++ b/client/src/main/java/org/spine3/option/EntityOptions.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.option;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+import org.spine3.annotation.Internal;
+import org.spine3.option.EntityOption.Visibility;
+import org.spine3.type.TypeName;
+
+/**
+ * Utilities for working with {@link EntityOption}s.
+ *
+ * @author Alexander Yevsyukov
+ */
+@Internal
+public class EntityOptions {
+
+    private EntityOptions() {
+        // Prevent instantiation of this utility class.
+    }
+
+    public static Visibility getVisibility(Class<? extends Message> stateClass) {
+        final Descriptors.Descriptor descriptor = TypeName.of(stateClass).getDescriptor();
+        final EntityOption entityOption = descriptor.getOptions()
+                                                    .getExtension(OptionsProto.entity);
+        final Visibility definedVisibility = entityOption.getVisibility();
+        final Visibility result = (definedVisibility == Visibility.VISIBILITY_UNKNOWN)
+                ? Visibility.FULL
+                : definedVisibility;
+        return result;
+    }
+}

--- a/client/src/main/java/org/spine3/option/EntityOptions.java
+++ b/client/src/main/java/org/spine3/option/EntityOptions.java
@@ -26,6 +26,8 @@ import org.spine3.annotation.Internal;
 import org.spine3.option.EntityOption.Visibility;
 import org.spine3.type.TypeName;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * Utilities for working with {@link EntityOption}s.
  *
@@ -39,6 +41,7 @@ public class EntityOptions {
     }
 
     public static Visibility getVisibility(Class<? extends Message> stateClass) {
+        checkNotNull(stateClass);
         final Descriptors.Descriptor descriptor = TypeName.of(stateClass).getDescriptor();
         final EntityOption entityOption = descriptor.getOptions()
                                                     .getExtension(OptionsProto.entity);

--- a/client/src/main/java/org/spine3/option/package-info.java
+++ b/client/src/main/java/org/spine3/option/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * This package provides generated classes and interfaces for Spine Options, and utilities for
+ * working with these options.
+ */
+
+@ParametersAreNonnullByDefault
+package org.spine3.option;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/client/src/test/java/org/spine3/option/EntityOptionsShould.java
+++ b/client/src/test/java/org/spine3/option/EntityOptionsShould.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.option;
+
+import org.junit.Test;
+import org.spine3.option.EntityOption.Visibility;
+import org.spine3.test.Tests;
+import org.spine3.test.options.FullAccessAggregate;
+import org.spine3.test.options.SubscribableAggregate;
+
+import static org.junit.Assert.assertEquals;
+import static org.spine3.option.EntityOptions.getVisibility;
+
+/**
+ * See `spine/test/option/entity_options_should.proto` for definitions of types used in the tests.
+ *
+ * @author Alexander Yevsyukov
+ */
+public class EntityOptionsShould {
+
+    @Test
+    public void have_utility_ctor() {
+        Tests.assertHasPrivateParameterlessCtor(EntityOptions.class);
+    }
+
+    @Test
+    public void assume_full_visibility_when_not_defined() {
+        assertEquals(Visibility.FULL, getVisibility(FullAccessAggregate.class));
+    }
+
+    @Test
+    public void get_defined_visibility_value() {
+        assertEquals(Visibility.SUBSCRIBE, getVisibility(SubscribableAggregate.class));
+    }
+}

--- a/client/src/test/java/org/spine3/option/EntityOptionsShould.java
+++ b/client/src/test/java/org/spine3/option/EntityOptionsShould.java
@@ -20,6 +20,7 @@
 
 package org.spine3.option;
 
+import com.google.common.testing.NullPointerTester;
 import org.junit.Test;
 import org.spine3.option.EntityOption.Visibility;
 import org.spine3.test.Tests;
@@ -49,5 +50,12 @@ public class EntityOptionsShould {
     @Test
     public void get_defined_visibility_value() {
         assertEquals(Visibility.SUBSCRIBE, getVisibility(SubscribableAggregate.class));
+    }
+
+    @Test
+    public void pass_null_tolerance_test() {
+        new NullPointerTester()
+                .setDefault(Visibility.class, Visibility.NONE)
+                .testAllPublicStaticMethods(EntityOptions.class);
     }
 }

--- a/client/src/test/proto/spine/test/option/entity_options_should.proto
+++ b/client/src/test/proto/spine/test/option/entity_options_should.proto
@@ -1,0 +1,45 @@
+//
+// Copyright 2017, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.test.options;
+
+option (type_url_prefix) = "type.spine3.org";
+option java_package="org.spine3.test.options";
+option java_multiple_files = true;
+option java_outer_classname = "EntityOptionsShouldProto";
+
+import "spine/options.proto";
+
+message FullAccessAggregate {
+    option (entity).kind = AGGREGATE;
+    // Do not specify visibility, assuming FULL.
+
+    uint64 id = 1;
+    string name = 2;
+}
+
+message SubscribableAggregate {
+    option (entity).kind = AGGREGATE;
+    option (entity).visibility = SUBSCRIBE;
+
+    uint64 id = 1;
+    string description = 2;
+}

--- a/client/src/test/proto/spine/test/option/entity_options_should.proto
+++ b/client/src/test/proto/spine/test/option/entity_options_should.proto
@@ -43,3 +43,11 @@ message SubscribableAggregate {
     uint64 id = 1;
     string description = 2;
 }
+
+message HiddenAggregate {
+    option (entity).kind = AGGREGATE;
+    option (entity).visibility = NONE;
+
+    string uuid = 1;
+    string secret = 2;
+}

--- a/server/src/main/java/org/spine3/server/BoundedContext.java
+++ b/server/src/main/java/org/spine3/server/BoundedContext.java
@@ -263,6 +263,9 @@ public final class BoundedContext
 
     private void registerAggregateRepository(AggregateRepository<?, ?> repository) {
         final Class<? extends Message> stateClass = repository.getAggregateStateClass();
+
+        //TODO:2017-05-06:alexander.yevsyukov: See if the state can be exposed by Visibility control in the state type descriptor.
+
         final AggregateRepository<?, ?> alreadyRegistered = aggregateRepositories.get(stateClass);
         if (alreadyRegistered != null) {
             final String errMsg = format(

--- a/server/src/main/java/org/spine3/server/BoundedContext.java
+++ b/server/src/main/java/org/spine3/server/BoundedContext.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import org.spine3.annotation.Internal;
 import org.spine3.base.Event;
 import org.spine3.base.Response;
+import org.spine3.option.EntityOption.Visibility;
 import org.spine3.server.aggregate.AggregateRepository;
 import org.spine3.server.command.EventFactory;
 import org.spine3.server.commandbus.CommandBus;
@@ -50,9 +51,11 @@ import org.spine3.server.stand.StandStorage;
 import org.spine3.server.storage.StorageFactory;
 import org.spine3.server.storage.StorageFactorySwitch;
 import org.spine3.server.tenant.TenantIndex;
+import org.spine3.type.TypeName;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -158,7 +161,9 @@ public final class BoundedContext
         return name + " closed.";
     }
 
-
+    /**
+     * Closes all repositories and clears {@link TenantIndex}.
+     */
     private void shutDownRepositories() throws Exception {
         guard.shutDownRepositories();
 
@@ -287,27 +292,31 @@ public final class BoundedContext
     }
 
     /** Obtains instance of {@link CommandBus} of this {@code BoundedContext}. */
-    @CheckReturnValue
     public CommandBus getCommandBus() {
         return this.commandBus;
     }
 
     /** Obtains instance of {@link EventBus} of this {@code BoundedContext}. */
-    @CheckReturnValue
     public EventBus getEventBus() {
         return this.eventBus;
     }
 
     /** Obtains instance of {@link FailureBus} of this {@code BoundedContext}. */
-    @CheckReturnValue
     public FailureBus getFailureBus() {
         return this.commandBus.failureBus();
     }
 
     /** Obtains instance of {@link Stand} of this {@code BoundedContext}. */
-    @CheckReturnValue
     public Stand getStand() {
         return stand;
+    }
+
+    /**
+     * Obtains a set of entity type names by their visibility.
+     */
+    public Set<TypeName> getEntityTypes(Visibility visibility) {
+        final Set<TypeName> result = guard.getEntityTypes(visibility);
+        return result;
     }
 
     /**

--- a/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
@@ -28,7 +28,6 @@ import org.spine3.base.Command;
 import org.spine3.base.CommandContext;
 import org.spine3.base.Event;
 import org.spine3.envelope.CommandEnvelope;
-import org.spine3.option.EntityOption;
 import org.spine3.server.BoundedContext;
 import org.spine3.server.commandbus.CommandDispatcher;
 import org.spine3.server.entity.Entity;
@@ -89,9 +88,6 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
 
     /** The constructor for creating entity instances. */
     private Constructor<A> entityConstructor;
-
-    /** Visibility of aggregates managed by this repository. */
-    private EntityOption.Visibility aggregateVisibility;
 
     /** The EventBus to which we post events produced by aggregates. */
     private final EventBus eventBus;

--- a/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
@@ -30,7 +30,6 @@ import org.spine3.base.Event;
 import org.spine3.envelope.CommandEnvelope;
 import org.spine3.server.BoundedContext;
 import org.spine3.server.commandbus.CommandDispatcher;
-import org.spine3.server.entity.Entity;
 import org.spine3.server.entity.LifecycleFlags;
 import org.spine3.server.entity.Repository;
 import org.spine3.server.entity.idfunc.GetTargetIdFromCommand;
@@ -150,15 +149,6 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      */
     Class<? extends Aggregate<I, ?, ?>> getAggregateClass() {
         return getEntityClass();
-    }
-
-    /**
-     * Obtains the class of the aggregate state.
-     */
-    public Class<? extends Message> getAggregateStateClass() {
-        final Class<? extends Aggregate<I, ?, ?>> aggregateClass = getAggregateClass();
-        final Class<? extends Message> stateClass = Entity.TypeInfo.getStateClass(aggregateClass);
-        return stateClass;
     }
 
     /**

--- a/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/org/spine3/server/aggregate/AggregateRepository.java
@@ -28,6 +28,7 @@ import org.spine3.base.Command;
 import org.spine3.base.CommandContext;
 import org.spine3.base.Event;
 import org.spine3.envelope.CommandEnvelope;
+import org.spine3.option.EntityOption;
 import org.spine3.server.BoundedContext;
 import org.spine3.server.commandbus.CommandDispatcher;
 import org.spine3.server.entity.Entity;
@@ -88,6 +89,9 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
 
     /** The constructor for creating entity instances. */
     private Constructor<A> entityConstructor;
+
+    /** Visibility of aggregates managed by this repository. */
+    private EntityOption.Visibility aggregateVisibility;
 
     /** The EventBus to which we post events produced by aggregates. */
     private final EventBus eventBus;

--- a/server/src/main/java/org/spine3/server/commandstore/Storage.java
+++ b/server/src/main/java/org/spine3/server/commandstore/Storage.java
@@ -192,7 +192,8 @@ class Storage extends DefaultRecordBasedRepository<CommandId, Entity, CommandRec
         }
     }
 
-    boolean isOpen() {
+    @Override
+    public boolean isOpen() {
         return storageAssigned();
     }
 

--- a/server/src/main/java/org/spine3/server/entity/Repository.java
+++ b/server/src/main/java/org/spine3/server/entity/Repository.java
@@ -263,7 +263,10 @@ public abstract class Repository<I, E extends Entity<I, ?>>
         }
     }
 
-    private boolean isOpen() {
+    /**
+     * Verifies if the repository open.
+     */
+    public boolean isOpen() {
         return storage != null;
     }
 

--- a/server/src/main/java/org/spine3/server/entity/VisibilityGuard.java
+++ b/server/src/main/java/org/spine3/server/entity/VisibilityGuard.java
@@ -89,6 +89,7 @@ public final class VisibilityGuard {
      * Verifies if there is a registered repository for the passed entity state class.
      */
     public boolean hasRepository(Class<? extends Message> stateClass) {
+        checkNotNull(stateClass);
         final boolean result = repositories.containsKey(stateClass);
         return result;
     }
@@ -105,6 +106,7 @@ public final class VisibilityGuard {
      *                                  {@linkplain #shutDownRepositories() shut down}
      */
     public Optional<Repository> getRepository(Class<? extends Message> stateClass) {
+        checkNotNull(stateClass);
         final RepositoryAccess repositoryAccess = repositories.get(stateClass);
         if (repositoryAccess == null) {
             throw newIllegalArgumentException(

--- a/server/src/main/java/org/spine3/server/entity/VisibilityGuard.java
+++ b/server/src/main/java/org/spine3/server/entity/VisibilityGuard.java
@@ -52,7 +52,7 @@ import static org.spine3.util.Exceptions.newIllegalStateException;
 @Internal
 public final class VisibilityGuard {
 
-    private final Map<Class, RepositoryAccess> repositories = newHashMap();
+    private final Map<Class<? extends Message>, RepositoryAccess> repositories = newHashMap();
 
     private VisibilityGuard() {
         // Prevent instantiation from outside.
@@ -70,7 +70,8 @@ public final class VisibilityGuard {
      */
     public void register(Repository repository) {
         checkNotNull(repository);
-        final Class stateClass = repository.getEntityStateClass();
+        @SuppressWarnings("unchecked") // The type is ensured by the called method.
+        final Class<? extends Message> stateClass = repository.getEntityStateClass();
         checkNotAlreadyRegistered(stateClass);
         repositories.put(stateClass, new RepositoryAccess(repository));
     }

--- a/server/src/main/java/org/spine3/server/entity/VisibilityGuard.java
+++ b/server/src/main/java/org/spine3/server/entity/VisibilityGuard.java
@@ -58,10 +58,16 @@ public final class VisibilityGuard {
         // Prevent instantiation from outside.
     }
 
+    /**
+     * Creates a new instance of the guard.
+     */
     public static VisibilityGuard newInstance() {
         return new VisibilityGuard();
     }
 
+    /**
+     * Registers the passed repository with the guard.
+     */
     public void register(Repository repository) {
         checkNotNull(repository);
         final Class stateClass = repository.getEntityStateClass();
@@ -78,11 +84,25 @@ public final class VisibilityGuard {
         }
     }
 
+    /**
+     * Verifies if there is a registered repository for the passed entity state class.
+     */
     public boolean hasRepository(Class<? extends Message> stateClass) {
         final boolean result = repositories.containsKey(stateClass);
         return result;
     }
 
+    /**
+     * Obtains the repository for the passed entity state class.
+     *
+     * @param stateClass the class of the state of entities managed by the repository
+     * @return the repository wrapped into {@code Optional} or {@code Optional#absent()} if the
+     * entity state is {@linkplain Visibility#NONE not visible}
+     * @throws IllegalArgumentException if the repository for the passed state class was not
+     *                                  {@linkplain #register(Repository) registered} with the guard
+     *                                  prior to this call, or if all repositories were
+     *                                  {@linkplain #shutDownRepositories() shut down}
+     */
     public Optional<Repository> getRepository(Class<? extends Message> stateClass) {
         final RepositoryAccess repositoryAccess = repositories.get(stateClass);
         if (repositoryAccess == null) {
@@ -93,6 +113,9 @@ public final class VisibilityGuard {
         return repositoryAccess.get();
     }
 
+    /**
+     * Obtains a set of entity type names by their visibility.
+     */
     public Set<TypeName> getEntityTypes(final Visibility visibility) {
         checkNotNull(visibility);
 
@@ -115,7 +138,7 @@ public final class VisibilityGuard {
                               public TypeName apply(@Nullable RepositoryAccess input) {
                                   checkNotNull(input);
                                   @SuppressWarnings("unchecked")
-                                        // Safe as it's bounded by Repository class definition.
+                                  // Safe as it's bounded by Repository class definition.
                                   final Class<? extends Message> cls =
                                           input.repository.getEntityStateClass();
                                   final TypeName result = TypeName.of(cls);

--- a/server/src/main/java/org/spine3/server/entity/VisibilityGuard.java
+++ b/server/src/main/java/org/spine3/server/entity/VisibilityGuard.java
@@ -126,6 +126,16 @@ public final class VisibilityGuard {
     }
 
     /**
+     * Closes all registered repositories and clears the registration list.
+     */
+    public void shutDownRepositories() {
+        for (RepositoryAccess repositoryAccess : repositories.values()) {
+            repositoryAccess.repository.close();
+        }
+        repositories.clear();
+    }
+
+    /**
      * Allows to get a reference to repository if states of its entities are visible.
      */
     private static class RepositoryAccess {

--- a/server/src/main/java/org/spine3/server/entity/VisibilityGuard.java
+++ b/server/src/main/java/org/spine3/server/entity/VisibilityGuard.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.entity;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Sets;
+import com.google.protobuf.Message;
+import org.spine3.annotation.Internal;
+import org.spine3.option.EntityOption.Visibility;
+import org.spine3.option.EntityOptions;
+import org.spine3.type.TypeName;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.Maps.filterValues;
+import static com.google.common.collect.Maps.newHashMap;
+import static org.spine3.util.Exceptions.newIllegalArgumentException;
+
+/**
+ * A registry of repositories that controls access to them depending on the visibility of
+ * corresponding entity states.
+ *
+ * @author Alexander Yevsyukov
+ * @see EntityOptions
+ */
+@Internal
+public final class VisibilityGuard {
+
+    private final Map<Class<? extends Message>, RepositoryAccess> repositories = newHashMap();
+
+    public void register(Repository<?, ? extends Message> repository) {
+        checkNotNull(repository);
+        final Class<? extends Message> stateClass = repository.getEntityStateClass();
+        repositories.put(stateClass, new RepositoryAccess(repository));
+    }
+
+    public Optional<Repository<?, ? extends Message>>
+    getRepository(Class<? extends Message> stateClass) {
+        final RepositoryAccess repositoryAccess = repositories.get(stateClass);
+        if (repositoryAccess == null) {
+            throw newIllegalArgumentException(
+                    "A repository for the state class (%s) was not registered in VisibilityGuard",
+                    stateClass.getName());
+        }
+        return repositoryAccess.get();
+    }
+
+    public Set<TypeName> getEntityTypes(final Visibility visibility) {
+        checkNotNull(visibility);
+
+        final Collection<RepositoryAccess> repos =
+                filterValues(repositories,
+                             new Predicate<RepositoryAccess>() {
+                                 @Override
+                                 public boolean apply(@Nullable RepositoryAccess input) {
+                                     checkNotNull(input);
+                                     return input.visibility == visibility;
+                                 }
+                             }).values();
+
+        final Iterable<TypeName> entityTypes =
+                transform(repos,
+                          new Function<RepositoryAccess, TypeName>() {
+                              @Override
+                              public TypeName apply(@Nullable RepositoryAccess input) {
+                                  checkNotNull(input);
+                                  final Class<? extends Message> cls =
+                                          input.repository.getEntityClass();
+                                  final TypeName result = TypeName.of(cls);
+                                  return result;
+                              }
+                          });
+        return Sets.newHashSet(entityTypes);
+    }
+
+    /**
+     * Allows to get a reference to repository if states of its entities are visible.
+     */
+    private static class RepositoryAccess {
+
+        private final Repository<?, ? extends Message> repository;
+        private final Visibility visibility;
+
+        private RepositoryAccess(Repository<?, ? extends Message> repository) {
+            this.repository = repository;
+            final Class<? extends Message> stateClass = repository.getEntityStateClass();
+
+            this.visibility = EntityOptions.getVisibility(stateClass);
+        }
+
+        private Optional<Repository<?, ? extends Message>> get() {
+            return (visibility == Visibility.NONE)
+                    ? Optional.<Repository<?, ? extends Message>>absent()
+                    : Optional.<Repository<?, ? extends Message>>of(repository);
+        }
+    }
+}

--- a/server/src/main/java/org/spine3/server/entity/VisibilityGuard.java
+++ b/server/src/main/java/org/spine3/server/entity/VisibilityGuard.java
@@ -68,15 +68,14 @@ public final class VisibilityGuard {
     /**
      * Registers the passed repository with the guard.
      */
-    public void register(Repository repository) {
+    public void register(Repository<?, ?> repository) {
         checkNotNull(repository);
-        @SuppressWarnings("unchecked") // The type is ensured by the called method.
         final Class<? extends Message> stateClass = repository.getEntityStateClass();
         checkNotAlreadyRegistered(stateClass);
         repositories.put(stateClass, new RepositoryAccess(repository));
     }
 
-    private void checkNotAlreadyRegistered(Class stateClass) {
+    private void checkNotAlreadyRegistered(Class<? extends Message> stateClass) {
         final RepositoryAccess alreadyRegistered = repositories.get(stateClass);
         if (alreadyRegistered != null) {
             throw newIllegalStateException(

--- a/server/src/test/java/org/spine3/server/bc/BoundedContextShould.java
+++ b/server/src/test/java/org/spine3/server/bc/BoundedContextShould.java
@@ -31,6 +31,7 @@ import org.spine3.base.CommandContext;
 import org.spine3.base.EventContext;
 import org.spine3.base.Response;
 import org.spine3.base.Subscribe;
+import org.spine3.option.EntityOption;
 import org.spine3.protobuf.AnyPacker;
 import org.spine3.server.BoundedContext;
 import org.spine3.server.aggregate.Aggregate;
@@ -66,6 +67,7 @@ import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -156,6 +158,7 @@ public class BoundedContextShould {
             super(id);
         }
     }
+
     private static class AnotherProjectAggregateRepository
                    extends AggregateRepository<ProjectId, AnotherProjectAggregate> {
         private AnotherProjectAggregateRepository(BoundedContext boundedContext) {
@@ -321,6 +324,24 @@ public class BoundedContextShould {
 
         assertEquals(bc.isMultitenant(), bc.getStand()
                                            .isMultitenant());
+    }
+
+    /**
+     * Simply checks that the result isn't empty to cover the integration with
+     * {@link org.spine3.server.entity.VisibilityGuard VisibilityGuard}.
+     *
+     * <p>See {@linkplain org.spine3.server.entity.VisibilityGuardShould tests of VisibilityGuard}
+     * for how visibility filtering works.
+     */
+    @Test
+    public void obtain_entity_types_by_visibility() {
+        assertTrue(boundedContext.getEntityTypes(EntityOption.Visibility.FULL)
+                                  .isEmpty());
+
+        registerAll();
+
+        assertFalse(boundedContext.getEntityTypes(EntityOption.Visibility.FULL)
+                                 .isEmpty());
     }
 
     private static class TestResponseObserver implements StreamObserver<Response> {

--- a/server/src/test/java/org/spine3/server/bc/BoundedContextShould.java
+++ b/server/src/test/java/org/spine3/server/bc/BoundedContextShould.java
@@ -357,6 +357,7 @@ public class BoundedContextShould {
 
     @Test(expected = IllegalStateException.class)
     public void throw_ISE_when_no_repository_registered() {
+        // Attempt to get a repository without registering.
         boundedContext.getAggregateRepository(Project.class);
     }
 

--- a/server/src/test/java/org/spine3/server/bc/BoundedContextShould.java
+++ b/server/src/test/java/org/spine3/server/bc/BoundedContextShould.java
@@ -344,6 +344,12 @@ public class BoundedContextShould {
                                  .isEmpty());
     }
 
+
+    @Test(expected = IllegalStateException.class)
+    public void throw_ISE_when_no_repository_registered() {
+        boundedContext.getAggregateRepository(Project.class);
+    }
+
     private static class TestResponseObserver implements StreamObserver<Response> {
 
         private Response responseHandled;

--- a/server/src/test/java/org/spine3/server/entity/VisibilityGuardShould.java
+++ b/server/src/test/java/org/spine3/server/entity/VisibilityGuardShould.java
@@ -51,7 +51,7 @@ public class VisibilityGuardShould {
     public void setUp() {
         final BoundedContext boundedContext = BoundedContext.newBuilder()
                                                             .build();
-        guard = new VisibilityGuard();
+        guard = VisibilityGuard.newInstance();
         guard.register(new ExposedRepository(boundedContext));
         guard.register(new SubscribableRepository(boundedContext));
         guard.register(new HiddenRepository(boundedContext));

--- a/server/src/test/java/org/spine3/server/entity/VisibilityGuardShould.java
+++ b/server/src/test/java/org/spine3/server/entity/VisibilityGuardShould.java
@@ -56,7 +56,7 @@ public class VisibilityGuardShould {
     @Before
     public void setUp() {
         boundedContext = BoundedContext.newBuilder()
-                                                            .build();
+                                       .build();
         repositories = Lists.newArrayList();
 
         guard = VisibilityGuard.newInstance();

--- a/server/src/test/java/org/spine3/server/entity/VisibilityGuardShould.java
+++ b/server/src/test/java/org/spine3/server/entity/VisibilityGuardShould.java
@@ -21,6 +21,7 @@
 package org.spine3.server.entity;
 
 import com.google.common.collect.Lists;
+import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Empty;
 import org.junit.After;
 import org.junit.Before;
@@ -121,6 +122,15 @@ public class VisibilityGuardShould {
     @Test(expected = IllegalArgumentException.class)
     public void reject_unregistered_state_class() {
         guard.getRepository(Empty.class);
+    }
+
+    @Test
+    public void do_not_allow_null_inputs() {
+        new NullPointerTester()
+                .setDefault(Repository.class, new ExposedRepository(boundedContext))
+                .setDefault(Class.class, FullAccessAggregate.class)
+                .setDefault(Visibility.class, Visibility.NONE)
+                .testAllPublicInstanceMethods(guard);
     }
 
     private static class Exposed

--- a/server/src/test/java/org/spine3/server/entity/VisibilityGuardShould.java
+++ b/server/src/test/java/org/spine3/server/entity/VisibilityGuardShould.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.entity;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.spine3.option.EntityOption.Visibility;
+import org.spine3.server.BoundedContext;
+import org.spine3.server.aggregate.Aggregate;
+import org.spine3.server.aggregate.AggregateRepository;
+import org.spine3.test.options.FullAccessAggregate;
+import org.spine3.test.options.HiddenAggregate;
+import org.spine3.test.options.SubscribableAggregate;
+import org.spine3.type.TypeName;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * See `client/spine/test/option/entity_options_should.proto` for definition of messages
+ * used for aggregates and repositories in this test.
+ *
+ * @author Alexander Yevsyukov
+ */
+public class VisibilityGuardShould {
+
+    private VisibilityGuard guard;
+
+    @Before
+    public void setUp() {
+        final BoundedContext boundedContext = BoundedContext.newBuilder()
+                                                            .build();
+        guard = new VisibilityGuard();
+        guard.register(new ExposedRepository(boundedContext));
+        guard.register(new SubscribableRepository(boundedContext));
+        guard.register(new HiddenRepository(boundedContext));
+    }
+
+    @Test
+    public void give_access_to_visible_repos() {
+        assertTrue(guard.getRepository(FullAccessAggregate.class)
+                        .isPresent());
+        assertTrue(guard.getRepository(SubscribableAggregate.class)
+                        .isPresent());
+    }
+
+    @Test
+    public void deny_access_to_invisible_repos() {
+        assertFalse(guard.getRepository(HiddenAggregate.class).isPresent());
+    }
+
+    @Test
+    public void obtain_repos_by_visibility() {
+        final Set<TypeName> full = guard.getEntityTypes(Visibility.FULL);
+        assertEquals(1, full.size());
+        assertTrue(full.contains(TypeName.of(FullAccessAggregate.class)));
+
+        final Set<TypeName> subscribable = guard.getEntityTypes(Visibility.SUBSCRIBE);
+        assertEquals(1, subscribable.size());
+        assertTrue(subscribable.contains(TypeName.of(SubscribableAggregate.class)));
+
+        final Set<TypeName> hidden = guard.getEntityTypes(Visibility.NONE);
+        assertEquals(1, hidden.size());
+        assertTrue(hidden.contains(TypeName.of(HiddenAggregate.class)));
+    }
+
+    private static class Exposed
+                   extends Aggregate<Long, FullAccessAggregate, FullAccessAggregate.Builder> {
+        private Exposed(Long id) {
+            super(id);
+        }
+    }
+
+    private static class ExposedRepository extends AggregateRepository<Long, Exposed> {
+        private ExposedRepository(BoundedContext boundedContext) {
+            super(boundedContext);
+        }
+    }
+
+    private static class Subscribable
+                   extends Aggregate<Long, SubscribableAggregate, SubscribableAggregate.Builder> {
+        protected Subscribable(Long id) {
+            super(id);
+        }
+    }
+
+    private static class SubscribableRepository extends AggregateRepository<Long, Subscribable> {
+        private SubscribableRepository(BoundedContext boundedContext) {
+            super(boundedContext);
+        }
+    }
+
+    private static class Hidden
+                   extends Aggregate<String, HiddenAggregate, HiddenAggregate.Builder> {
+        private Hidden(String id) {
+            super(id);
+        }
+    }
+
+    private static class HiddenRepository extends AggregateRepository<String, Hidden> {
+        private HiddenRepository(BoundedContext boundedContext) {
+            super(boundedContext);
+        }
+    }
+}

--- a/server/src/test/proto/spine/test/bc/project.proto
+++ b/server/src/test/proto/spine/test/bc/project.proto
@@ -58,3 +58,11 @@ message Task {
     string title = 2;
     string description = 3;
 }
+
+message SecretProject {
+    option (entity).kind = AGGREGATE;
+    option (entity).visibility = NONE;
+
+    string id = 1;
+    string name = 2;
+}


### PR DESCRIPTION
This PR introduces `VisiblityGuard` which allows to get an access to a registered repository depending on the visibility state of entities this repository manages. 

`BoundedContext` now is able to return type names of entity states by their visibility.

In addition:
* `Repository.isOpen()` made public.