### PR TITLE
Make direct `Delivery` strategies non-singletons

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
 
         spineRepository = 'http://maven.teamdev.com/repository/spine'
         spineSnapshotsRepository = 'http://maven.teamdev.com/repository/spine-snapshots'
-        spineVersion = '0.9.25-SNAPSHOT'
+        spineVersion = '0.9.26-SNAPSHOT'
 
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all
         // the components and change the version of the dependency below to

--- a/server/src/main/java/io/spine/server/event/DispatcherEventDelivery.java
+++ b/server/src/main/java/io/spine/server/event/DispatcherEventDelivery.java
@@ -78,28 +78,15 @@ public abstract class DispatcherEventDelivery extends CommandOutputDelivery<Even
      * {@link com.google.common.util.concurrent.MoreExecutors#directExecutor() direct executor}
      * for operation.
      *
-     * @return the pre-configured default executor.
+     * @return the pre-configured direct delivery
      */
     public static DispatcherEventDelivery directDelivery() {
-        return PredefinedDeliveryStrategies.DIRECT_DELIVERY;
-    }
-
-    /** Utility wrapper class for predefined delivery strategies designed to be constants. */
-    private static final class PredefinedDeliveryStrategies {
-
-        /**
-         * A pre-defined instance of the {@code DispatcherEventDelivery},
-         * which does not postpone any event dispatching and uses
-         * {@link com.google.common.util.concurrent.MoreExecutors#directExecutor() direct executor}
-         * for operation.
-         */
-        private static final DispatcherEventDelivery DIRECT_DELIVERY =
-                new DispatcherEventDelivery() {
-                    @Override
-                    public boolean shouldPostponeDelivery(EventEnvelope envelope,
-                                                          EventDispatcher dispatcher) {
-                        return false;
-                    }
-                };
+        return new DispatcherEventDelivery() {
+            @Override
+            public boolean shouldPostponeDelivery(EventEnvelope envelope,
+                                                  EventDispatcher dispatcher) {
+                return false;
+            }
+        };
     }
 }

--- a/server/src/main/java/io/spine/server/event/DispatcherEventDelivery.java
+++ b/server/src/main/java/io/spine/server/event/DispatcherEventDelivery.java
@@ -19,6 +19,7 @@
  */
 package io.spine.server.event;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.spine.annotation.SPI;
 import io.spine.base.Event;
 import io.spine.envelope.EventEnvelope;
@@ -81,12 +82,20 @@ public abstract class DispatcherEventDelivery extends CommandOutputDelivery<Even
      * @return the pre-configured direct delivery
      */
     public static DispatcherEventDelivery directDelivery() {
-        return new DispatcherEventDelivery() {
-            @Override
-            public boolean shouldPostponeDelivery(EventEnvelope envelope,
-                                                  EventDispatcher dispatcher) {
-                return false;
-            }
-        };
+        return new DirectDelivery();
+    }
+
+    /**
+     * A delivery implementation which does not postpone events.
+     *
+     * @see #directDelivery()
+     */
+    @VisibleForTesting
+    static final class DirectDelivery extends DispatcherEventDelivery {
+        @Override
+        public boolean shouldPostponeDelivery(EventEnvelope envelope,
+                                              EventDispatcher dispatcher) {
+            return false;
+        }
     }
 }

--- a/server/src/main/java/io/spine/server/failure/DispatcherFailureDelivery.java
+++ b/server/src/main/java/io/spine/server/failure/DispatcherFailureDelivery.java
@@ -78,28 +78,15 @@ public abstract class DispatcherFailureDelivery extends CommandOutputDelivery<Fa
      * {@link com.google.common.util.concurrent.MoreExecutors#directExecutor() direct executor}
      * for operation.
      *
-     * @return the pre-configured default executor.
+     * @return the pre-configured direct delivery
      */
     public static DispatcherFailureDelivery directDelivery() {
-        return PredefinedDeliveryStrategies.DIRECT_DELIVERY;
-    }
-
-    /** Utility wrapper class for predefined delivery strategies designed to be constants. */
-    private static final class PredefinedDeliveryStrategies {
-
-        /**
-         * A pre-defined instance of the {@code DispatcherFailureDelivery},
-         * which does not postpone any failure dispatching and uses
-         * {@link com.google.common.util.concurrent.MoreExecutors#directExecutor() direct executor}
-         * for operation.
-         */
-        private static final DispatcherFailureDelivery DIRECT_DELIVERY =
-                new DispatcherFailureDelivery() {
-                    @Override
-                    public boolean shouldPostponeDelivery(FailureEnvelope envelope,
-                                                          FailureDispatcher dispatcher) {
-                        return false;
-                    }
-                };
+        return new DispatcherFailureDelivery() {
+            @Override
+            public boolean shouldPostponeDelivery(FailureEnvelope envelope,
+                                                  FailureDispatcher dispatcher) {
+                return false;
+            }
+        };
     }
 }

--- a/server/src/main/java/io/spine/server/failure/DispatcherFailureDelivery.java
+++ b/server/src/main/java/io/spine/server/failure/DispatcherFailureDelivery.java
@@ -19,6 +19,7 @@
  */
 package io.spine.server.failure;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.spine.annotation.SPI;
 import io.spine.base.Failure;
 import io.spine.envelope.FailureEnvelope;
@@ -81,12 +82,20 @@ public abstract class DispatcherFailureDelivery extends CommandOutputDelivery<Fa
      * @return the pre-configured direct delivery
      */
     public static DispatcherFailureDelivery directDelivery() {
-        return new DispatcherFailureDelivery() {
-            @Override
-            public boolean shouldPostponeDelivery(FailureEnvelope envelope,
-                                                  FailureDispatcher dispatcher) {
-                return false;
-            }
-        };
+        return new DirectDelivery();
+    }
+
+    /**
+     * A delivery implementation which does not postpone events.
+     *
+     * @see #directDelivery()
+     */
+    @VisibleForTesting
+    static final class DirectDelivery extends DispatcherFailureDelivery {
+        @Override
+        public boolean shouldPostponeDelivery(FailureEnvelope envelope,
+                                              FailureDispatcher dispatcher) {
+            return false;
+        }
     }
 }

--- a/server/src/main/java/io/spine/server/stand/Stand.java
+++ b/server/src/main/java/io/spine/server/stand/Stand.java
@@ -236,6 +236,11 @@ public class Stand implements AutoCloseable {
         return multitenant;
     }
 
+    @VisibleForTesting
+    StandUpdateDelivery delivery() {
+        return delivery;
+    }
+
     /**
      * Subscribes for all further changes of an entity state, which satisfies the {@link Topic}.
      *

--- a/server/src/main/java/io/spine/server/stand/StandUpdateDelivery.java
+++ b/server/src/main/java/io/spine/server/stand/StandUpdateDelivery.java
@@ -75,35 +75,15 @@ public abstract class StandUpdateDelivery extends Delivery<EntityStateEnvelope<?
     }
 
     /**
-     * Returns an instance of {@code StandUpdateDelivery} which does NOT postpone any state
-     * update propagation and uses the specified {@code executor} for the operation.
+     * Obtains a pre-defined instance of the {@code StandUpdateDelivery}, which does NOT
+     * postpone any event dispatching and uses
+     * {@link com.google.common.util.concurrent.MoreExecutors#directExecutor() direct executor}
+     * for operation.
      *
-     * @param executor an instance of {@code Executor} to use for the delivery
-     * @return the instance of {@code StandUpdateDelivery} with the given executor
+     * @return the pre-configured direct delivery
      */
-    public static StandUpdateDelivery immediateDeliveryWithExecutor(Executor executor) {
-        final StandUpdateDelivery immediateDelivery = new StandUpdateDelivery(executor) {
-            @Override
-            protected boolean shouldPostponeDelivery(EntityStateEnvelope deliverable,
-                                                     Stand consumer) {
-                return false;
-            }
-        };
-        return immediateDelivery;
-    }
-
     public static StandUpdateDelivery directDelivery() {
-        return PredefinedDeliveryStrategies.DIRECT_DELIVERY;
-    }
-
-    /** Utility wrapper class for predefined delivery strategies designed to be constants. */
-    private static final class PredefinedDeliveryStrategies {
-
-        /**
-         * A pre-defined instance of the {@code StandUpdateDelivery}, which does not postpone any
-         * update delivery and uses a default executor for the operation.
-         */
-        private static final StandUpdateDelivery DIRECT_DELIVERY = new StandUpdateDelivery() {
+        return new StandUpdateDelivery() {
 
             @Override
             protected boolean shouldPostponeDelivery(EntityStateEnvelope deliverable,

--- a/server/src/main/java/io/spine/server/stand/StandUpdateDelivery.java
+++ b/server/src/main/java/io/spine/server/stand/StandUpdateDelivery.java
@@ -21,6 +21,7 @@
  */
 package io.spine.server.stand;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import io.spine.annotation.SPI;
 import io.spine.server.delivery.Delivery;
@@ -83,13 +84,20 @@ public abstract class StandUpdateDelivery extends Delivery<EntityStateEnvelope<?
      * @return the pre-configured direct delivery
      */
     public static StandUpdateDelivery directDelivery() {
-        return new StandUpdateDelivery() {
+        return new DirectDelivery();
+    }
 
-            @Override
-            protected boolean shouldPostponeDelivery(EntityStateEnvelope deliverable,
-                                                     Stand consumer) {
-                return false;
-            }
-        };
+    /**
+     * A delivery implementation which does not postpone events.
+     *
+     * @see #directDelivery()
+     */
+    @VisibleForTesting
+    static final class DirectDelivery extends StandUpdateDelivery {
+        @Override
+        public boolean shouldPostponeDelivery(EntityStateEnvelope envelope,
+                                              Stand consumer) {
+            return false;
+        }
     }
 }

--- a/server/src/test/java/io/spine/server/event/EventBusBuilderShould.java
+++ b/server/src/test/java/io/spine/server/event/EventBusBuilderShould.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
@@ -132,7 +133,7 @@ public class EventBusBuilderShould {
                                                             .setStorageFactory(storageFactory)
                                                             .build()
                                                             .delivery();
-        assertEquals(DispatcherEventDelivery.directDelivery(), actualValue);
+        assertTrue(actualValue instanceof DispatcherEventDelivery.DirectDelivery);
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/event/EventBusShould.java
+++ b/server/src/test/java/io/spine/server/event/EventBusShould.java
@@ -223,6 +223,12 @@ public class EventBusShould {
     }
 
     @Test
+    public void return_direct_DispatcherDelivery_if_none_customized() {
+        final DispatcherEventDelivery actual = eventBus.delivery();
+        assertTrue(actual instanceof DispatcherEventDelivery.DirectDelivery);
+    }
+
+    @Test
     public void not_call_dispatchers_if_dispatcher_event_execution_postponed() {
         final BareDispatcher dispatcher = new BareDispatcher();
 

--- a/server/src/test/java/io/spine/server/failure/FailureBusShould.java
+++ b/server/src/test/java/io/spine/server/failure/FailureBusShould.java
@@ -113,8 +113,7 @@ public class FailureBusShould {
     @Test
     public void return_direct_DispatcherDelivery_if_none_customized() {
         final DispatcherFailureDelivery actual = failureBus.delivery();
-        final DispatcherFailureDelivery expected = DispatcherFailureDelivery.directDelivery();
-        assertEquals(expected, actual);
+        assertTrue(actual instanceof DispatcherFailureDelivery.DirectDelivery);
     }
 
     @Test   // as the FailureBus instances do not support enrichment yet.

--- a/server/src/test/java/io/spine/server/procman/ProcessManagerRepositoryShould.java
+++ b/server/src/test/java/io/spine/server/procman/ProcessManagerRepositoryShould.java
@@ -33,7 +33,6 @@ import io.spine.envelope.CommandEnvelope;
 import io.spine.envelope.EventEnvelope;
 import io.spine.server.BoundedContext;
 import io.spine.server.command.EventFactory;
-import io.spine.server.commandbus.CommandDispatcher;
 import io.spine.server.entity.RecordBasedRepository;
 import io.spine.server.entity.RecordBasedRepositoryShould;
 import io.spine.server.event.EventSubscriber;
@@ -51,7 +50,6 @@ import io.spine.test.procman.event.ProjectCreated;
 import io.spine.test.procman.event.ProjectStarted;
 import io.spine.test.procman.event.TaskAdded;
 import io.spine.testdata.Sample;
-import io.spine.testdata.TestBoundedContextFactory;
 import io.spine.type.CommandClass;
 import io.spine.type.EventClass;
 import org.junit.After;
@@ -130,9 +128,7 @@ public class ProcessManagerRepositoryShould
 
     @Override
     protected RecordBasedRepository<ProjectId, TestProcessManager, Project> createRepository() {
-        boundedContext = TestBoundedContextFactory.MultiTenant.newBoundedContext();
         final TestProcessManagerRepository repo = new TestProcessManagerRepository();
-        boundedContext.register(repo);
         return repo;
     }
 
@@ -177,20 +173,7 @@ public class ProcessManagerRepositoryShould
                                        .setMultitenant(true)
                                        .build();
 
-        boundedContext.getCommandBus()
-                      .register(new CommandDispatcher() {
-                          @Override
-                          public Set<CommandClass> getMessageClasses() {
-                              return CommandClass.setOf(AddTask.class);
-                          }
-
-                          @Override
-                          public void dispatch(CommandEnvelope envelope) {
-                              /* Simply swallow the command. We need this dispatcher for allowing
-                                 Process Manager under test to route the AddTask command. */
-                          }
-                      });
-
+        boundedContext.register(repository);
         TestProcessManager.clearMessageDeliveryHistory();
     }
 

--- a/server/src/test/java/io/spine/server/stand/StandShould.java
+++ b/server/src/test/java/io/spine/server/stand/StandShould.java
@@ -179,7 +179,7 @@ public class StandShould extends TenantAwareTest {
     }
 
     @Test
-    public void initialize_with_direct_DispatcherDelivery_if_none_customized() {
+    public void initialize_with_direct_UpdateDelivery_if_none_customized() {
         final Stand.Builder builder = Stand.newBuilder()
                                            .setMultitenant(isMultitenant());
         final Stand stand = builder.build();

--- a/server/src/test/java/io/spine/server/stand/StandShould.java
+++ b/server/src/test/java/io/spine/server/stand/StandShould.java
@@ -179,6 +179,16 @@ public class StandShould extends TenantAwareTest {
     }
 
     @Test
+    public void initialize_with_direct_DispatcherDelivery_if_none_customized() {
+        final Stand.Builder builder = Stand.newBuilder()
+                                           .setMultitenant(isMultitenant());
+        final Stand stand = builder.build();
+
+        final StandUpdateDelivery actual = stand.delivery();
+        assertTrue(actual instanceof StandUpdateDelivery.DirectDelivery);
+    }
+
+    @Test
     public void register_projection_repositories() {
         final boolean multitenant = isMultitenant();
         final BoundedContext boundedContext = BoundedContext.newBuilder()


### PR DESCRIPTION
Before this PR there were some side effects from having the `...Delivery.directDelivery()` returning singletons for each of delivery subclasses. 

In particular, several bounded contexts created within a single JVM could share the same delivery strategy (since it was a singleton) and thus reference the same consumer provider.

This PR addresses this issue, implementing the "direct" delivery by creating a new instance each time instead of sharing the singleton instance.

The framework version is increased to `0.9.26-SNAPSHOT`.