### PR TITLE
Publish `core`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ ext {
 
     credentialsPropertyFile = 'credentials.properties'
     publishPlugin = "$rootDir/scripts/publish.gradle"
-    projectsToPublish = ["base", "client", "server", "testutil-base", "testutil-client", "testutil-server"]
+    projectsToPublish = ["base", "core", "client", "server", "testutil-base", "testutil-client", "testutil-server"]
 }
 
 allprojects {


### PR DESCRIPTION
This PR includes the `core` module into publishing. The version is not bumped since it just fixed the publishing problem of the version increased by the previous PR.