### PR TITLE
Introduce `ThrowableMessage` and use it instead of `FailureThrowable` where possible

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -2,6 +2,7 @@
 exclude_paths:
 - "client/src/main/java/io/spine/net/Patterns.java"
 - "base/src/test/**/*.*"
+- "core/src/test/**/*.*"
 - "client/src/test/**/*.*"
 - "server/src/test/**/*.*"
 - "server-deployment/src/test/**/*.*"

--- a/.gitignore
+++ b/.gitignore
@@ -14,14 +14,10 @@
 /core-java/target
 
 # Generated source code
-*/generated/*
+generated/
 
 # Gradle build files
-build/*
-*/build/*
-
-# Class files produced by the IDE
-classes/*
+build/
 
 # Login details to Maven repository.
 # Each workstation should have developer's login defined in this file.

--- a/base/src/main/java/io/spine/base/ThrowableMessage.java
+++ b/base/src/main/java/io/spine/base/ThrowableMessage.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.spine.base;
+
+import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.Message;
+import com.google.protobuf.Timestamp;
+
+import static io.spine.time.Time.getCurrentTime;
+
+/**
+ * A {@code Throwable}, which state is a {@link Message}.
+ *
+ * <p>Typically used to signalize about a business failure, occurred in a system. In which case
+ * the {@code message} thrown is a detailed description of the failure reason.
+ *
+ * @author Alex Tymchenko
+ */
+public abstract class ThrowableMessage extends Throwable {
+
+    private static final long serialVersionUID = 0L;
+
+    /**
+     * We accept GeneratedMessage (instead of Message) because generated messages
+     * implement {@code Serializable}.
+     */
+    private final GeneratedMessageV3 message;
+
+    /** The moment of creation of this object. */
+    private final Timestamp timestamp;
+
+    protected ThrowableMessage(GeneratedMessageV3 message) {
+        super();
+        this.message = message;
+        this.timestamp = getCurrentTime();
+    }
+
+    public Message getMessageThrown() {
+        return message;
+    }
+
+    /**
+     * Returns timestamp of the failure message creation.
+     */
+    public Timestamp getTimestamp() {
+        return timestamp;
+    }
+}

--- a/base/src/test/java/io/spine/base/ThrowableMessageShould.java
+++ b/base/src/test/java/io/spine/base/ThrowableMessageShould.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.spine.base;
+
+import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.util.Timestamps;
+import io.spine.protobuf.Wrapper;
+import org.junit.Test;
+
+import static io.spine.Identifier.newUuid;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Alex Tymchenko
+ */
+public class ThrowableMessageShould {
+
+    @Test
+    public void create_instance() {
+        final StringValue message = Wrapper.forString(newUuid());
+
+        final ThrowableMessage throwableMessage = new TestThrowableMessage(message);
+
+        assertEquals(message, throwableMessage.getMessageThrown());
+        assertTrue(Timestamps.isValid(throwableMessage.getTimestamp()));
+    }
+
+    /**
+     * Sample {@code ThrowableMessage} class used for test purposes only.
+     */
+    private static class TestThrowableMessage extends ThrowableMessage {
+
+        private static final long serialVersionUID = 0L;
+
+        private TestThrowableMessage(GeneratedMessageV3 failure) {
+            super(failure);
+        }
+    }
+}

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.9.28-SNAPSHOT'
+def final SPINE_VERSION = '0.9.29-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION

--- a/server/src/main/java/io/spine/server/bus/Bus.java
+++ b/server/src/main/java/io/spine/server/bus/Bus.java
@@ -114,7 +114,7 @@ public abstract class Bus<T extends Message,
      * an {@link io.spine.base.Status.StatusCase#OK OK} status {@link IsSent} instance. Usually,
      * the {@link io.spine.base.Failure} status may only pop up if the {@link MessageDispatcher}
      * processes the message sequentially and throws
-     * the {@linkplain io.spine.base.FailureThrowable FailureThrowables} (wrapped in a
+     * the {@linkplain io.spine.base.ThrowableMessage ThrowableMessages} (wrapped in a
      * {@link RuntimeException}) instead of handling them. Otherwise, the {@code OK} status should
      * be expected.
      *
@@ -237,7 +237,7 @@ public abstract class Bus<T extends Message,
      *             <li>{@link io.spine.base.Failure Failure} status, if a {@code Failure} has
      *                 happened during the message handling (if applicable);
      *             <li>{@link io.spine.base.Error Error} status if a {@link Throwable}, which is not
-     *                 a {@link io.spine.base.FailureThrowable FailureThrowable}, has been thrown
+     *                 a {@link io.spine.base.ThrowableMessage ThrowableMessage}, has been thrown
      *                 during the message posting.
      *         </ul>
      * @see #post(Message, StreamObserver) for the public API

--- a/server/src/main/java/io/spine/server/command/CommandHandlingEntity.java
+++ b/server/src/main/java/io/spine/server/command/CommandHandlingEntity.java
@@ -23,7 +23,6 @@ package io.spine.server.command;
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import io.spine.Identifier;
-import io.spine.base.Command;
 import io.spine.base.CommandContext;
 import io.spine.base.ThrowableMessage;
 import io.spine.change.MessageMismatch;
@@ -52,7 +51,8 @@ import java.util.List;
  * <p>The method may throw one or more throwables derived from
  * {@link io.spine.base.ThrowableMessage ThrowableMessage}.
  * Throwing a {@code ThrowableMessage} indicates that the passed command cannot be handled
- * because of a {@linkplain io.spine.base.Failures#toFailure(ThrowableMessage, Command)
+ * because of a
+ * {@linkplain io.spine.base.Failures#toFailure(ThrowableMessage, io.spine.base.Command)
  * business failure}.
  *
  * {@inheritDoc}

--- a/server/src/main/java/io/spine/server/command/CommandHandlingEntity.java
+++ b/server/src/main/java/io/spine/server/command/CommandHandlingEntity.java
@@ -23,8 +23,9 @@ package io.spine.server.command;
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import io.spine.Identifier;
+import io.spine.base.Command;
 import io.spine.base.CommandContext;
-import io.spine.base.FailureThrowable;
+import io.spine.base.ThrowableMessage;
 import io.spine.change.MessageMismatch;
 import io.spine.change.StringMismatch;
 import io.spine.change.ValueMismatch;
@@ -49,9 +50,10 @@ import java.util.List;
  * if it produces more than one event.
  *
  * <p>The method may throw one or more throwables derived from
- * {@link FailureThrowable FailureThrowable}.
- * Throwing a {@code FailureThrowable} indicates that the passed command cannot be handled
- * because of a {@linkplain FailureThrowable#getFailureMessage() business failure}.
+ * {@link io.spine.base.ThrowableMessage ThrowableMessage}.
+ * Throwing a {@code ThrowableMessage} indicates that the passed command cannot be handled
+ * because of a {@linkplain io.spine.base.Failures#toFailure(ThrowableMessage, Command)
+ * business failure}.
  *
  * {@inheritDoc}
  *

--- a/server/src/main/java/io/spine/server/commandbus/CommandBus.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandBus.java
@@ -31,8 +31,8 @@ import io.spine.base.Command;
 import io.spine.base.CommandClass;
 import io.spine.base.Error;
 import io.spine.base.Failure;
-import io.spine.base.FailureThrowable;
 import io.spine.base.IsSent;
+import io.spine.base.ThrowableMessage;
 import io.spine.envelope.CommandEnvelope;
 import io.spine.server.Environment;
 import io.spine.server.bus.Bus;
@@ -46,6 +46,7 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.getRootCause;
+import static io.spine.base.Failures.toFailure;
 import static io.spine.server.bus.Buses.acknowledge;
 import static io.spine.server.bus.Buses.reject;
 import static io.spine.util.Exceptions.toError;
@@ -189,9 +190,9 @@ public class CommandBus extends Bus<Command,
             final Throwable cause = getRootCause(e);
             commandStore.updateCommandStatus(envelope, cause, log);
 
-            if (cause instanceof FailureThrowable) {
-                final FailureThrowable failureThrowable = (FailureThrowable) cause;
-                final Failure failure = failureThrowable.toFailure(envelope.getCommand());
+            if (cause instanceof ThrowableMessage) {
+                final ThrowableMessage throwableMessage = (ThrowableMessage) cause;
+                final Failure failure = toFailure(throwableMessage, envelope.getCommand());
                 failureBus().post(failure);
                 result = reject(envelope.getId(), failure);
             } else {

--- a/server/src/main/java/io/spine/server/commandbus/CommandBus.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandBus.java
@@ -31,6 +31,7 @@ import io.spine.base.Command;
 import io.spine.base.CommandClass;
 import io.spine.base.Error;
 import io.spine.base.Failure;
+import io.spine.base.FailureThrowable;
 import io.spine.base.IsSent;
 import io.spine.base.ThrowableMessage;
 import io.spine.envelope.CommandEnvelope;
@@ -193,6 +194,11 @@ public class CommandBus extends Bus<Command,
             if (cause instanceof ThrowableMessage) {
                 final ThrowableMessage throwableMessage = (ThrowableMessage) cause;
                 final Failure failure = toFailure(throwableMessage, envelope.getCommand());
+                failureBus().post(failure);
+                result = reject(envelope.getId(), failure);
+            } if (cause instanceof FailureThrowable) {
+                final FailureThrowable failureThrowable = (FailureThrowable) cause;
+                final Failure failure = failureThrowable.toFailure(envelope.getCommand());
                 failureBus().post(failure);
                 result = reject(envelope.getId(), failure);
             } else {

--- a/server/src/main/java/io/spine/server/commandbus/Log.java
+++ b/server/src/main/java/io/spine/server/commandbus/Log.java
@@ -23,6 +23,7 @@ package io.spine.server.commandbus;
 import com.google.protobuf.Message;
 import io.spine.Identifier;
 import io.spine.base.CommandId;
+import io.spine.base.FailureThrowable;
 import io.spine.base.ThrowableMessage;
 import io.spine.type.TypeName;
 import org.slf4j.Logger;
@@ -55,6 +56,14 @@ public class Log {
     public void failureHandling(ThrowableMessage flr, Message commandMessage, CommandId commandId) {
         final String msg = formatMessageTypeAndId(
                 "Business failure occurred when handling command `%s` (ID: `%s`)",
+                commandMessage,
+                commandId);
+        log().warn(msg, flr);
+    }
+
+    public void failureHandling(FailureThrowable flr, Message commandMessage, CommandId commandId) {
+        final String msg = formatMessageTypeAndId(
+                "Business failure throwable occurred when handling command `%s` (ID: `%s`)",
                 commandMessage,
                 commandId);
         log().warn(msg, flr);

--- a/server/src/main/java/io/spine/server/commandbus/Log.java
+++ b/server/src/main/java/io/spine/server/commandbus/Log.java
@@ -23,7 +23,7 @@ package io.spine.server.commandbus;
 import com.google.protobuf.Message;
 import io.spine.Identifier;
 import io.spine.base.CommandId;
-import io.spine.base.FailureThrowable;
+import io.spine.base.ThrowableMessage;
 import io.spine.type.TypeName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +52,7 @@ public class Log {
         log().error(msg, exception);
     }
 
-    public void failureHandling(FailureThrowable flr, Message commandMessage, CommandId commandId) {
+    public void failureHandling(ThrowableMessage flr, Message commandMessage, CommandId commandId) {
         final String msg = formatMessageTypeAndId(
                 "Business failure occurred when handling command `%s` (ID: `%s`)",
                 commandMessage,

--- a/server/src/main/java/io/spine/server/commandstore/CommandStore.java
+++ b/server/src/main/java/io/spine/server/commandstore/CommandStore.java
@@ -27,6 +27,7 @@ import io.spine.base.CommandStatus;
 import io.spine.base.Error;
 import io.spine.base.Errors;
 import io.spine.base.Failure;
+import io.spine.base.FailureThrowable;
 import io.spine.base.ThrowableMessage;
 import io.spine.envelope.CommandEnvelope;
 import io.spine.server.commandbus.CommandException;
@@ -266,7 +267,11 @@ public class CommandStore implements AutoCloseable {
             final ThrowableMessage throwableMessage = (ThrowableMessage) cause;
             log.failureHandling(throwableMessage, commandMessage, commandId);
             updateStatus(commandEnvelope, toFailure(throwableMessage, commandEnvelope.getCommand()));
-        } else if (cause instanceof Exception) {
+        }  if (cause instanceof FailureThrowable) {
+            final FailureThrowable failureThrowable = (FailureThrowable) cause;
+            log.failureHandling(failureThrowable, commandMessage, commandId);
+            updateStatus(commandEnvelope, failureThrowable.toFailure(commandEnvelope.getCommand()));
+        }else if (cause instanceof Exception) {
             final Exception exception = (Exception) cause;
             log.errorHandling(exception, commandMessage, commandId);
             updateStatus(commandEnvelope, exception);

--- a/server/src/main/java/io/spine/server/commandstore/CommandStore.java
+++ b/server/src/main/java/io/spine/server/commandstore/CommandStore.java
@@ -27,7 +27,7 @@ import io.spine.base.CommandStatus;
 import io.spine.base.Error;
 import io.spine.base.Errors;
 import io.spine.base.Failure;
-import io.spine.base.FailureThrowable;
+import io.spine.base.ThrowableMessage;
 import io.spine.envelope.CommandEnvelope;
 import io.spine.server.commandbus.CommandException;
 import io.spine.server.commandbus.CommandRecord;
@@ -44,6 +44,7 @@ import java.util.Iterator;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static io.spine.base.Failures.toFailure;
 
 /**
  * Manages storage of commands received by a Bounded Context.
@@ -261,10 +262,10 @@ public class CommandStore implements AutoCloseable {
     public void updateCommandStatus(CommandEnvelope commandEnvelope, Throwable cause, Log log) {
         final Message commandMessage = commandEnvelope.getMessage();
         final CommandId commandId = commandEnvelope.getId();
-        if (cause instanceof FailureThrowable) {
-            final FailureThrowable failure = (FailureThrowable) cause;
-            log.failureHandling(failure, commandMessage, commandId);
-            updateStatus(commandEnvelope, failure.toFailure(commandEnvelope.getCommand()));
+        if (cause instanceof ThrowableMessage) {
+            final ThrowableMessage throwableMessage = (ThrowableMessage) cause;
+            log.failureHandling(throwableMessage, commandMessage, commandId);
+            updateStatus(commandEnvelope, toFailure(throwableMessage, commandEnvelope.getCommand()));
         } else if (cause instanceof Exception) {
             final Exception exception = (Exception) cause;
             log.errorHandling(exception, commandMessage, commandId);

--- a/server/src/main/java/io/spine/server/failure/FailureBus.java
+++ b/server/src/main/java/io/spine/server/failure/FailureBus.java
@@ -45,12 +45,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @author Alexander Yevsyuov
  * @author Alex Tymchenko
- * @see io.spine.base.FailureThrowable
+ * @see io.spine.base.ThrowableMessage
+ * @see io.spine.base.Failures
  * @see io.spine.base.Subscribe @Subscribe
  */
 public class FailureBus extends CommandOutputBus<Failure,
                                                  FailureEnvelope,
-        FailureClass,
+                                                 FailureClass,
                                                  FailureDispatcher> {
 
     /**

--- a/server/src/test/java/io/spine/server/commandbus/CommandStoreShould.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandStoreShould.java
@@ -29,8 +29,8 @@ import io.spine.base.CommandContext;
 import io.spine.base.CommandId;
 import io.spine.base.CommandStatus;
 import io.spine.base.Error;
-import io.spine.base.FailureThrowable;
 import io.spine.base.TenantId;
+import io.spine.base.ThrowableMessage;
 import io.spine.envelope.CommandEnvelope;
 import io.spine.protobuf.Wrapper;
 import io.spine.server.command.Assign;
@@ -51,6 +51,7 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Lists.newArrayList;
 import static io.spine.base.Commands.getMessage;
+import static io.spine.base.Failures.toFailure;
 import static io.spine.server.commandbus.Given.Command.addTask;
 import static io.spine.server.commandbus.Given.Command.createProject;
 import static io.spine.server.commandbus.Given.Command.startProject;
@@ -123,7 +124,7 @@ public abstract class CommandStoreShould extends AbstractCommandBusTestSuite {
         final ProcessingStatus status = getStatus(commandId, tenantId);
 
         assertEquals(CommandStatus.FAILURE, status.getCode());
-        assertEquals(failure.toFailure(command)
+        assertEquals(toFailure(failure, command)
                             .getMessage(), status.getFailure()
                                                  .getMessage());
     }
@@ -269,7 +270,7 @@ public abstract class CommandStoreShould extends AbstractCommandBusTestSuite {
      * Throwables
      ********************/
 
-    private static class TestFailure extends FailureThrowable {
+    private static class TestFailure extends ThrowableMessage {
         private static final long serialVersionUID = 0L;
 
         private TestFailure() {

--- a/server/src/test/java/io/spine/server/commandbus/CommandStoreShould.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandStoreShould.java
@@ -29,8 +29,8 @@ import io.spine.base.CommandContext;
 import io.spine.base.CommandId;
 import io.spine.base.CommandStatus;
 import io.spine.base.Error;
+import io.spine.base.FailureThrowable;
 import io.spine.base.TenantId;
-import io.spine.base.ThrowableMessage;
 import io.spine.envelope.CommandEnvelope;
 import io.spine.protobuf.Wrapper;
 import io.spine.server.command.Assign;
@@ -51,7 +51,6 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Lists.newArrayList;
 import static io.spine.base.Commands.getMessage;
-import static io.spine.base.Failures.toFailure;
 import static io.spine.server.commandbus.Given.Command.addTask;
 import static io.spine.server.commandbus.Given.Command.createProject;
 import static io.spine.server.commandbus.Given.Command.startProject;
@@ -124,7 +123,7 @@ public abstract class CommandStoreShould extends AbstractCommandBusTestSuite {
         final ProcessingStatus status = getStatus(commandId, tenantId);
 
         assertEquals(CommandStatus.FAILURE, status.getCode());
-        assertEquals(toFailure(failure, command)
+        assertEquals(failure.toFailure(command)
                             .getMessage(), status.getFailure()
                                                  .getMessage());
     }
@@ -270,7 +269,7 @@ public abstract class CommandStoreShould extends AbstractCommandBusTestSuite {
      * Throwables
      ********************/
 
-    private static class TestFailure extends ThrowableMessage {
+    private static class TestFailure extends FailureThrowable {
         private static final long serialVersionUID = 0L;
 
         private TestFailure() {

--- a/testutil-base/src/main/java/io/spine/test/Spy.java
+++ b/testutil-base/src/main/java/io/spine/test/Spy.java
@@ -30,8 +30,7 @@ import static io.spine.util.Exceptions.illegalArgumentWithCauseOf;
  * Utility for injecting a Mockito spy in a private field of an object.
  *
  * <p>Although, it's a not recommended way of testing, in some cases such an approach is needed for
- * testing interactions in a complex objects like {@link io.spine.server.BoundedContext
- * BoundedContext}.
+ * testing interactions in complex objects.
  *
  * @author Alexander Yevsyukov
  */


### PR DESCRIPTION
This PR introduces a `ThrowableMessage` as a more generic abstraction for the `Throwables`, having a complex state, than `FailureThrowable`s we had before.

This exception is a base routine, which is later going to be used in Failure generator plugin (part of a `base/model-compiler`.

In the following PRs, the `FailureThrowable` will be phased out and removed from the source code base. It is impossible to do now, since it is still used in the generated code.

Also, `.gitignore` is optimized.

The framework version is increased to `0.9.29-SNAPSHOT`.