### PR TITLE
Change Google Cloud Storage configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -326,5 +326,5 @@ cleanGCS {
     authKeyPath = "gcs-auth-key.json"
     bucketName = properties.getProperty("artifacts.bucket")
     targetFolder = properties.getProperty("artifacts.folder")
-    threshold = TimeCategory.getDays(30)
+    threshold = TimeCategory.getDays(5)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -326,5 +326,5 @@ cleanGCS {
     authKeyPath = "gcs-auth-key.json"
     bucketName = properties.getProperty("artifacts.bucket")
     targetFolder = properties.getProperty("artifacts.folder")
-    threshold = TimeCategory.getDays(5)
+    threshold = TimeCategory.getDays(10)
 }

--- a/scripts/upload-artifacts.sh
+++ b/scripts/upload-artifacts.sh
@@ -19,6 +19,6 @@ dpl --provider=gcs \
     --access-key-id=GOOGX66ER6DXLZH7IKQF \
     --secret-access-key=${GCS_SECRET} \
     --bucket="$(getProp 'artifacts.bucket')" \
-    --upload-dir="$(getProp 'artifacts.folder')"/${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}-${TRAVIS_BUILD_NUMBER} \
+    --upload-dir="$(getProp 'artifacts.folder')"/${TRAVIS_BUILD_NUMBER}-${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} \
     --local-dir=reports \
     --skip_cleanup=true


### PR DESCRIPTION
This PR enables more convenient configuration related to uploading artifacts to Google Cloud Storage.

Summary:
- Path for artifacts was changed to `core-java/builds/TRAVIS_BUILD_NUMBER-BRANCH_NAME`.
- Cleaning threshold was set to 10 days.