### PR TITLE
Fix the right margin plugin output in a build log.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ buildscript {
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all
         // the components and change the version of the dependency below to
         // `spineVersion` defined above.
-        spineToolsVersion = '0.9.4-SNAPSHOT'
+        spineToolsVersion = '0.9.5-SNAPSHOT'
 
         // Defines option for the `spine-model-compiler` plugin.
         // Indicates whether the generation of the validating builders is enabled.


### PR DESCRIPTION
We need to fix the right margin plugin so that it should log the result only once per project without duplicating for every module.