### PR TITLE
Serializable Columns

### DIFF
--- a/server/src/main/java/org/spine3/server/entity/storage/Column.java
+++ b/server/src/main/java/org/spine3/server/entity/storage/Column.java
@@ -133,13 +133,19 @@ import static java.lang.String.format;
  * @see ColumnType
  * @author Dmytro Dashenkov
  */
-public /*final*/ class Column implements Serializable {
+public class Column implements Serializable {
 
     private static final long serialVersionUID = 8200711636725154347L;
 
     private static final String GETTER_PREFIX_REGEX = "(get)|(is)";
     private static final Pattern GETTER_PREFIX_PATTERN = Pattern.compile(GETTER_PREFIX_REGEX);
 
+    /**
+     * This field is left non-final for serialization purposes.
+     *
+     * <p>The only place where this field is updated, except the constructor, is
+     * {@link #readObject(ObjectInputStream)} method.
+     */
     private /*final*/ transient Method getter;
 
     private final Class<?> entityType;

--- a/server/src/main/java/org/spine3/server/entity/storage/Column.java
+++ b/server/src/main/java/org/spine3/server/entity/storage/Column.java
@@ -129,7 +129,7 @@ import static java.lang.String.format;
  * @see ColumnType
  * @author Dmytro Dashenkov
  */
-public class Column implements Serializable {
+public /*final*/ class Column implements Serializable {
 
     private static final long serialVersionUID = 8200711636725154347L;
 
@@ -297,7 +297,9 @@ public class Column implements Serializable {
      * @see Column#memoizeFor(Entity)
      */
     @Internal
-    static class MemoizedValue {
+    static class MemoizedValue implements Serializable {
+
+        private static final long serialVersionUID = -6041163252051925293L;
 
         private final Column sourceColumn;
 

--- a/server/src/main/java/org/spine3/server/entity/storage/Column.java
+++ b/server/src/main/java/org/spine3/server/entity/storage/Column.java
@@ -20,6 +20,7 @@
 
 package org.spine3.server.entity.storage;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import org.spine3.annotation.Internal;
 import org.spine3.server.entity.Entity;
@@ -306,7 +307,8 @@ public /*final*/ class Column implements Serializable {
         @Nullable
         private final Serializable value;
 
-        private MemoizedValue(Column sourceColumn, @Nullable Serializable value) {
+        @VisibleForTesting
+        MemoizedValue(Column sourceColumn, @Nullable Serializable value) {
             this.sourceColumn = sourceColumn;
             this.value = value;
         }
@@ -325,6 +327,24 @@ public /*final*/ class Column implements Serializable {
          */
         Column getSourceColumn() {
             return sourceColumn;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            MemoizedValue value1 = (MemoizedValue) o;
+            return Objects.equal(getSourceColumn(), value1.getSourceColumn()) &&
+                    Objects.equal(getValue(), value1.getValue());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(getSourceColumn(), getValue());
         }
     }
 }

--- a/server/src/main/java/org/spine3/server/entity/storage/Column.java
+++ b/server/src/main/java/org/spine3/server/entity/storage/Column.java
@@ -138,7 +138,7 @@ public /*final*/ class Column implements Serializable {
 
     private /*final*/ transient Method getter;
 
-    private final Class<?> type;
+    private final Class<?> entityType;
 
     private final String getterMethodName;
 
@@ -148,7 +148,7 @@ public /*final*/ class Column implements Serializable {
 
     private Column(Method getter, String name, boolean nullable) {
         this.getter = getter;
-        this.type = getter.getReturnType();
+        this.entityType = getter.getDeclaringClass();
         this.getterMethodName = getter.getName();
         this.name = name;
         this.nullable = nullable;
@@ -248,7 +248,7 @@ public /*final*/ class Column implements Serializable {
      * @return the type of the Column
      */
     public Class getType() {
-        return type;
+        return getter.getReturnType();
     }
 
     @SuppressWarnings("NonFinalFieldReferenceInEquals") // `getter` field is effectively final
@@ -279,11 +279,11 @@ public /*final*/ class Column implements Serializable {
     private Method restoreGetter() {
         checkState(getter == null, "Getter method is already restored.");
         try {
-            final Method method = type.getMethod(getterMethodName);
+            final Method method = entityType.getMethod(getterMethodName);
             return method;
         } catch (NoSuchMethodException e) {
             final String errorMsg = format("Cannot find method %s.%s().",
-                                           type.getCanonicalName(),
+                                           entityType.getCanonicalName(),
                                            getterMethodName);
             throw new IllegalStateException(errorMsg, e);
         }

--- a/server/src/main/java/org/spine3/server/entity/storage/ColumnRecords.java
+++ b/server/src/main/java/org/spine3/server/entity/storage/ColumnRecords.java
@@ -34,7 +34,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @author Dmytro Dashenkov
  */
-public class ColumnRecords {
+public final class ColumnRecords {
 
     private ColumnRecords() {
         // Prevent initialization of the utility class

--- a/server/src/main/java/org/spine3/server/entity/storage/ColumnRecords.java
+++ b/server/src/main/java/org/spine3/server/entity/storage/ColumnRecords.java
@@ -55,8 +55,8 @@ public class ColumnRecords {
      * @param mapColumnIdentifier a {@linkplain Function} mapping
      *                            the {@linkplain Column#getName() column name} to the database
      *                            specific column identifier
-     * @param <D> the type of the database record
-     * @param <I> the type of the column identifier
+     * @param <D>                 the type of the database record
+     * @param <I>                 the type of the column identifier
      */
     public static <D, I> void feedColumnsTo(
             D destination,
@@ -70,14 +70,12 @@ public class ColumnRecords {
         checkArgument(recordWithColumns.hasColumns(),
                       "Passed record has no Entity Columns.");
 
-        for (Map.Entry<String, MemoizedValue<?>> column : recordWithColumns.getColumnValues()
-                                                                                  .entrySet()) {
+        for (Map.Entry<String, MemoizedValue> column : recordWithColumns.getColumnValues()
+                                                                        .entrySet()) {
             final I columnIdentifier = mapColumnIdentifier.apply(column.getKey());
             checkNotNull(columnIdentifier);
-            @SuppressWarnings("unchecked") // We don't know the exact type of the value
-            final MemoizedValue<Object> columnValue =
-                    (MemoizedValue<Object>) column.getValue();
-            final Column<?> columnMetadata = columnValue.getSourceColumn();
+            final MemoizedValue columnValue = column.getValue();
+            final Column columnMetadata = columnValue.getSourceColumn();
             @SuppressWarnings("unchecked") // We don't know the exact types of the value
             final ColumnType<Object, Object, D, I> columnType =
                     (ColumnType<Object, Object, D, I>) columnTypeRegistry.get(columnMetadata);
@@ -89,11 +87,12 @@ public class ColumnRecords {
         }
     }
 
-    private static <J, S, D, I> void setValue(MemoizedValue<J> columnValue,
+    private static <J, S, D, I> void setValue(MemoizedValue columnValue,
                                               D destination,
                                               I columnIdentifier,
                                               ColumnType<J, S, D, I> columnType) {
-        final J initialValue = columnValue.getValue();
+        @SuppressWarnings("unchecked") // Checked at runtime
+        final J initialValue = (J) columnValue.getValue();
         if (initialValue == null) {
             columnType.setNull(destination, columnIdentifier);
         } else {

--- a/server/src/main/java/org/spine3/server/entity/storage/ColumnTypeRegistry.java
+++ b/server/src/main/java/org/spine3/server/entity/storage/ColumnTypeRegistry.java
@@ -89,7 +89,7 @@ public final class ColumnTypeRegistry<C extends ColumnType> {
      * @param field the {@link Column} to get type conversion strategy for
      * @return the {@link ColumnType} for the given {@link Column}
      */
-    public C get(Column<?> field) {
+    public C get(Column field) {
         checkNotNull(field);
 
         Class javaType = field.getType();

--- a/server/src/main/java/org/spine3/server/entity/storage/Columns.java
+++ b/server/src/main/java/org/spine3/server/entity/storage/Columns.java
@@ -49,6 +49,10 @@ import static java.lang.String.format;
  * <a href="http://download.oracle.com/otndocs/jcp/7224-javabeans-1.01-fr-spec-oth-JSpec/">
  * the Java Bean</a> getter spec are considered {@link Column Columns}.
  *
+ * <p>Note that the returned type of a {@link Column} getter must either be primitive or
+ * serializable, otherwise a runtime exception is thrown when trying to get an instance of
+ * {@link Column}.
+ *
  * <p>When passing an instance of an already known {@link Entity} type, the getters are retrieved
  * from a cache and are not updated.
  *

--- a/server/src/main/java/org/spine3/server/entity/storage/Columns.java
+++ b/server/src/main/java/org/spine3/server/entity/storage/Columns.java
@@ -84,9 +84,9 @@ class Columns {
      *
      * <p>This container is mutable and thread safe.
      */
-    private static final Multimap<Class<? extends Entity>, Column<?>> knownEntityProperties =
+    private static final Multimap<Class<? extends Entity>, Column> knownEntityProperties =
             synchronizedListMultimap(
-                    LinkedListMultimap.<Class<? extends Entity>, Column<?>>create());
+                    LinkedListMultimap.<Class<? extends Entity>, Column>create());
 
     private Columns() {
         // Prevent initialization of a utility class
@@ -106,7 +106,7 @@ class Columns {
      * {@linkplain Column.MemoizedValue memoized values}.
      * @see Column.MemoizedValue
      */
-    static <E extends Entity<?, ?>> Map<String, Column.MemoizedValue<?>> from(E entity) {
+    static <E extends Entity<?, ?>> Map<String, Column.MemoizedValue> from(E entity) {
         checkNotNull(entity);
         final Class<? extends Entity> entityType = entity.getClass();
         final int modifiers = entityType.getModifiers();
@@ -116,7 +116,7 @@ class Columns {
         }
         ensureRegistered(entityType);
 
-        final Map<String, Column.MemoizedValue<?>> fields = extractColumns(entityType, entity);
+        final Map<String, Column.MemoizedValue> fields = extractColumns(entityType, entity);
         return fields;
     }
 
@@ -133,13 +133,13 @@ class Columns {
      * @return an instance of {@link Column} with the given name
      * @throws IllegalArgumentException if the {@link Column} is not found
      */
-    static Column<?> findColumn(Class<? extends Entity> entityClass, String columnName) {
+    static Column findColumn(Class<? extends Entity> entityClass, String columnName) {
         checkNotNull(entityClass);
         checkNotNull(columnName);
         ensureRegistered(entityClass);
 
-        final Collection<Column<?>> cachedColumns = knownEntityProperties.get(entityClass);
-        for (Column<?> column : cachedColumns) {
+        final Collection<Column> cachedColumns = knownEntityProperties.get(entityClass);
+        for (Column column : cachedColumns) {
             if (column.getName()
                       .equals(columnName)) {
                 return column;
@@ -160,17 +160,17 @@ class Columns {
      * @param entity     the object which to take the values from
      * @return a {@link Map} of the {@link Column Columns}
      */
-    private static Map<String, Column.MemoizedValue<?>> extractColumns(
+    private static Map<String, Column.MemoizedValue> extractColumns(
             Class<? extends Entity> entityType,
             Entity entity) {
-        final Collection<Column<?>> storageFieldProperties =
+        final Collection<Column> storageFieldProperties =
                 knownEntityProperties.get(entityType);
-        final Map<String, Column.MemoizedValue<?>> values =
+        final Map<String, Column.MemoizedValue> values =
                 new HashMap<>(storageFieldProperties.size());
 
-        for (Column<?> column : storageFieldProperties) {
+        for (Column column : storageFieldProperties) {
             final String name = column.getName();
-            final Column.MemoizedValue<?> value = column.memoizeFor(entity);
+            final Column.MemoizedValue value = column.memoizeFor(entity);
             values.put(name, value);
         }
         return values;
@@ -197,7 +197,7 @@ class Columns {
         for (PropertyDescriptor property : entityDescriptor.getPropertyDescriptors()) {
             final Method getter = property.getReadMethod();
             if (!ExcludedMethod.contain(getter.getName())) {
-                final Column<?> storageField = Column.from(getter);
+                final Column storageField = Column.from(getter);
                 knownEntityProperties.put(entityType, storageField);
             }
         }

--- a/server/src/main/java/org/spine3/server/entity/storage/EntityQueries.java
+++ b/server/src/main/java/org/spine3/server/entity/storage/EntityQueries.java
@@ -72,7 +72,7 @@ public final class EntityQueries {
         final QueryParameters.Builder builder = QueryParameters.newBuilder();
 
         for (ColumnFilter filter : entityFilters.getColumnFilterList()) {
-            final Column<?> column = Columns.findColumn(entityClass, filter.getColumnName());
+            final Column column = Columns.findColumn(entityClass, filter.getColumnName());
             builder.put(column, filter);
         }
         return builder.build();

--- a/server/src/main/java/org/spine3/server/entity/storage/EntityQuery.java
+++ b/server/src/main/java/org/spine3/server/entity/storage/EntityQuery.java
@@ -24,6 +24,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 
@@ -61,7 +62,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @author Dmytro Dashenkov
  * @see EntityRecordWithColumns
  */
-public final class EntityQuery<I> {
+public final class EntityQuery<I> implements Serializable {
+
+    private static final long serialVersionUID = 7007336125384634462L;
 
     private final ImmutableSet<I> ids;
     private final QueryParameters parameters;

--- a/server/src/main/java/org/spine3/server/entity/storage/EntityQueryMatcher.java
+++ b/server/src/main/java/org/spine3/server/entity/storage/EntityQueryMatcher.java
@@ -80,10 +80,10 @@ public final class EntityQueryMatcher<I> implements Predicate<EntityRecordWithCo
     }
 
     private boolean columnValuesMatch(EntityRecordWithColumns record) {
-        final Map<String, MemoizedValue<?>> entityColumns = record.getColumnValues();
+        final Map<String, MemoizedValue> entityColumns = record.getColumnValues();
         for (ColumnFilter filter : queryParams) {
             final String columnName = filter.getColumnName();
-            final MemoizedValue<?> memoizedValue = entityColumns.get(columnName);
+            final MemoizedValue memoizedValue = entityColumns.get(columnName);
             final boolean matches = checkSingleParameter(filter, memoizedValue);
             if (!matches) {
                 return false;
@@ -93,7 +93,7 @@ public final class EntityQueryMatcher<I> implements Predicate<EntityRecordWithCo
     }
 
     private static boolean checkSingleParameter(ColumnFilter filter,
-                                                @Nullable MemoizedValue<?> actualValue) {
+                                                @Nullable MemoizedValue actualValue) {
         if (actualValue == null) {
             return false;
         }

--- a/server/src/main/java/org/spine3/server/entity/storage/EntityRecordWithColumns.java
+++ b/server/src/main/java/org/spine3/server/entity/storage/EntityRecordWithColumns.java
@@ -40,7 +40,7 @@ public final class EntityRecordWithColumns {
 
     private final EntityRecord record;
 
-    private final ImmutableMap<String, Column.MemoizedValue<?>> storageFields;
+    private final ImmutableMap<String, Column.MemoizedValue> storageFields;
     private final boolean hasStorageFields;
 
     /**
@@ -50,7 +50,7 @@ public final class EntityRecordWithColumns {
      * @param columns {@linkplain Columns#from(Entity) {@link Column Columns} map} to pack
      */
     private EntityRecordWithColumns(EntityRecord record,
-                                    Map<String, Column.MemoizedValue<?>> columns) {
+                                    Map<String, Column.MemoizedValue> columns) {
         this.record = checkNotNull(record);
         this.storageFields = ImmutableMap.copyOf(columns);
         this.hasStorageFields = true;
@@ -77,7 +77,7 @@ public final class EntityRecordWithColumns {
      * {@linkplain Column Column values} from the given {@linkplain Entity}.
      */
     public static EntityRecordWithColumns create(EntityRecord record, Entity entity) {
-        final Map<String, Column.MemoizedValue<?>> columns = Columns.from(entity);
+        final Map<String, Column.MemoizedValue> columns = Columns.from(entity);
         return of(record, columns);
     }
 
@@ -99,7 +99,7 @@ public final class EntityRecordWithColumns {
     @VisibleForTesting
     static EntityRecordWithColumns of(
             EntityRecord record,
-            Map<String, Column.MemoizedValue<?>> storageFields) {
+            Map<String, Column.MemoizedValue> storageFields) {
         return new EntityRecordWithColumns(record, storageFields);
     }
 
@@ -107,13 +107,14 @@ public final class EntityRecordWithColumns {
         return record;
     }
 
-    public Map<String, Column<?>> getColumns() {
+    public Map<String, Column> getColumns() {
         return Maps.transformEntries(storageFields,
                                      ColumnTransformer.INSTANCE);
     }
 
-    @SuppressWarnings("ReturnOfCollectionOrArrayField") // Immutable structure
-    Map<String, Column.MemoizedValue<?>> getColumnValues() {
+    @SuppressWarnings("ReturnOfCollectionOrArrayField")
+        // Immutable structure
+    Map<String, Column.MemoizedValue> getColumnValues() {
         return storageFields;
     }
 
@@ -151,13 +152,13 @@ public final class EntityRecordWithColumns {
     }
 
     private enum ColumnTransformer
-            implements Maps.EntryTransformer<String, Column.MemoizedValue<?>, Column<?>> {
+            implements Maps.EntryTransformer<String, Column.MemoizedValue, Column> {
 
         INSTANCE;
 
         @Override
-        public Column<?> transformEntry(@Nullable String s,
-                @Nullable Column.MemoizedValue<?> memoizedValue) {
+        public Column transformEntry(@Nullable String s,
+                                     @Nullable Column.MemoizedValue memoizedValue) {
             checkNotNull(s);
             checkNotNull(memoizedValue);
             return memoizedValue.getSourceColumn();

--- a/server/src/main/java/org/spine3/server/entity/storage/EntityRecordWithColumns.java
+++ b/server/src/main/java/org/spine3/server/entity/storage/EntityRecordWithColumns.java
@@ -27,6 +27,7 @@ import org.spine3.server.entity.Entity;
 import org.spine3.server.entity.EntityRecord;
 
 import javax.annotation.Nullable;
+import java.io.Serializable;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -36,10 +37,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @author Dmytro Dashenkov
  */
-public final class EntityRecordWithColumns {
+public final class EntityRecordWithColumns implements Serializable {
+
+    private static final long serialVersionUID = 1576133534602043154L;
 
     private final EntityRecord record;
-
     private final ImmutableMap<String, Column.MemoizedValue> storageFields;
     private final boolean hasStorageFields;
 

--- a/server/src/main/java/org/spine3/server/entity/storage/EntityRecordWithColumns.java
+++ b/server/src/main/java/org/spine3/server/entity/storage/EntityRecordWithColumns.java
@@ -143,9 +143,9 @@ public final class EntityRecordWithColumns implements Serializable {
             return false;
         }
 
-        EntityRecordWithColumns envelope = (EntityRecordWithColumns) o;
+        EntityRecordWithColumns other = (EntityRecordWithColumns) o;
 
-        return getRecord().equals(envelope.getRecord());
+        return getRecord().equals(other.getRecord());
     }
 
     @Override

--- a/server/src/main/java/org/spine3/server/entity/storage/QueryParameters.java
+++ b/server/src/main/java/org/spine3/server/entity/storage/QueryParameters.java
@@ -37,7 +37,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public final class QueryParameters implements Iterable<ColumnFilter> {
 
-    private final ImmutableMap<Column<?>, ColumnFilter> parameters;
+    private final ImmutableMap<Column, ColumnFilter> parameters;
 
     private QueryParameters(Builder builder) {
         this.parameters = builder.getParameters()
@@ -51,7 +51,7 @@ public final class QueryParameters implements Iterable<ColumnFilter> {
      * @param column the target {@link Column} of the result {@link ColumnFilter}
      * @return the corresponding {@link ColumnFilter}
      */
-    public Optional<ColumnFilter> get(Column<?> column) {
+    public Optional<ColumnFilter> get(Column column) {
         final ColumnFilter filter = parameters.get(column);
         return fromNullable(filter);
     }
@@ -93,7 +93,7 @@ public final class QueryParameters implements Iterable<ColumnFilter> {
      */
     public static class Builder {
 
-        private final ImmutableMap.Builder<Column<?>, ColumnFilter> parameters;
+        private final ImmutableMap.Builder<Column, ColumnFilter> parameters;
 
         private Builder() {
             parameters = ImmutableMap.builder();
@@ -105,7 +105,7 @@ public final class QueryParameters implements Iterable<ColumnFilter> {
          *
          * @return self for method chaining
          */
-        public Builder put(Column<?> column, ColumnFilter columnFilter) {
+        public Builder put(Column column, ColumnFilter columnFilter) {
             checkNotNull(column);
             checkNotNull(columnFilter);
 
@@ -114,7 +114,7 @@ public final class QueryParameters implements Iterable<ColumnFilter> {
             return this;
         }
 
-        private ImmutableMap.Builder<Column<?>, ColumnFilter> getParameters() {
+        private ImmutableMap.Builder<Column, ColumnFilter> getParameters() {
             return parameters;
         }
 

--- a/server/src/main/java/org/spine3/server/entity/storage/QueryParameters.java
+++ b/server/src/main/java/org/spine3/server/entity/storage/QueryParameters.java
@@ -25,6 +25,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import org.spine3.client.ColumnFilter;
 
+import java.io.Serializable;
 import java.util.Iterator;
 
 import static com.google.common.base.Optional.fromNullable;
@@ -35,7 +36,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @author Dmytro Dashenkov
  */
-public final class QueryParameters implements Iterable<ColumnFilter> {
+public final class QueryParameters implements Iterable<ColumnFilter>, Serializable {
+
+    private static final long serialVersionUID = 526400152015141524L;
 
     private final ImmutableMap<Column, ColumnFilter> parameters;
 

--- a/server/src/test/java/org/spine3/server/entity/storage/ColumnMemoizedValueShould.java
+++ b/server/src/test/java/org/spine3/server/entity/storage/ColumnMemoizedValueShould.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.server.entity.storage;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+import static com.google.common.testing.SerializableTester.reserializeAndAssert;
+import static org.mockito.Mockito.mock;
+import static org.spine3.server.entity.storage.Column.MemoizedValue;
+import static org.spine3.server.entity.storage.ColumnShould.TestEntity;
+import static org.spine3.server.entity.storage.Columns.findColumn;
+import static org.spine3.server.storage.LifecycleFlagField.archived;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public class ColumnMemoizedValueShould {
+
+    private static final String MUTABLE_STATE_COLUMN = "mutableState";
+    private static final String ARCHIVED_COLUMN = archived.name();
+
+    @Test
+    public void be_serializable() {
+        final Column column = findColumn(TestEntity.class, MUTABLE_STATE_COLUMN);
+        final TestEntity entity = new TestEntity("my-id");
+        entity.setMutableState(42);
+        final MemoizedValue value = column.memoizeFor(entity);
+
+        reserializeAndAssert(value);
+    }
+
+    @Test
+    public void support_equality() {
+        final Column columnA = findColumn(TestEntity.class, MUTABLE_STATE_COLUMN);
+        final Column columnB = findColumn(TestEntity.class, ARCHIVED_COLUMN);
+        final Column columnC = mock(Column.class);
+
+        final TestEntity entity = new TestEntity("ID");
+
+        final MemoizedValue valueA1 = columnA.memoizeFor(entity);
+        final MemoizedValue valueA2 = columnA.memoizeFor(entity);
+        final MemoizedValue valueA3 = columnA.memoizeFor(entity);
+
+        entity.setMutableState(42);
+
+        final MemoizedValue valueAMutated = columnA.memoizeFor(entity);
+
+        final MemoizedValue valueB = columnB.memoizeFor(entity);
+
+        final MemoizedValue valueC = new MemoizedValue(columnC, entity.getState());
+
+        new EqualsTester().addEqualityGroup(valueA1, valueA2, valueA3)
+                          .addEqualityGroup(valueAMutated)
+                          .addEqualityGroup(valueB)
+                          .addEqualityGroup(valueC)
+                          .testEquals();
+    }
+}

--- a/server/src/test/java/org/spine3/server/entity/storage/ColumnRecordsShould.java
+++ b/server/src/test/java/org/spine3/server/entity/storage/ColumnRecordsShould.java
@@ -82,7 +82,7 @@ public class ColumnRecordsShould {
         // Set up mocks and arguments
         final List<Object> destination = new ArrayList<>(MOCK_COLUMNS_COUNT);
 
-        final Map<String, Column.MemoizedValue<?>> columns = setupMockColumnsAllowingNulls();
+        final Map<String, Column.MemoizedValue> columns = setupMockColumnsAllowingNulls();
 
         final CollectAnyColumnType type = spy(CollectAnyColumnType.class);
         final ColumnTypeRegistry<CollectAnyColumnType> registry =
@@ -108,10 +108,10 @@ public class ColumnRecordsShould {
         assertContainsAll(destination, getNonNullColumnValues().toArray());
     }
 
-    private static Map<String, Column.MemoizedValue<?>> setupMockColumnsAllowingNulls() {
+    private static Map<String, Column.MemoizedValue> setupMockColumnsAllowingNulls() {
         final Column mockColumn = mock(Column.class);
         when(mockColumn.getType()).thenReturn(Object.class);
-        final Map<String, Column.MemoizedValue<?>> columns = new HashMap<>(MOCK_COLUMNS_COUNT);
+        final Map<String, Column.MemoizedValue> columns = new HashMap<>(MOCK_COLUMNS_COUNT);
         for (int i = 0; i < MOCK_COLUMNS_COUNT; i++) {
             final Integer columnValueToPersist = (i % 2 != 0) ? null : i;
 

--- a/server/src/test/java/org/spine3/server/entity/storage/ColumnShould.java
+++ b/server/src/test/java/org/spine3/server/entity/storage/ColumnShould.java
@@ -23,8 +23,9 @@ package org.spine3.server.entity.storage;
 import com.google.common.testing.EqualsTester;
 import com.google.protobuf.Any;
 import org.junit.Test;
+import org.spine3.base.Version;
 import org.spine3.server.entity.AbstractVersionableEntity;
-import org.spine3.server.entity.Entity;
+import org.spine3.server.entity.EntityWithLifecycle;
 import org.spine3.server.entity.VersionableEntity;
 import org.spine3.test.Given;
 
@@ -59,19 +60,21 @@ public class ColumnShould {
     @Test
     public void invoke_getter() {
         final String entityId = "entity-id";
-        final Column column = forMethod("getId", Entity.class);
+        final int version = 2;
+        final Column column = forMethod("getVersion", VersionableEntity.class);
         final TestEntity entity = Given.entityOfClass(TestEntity.class)
                                        .withId(entityId)
+                                       .withVersion(version)
                                        .build();
-        final String actualId = (String) column.getFor(entity);
-        assertEquals(entityId, actualId);
+        final Version actualVersion = (Version) column.getFor(entity);
+        assertEquals(version, actualVersion.getNumber());
     }
 
     @Test
     public void have_equals_and_hashCode() {
-        final Column col1 = forMethod("getId", Entity.class);
-        final Column col2 = forMethod("getId", Entity.class);
-        final Column col3 = forMethod("getState", Entity.class);
+        final Column col1 = forMethod("getVersion", VersionableEntity.class);
+        final Column col2 = forMethod("getVersion", VersionableEntity.class);
+        final Column col3 = forMethod("isDeleted", EntityWithLifecycle.class);
         new EqualsTester()
                 .addEqualityGroup(col1, col2)
                 .addEqualityGroup(col3)
@@ -187,12 +190,12 @@ public class ColumnShould {
             return 42L;
         }
 
-        public Object getNotNull() {
+        public String getNotNull() {
             return null;
         }
 
         @Nullable
-        public Object getNull() {
+        public String getNull() {
             return null;
         }
     }

--- a/server/src/test/java/org/spine3/server/entity/storage/ColumnShould.java
+++ b/server/src/test/java/org/spine3/server/entity/storage/ColumnShould.java
@@ -25,11 +25,13 @@ import com.google.protobuf.Any;
 import org.junit.Test;
 import org.spine3.server.entity.AbstractVersionableEntity;
 import org.spine3.server.entity.Entity;
+import org.spine3.server.entity.VersionableEntity;
 import org.spine3.test.Given;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.Method;
 
+import static com.google.common.testing.SerializableTester.reserializeAndAssert;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -42,8 +44,14 @@ import static org.junit.Assert.assertTrue;
 @SuppressWarnings("DuplicateStringLiteralInspection") // Many string literals for method names
 public class ColumnShould {
 
+    @Test
+    public void be_serializable() {
+        final Column column = forMethod("getVersion", VersionableEntity.class);
+        reserializeAndAssert(column);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void costruct_for_getter_method_only() {
+    public void construct_for_getter_method_only() {
         forMethod("toString", Object.class);
     }
 
@@ -146,12 +154,12 @@ public class ColumnShould {
         assertSame(column, memoizedValue.getSourceColumn());
     }
 
-    private static <T> Column forMethod(String name, Class<?> enclosingClass) {
+    private static Column forMethod(String name, Class<?> enclosingClass) {
         try {
             final Method result = enclosingClass.getDeclaredMethod(name);
             return Column.from(result);
         } catch (NoSuchMethodException e) {
-            throw new AssertionError(e.getMessage());
+            throw new RuntimeException(e);
         }
     }
 

--- a/server/src/test/java/org/spine3/server/entity/storage/ColumnShould.java
+++ b/server/src/test/java/org/spine3/server/entity/storage/ColumnShould.java
@@ -50,19 +50,19 @@ public class ColumnShould {
     @Test
     public void invoke_getter() {
         final String entityId = "entity-id";
-        final Column<String> column = forMethod("getId", Entity.class);
+        final Column column = forMethod("getId", Entity.class);
         final TestEntity entity = Given.entityOfClass(TestEntity.class)
                                        .withId(entityId)
                                        .build();
-        final String actualId = column.getFor(entity);
+        final String actualId = (String) column.getFor(entity);
         assertEquals(entityId, actualId);
     }
 
     @Test
     public void have_equals_and_hashCode() {
-        final Column<?> col1 = forMethod("getId", Entity.class);
-        final Column<?> col2 = forMethod("getId", Entity.class);
-        final Column<?> col3 = forMethod("getState", Entity.class);
+        final Column col1 = forMethod("getId", Entity.class);
+        final Column col2 = forMethod("getId", Entity.class);
+        final Column col3 = forMethod("getState", Entity.class);
         new EqualsTester()
                 .addEqualityGroup(col1, col2)
                 .addEqualityGroup(col3)
@@ -71,55 +71,54 @@ public class ColumnShould {
 
     @Test
     public void memoize_value_at_at_point_in_time() {
-        final Column<Integer> mutableColumn = forMethod("getMutableState", TestEntity.class);
+        final Column mutableColumn = forMethod("getMutableState", TestEntity.class);
         final TestEntity entity = new TestEntity("");
         final int initialState = 1;
         final int changedState = 42;
         entity.setMutableState(initialState);
-        final Column.MemoizedValue<Integer> memoizedState = mutableColumn.memoizeFor(entity);
+        final Column.MemoizedValue memoizedState = mutableColumn.memoizeFor(entity);
         entity.setMutableState(changedState);
-        final int extractedState = mutableColumn.getFor(entity);
+        final int extractedState = (int) mutableColumn.getFor(entity);
 
-        assertEquals(initialState, memoizedState.getValue()
-                                                .intValue());
+        assertEquals(initialState, ((Integer) memoizedState.getValue()).intValue());
         assertEquals(changedState, extractedState);
     }
 
     @Test(expected = IllegalStateException.class)
     public void fail_to_get_value_from_private_method() {
-        final Column<Long> column = forMethod("getFortyTwoLong", TestEntity.class);
+        final Column column = forMethod("getFortyTwoLong", TestEntity.class);
         column.getFor(new TestEntity(""));
     }
 
     @Test(expected = IllegalStateException.class)
     public void fail_to_memoize_value_from_private_method() {
-        final Column<Long> column = forMethod("getFortyTwoLong", TestEntity.class);
+        final Column column = forMethod("getFortyTwoLong", TestEntity.class);
         column.memoizeFor(new TestEntity(""));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void fail_to_get_value_from_wrong_object() {
-        final Column<Long> column = forMethod("getMutableState", TestEntity.class);
+        final Column column = forMethod("getMutableState", TestEntity.class);
         column.getFor(new DifferentTestEntity(""));
     }
 
     @Test(expected = NullPointerException.class)
     public void check_value_if_getter_is_not_null() {
-        final Column<?> column = forMethod("getNotNull", TestEntity.class);
+        final Column column = forMethod("getNotNull", TestEntity.class);
         column.getFor(new TestEntity(""));
     }
 
     @Test
     public void allow_nulls_if_getter_is_nullable() {
-        final Column<?> column = forMethod("getNull", TestEntity.class);
+        final Column column = forMethod("getNull", TestEntity.class);
         final Object value = column.getFor(new TestEntity(""));
         assertNull(value);
     }
 
     @Test
     public void tell_if_property_is_nullable() {
-        final Column<?> notNullColumn = forMethod("getNotNull", TestEntity.class);
-        final Column<?> nullableColumn = forMethod("getNull", TestEntity.class);
+        final Column notNullColumn = forMethod("getNotNull", TestEntity.class);
+        final Column nullableColumn = forMethod("getNull", TestEntity.class);
 
         assertFalse(notNullColumn.isNullable());
         assertTrue(nullableColumn.isNullable());
@@ -127,27 +126,27 @@ public class ColumnShould {
 
     @Test
     public void contain_property_type() {
-        final Column<Long> column = forMethod("getFortyTwoLong", TestEntity.class);
+        final Column column = forMethod("getFortyTwoLong", TestEntity.class);
         assertEquals(Long.TYPE, column.getType());
     }
 
     @Test
     public void memoize_value_regarding_nulls() {
-        final Column<?> nullableColumn = forMethod("getNull", TestEntity.class);
-        final Column.MemoizedValue<?> memoizedNull = nullableColumn.memoizeFor(new TestEntity(""));
+        final Column nullableColumn = forMethod("getNull", TestEntity.class);
+        final Column.MemoizedValue memoizedNull = nullableColumn.memoizeFor(new TestEntity(""));
         assertTrue(memoizedNull.isNull());
         assertNull(memoizedNull.getValue());
     }
 
     @Test
     public void memoize_value_which_has_reference_on_Column_itself() {
-        final Column<Long> column = forMethod("getMutableState", TestEntity.class);
+        final Column column = forMethod("getMutableState", TestEntity.class);
         final TestEntity entity = new TestEntity("");
-        final Column.MemoizedValue<Long> memoizedValue = column.memoizeFor(entity);
+        final Column.MemoizedValue memoizedValue = column.memoizeFor(entity);
         assertSame(column, memoizedValue.getSourceColumn());
     }
 
-    private static <T> Column<T> forMethod(String name, Class<?> enclosingClass) {
+    private static <T> Column forMethod(String name, Class<?> enclosingClass) {
         try {
             final Method result = enclosingClass.getDeclaredMethod(name);
             return Column.from(result);

--- a/server/src/test/java/org/spine3/server/entity/storage/ColumnShould.java
+++ b/server/src/test/java/org/spine3/server/entity/storage/ColumnShould.java
@@ -34,6 +34,7 @@ import java.lang.reflect.Method;
 import static com.google.common.testing.SerializableTester.reserializeAndAssert;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -88,7 +89,9 @@ public class ColumnShould {
         entity.setMutableState(changedState);
         final int extractedState = (int) mutableColumn.getFor(entity);
 
-        assertEquals(initialState, ((Integer) memoizedState.getValue()).intValue());
+        final Integer value = (Integer) memoizedState.getValue();
+        assertNotNull(value);
+        assertEquals(initialState, value.intValue());
         assertEquals(changedState, extractedState);
     }
 

--- a/server/src/test/java/org/spine3/server/entity/storage/ColumnTypeRegistryShould.java
+++ b/server/src/test/java/org/spine3/server/entity/storage/ColumnTypeRegistryShould.java
@@ -104,9 +104,9 @@ public class ColumnTypeRegistryShould {
         assertEquals(integerColumnType, intColumnType);
     }
 
-    private static <T> Column<T> mockProperty(Class<T> cls) {
+    private static <T> Column mockProperty(Class<T> cls) {
         @SuppressWarnings("unchecked")
-        final Column<T> column = (Column<T>) mock(Column.class);
+        final Column column = (Column) mock(Column.class);
         when(column.getType()).thenReturn(cls);
         return column;
     }

--- a/server/src/test/java/org/spine3/server/entity/storage/ColumnsShould.java
+++ b/server/src/test/java/org/spine3/server/entity/storage/ColumnsShould.java
@@ -68,7 +68,7 @@ public class ColumnsShould {
 
     @Test
     public void return_empty_map() {
-        final Map<String, Column.MemoizedValue<?>> emptyFields = Collections.emptyMap();
+        final Map<String, Column.MemoizedValue> emptyFields = Collections.emptyMap();
         assertNotNull(emptyFields);
         assertEmpty(emptyFields);
     }
@@ -76,7 +76,7 @@ public class ColumnsShould {
     @Test
     public void extract_no_fields_if_none_defined() {
         final Entity entity = new EntityWithNoStorageFields(STRING_ID);
-        final Map<String, Column.MemoizedValue<?>> fields = Columns.from(entity);
+        final Map<String, Column.MemoizedValue> fields = Columns.from(entity);
         assertNotNull(fields);
         assertEmpty(fields);
     }
@@ -84,14 +84,14 @@ public class ColumnsShould {
     @Test
     public void put_non_null_fields_to_fields_maps() {
         final EntityWithManyGetters entity = new EntityWithManyGetters(STRING_ID);
-        final Map<String, Column.MemoizedValue<?>> fields = Columns.from(entity);
+        final Map<String, Column.MemoizedValue> fields = Columns.from(entity);
         assertNotNull(fields);
 
         assertSize(3, fields);
 
         final String floatNullKey = "floatNull";
-        @SuppressWarnings("unchecked") final Column.MemoizedValue<Float> floatMemoizedNull =
-                (Column.MemoizedValue<Float>) fields.get(floatNullKey);
+        @SuppressWarnings("unchecked") final Column.MemoizedValue floatMemoizedNull =
+                (Column.MemoizedValue) fields.get(floatNullKey);
         assertNotNull(floatMemoizedNull);
         assertNull(floatMemoizedNull.getValue());
 
@@ -108,9 +108,9 @@ public class ColumnsShould {
 
     @Test
     public void ignore_static_members() {
-        final Map<String, Column.MemoizedValue<?>> fields =
+        final Map<String, Column.MemoizedValue> fields =
                 Columns.from(new EntityWithManyGetters(STRING_ID));
-        final Column.MemoizedValue<?> staticValue = fields.get("staticMember");
+        final Column.MemoizedValue staticValue = fields.get("staticMember");
         assertNull(staticValue);
     }
 
@@ -147,7 +147,7 @@ public class ColumnsShould {
     public void retrieve_column_metadata_from_given_class() {
         final Class<? extends Entity<?, ?>> entityClass = RealLifeEntity.class;
         final String existingColumnName = "archived";
-        final Column<?> archivedColumn = Columns.findColumn(entityClass, existingColumnName);
+        final Column archivedColumn = Columns.findColumn(entityClass, existingColumnName);
         assertNotNull(archivedColumn);
         assertEquals(existingColumnName, archivedColumn.getName());
     }

--- a/server/src/test/java/org/spine3/server/entity/storage/ColumnsShould.java
+++ b/server/src/test/java/org/spine3/server/entity/storage/ColumnsShould.java
@@ -22,7 +22,6 @@ package org.spine3.server.entity.storage;
 
 import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Any;
-import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
 import org.junit.Test;
 import org.spine3.server.entity.AbstractEntity;
@@ -168,7 +167,7 @@ public class ColumnsShould {
     @SuppressWarnings("unused")  // Reflective access
     public static class EntityWithManyGetters extends AbstractEntity<String, Any> {
 
-        private final Message someMessage = Sample.messageOfType(Project.class);
+        private final Project someMessage = Sample.messageOfType(Project.class);
 
         protected EntityWithManyGetters(String id) {
             super(id);
@@ -183,7 +182,7 @@ public class ColumnsShould {
             return null;
         }
 
-        public Message getSomeMessage() {
+        public Project getSomeMessage() {
             return someMessage;
         }
 

--- a/server/src/test/java/org/spine3/server/entity/storage/EntityQueryMatcherShould.java
+++ b/server/src/test/java/org/spine3/server/entity/storage/EntityQueryMatcherShould.java
@@ -30,6 +30,7 @@ import org.spine3.test.entity.ProjectId;
 import org.spine3.test.entity.TaskId;
 import org.spine3.testdata.Sample;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -82,11 +83,11 @@ public class EntityQueryMatcherShould {
     @Test
     public void match_columns() {
         final String targetName = "feature";
-        final Column<?> target = mock(Column.class);
+        final Column target = mock(Column.class);
         when(target.isNullable()).thenReturn(true);
         when(target.getName()).thenReturn(targetName);
-        when(target.getType()).thenReturn((Class) Boolean.class);
-        final Object acceptedValue = true;
+        when(target.getType()).thenReturn(Boolean.class);
+        final Serializable acceptedValue = true;
 
         final Collection<Object> ids = Collections.emptyList();
         final QueryParameters params = QueryParameters.newBuilder()
@@ -107,8 +108,8 @@ public class EntityQueryMatcherShould {
         final Column.MemoizedValue storedValue = mock(Column.MemoizedValue.class);
         when(storedValue.getSourceColumn()).thenReturn(target);
         when(storedValue.getValue()).thenReturn(acceptedValue);
-        final Map<String, Column.MemoizedValue<?>> matchingColumns =
-                ImmutableMap.<String, Column.MemoizedValue<?>>of(targetName, storedValue);
+        final Map<String, Column.MemoizedValue> matchingColumns =
+                ImmutableMap.<String, Column.MemoizedValue>of(targetName, storedValue);
         final EntityRecordWithColumns nonMatchingRecord = of(nonMatching);
         final EntityRecordWithColumns matchingRecord = of(matching, matchingColumns);
 

--- a/server/src/test/java/org/spine3/server/entity/storage/EntityQueryShould.java
+++ b/server/src/test/java/org/spine3/server/entity/storage/EntityQueryShould.java
@@ -70,7 +70,7 @@ public class EntityQueryShould {
 
     private static void addEqualityGroupA(EqualsTester tester) {
         final Collection<?> ids = Arrays.asList(Sample.messageOfType(ProjectId.class), 0);
-        final Map<Column<?>, Object> params = new IdentityHashMap<>(2);
+        final Map<Column, Object> params = new IdentityHashMap<>(2);
         params.put(mockColumn(), "anything");
         params.put(mockColumn(), 5);
         final EntityQuery<?> query = EntityQuery.of(ids, paramsFromValues(params));
@@ -79,7 +79,7 @@ public class EntityQueryShould {
 
     private static void addEqualityGroupB(EqualsTester tester) {
         final Collection<?> ids = emptyList();
-        final Map<Column<?>, Object> params = new HashMap<>(1);
+        final Map<Column, Object> params = new HashMap<>(1);
         params.put(mockColumn(), 5);
         final EntityQuery<?> query1 = EntityQuery.of(ids, paramsFromValues(params));
         final EntityQuery<?> query2 = EntityQuery.of(ids, paramsFromValues(params));
@@ -88,11 +88,11 @@ public class EntityQueryShould {
 
     private static void addEqualityGroupC(EqualsTester tester) {
         final Collection<?> ids = emptySet();
-        final Column<?> column = mockColumn();
+        final Column column = mockColumn();
         final Object value = 42;
-        final Map<Column<?>, Object> params1 = new HashMap<>(1);
+        final Map<Column, Object> params1 = new HashMap<>(1);
         params1.put(column, value);
-        final Map<Column<?>, Object> params2 = new HashMap<>(1);
+        final Map<Column, Object> params2 = new HashMap<>(1);
         params2.put(column, value);
         final EntityQuery<?> query1 = EntityQuery.of(ids, paramsFromValues(params1));
         final EntityQuery<?> query2 = EntityQuery.of(ids, paramsFromValues(params2));
@@ -101,7 +101,7 @@ public class EntityQueryShould {
 
     private static void addEqualityGroupD(EqualsTester tester) {
         final Collection<ProjectId> ids = singleton(Sample.messageOfType(ProjectId.class));
-        final Map<Column<?>, Object> columns = Collections.emptyMap();
+        final Map<Column, Object> columns = Collections.emptyMap();
         final EntityQuery<?> query = EntityQuery.of(ids, paramsFromValues(columns));
         tester.addEqualityGroup(query);
     }
@@ -110,10 +110,10 @@ public class EntityQueryShould {
     public void support_toString() {
         final Object someId = Sample.messageOfType(ProjectId.class);
         final Collection<Object> ids = singleton(someId);
-        final Column<?> someColumn = mockColumn();
+        final Column someColumn = mockColumn();
         final Object someValue = "something";
 
-        final Map<Column<?>, Object> params = new HashMap<>(1);
+        final Map<Column, Object> params = new HashMap<>(1);
         params.put(someColumn, someValue);
 
         final EntityQuery query = EntityQuery.of(ids, paramsFromValues(params));
@@ -125,17 +125,17 @@ public class EntityQueryShould {
                             .toString(), repr);
     }
 
-    private static <T> Column<T> mockColumn() {
+    private static <T> Column mockColumn() {
         @SuppressWarnings("unchecked") // Mock cannot have type parameters
-        final Column<T> column = mock(Column.class);
+        final Column column = mock(Column.class);
         when(column.getName()).thenReturn("mockColumn");
         return column;
     }
 
-    private static QueryParameters paramsFromValues(Map<Column<?>, Object> values) {
+    private static QueryParameters paramsFromValues(Map<Column, Object> values) {
         final QueryParameters.Builder builder = QueryParameters.newBuilder();
-        for (Map.Entry<Column<?>, Object> param : values.entrySet()) {
-            final Column<?> column = param.getKey();
+        for (Map.Entry<Column, Object> param : values.entrySet()) {
+            final Column column = param.getKey();
             final ColumnFilter filter = ColumnFilter.newBuilder()
                                                     .setOperator(EQUAL)
                                                     .setValue(toAny(param.getValue()))

--- a/server/src/test/java/org/spine3/server/entity/storage/EntityQueryShould.java
+++ b/server/src/test/java/org/spine3/server/entity/storage/EntityQueryShould.java
@@ -24,7 +24,9 @@ import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
 import org.junit.Test;
 import org.spine3.client.ColumnFilter;
+import org.spine3.client.ColumnFilters;
 import org.spine3.client.EntityIdFilter;
+import org.spine3.server.entity.EntityWithLifecycle;
 import org.spine3.test.entity.ProjectId;
 import org.spine3.testdata.Sample;
 
@@ -34,7 +36,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Set;
 
+import static com.google.common.testing.SerializableTester.reserializeAndAssert;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
@@ -48,6 +52,19 @@ import static org.spine3.test.Verify.assertContains;
  * @author Dmytro Dashenkov
  */
 public class EntityQueryShould {
+
+    @Test
+    public void be_serializable() {
+        final String columnName = "deleted";
+        final Column column = Columns.findColumn(EntityWithLifecycle.class, columnName);
+        final ColumnFilter filter = ColumnFilters.eq(columnName, false);
+        final QueryParameters parameters = QueryParameters.newBuilder()
+                                                          .put(column, filter)
+                                                          .build();
+        final Set<String> ids = singleton("my-awesome-id");
+        final EntityQuery<String> query = EntityQuery.of(ids, parameters);
+        reserializeAndAssert(query);
+    }
 
     @Test
     public void not_accept_nulls() {

--- a/server/src/test/java/org/spine3/server/entity/storage/EntityRecordWithColumnsShould.java
+++ b/server/src/test/java/org/spine3/server/entity/storage/EntityRecordWithColumnsShould.java
@@ -47,7 +47,7 @@ public class EntityRecordWithColumnsShould {
     public void initialize_with_record_and_storage_fields() {
         final EntityRecordWithColumns record =
                 EntityRecordWithColumns.of(EntityRecord.getDefaultInstance(),
-                                           Collections.<String, Column.MemoizedValue<?>>emptyMap());
+                                           Collections.<String, Column.MemoizedValue>emptyMap());
         assertNotNull(record);
     }
 
@@ -74,35 +74,35 @@ public class EntityRecordWithColumnsShould {
 
     @Test
     public void store_column_values() {
-        final Column.MemoizedValue<?> mockValue = mock(Column.MemoizedValue.class);
-        final Map<String, Column.MemoizedValue<?>> columnsExpected =
-                Collections.<String, Column.MemoizedValue<?>>singletonMap("some-key", mockValue);
+        final Column.MemoizedValue mockValue = mock(Column.MemoizedValue.class);
+        final Map<String, Column.MemoizedValue> columnsExpected =
+                Collections.<String, Column.MemoizedValue>singletonMap("some-key", mockValue);
 
         final EntityRecordWithColumns record =
                 EntityRecordWithColumns.of(Sample.messageOfType(EntityRecord.class),
                                            columnsExpected);
         assertTrue(record.hasColumns());
 
-        final Map<String, Column.MemoizedValue<?>> columnsActual =
+        final Map<String, Column.MemoizedValue> columnsActual =
                 record.getColumnValues();
         assertMapsEqual(columnsExpected, columnsActual, "column values");
     }
 
     @Test
     public void store_column_definitions() {
-        final Column.MemoizedValue<?> mockValue = mock(Column.MemoizedValue.class);
+        final Column.MemoizedValue mockValue = mock(Column.MemoizedValue.class);
         final Column mockColumn = mock(Column.class);
         when(mockValue.getSourceColumn()).thenReturn(mockColumn);
 
         final String key = "arbitrary";
-        final Map<String, Column.MemoizedValue<?>> columnsExpected =
-                Collections.<String, Column.MemoizedValue<?>>singletonMap(key, mockValue);
+        final Map<String, Column.MemoizedValue> columnsExpected =
+                Collections.<String, Column.MemoizedValue>singletonMap(key, mockValue);
 
         final EntityRecordWithColumns record =
                 EntityRecordWithColumns.of(Sample.messageOfType(EntityRecord.class),
                                            columnsExpected);
         assertTrue(record.hasColumns());
-        final Map<String, Column<?>> columnsActual = record.getColumns();
+        final Map<String, Column> columnsActual = record.getColumns();
         assertContainsKeyValue(key, mockColumn, columnsActual);
     }
 
@@ -112,25 +112,25 @@ public class EntityRecordWithColumnsShould {
         final EntityRecordWithColumns record =
                 EntityRecordWithColumns.of(EntityRecord.getDefaultInstance());
         assertFalse(record.hasColumns());
-        final Map<String, Column.MemoizedValue<?>> fields = record.getColumnValues();
+        final Map<String, Column.MemoizedValue> fields = record.getColumnValues();
         assertEmpty(fields);
     }
 
     @Test
     public void have_equals() {
-        final Column.MemoizedValue<?> mockValue = mock(Column.MemoizedValue.class);
+        final Column.MemoizedValue mockValue = mock(Column.MemoizedValue.class);
         final EntityRecordWithColumns noFieldsEnvelope =
                 EntityRecordWithColumns.of(EntityRecord.getDefaultInstance()
                 );
         final EntityRecordWithColumns emptyFieldsEnvelope =
                 EntityRecordWithColumns.of(
                         EntityRecord.getDefaultInstance(),
-                        Collections.<String, Column.MemoizedValue<?>>emptyMap()
+                        Collections.<String, Column.MemoizedValue>emptyMap()
                 );
         final EntityRecordWithColumns notEmptyFieldsEnvelope =
                 EntityRecordWithColumns.of(
                         EntityRecord.getDefaultInstance(),
-                        Collections.<String, Column.MemoizedValue<?>>singletonMap("key", mockValue)
+                        Collections.<String, Column.MemoizedValue>singletonMap("key", mockValue)
                 );
         new EqualsTester()
                 .addEqualityGroup(noFieldsEnvelope, emptyFieldsEnvelope, notEmptyFieldsEnvelope)
@@ -141,6 +141,6 @@ public class EntityRecordWithColumnsShould {
 
     private static EntityRecordWithColumns newRecord() {
         return EntityRecordWithColumns.of(Sample.messageOfType(EntityRecord.class),
-                                          Collections.<String, Column.MemoizedValue<?>>emptyMap());
+                                          Collections.<String, Column.MemoizedValue>emptyMap());
     }
 }

--- a/server/src/test/java/org/spine3/server/entity/storage/EntityRecordWithColumnsShould.java
+++ b/server/src/test/java/org/spine3/server/entity/storage/EntityRecordWithColumnsShould.java
@@ -23,17 +23,25 @@ package org.spine3.server.entity.storage;
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
 import org.junit.Test;
+import org.spine3.server.entity.AbstractVersionableEntity;
 import org.spine3.server.entity.EntityRecord;
+import org.spine3.server.entity.VersionableEntity;
+import org.spine3.test.Given;
+import org.spine3.test.entity.Project;
 import org.spine3.testdata.Sample;
 
 import java.util.Collections;
 import java.util.Map;
 
+import static com.google.common.testing.SerializableTester.reserializeAndAssert;
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.spine3.server.entity.storage.Column.MemoizedValue;
+import static org.spine3.server.entity.storage.EntityRecordWithColumns.of;
 import static org.spine3.test.Verify.assertContainsKeyValue;
 import static org.spine3.test.Verify.assertEmpty;
 import static org.spine3.test.Verify.assertMapsEqual;
@@ -44,17 +52,31 @@ import static org.spine3.test.Verify.assertMapsEqual;
 public class EntityRecordWithColumnsShould {
 
     @Test
+    public void be_serializable() {
+        final EntityRecord record = Sample.messageOfType(EntityRecord.class);
+        final VersionableEntity<?, ?> entity = Given.entityOfClass(TestEntity.class)
+                                                    .withVersion(1)
+                                                    .build();
+        final String columnName = "version";
+        final Column column = Columns.findColumn(VersionableEntity.class, columnName);
+        final MemoizedValue value = column.memoizeFor(entity);
+
+        final Map<String, Column.MemoizedValue> columns = singletonMap(columnName, value);
+        final EntityRecordWithColumns recordWithColumns = of(record, columns);
+        reserializeAndAssert(recordWithColumns);
+    }
+
+    @Test
     public void initialize_with_record_and_storage_fields() {
-        final EntityRecordWithColumns record =
-                EntityRecordWithColumns.of(EntityRecord.getDefaultInstance(),
-                                           Collections.<String, Column.MemoizedValue>emptyMap());
+        final EntityRecordWithColumns record = of(EntityRecord.getDefaultInstance(),
+                                                  Collections.<String, MemoizedValue>emptyMap());
         assertNotNull(record);
     }
 
     @Test
     public void initialize_with_record_only() {
         final EntityRecordWithColumns record =
-                EntityRecordWithColumns.of(EntityRecord.getDefaultInstance());
+                of(EntityRecord.getDefaultInstance());
         assertNotNull(record);
     }
 
@@ -74,13 +96,13 @@ public class EntityRecordWithColumnsShould {
 
     @Test
     public void store_column_values() {
-        final Column.MemoizedValue mockValue = mock(Column.MemoizedValue.class);
+        final MemoizedValue mockValue = mock(MemoizedValue.class);
         final Map<String, Column.MemoizedValue> columnsExpected =
-                Collections.<String, Column.MemoizedValue>singletonMap("some-key", mockValue);
+                Collections.<String, MemoizedValue>singletonMap("some-key", mockValue);
 
         final EntityRecordWithColumns record =
-                EntityRecordWithColumns.of(Sample.messageOfType(EntityRecord.class),
-                                           columnsExpected);
+                of(Sample.messageOfType(EntityRecord.class),
+                   columnsExpected);
         assertTrue(record.hasColumns());
 
         final Map<String, Column.MemoizedValue> columnsActual =
@@ -90,27 +112,26 @@ public class EntityRecordWithColumnsShould {
 
     @Test
     public void store_column_definitions() {
-        final Column.MemoizedValue mockValue = mock(Column.MemoizedValue.class);
+        final MemoizedValue mockValue = mock(MemoizedValue.class);
         final Column mockColumn = mock(Column.class);
         when(mockValue.getSourceColumn()).thenReturn(mockColumn);
 
         final String key = "arbitrary";
         final Map<String, Column.MemoizedValue> columnsExpected =
-                Collections.<String, Column.MemoizedValue>singletonMap(key, mockValue);
+                Collections.<String, MemoizedValue>singletonMap(key, mockValue);
 
         final EntityRecordWithColumns record =
-                EntityRecordWithColumns.of(Sample.messageOfType(EntityRecord.class),
-                                           columnsExpected);
+                of(Sample.messageOfType(EntityRecord.class),
+                   columnsExpected);
         assertTrue(record.hasColumns());
         final Map<String, Column> columnsActual = record.getColumns();
         assertContainsKeyValue(key, mockColumn, columnsActual);
     }
 
-
     @Test
     public void return_empty_map_if_no_storage_fields() {
         final EntityRecordWithColumns record =
-                EntityRecordWithColumns.of(EntityRecord.getDefaultInstance());
+                of(EntityRecord.getDefaultInstance());
         assertFalse(record.hasColumns());
         final Map<String, Column.MemoizedValue> fields = record.getColumnValues();
         assertEmpty(fields);
@@ -118,19 +139,19 @@ public class EntityRecordWithColumnsShould {
 
     @Test
     public void have_equals() {
-        final Column.MemoizedValue mockValue = mock(Column.MemoizedValue.class);
+        final MemoizedValue mockValue = mock(MemoizedValue.class);
         final EntityRecordWithColumns noFieldsEnvelope =
-                EntityRecordWithColumns.of(EntityRecord.getDefaultInstance()
+                of(EntityRecord.getDefaultInstance()
                 );
         final EntityRecordWithColumns emptyFieldsEnvelope =
-                EntityRecordWithColumns.of(
+                of(
                         EntityRecord.getDefaultInstance(),
-                        Collections.<String, Column.MemoizedValue>emptyMap()
+                        Collections.<String, MemoizedValue>emptyMap()
                 );
         final EntityRecordWithColumns notEmptyFieldsEnvelope =
-                EntityRecordWithColumns.of(
+                of(
                         EntityRecord.getDefaultInstance(),
-                        Collections.<String, Column.MemoizedValue>singletonMap("key", mockValue)
+                        Collections.<String, MemoizedValue>singletonMap("key", mockValue)
                 );
         new EqualsTester()
                 .addEqualityGroup(noFieldsEnvelope, emptyFieldsEnvelope, notEmptyFieldsEnvelope)
@@ -140,7 +161,14 @@ public class EntityRecordWithColumnsShould {
     }
 
     private static EntityRecordWithColumns newRecord() {
-        return EntityRecordWithColumns.of(Sample.messageOfType(EntityRecord.class),
-                                          Collections.<String, Column.MemoizedValue>emptyMap());
+        return of(Sample.messageOfType(EntityRecord.class),
+                  Collections.<String, MemoizedValue>emptyMap());
+    }
+
+    public static class TestEntity extends AbstractVersionableEntity<String, Project> {
+
+        protected TestEntity(String id) {
+            super(id);
+        }
     }
 }

--- a/server/src/test/java/org/spine3/server/entity/storage/QueryParametersShould.java
+++ b/server/src/test/java/org/spine3/server/entity/storage/QueryParametersShould.java
@@ -26,7 +26,9 @@ import com.google.common.testing.EqualsTester;
 import org.junit.Test;
 import org.spine3.client.ColumnFilter;
 import org.spine3.client.ColumnFilters;
+import org.spine3.server.entity.VersionableEntity;
 
+import static com.google.common.testing.SerializableTester.reserializeAndAssert;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -42,6 +44,17 @@ import static org.spine3.time.Time.getCurrentTime;
  * @author Dmytro Dashenkov
  */
 public class QueryParametersShould {
+
+    @Test
+    public void be_serializable() {
+        final String columnName = "version";
+        final Column column = Columns.findColumn(VersionableEntity.class, columnName);
+        final ColumnFilter filter = ColumnFilters.eq(columnName, 1);
+        final QueryParameters parameters = QueryParameters.newBuilder()
+                                                          .put(column, filter)
+                                                          .build();
+        reserializeAndAssert(parameters);
+    }
 
     @Test
     public void construct_from_empty_builder() {


### PR DESCRIPTION
Since we need to pass the Entity Columns values and queries between several instances of JVM, we need to make `Column` class and the aggregating types `Serializable`.

Also, in this PR we revoke the type parameter from the `Column` class since it created no compile-time checks, but only `"unchecked"` warnings.