### PR TITLE
Make getStorage method to take Entity class as a parameter.

### DIFF
--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
@@ -79,20 +79,18 @@ public abstract class AggregateStorageShould
         close(storage);
     }
 
-
-
     /**
      * Used to get a storage in tests with different ID types.
      *
      * <p>NOTE: the storage is closed after each test.
      *
-     * @param idClass class of aggregate ID
+     * @param idClass        class of aggregate ID
      * @param aggregateClass aggregate class
-     * @param <I> the type of aggregate IDs
+     * @param <I>            the type of aggregate IDs
      * @return an empty storage instance
      */
-
-    protected abstract <I> AggregateStorage<I> getStorage(Class<? extends I> idClass, Class<? extends Entity> aggregateClass);
+    protected abstract <I> AggregateStorage<I> getStorage(Class<? extends I> idClass,
+                                                          Class<? extends Entity> aggregateClass);
 
     @Override
     protected AggregateStateRecord newStorageRecord() {
@@ -156,21 +154,24 @@ public abstract class AggregateStorageShould
 
     @Test
     public void write_and_read_event_by_String_id() {
-        final AggregateStorage<String> storage = getStorage(String.class, TestAggregateWithIdString.class);
+        final AggregateStorage<String> storage = getStorage(String.class,
+                                                            TestAggregateWithIdString.class);
         final String id = newUuid();
         writeAndReadEventTest(id, storage);
     }
 
     @Test
     public void write_and_read_event_by_Long_id() {
-        final AggregateStorage<Long> storage = getStorage(Long.class, TestAggregateWithIdLong.class);
+        final AggregateStorage<Long> storage = getStorage(Long.class,
+                                                          TestAggregateWithIdLong.class);
         final long id = 10L;
         writeAndReadEventTest(id, storage);
     }
 
     @Test
     public void write_and_read_event_by_Integer_id() {
-        final AggregateStorage<Integer> storage = getStorage(Integer.class, TestAggregateWithIdInteger.class);
+        final AggregateStorage<Integer> storage = getStorage(Integer.class,
+                                                             TestAggregateWithIdInteger.class);
         final int id = 10;
         writeAndReadEventTest(id, storage);
     }

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
@@ -27,6 +27,7 @@ import com.google.protobuf.Duration;
 import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
 import io.spine.base.Event;
+import io.spine.server.entity.Entity;
 import io.spine.server.event.Given.EventMessage;
 import io.spine.server.storage.AbstractStorageShould;
 import io.spine.test.TestEventFactory;
@@ -70,7 +71,7 @@ public abstract class AggregateStorageShould
 
     @Before
     public void setUpAggregateStorageTest() {
-        storage = getStorage();
+        storage = getStorage(Entity.class);
     }
 
     @After
@@ -78,18 +79,20 @@ public abstract class AggregateStorageShould
         close(storage);
     }
 
+
+
     /**
      * Used to get a storage in tests with different ID types.
      *
      * <p>NOTE: the storage is closed after each test.
      *
+     * @param idClass class of aggregate ID
+     * @param aggregateClass aggregate class
      * @param <I> the type of aggregate IDs
      * @return an empty storage instance
      */
-    protected abstract <I> AggregateStorage<I> getStorage(
-            Class<? extends Aggregate<I,
-                                      ? extends Message,
-                                      ? extends ValidatingBuilder<?, ?>>> aggregateClass);
+
+    protected abstract <I> AggregateStorage<I> getStorage(Class<? extends I> idClass, Class<? extends Entity> aggregateClass);
 
     @Override
     protected AggregateStateRecord newStorageRecord() {
@@ -153,21 +156,21 @@ public abstract class AggregateStorageShould
 
     @Test
     public void write_and_read_event_by_String_id() {
-        final AggregateStorage<String> storage = getStorage(TestAggregateWithIdString.class);
+        final AggregateStorage<String> storage = getStorage(String.class, TestAggregateWithIdString.class);
         final String id = newUuid();
         writeAndReadEventTest(id, storage);
     }
 
     @Test
     public void write_and_read_event_by_Long_id() {
-        final AggregateStorage<Long> storage = getStorage(TestAggregateWithIdLong.class);
+        final AggregateStorage<Long> storage = getStorage(Long.class, TestAggregateWithIdLong.class);
         final long id = 10L;
         writeAndReadEventTest(id, storage);
     }
 
     @Test
     public void write_and_read_event_by_Integer_id() {
-        final AggregateStorage<Integer> storage = getStorage(TestAggregateWithIdInteger.class);
+        final AggregateStorage<Integer> storage = getStorage(Integer.class, TestAggregateWithIdInteger.class);
         final int id = 10;
         writeAndReadEventTest(id, storage);
     }

--- a/server/src/test/java/io/spine/server/projection/ProjectionStorageShould.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionStorageShould.java
@@ -25,6 +25,7 @@ import com.google.protobuf.FieldMask;
 import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
 import io.spine.protobuf.AnyPacker;
+import io.spine.server.entity.Entity;
 import io.spine.server.entity.EntityRecord;
 import io.spine.server.storage.RecordStorageShould;
 import io.spine.test.Tests;
@@ -75,7 +76,7 @@ public abstract class ProjectionStorageShould<I>
 
     @Before
     public void setUpProjectionStorageTest() {
-        storage = getStorage();
+        storage = getStorage(Entity.class);
     }
 
     @After

--- a/server/src/test/java/io/spine/server/stand/StandStorageShould.java
+++ b/server/src/test/java/io/spine/server/stand/StandStorageShould.java
@@ -29,6 +29,7 @@ import com.google.protobuf.FieldMask;
 import com.google.protobuf.Message;
 import io.spine.base.Identifier;
 import io.spine.protobuf.AnyPacker;
+import io.spine.server.entity.Entity;
 import io.spine.server.entity.EntityRecord;
 import io.spine.server.entity.FieldMasks;
 import io.spine.server.storage.RecordStorage;
@@ -84,11 +85,11 @@ public abstract class StandStorageShould extends RecordStorageShould<AggregateSt
     }
 
     @Override
-    protected abstract StandStorage getStorage();
+    protected abstract StandStorage getStorage(Class<? extends Entity> cls);
 
     @Test
     public void retrieve_all_records() {
-        final StandStorage storage = getStorage();
+        final StandStorage storage = getStorage(TestCounterEntity.class);
         final List<AggregateStateId> ids = fill(storage, 10, DEFAULT_ID_SUPPLIER);
 
         final Iterator<EntityRecord> allRecords = storage.readAll();
@@ -97,7 +98,7 @@ public abstract class StandStorageShould extends RecordStorageShould<AggregateSt
 
     @Test
     public void retrieve_records_by_ids() {
-        final StandStorage storage = getStorage();
+        final StandStorage storage = getStorage(TestCounterEntity.class);
         // Use a subset of IDs
         final List<AggregateStateId> ids = fill(storage, 10, DEFAULT_ID_SUPPLIER).subList(0, 5);
 
@@ -119,7 +120,7 @@ public abstract class StandStorageShould extends RecordStorageShould<AggregateSt
     @SuppressWarnings({"MethodWithMultipleLoops", "ConstantConditions"}) // OK for this test.
     private void checkByTypeRead(FieldMask fieldMask) {
         final boolean withFieldMask = !fieldMask.equals(FieldMask.getDefaultInstance());
-        final StandStorage storage = getStorage();
+        final StandStorage storage = getStorage(TestCounterEntity.class);
         final TypeUrl type = TypeUrl.from(Project.getDescriptor());
 
         final int projectsCount = 4;

--- a/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
@@ -23,6 +23,7 @@ package io.spine.server.storage;
 import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
 import com.google.protobuf.Message;
+import io.spine.server.entity.Entity;
 import io.spine.test.Tests;
 import io.spine.test.Verify;
 import org.junit.After;
@@ -56,7 +57,7 @@ public abstract class AbstractStorageShould<I,
 
     @Before
     public void setUpAbstractStorageTest() {
-        storage = getStorage();
+        storage = getStorage(Entity.class);
     }
 
     @After
@@ -72,7 +73,7 @@ public abstract class AbstractStorageShould<I,
      * @return an empty storage instance
      * @see AbstractStorage#close()
      */
-    protected abstract S getStorage();
+    protected abstract S getStorage(Class<? extends Entity> cls);
 
     /** Creates a new storage record. */
     protected abstract R newStorageRecord();

--- a/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
@@ -133,7 +133,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     // Converter nullability issues and Optional getting
     @Test
     public void write_and_read_record_by_Message_id() {
-        final RecordStorage<I> storage = getStorage();
+        final RecordStorage<I> storage = getStorage(TestCounterEntity.class);
         final I id = newId();
         final EntityRecord expected = newStorageRecord(id);
         storage.write(id, expected);
@@ -150,7 +150,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final FieldMask nonEmptyFieldMask = FieldMask.newBuilder()
                                                      .addPaths("invalid-path")
                                                      .build();
-        final RecordStorage storage = getStorage();
+        final RecordStorage storage = getStorage(TestCounterEntity.class);
         final Iterator empty = storage.readAll(nonEmptyFieldMask);
 
         assertNotNull(empty);
@@ -162,7 +162,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     public void read_single_record_with_mask() {
         final I id = newId();
         final EntityRecord record = newStorageRecord(id);
-        final RecordStorage<I> storage = getStorage();
+        final RecordStorage<I> storage = getStorage(TestCounterEntity.class);
         storage.write(id, record);
 
         final Descriptors.Descriptor descriptor = newState(id).getDescriptorForType();
@@ -180,7 +180,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     // Converter nullability issues
     @Test
     public void read_multiple_records_with_field_mask() {
-        final RecordStorage<I> storage = getStorage();
+        final RecordStorage<I> storage = getStorage(TestCounterEntity.class);
         final int count = 10;
         final List<I> ids = new LinkedList<>();
         Descriptors.Descriptor typeDescriptor = null;
@@ -213,7 +213,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     @SuppressWarnings("ConstantConditions") // converter nullability issues
     @Test
     public void delete_record() {
-        final RecordStorage<I> storage = getStorage();
+        final RecordStorage<I> storage = getStorage(TestCounterEntity.class);
         final I id = newId();
         final EntityRecord record = newStorageRecord(id);
 
@@ -230,7 +230,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
 
     @Test
     public void write_none_storage_fields_is_none_passed() {
-        final RecordStorage<I> storage = spy(getStorage());
+        final RecordStorage<I> storage = spy(getStorage(TestCounterEntity.class));
         final I id = newId();
         final Any state = pack(Sample.messageOfType(Project.class));
         final EntityRecord record =
@@ -243,7 +243,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
 
     @Test
     public void write_record_bulk() {
-        final RecordStorage<I> storage = getStorage();
+        final RecordStorage<I> storage = getStorage(TestCounterEntity.class);
         final int bulkSize = 5;
 
         final Map<I, EntityRecordWithColumns> initial = new HashMap<>(bulkSize);
@@ -270,7 +270,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     @Test
     public void rewrite_records_in_bulk() {
         final int recordCount = 3;
-        final RecordStorage<I> storage = getStorage();
+        final RecordStorage<I> storage = getStorage(TestCounterEntity.class);
 
         final Function<EntityRecord, EntityRecordWithColumns> recordPacker =
                 new Function<EntityRecord, EntityRecordWithColumns>() {
@@ -312,7 +312,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     @Test(expected = IllegalStateException.class)
     public void fail_to_write_visibility_to_non_existing_record() {
         final I id = newId();
-        final RecordStorage<I> storage = getStorage();
+        final RecordStorage<I> storage = getStorage(TestCounterEntity.class);
 
         storage.writeLifecycleFlags(id, archived());
     }
@@ -320,7 +320,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     @Test
     public void return_absent_visibility_for_missing_record() {
         final I id = newId();
-        final RecordStorage<I> storage = getStorage();
+        final RecordStorage<I> storage = getStorage(TestCounterEntity.class);
         final Optional<LifecycleFlags> optional = storage.readLifecycleFlags(id);
         assertFalse(optional.isPresent());
     }
@@ -330,7 +330,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     public void return_default_visibility_for_new_record() {
         final I id = newId();
         final EntityRecord record = newStorageRecord(id);
-        final RecordStorage<I> storage = getStorage();
+        final RecordStorage<I> storage = getStorage(TestCounterEntity.class);
         storage.write(id, record);
 
         final Optional<LifecycleFlags> optional = storage.readLifecycleFlags(id);
@@ -343,7 +343,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     public void load_visibility_when_updated() {
         final I id = newId();
         final EntityRecord record = newStorageRecord(id);
-        final RecordStorage<I> storage = getStorage();
+        final RecordStorage<I> storage = getStorage(TestCounterEntity.class);
         storage.write(id, EntityRecordWithColumns.of(record));
 
         storage.writeLifecycleFlags(id, archived());
@@ -361,7 +361,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityRecordWithColumns recordWithStorageFields =
                 EntityRecordWithColumns.of(record);
         assertFalse(recordWithStorageFields.hasColumns());
-        final RecordStorage<I> storage = getStorage();
+        final RecordStorage<I> storage = getStorage(TestCounterEntity.class);
 
         storage.write(id, recordWithStorageFields);
         final Optional<EntityRecord> actualRecord = storage.read(id);
@@ -376,7 +376,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final TestCounterEntity<?> testEntity = new TestCounterEntity<>(id);
         final EntityRecordWithColumns recordWithColumns =
                 create(record, testEntity);
-        final S storage = getStorage();
+        final S storage = getStorage(TestCounterEntity.class);
         storage.write(id, recordWithColumns);
 
         final Optional<EntityRecord> readRecord = storage.read(id);
@@ -432,7 +432,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityRecordWithColumns recordWrong1 = create(notFineRecord1, wrongEntity1);
         final EntityRecordWithColumns recordWrong2 = create(notFineRecord2, wrongEntity2);
 
-        final RecordStorage<I> storage = getStorage();
+        final RecordStorage<I> storage = getStorage(TestCounterEntity.class);
 
         storage.write(idMatching, recordRight);
         storage.write(idWrong1, recordWrong1);
@@ -465,7 +465,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityRecordWithColumns recordWrong1 = create(notFineRecord1, wrongEntity1);
         final EntityRecordWithColumns recordWrong2 = create(notFineRecord2, wrongEntity2);
 
-        final RecordStorage<I> storage = getStorage();
+        final RecordStorage<I> storage = getStorage(TestCounterEntity.class);
 
         // Fill the storage
         storage.write(idWrong1, recordWrong1);

--- a/server/src/test/java/io/spine/server/storage/memory/InMemoryAggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/memory/InMemoryAggregateStorageShould.java
@@ -20,12 +20,10 @@
 
 package io.spine.server.storage.memory;
 
-import com.google.protobuf.Message;
-import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.AggregateStorage;
 import io.spine.server.aggregate.AggregateStorageShould;
+import io.spine.server.entity.Entity;
 import io.spine.test.aggregate.ProjectId;
-import io.spine.validate.ValidatingBuilder;
 
 /**
  * @author Alexander Litus
@@ -33,15 +31,13 @@ import io.spine.validate.ValidatingBuilder;
 public class InMemoryAggregateStorageShould extends AggregateStorageShould {
 
     @Override
-    protected AggregateStorage<ProjectId> getStorage() {
+    protected AggregateStorage<ProjectId> getStorage(Class<? extends Entity> cls) {
         return InMemoryAggregateStorage.newInstance();
     }
 
     @Override
-    protected <Id> AggregateStorage<Id> getStorage(
-            Class<? extends Aggregate<Id,
-                                      ? extends Message,
-                                      ? extends ValidatingBuilder<?,?>>> aggregateClass) {
+    protected <I> AggregateStorage<I> getStorage(Class<? extends I> idClass,
+                                                 Class<? extends Entity> aggregateClass) {
         return InMemoryAggregateStorage.newInstance();
     }
 }

--- a/server/src/test/java/io/spine/server/storage/memory/InMemoryProjectionStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/memory/InMemoryProjectionStorageShould.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.storage.memory;
 
+import io.spine.server.entity.Entity;
 import io.spine.server.projection.ProjectionStorage;
 import io.spine.server.projection.ProjectionStorageShould;
 import io.spine.type.TypeUrl;
@@ -32,7 +33,7 @@ import static io.spine.base.Identifier.newUuid;
 public class InMemoryProjectionStorageShould extends ProjectionStorageShould<String> {
 
     @Override
-    protected ProjectionStorage<String> getStorage() {
+    protected ProjectionStorage<String> getStorage(Class<? extends Entity> cls) {
         final StorageSpec<String> spec = StorageSpec.of(
                 getClass().getSimpleName(),
                 TypeUrl.of(io.spine.test.projection.Project.class),

--- a/server/src/test/java/io/spine/server/storage/memory/InMemoryRecordStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/memory/InMemoryRecordStorageShould.java
@@ -21,6 +21,7 @@
 package io.spine.server.storage.memory;
 
 import com.google.protobuf.Message;
+import io.spine.server.entity.Entity;
 import io.spine.server.storage.RecordStorage;
 import io.spine.server.storage.RecordStorageShould;
 import io.spine.test.storage.Project;
@@ -40,7 +41,7 @@ public class InMemoryRecordStorageShould
         extends RecordStorageShould<ProjectId, RecordStorage<ProjectId>> {
 
     @Override
-    protected RecordStorage<ProjectId> getStorage() {
+    protected RecordStorage<ProjectId> getStorage(Class<? extends Entity> cls) {
         final StorageSpec<ProjectId> spec = StorageSpec.of(getClass().getSimpleName(),
                                                            TypeUrl.of(Project.class),
                                                            ProjectId.class);
@@ -68,7 +69,7 @@ public class InMemoryRecordStorageShould
 
     @Test
     public void return_storage_spec() {
-        final StorageSpec spec = ((InMemoryRecordStorage) getStorage()).getSpec();
+        final StorageSpec spec = ((InMemoryRecordStorage) getStorage(Entity.class)).getSpec();
         assertEquals(ProjectId.class, spec.getIdClass());
     }
 }

--- a/server/src/test/java/io/spine/server/storage/memory/InMemoryStandStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/memory/InMemoryStandStorageShould.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.storage.memory;
 
+import io.spine.server.entity.Entity;
 import io.spine.server.stand.StandStorage;
 import io.spine.server.stand.StandStorageShould;
 
@@ -29,7 +30,7 @@ import io.spine.server.stand.StandStorageShould;
 public class InMemoryStandStorageShould extends StandStorageShould {
 
     @Override
-    protected StandStorage getStorage() {
+    protected StandStorage getStorage(Class<? extends Entity> cls) {
         return InMemoryStandStorage.newBuilder()
                                    .setBoundedContextName(getClass().getSimpleName())
                                    .setMultitenant(false)


### PR DESCRIPTION
We need to make getStorage to take an entity class as a parameter because we need to create a storage with the same columns that are used in further test cases.