### PR TITLE
Method naming convention change

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -148,11 +148,6 @@
     <inspection_tool class="ConfusingMainMethod" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConfusingOctalEscape" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConstantAssertCondition" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ConstantConditions" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="false" />
-      <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="false" />
-      <option name="REPORT_UNCHECKED_OPTIONALS" value="false" />
-    </inspection_tool>
     <inspection_tool class="ConstantNamingConvention" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="onlyCheckImmutables" value="true" />
       <option name="m_regex" value="[A-Z_\d]*" />
@@ -527,7 +522,7 @@
     <inspection_tool class="PackageWithTooManyClasses" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="limit" value="50" />
     </inspection_tool>
-    <inspection_tool class="ParameterNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
+    <inspection_tool class="ParameterNamingConvention" enabled="true" level="TYPO" enabled_by_default="true">
       <option name="m_regex" value="[a-z][A-Za-z\d]*" />
       <option name="m_minLength" value="1" />
       <option name="m_maxLength" value="20" />

--- a/client/src/test/java/io/spine/client/QueryFactoryShould.java
+++ b/client/src/test/java/io/spine/client/QueryFactoryShould.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Alex Tymchenko
  */
-@SuppressWarnings({"LocalVariableNamingConvention", "MethodParameterNamingConvention"})
+@SuppressWarnings("LocalVariableNamingConvention")
 public class QueryFactoryShould extends ActorRequestFactoryShould {
 
     // See {@code client_requests} for declaration.

--- a/server/src/main/java/io/spine/server/event/EventBus.java
+++ b/server/src/main/java/io/spine/server/event/EventBus.java
@@ -423,7 +423,7 @@ public class EventBus extends CommandOutputBus<Event,
          *
          * @see #setEventStore(EventStore)
          */
-        @SuppressWarnings("MethodParameterNamingConvention")
+
         public Builder setEventStoreStreamExecutor(Executor eventStoreStreamExecutor) {
             checkState(eventStore == null, MSG_EVENT_STORE_CONFIGURED);
             this.eventStoreStreamExecutor = eventStoreStreamExecutor;


### PR DESCRIPTION
- [ ]  Reduce the issue level to "typo" in IDEA settings.
- [ ]  Update all the projects with the most recent configuration.
- [ ]  Remove all @SuppressWarnings("MethodParameterNamingConvention") as redundant.