### PR TITLE
Updated FieldValidator with Map handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
 
         spineRepository = 'http://maven.teamdev.com/repository/spine'
         spineSnapshotsRepository = 'http://maven.teamdev.com/repository/spine-snapshots'
-        spineVersion = '0.9.26-SNAPSHOT'
+        spineVersion = '0.9.27-SNAPSHOT'
 
         //TODO:2016-12-12:alexander.yevsyukov: Advance the plug-in version together with all
         // the components and change the version of the dependency below to

--- a/client/src/test/java/io/spine/validate/FieldValidatorFactoryShould.java
+++ b/client/src/test/java/io/spine/validate/FieldValidatorFactoryShould.java
@@ -27,10 +27,14 @@ import com.google.protobuf.Int32Value;
 import com.google.protobuf.Int64Value;
 import com.google.protobuf.StringValue;
 import io.spine.base.FieldPath;
+import io.spine.test.validate.msg.MapRequiredMsgFieldValue;
+import io.spine.test.validate.msg.RepeatedRequiredMsgFieldValue;
 import io.spine.test.validate.msg.RequiredByteStringFieldValue;
 import io.spine.test.validate.msg.RequiredEnumFieldValue;
 import io.spine.test.validate.msg.RequiredMsgFieldValue;
 import org.junit.Test;
+
+import java.util.Collections;
 
 import static com.google.protobuf.Descriptors.FieldDescriptor;
 import static org.junit.Assert.assertTrue;
@@ -41,6 +45,28 @@ import static org.junit.Assert.assertTrue;
 public class FieldValidatorFactoryShould {
 
     private static final FieldPath FIELD_PATH = FieldPath.getDefaultInstance();
+
+    @Test
+    public void create_map_field_validator() {
+        final FieldDescriptor field = MapRequiredMsgFieldValue.getDescriptor().getFields().get(0);
+
+        final Object fieldValue = Collections.singletonMap(StringValue.getDefaultInstance(), StringValue.getDefaultInstance());
+
+        final FieldValidator validator = FieldValidatorFactory.create(field, fieldValue, FIELD_PATH);
+
+        assertTrue(validator instanceof MessageFieldValidator);
+    }
+
+    @Test
+    public void create_repeated_field_validator() {
+        final FieldDescriptor field = RepeatedRequiredMsgFieldValue.getDescriptor().getFields().get(0);
+
+        final Object fieldValue = Collections.singletonList(StringValue.getDefaultInstance());
+
+        final FieldValidator validator = FieldValidatorFactory.create(field, fieldValue, FIELD_PATH);
+
+        assertTrue(validator instanceof MessageFieldValidator);
+    }
 
     @Test
     public void create_message_field_validator() {

--- a/client/src/test/java/io/spine/validate/MessageValidatorShould.java
+++ b/client/src/test/java/io/spine/validate/MessageValidatorShould.java
@@ -53,6 +53,7 @@ import io.spine.test.validate.msg.EntityIdLongFieldValue;
 import io.spine.test.validate.msg.EntityIdMsgFieldValue;
 import io.spine.test.validate.msg.EntityIdRepeatedFieldValue;
 import io.spine.test.validate.msg.EntityIdStringFieldValue;
+import io.spine.test.validate.msg.MapRequiredMsgFieldValue;
 import io.spine.test.validate.msg.MaxNumberFieldValue;
 import io.spine.test.validate.msg.MinNumberFieldValue;
 import io.spine.test.validate.msg.PatternStringFieldValue;
@@ -118,6 +119,22 @@ public class MessageValidatorShould {
     /*
      * Required option tests.
      */
+
+    @Test
+    public void find_out_that_map_required_field_has_no_values() {
+        validate(MapRequiredMsgFieldValue.getDefaultInstance());
+        assertIsValid(false);
+    }
+
+    @Test
+    public void find_out_that_map_required_field_has_valid_values() {
+        final MapRequiredMsgFieldValue validMsg = MapRequiredMsgFieldValue.newBuilder()
+                                                                     .putValue(newUuid(), newStringValue())
+                                                                     .putValue(newUuid(), newStringValue())
+                                                                     .build();
+        validate(validMsg);
+        assertIsValid(true);
+    }
 
     @Test
     public void find_out_that_required_Message_field_is_set() {

--- a/client/src/test/proto/spine/test/validate/msg/messages.proto
+++ b/client/src/test/proto/spine/test/validate/msg/messages.proto
@@ -60,6 +60,10 @@ message RepeatedRequiredMsgFieldValue {
     repeated google.protobuf.StringValue value = 1 [(required) = true];
 }
 
+message MapRequiredMsgFieldValue {
+    map<string, google.protobuf.StringValue> value = 1 [(required) = true];
+}
+
 message RequiredEnumFieldValue {
     Time value = 1 [(required) = true];
 }


### PR DESCRIPTION
Previously `FieldValidator` wasn't aware of possible `Map` values passed to validate, that's why generated `ValidatingBuilders` were not able to validate `map` values.

This PR fixes `ClassCastException` that was thrown by `MessageFieldValidator.isTimestamp()` when `AbstractValidatingBuilder` was trying to `validate` values, that are going to be passed to `map` type field, e.g. for such message:
```proto
message MapRequiredMsgFieldValue {
    map<string, google.protobuf.StringValue> value = 1;
}
```

Also, I've added several unit tests to be sure, that validators could be created for protobuf fields with `reapeated` and `map` types.