### PR TITLE
Move `GivenCommandContext` to `testutil-core`

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.9.36-SNAPSHOT'
+def final SPINE_VERSION = '0.9.37-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/test/java/io/spine/server/commandbus/ValidatorShould.java
+++ b/server/src/test/java/io/spine/server/commandbus/ValidatorShould.java
@@ -25,7 +25,6 @@ import io.spine.client.TestActorRequestFactory;
 import io.spine.core.Command;
 import io.spine.core.CommandContext;
 import io.spine.core.CommandEnvelope;
-import io.spine.core.given.GivenCommandContext;
 import io.spine.protobuf.AnyPacker;
 import io.spine.test.command.CreateProject;
 import io.spine.time.Time;
@@ -35,6 +34,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static io.spine.core.Commands.generateId;
+import static io.spine.core.given.GivenCommandContext.withRandomActor;
 import static io.spine.server.commandbus.Given.CommandMessage.createProjectMessage;
 import static org.junit.Assert.assertEquals;
 
@@ -60,8 +60,7 @@ public class ValidatorShould {
         final Command commandWithEmptyMessage = Command.newBuilder()
                                                        .setId(generateId())
                                                        .setMessage(invalidMessagePacked)
-                                                       .setContext(
-                                                               GivenCommandContext.withRandomUser())
+                                                       .setContext(withRandomActor())
                                                        .build();
 
         final List<ConstraintViolation> violations =

--- a/server/src/test/java/io/spine/server/event/EventStoreShould.java
+++ b/server/src/test/java/io/spine/server/event/EventStoreShould.java
@@ -30,7 +30,6 @@ import io.spine.core.CommandContext;
 import io.spine.core.Event;
 import io.spine.core.EventContext;
 import io.spine.core.TenantId;
-import io.spine.core.given.GivenCommandContext;
 import io.spine.server.BoundedContext;
 import io.spine.server.command.TestEventFactory;
 import io.spine.test.event.ProjectCreated;
@@ -48,6 +47,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.google.common.collect.Sets.newConcurrentHashSet;
 import static com.google.protobuf.util.Timestamps.add;
 import static com.google.protobuf.util.Timestamps.subtract;
+import static io.spine.core.given.GivenCommandContext.withRandomActor;
 import static io.spine.test.Verify.assertContainsAll;
 import static io.spine.test.Verify.assertSize;
 import static io.spine.time.Time.getCurrentTime;
@@ -78,7 +78,7 @@ public class EventStoreShould {
 
     @BeforeClass
     public static void prepare() {
-        final CommandContext context = GivenCommandContext.withRandomUser();
+        final CommandContext context = withRandomActor();
         eventFactory = TestEventFactory.newInstance(EventStoreShould.class, context);
     }
 

--- a/testutil-core/src/main/java/io/spine/core/given/GivenCommandContext.java
+++ b/testutil-core/src/main/java/io/spine/core/given/GivenCommandContext.java
@@ -32,27 +32,37 @@ import static io.spine.time.Time.getCurrentTime;
 import static io.spine.time.ZoneOffsets.UTC;
 
 /**
- * Creates Context for tests.
+ * Factory methods to create {@code CommandContext} instances for test purposes.
  *
  * @author Mikhail Mikhaylov
  */
 public class GivenCommandContext {
 
     private GivenCommandContext() {
+        // Prevent instantiation of this utility class.
     }
 
-    /** Creates a new {@link CommandContext} instance. */
-    public static CommandContext withRandomUser() {
+    /**
+     * Creates a new {@link CommandContext} instance with a randomly
+     * generated {@linkplain UserId actor} and current timestamp as a creation date.
+     *
+     * @return a new {@code CommandContext} instance
+     */
+    public static CommandContext withRandomActor() {
         final UserId userId = GivenUserId.newUuid();
         final Timestamp now = getCurrentTime();
-        return withUserAndTime(userId, now);
+        return withActorAndTime(userId, now);
     }
 
-    /** Creates a new {@link CommandContext} instance. */
-    public static CommandContext withUserAndTime(UserId userId, Timestamp when) {
+    /**
+     * Creates a new {@link CommandContext} instance based upon given actor and creation date.
+     *
+     * @return a new {@code CommandContext} instance
+     */
+    public static CommandContext withActorAndTime(UserId actor, Timestamp when) {
         final TenantId tenantId = GivenTenantId.newUuid();
         final ActorContext.Builder actorContext = ActorContext.newBuilder()
-                                                              .setActor(userId)
+                                                              .setActor(actor)
                                                               .setTimestamp(when)
                                                               .setZoneOffset(UTC)
                                                               .setTenantId(tenantId);
@@ -61,7 +71,13 @@ public class GivenCommandContext {
         return builder.build();
     }
 
-    /** Creates a new context with the given delay before the delivery time. */
+    /**
+     * Creates a new {@link CommandContext} with the given delay before the delivery time.
+     *
+     * <p>The actor identifier for the context is generated randomly.
+     *
+     * @return a new {@code CommandContext} instance
+     */
     public static CommandContext withScheduledDelayOf(Duration delay) {
         final Schedule schedule = Schedule.newBuilder()
                                           .setDelay(delay)
@@ -69,10 +85,16 @@ public class GivenCommandContext {
         return withSchedule(schedule);
     }
 
-    /** Creates a new context with the given scheduling options. */
+    /**
+     * Creates a new {@link CommandContext} with the given scheduling options.
+     *
+     * <p>The actor identifier for the context is generated randomly.
+     *
+     * @return a new {@code CommandContext} instance
+     */
     private static CommandContext withSchedule(Schedule schedule) {
-        final CommandContext.Builder builder = withRandomUser().toBuilder()
-                                                               .setSchedule(schedule);
+        final CommandContext.Builder builder = withRandomActor().toBuilder()
+                                                                .setSchedule(schedule);
         return builder.build();
     }
 }

--- a/testutil-core/src/test/java/io/spine/core/given/GivenCommandContextShould.java
+++ b/testutil-core/src/test/java/io/spine/core/given/GivenCommandContextShould.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.spine.core.given;
+
+import com.google.common.testing.NullPointerTester;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Timestamp;
+import io.spine.core.ActorContext;
+import io.spine.core.CommandContext;
+import io.spine.core.CommandContext.Schedule;
+import io.spine.core.UserId;
+import io.spine.test.Tests;
+import io.spine.time.Durations2;
+import org.junit.Test;
+
+import static com.google.protobuf.util.Timestamps.add;
+import static io.spine.core.given.GivenUserId.newUuid;
+import static io.spine.time.Durations2.fromMinutes;
+import static io.spine.time.Time.getCurrentTime;
+import static io.spine.validate.Validate.checkValid;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * @author Alex Tymchenko
+ */
+public class GivenCommandContextShould {
+
+    @Test
+    public void have_utility_ctor() {
+        Tests.assertHasPrivateParameterlessCtor(GivenCommandContext.class);
+    }
+
+    @Test
+    public void pass_null_tolerance_check() {
+        new NullPointerTester()
+                .setDefault(UserId.class, UserId.getDefaultInstance())
+                .setDefault(Timestamp.class, Timestamp.getDefaultInstance())
+                .testAllPublicStaticMethods(GivenCommandContext.class);
+    }
+
+    @Test
+    public void create_with_random_actor() {
+        final CommandContext first = GivenCommandContext.withRandomActor();
+        final CommandContext second = GivenCommandContext.withRandomActor();
+
+        checkValid(first);
+        checkValid(second);
+
+        final ActorContext firstActorContext = first.getActorContext();
+        final ActorContext secondActorContext = second.getActorContext();
+        assertNotEquals(firstActorContext.getActor(), secondActorContext.getActor());
+    }
+
+    @Test
+    public void create_with_actor_and_time() {
+        final UserId actorId = newUuid();
+        final Timestamp when = add(getCurrentTime(), fromMinutes(42));
+
+        final CommandContext context = GivenCommandContext.withActorAndTime(actorId, when);
+        checkValid(context);
+
+        final ActorContext actualActorContext = context.getActorContext();
+
+        assertEquals(actorId, actualActorContext.getActor());
+        assertEquals(when, actualActorContext.getTimestamp());
+    }
+
+    @Test
+    public void create_with_scheduled_delay() {
+        final Duration delay = Durations2.fromHours(42);
+        final Schedule expectedSchedule = Schedule.newBuilder()
+                                                  .setDelay(delay)
+                                                  .build();
+
+        final CommandContext context = GivenCommandContext.withScheduledDelayOf(delay);
+        checkValid(context);
+
+        final Schedule actualSchedule = context.getSchedule();
+        assertEquals(expectedSchedule, actualSchedule);
+    }
+}


### PR DESCRIPTION
In scope of this PR the `GivenCommandContext` test utility is moved to `testutil-core`. 

Thus, all the `Given...` utilities become located in the same `io.spine.core.given` package of `testutil-core` module. It allows the rest of Spine libraries to depend on `testutil` modules rather than on `spine-core`.

The framework version has been increased to `0.9.37-SNAPSHOT`.

