### PR TITLE
Manage annotations under `org.spine3.annotation` package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
         
-        spineVersion = '0.9.11-SNAPSHOT'
+        spineVersion = '0.9.12-SNAPSHOT'
         
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all
         // the components and change the version of the dependency below to

--- a/client/src/main/java/org/spine3/annotation/Beta.java
+++ b/client/src/main/java/org/spine3/annotation/Beta.java
@@ -35,8 +35,6 @@ import java.lang.annotation.Target;
  * quality of the API in question, only the fact that it is not "API-frozen."
  * It is generally safe for applications to depend on beta APIs, at the cost of some extra work
  * during upgrades.
- *
- * @author Dmytro Grankin
  */
 @Retention(RetentionPolicy.SOURCE)
 @Target({

--- a/client/src/main/java/org/spine3/annotation/Beta.java
+++ b/client/src/main/java/org/spine3/annotation/Beta.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.spine3.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Signifies that a public API is subject to incompatible changes, or even removal,
+ * in a future release.
+ *
+ * An API bearing this annotation is exempt from any compatibility guarantees made by its
+ * containing library. Note that the presence of this annotation implies nothing about the
+ * quality of the API in question, only the fact that it is not "API-frozen."
+ * It is generally safe for applications to depend on beta APIs, at the cost of some extra work
+ * during upgrades.
+ *
+ * @author Dmytro Grankin
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({
+        ElementType.ANNOTATION_TYPE,
+        ElementType.CONSTRUCTOR,
+        ElementType.FIELD,
+        ElementType.METHOD,
+        ElementType.PACKAGE,
+        ElementType.TYPE})
+@Documented
+public @interface Beta {
+    /**
+     * Context information such as links to discussion thread, tracking issue etc.
+     */
+    String value() default "";
+}

--- a/client/src/main/java/org/spine3/annotation/Experimental.java
+++ b/client/src/main/java/org/spine3/annotation/Experimental.java
@@ -47,7 +47,7 @@ import java.lang.annotation.Target;
         ElementType.PACKAGE,
         ElementType.TYPE})
 @Documented
-public @interface ExperimentalApi {
+public @interface Experimental {
     /**
      * Context information such as links to discussion thread, tracking issue etc.
      */

--- a/client/src/main/java/org/spine3/annotation/Subscribe.java
+++ b/client/src/main/java/org/spine3/annotation/Subscribe.java
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package org.spine3.base;
+package org.spine3.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/client/src/main/java/org/spine3/time/Intervals.java
+++ b/client/src/main/java/org/spine3/time/Intervals.java
@@ -22,7 +22,7 @@ package org.spine3.time;
 
 import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
-import org.spine3.annotation.ExperimentalApi;
+import org.spine3.annotation.Experimental;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Math.abs;
@@ -34,7 +34,7 @@ import static org.spine3.time.Timestamps2.isLaterThan;
  *
  * @author Alexander Litus
  */
-@ExperimentalApi
+@Experimental
 public final class Intervals {
 
     private Intervals() {

--- a/server/src/main/java/org/spine3/server/event/EventBus.java
+++ b/server/src/main/java/org/spine3/server/event/EventBus.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 import org.spine3.annotation.Internal;
 import org.spine3.base.Event;
 import org.spine3.base.Response;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.envelope.EventEnvelope;
 import org.spine3.io.StreamObservers;
 import org.spine3.server.event.enrich.EventEnricher;

--- a/server/src/main/java/org/spine3/server/failure/FailureBus.java
+++ b/server/src/main/java/org/spine3/server/failure/FailureBus.java
@@ -27,7 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spine3.base.Failure;
 import org.spine3.base.Response;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.envelope.FailureEnvelope;
 import org.spine3.io.StreamObservers;
 import org.spine3.server.outbus.CommandOutputBus;

--- a/server/src/main/java/org/spine3/server/reflect/EventSubscriberMethod.java
+++ b/server/src/main/java/org/spine3/server/reflect/EventSubscriberMethod.java
@@ -24,7 +24,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Message;
 import org.spine3.base.EventContext;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.type.EventClass;
 
 import javax.annotation.CheckReturnValue;

--- a/server/src/main/java/org/spine3/server/reflect/FailureSubscriberMethod.java
+++ b/server/src/main/java/org/spine3/server/reflect/FailureSubscriberMethod.java
@@ -23,7 +23,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Message;
 import org.spine3.base.CommandContext;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.type.FailureClass;
 
 import javax.annotation.CheckReturnValue;
@@ -94,7 +94,7 @@ public class FailureSubscriberMethod extends HandlerMethod<CommandContext> {
                                                             throws InvocationTargetException {
         throw new IllegalStateException("Failure handling method requires " +
                                         "at least two Message arguments. " +
-                                        "See org.spine3.base.Subscribe for more details");
+                                        "See org.spine3.annotation.Subscribe for more details");
     }
 
     /**

--- a/server/src/test/java/org/spine3/server/QueryServiceShould.java
+++ b/server/src/test/java/org/spine3/server/QueryServiceShould.java
@@ -26,7 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.spine3.base.EventContext;
 import org.spine3.base.Responses;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.client.Query;
 import org.spine3.client.QueryResponse;
 import org.spine3.server.projection.Projection;

--- a/server/src/test/java/org/spine3/server/aggregate/AggregateCommandEndpointShould.java
+++ b/server/src/test/java/org/spine3/server/aggregate/AggregateCommandEndpointShould.java
@@ -28,7 +28,7 @@ import org.mockito.ArgumentCaptor;
 import org.spine3.base.Command;
 import org.spine3.base.CommandContext;
 import org.spine3.base.Identifiers;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.envelope.CommandEnvelope;
 import org.spine3.server.BoundedContext;
 import org.spine3.server.command.Assign;

--- a/server/src/test/java/org/spine3/server/bc/BoundedContextShould.java
+++ b/server/src/test/java/org/spine3/server/bc/BoundedContextShould.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.spine3.base.CommandContext;
 import org.spine3.base.EventContext;
 import org.spine3.base.Response;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.option.EntityOption;
 import org.spine3.protobuf.AnyPacker;
 import org.spine3.server.BoundedContext;

--- a/server/src/test/java/org/spine3/server/event/EventBusShould.java
+++ b/server/src/test/java/org/spine3/server/event/EventBusShould.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.spine3.base.Event;
 import org.spine3.base.EventContext;
 import org.spine3.base.Responses;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.envelope.EventEnvelope;
 import org.spine3.server.event.enrich.EventEnricher;
 import org.spine3.server.storage.StorageFactory;

--- a/server/src/test/java/org/spine3/server/event/enrich/EventEnricherShould.java
+++ b/server/src/test/java/org/spine3/server/event/enrich/EventEnricherShould.java
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.spine3.base.Event;
 import org.spine3.base.EventContext;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.protobuf.Wrapper;
 import org.spine3.server.BoundedContext;
 import org.spine3.server.event.EventBus;

--- a/server/src/test/java/org/spine3/server/failure/FailureBusShould.java
+++ b/server/src/test/java/org/spine3/server/failure/FailureBusShould.java
@@ -26,7 +26,7 @@ import org.spine3.base.CommandContext;
 import org.spine3.base.Commands;
 import org.spine3.base.Failure;
 import org.spine3.base.Failures;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.change.StringChange;
 import org.spine3.envelope.FailureEnvelope;
 import org.spine3.test.failure.ProjectFailures;

--- a/server/src/test/java/org/spine3/server/procman/ProcManTransactionShould.java
+++ b/server/src/test/java/org/spine3/server/procman/ProcManTransactionShould.java
@@ -22,7 +22,7 @@ package org.spine3.server.procman;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Message;
 import org.spine3.base.Event;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.base.Version;
 import org.spine3.server.entity.ThrowingValidatingBuilder;
 import org.spine3.server.entity.Transaction;

--- a/server/src/test/java/org/spine3/server/procman/ProcessManagerRepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/procman/ProcessManagerRepositoryShould.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.spine3.base.CommandContext;
 import org.spine3.base.Event;
 import org.spine3.base.EventContext;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.envelope.CommandEnvelope;
 import org.spine3.server.BoundedContext;
 import org.spine3.server.command.Assign;

--- a/server/src/test/java/org/spine3/server/procman/ProcessManagerShould.java
+++ b/server/src/test/java/org/spine3/server/procman/ProcessManagerShould.java
@@ -32,7 +32,7 @@ import org.spine3.base.CommandContext;
 import org.spine3.base.Event;
 import org.spine3.base.EventContext;
 import org.spine3.base.Events;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.envelope.CommandEnvelope;
 import org.spine3.protobuf.AnyPacker;
 import org.spine3.protobuf.Wrapper;

--- a/server/src/test/java/org/spine3/server/projection/ProjectionRepositoryShould.java
+++ b/server/src/test/java/org/spine3/server/projection/ProjectionRepositoryShould.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 import org.spine3.base.Event;
 import org.spine3.base.EventContext;
 import org.spine3.base.Events;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.server.BoundedContext;
 import org.spine3.server.entity.RecordBasedRepository;
 import org.spine3.server.entity.RecordBasedRepositoryShould;

--- a/server/src/test/java/org/spine3/server/projection/ProjectionShould.java
+++ b/server/src/test/java/org/spine3/server/projection/ProjectionShould.java
@@ -27,7 +27,7 @@ import com.google.protobuf.StringValue;
 import org.junit.Before;
 import org.junit.Test;
 import org.spine3.base.EventContext;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.protobuf.Wrapper;
 import org.spine3.test.Given;
 import org.spine3.type.EventClass;

--- a/server/src/test/java/org/spine3/server/projection/ProjectionTransactionShould.java
+++ b/server/src/test/java/org/spine3/server/projection/ProjectionTransactionShould.java
@@ -22,7 +22,7 @@ package org.spine3.server.projection;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Message;
 import org.spine3.base.Event;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.base.Version;
 import org.spine3.server.entity.ThrowingValidatingBuilder;
 import org.spine3.server.entity.Transaction;

--- a/server/src/test/java/org/spine3/server/reflect/EventSubscriberMethodShould.java
+++ b/server/src/test/java/org/spine3/server/reflect/EventSubscriberMethodShould.java
@@ -23,7 +23,7 @@ package org.spine3.server.reflect;
 import com.google.common.testing.NullPointerTester;
 import org.junit.Test;
 import org.spine3.base.EventContext;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.test.reflect.event.ProjectCreated;
 
 import java.lang.reflect.InvocationTargetException;

--- a/server/src/test/java/org/spine3/server/reflect/FailureSubscriberMethodShould.java
+++ b/server/src/test/java/org/spine3/server/reflect/FailureSubscriberMethodShould.java
@@ -22,7 +22,7 @@ package org.spine3.server.reflect;
 import com.google.common.testing.NullPointerTester;
 import org.junit.Test;
 import org.spine3.base.CommandContext;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.test.failure.command.UpdateProjectName;
 import org.spine3.test.reflect.ReflectFailures;
 

--- a/server/src/test/java/org/spine3/server/stand/Given.java
+++ b/server/src/test/java/org/spine3/server/stand/Given.java
@@ -29,7 +29,7 @@ import org.spine3.base.Enrichment;
 import org.spine3.base.Event;
 import org.spine3.base.EventContext;
 import org.spine3.base.Identifiers;
-import org.spine3.base.Subscribe;
+import org.spine3.annotation.Subscribe;
 import org.spine3.base.Version;
 import org.spine3.protobuf.Wrapper;
 import org.spine3.server.BoundedContext;


### PR DESCRIPTION
This PR addresses the [issue](https://github.com/SpineEventEngine/core-java/issues/439).

Summary:
- Introduced `Beta` annotation.
- `@Subscribe` was moved to `org.spine3.annotation`.
- `ExperimentalApi` was renamed to `Experimental`.