### PR TITLE
Rename ConstraintViolationThrowable to ConstraintViolationException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
         
-        spineVersion = '0.9.9-SNAPSHOT'
+        spineVersion = '0.9.10-SNAPSHOT'
         
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all
         // the components and change the version of the dependency below to

--- a/client/src/main/java/org/spine3/validate/ConstraintViolationException.java
+++ b/client/src/main/java/org/spine3/validate/ConstraintViolationException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.validate;
+
+import java.util.List;
+
+import static java.util.Collections.unmodifiableList;
+
+/**
+ * Signals that the validated value violates the constraints set for it.
+ *
+ * @author Illia Shepilov
+ */
+public class ConstraintViolationException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<ConstraintViolation> constraintViolations;
+
+    public ConstraintViolationException(List<ConstraintViolation> constraintViolations) {
+        super();
+        this.constraintViolations = constraintViolations;
+    }
+
+    public List<ConstraintViolation> getConstraintViolations() {
+        return unmodifiableList(constraintViolations);
+    }
+}

--- a/client/src/main/java/org/spine3/validate/ConstraintViolationThrowable.java
+++ b/client/src/main/java/org/spine3/validate/ConstraintViolationThrowable.java
@@ -26,7 +26,7 @@ import static java.util.Collections.unmodifiableList;
 
 /**
  * Signals that the validated value violates the constraints set for it.
- *
+ * @deprecated due to changing to a new class name {@link ConstraintViolationException}.
  * @author Illia Shepilov
  */
 @Deprecated

--- a/client/src/main/java/org/spine3/validate/ConstraintViolationThrowable.java
+++ b/client/src/main/java/org/spine3/validate/ConstraintViolationThrowable.java
@@ -29,6 +29,7 @@ import static java.util.Collections.unmodifiableList;
  *
  * @author Illia Shepilov
  */
+@Deprecated
 public class ConstraintViolationThrowable extends RuntimeException {
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
This PR addresses #482 issue.
In order to make the naming consistent, we should perform the renaming of `ConstraintViolationThrowable` to `ConstraintViolationException`.