### PR TITLE
Fix `AggregateEventRecord` test data creation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ buildscript {
         guavaVersion = '20.0'
         protobufGradlePluginVerison = '0.8.0'
 
-        spineVersion = '0.9.19-SNAPSHOT'
+        spineVersion = '0.9.20-SNAPSHOT'
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all
         // the components and change the version of the dependency below to
         // `spineVersion` defined above.

--- a/server/src/test/java/io/spine/server/aggregate/Given.java
+++ b/server/src/test/java/io/spine/server/aggregate/Given.java
@@ -164,7 +164,9 @@ class Given {
         static AggregateEventRecord create(Timestamp timestamp) {
             final AggregateEventRecord.Builder builder
                     = AggregateEventRecord.newBuilder()
-                                          .setTimestamp(timestamp);
+                                          .setTimestamp(timestamp)
+                                          .setEvent(Event.getDefaultInstance());
+                                             // To guarantee KindCase presence
             return builder.build();
         }
 


### PR DESCRIPTION
Now any test `AggregateEventRecord` created with `io.spine.server.aggregate.Given.StorageRecord` will have a `KindCase`. By default it is `EVENT`.