### PR TITLE
AggregateStateId clean up

### DIFF
--- a/server/src/main/java/io/spine/server/stand/AggregateStateId.java
+++ b/server/src/main/java/io/spine/server/stand/AggregateStateId.java
@@ -43,7 +43,8 @@ public final class AggregateStateId<I> {
 
     static {
         StringifierRegistry.getInstance()
-                           .register(new AggregateStateIdStringifier(), AggregateStateId.class);
+                           .register(AggregateStateIdStringifier.getInstance(),
+                                     AggregateStateId.class);
     }
 
     private final I aggregateId;

--- a/server/src/main/java/io/spine/server/stand/AggregateStateId.java
+++ b/server/src/main/java/io/spine/server/stand/AggregateStateId.java
@@ -49,12 +49,6 @@ public final class AggregateStateId<I> {
     private final I aggregateId;
     private final TypeUrl stateType;
 
-    static {
-        StringifierRegistry.getInstance()
-                           .register(new AggregateStateIdStringifier(),
-                                     AggregateStateId.class);
-    }
-
     private AggregateStateId(I aggregateId, TypeUrl stateType) {
         this.aggregateId = checkNotNull(aggregateId);
         this.stateType = checkNotNull(stateType);

--- a/server/src/main/java/io/spine/server/stand/AggregateStateIdStringifier.java
+++ b/server/src/main/java/io/spine/server/stand/AggregateStateIdStringifier.java
@@ -42,12 +42,20 @@ import static io.spine.util.Exceptions.illegalStateWithCauseOf;
  *
  * @author Dmytro Dashenkov
  */
-class AggregateStateIdStringifier extends Stringifier<AggregateStateId> {
+final class AggregateStateIdStringifier extends Stringifier<AggregateStateId> {
 
     private static final String DIVIDER = "-";
     private static final int MEAN_STRING_LENGTH = 256;
     private static final String TYPE_NAME_DIVIDER = ".";
     private static final String JAVA_LANG_PACKAGE_NAME = "java.lang.";
+
+    static Stringifier<AggregateStateId> getInstance() {
+        return Singleton.INSTANCE.value;
+    }
+
+    private AggregateStateIdStringifier() {
+        // Prevent direct instantiation.
+    }
 
     @Override
     protected String toString(AggregateStateId id) {
@@ -118,5 +126,11 @@ class AggregateStateIdStringifier extends Stringifier<AggregateStateId> {
             }
         }
         return result;
+    }
+
+    private enum Singleton {
+        INSTANCE;
+        @SuppressWarnings("NonSerializableFieldInSerializableClass")
+        private final Stringifier<AggregateStateId> value = new AggregateStateIdStringifier();
     }
 }

--- a/server/src/test/java/io/spine/server/stand/AggregateStateIdStringifierShould.java
+++ b/server/src/test/java/io/spine/server/stand/AggregateStateIdStringifierShould.java
@@ -195,6 +195,6 @@ public class AggregateStateIdStringifierShould {
     }
 
     private static Stringifier<AggregateStateId> stringifier() {
-        return new AggregateStateIdStringifier();
+        return AggregateStateIdStringifier.getInstance();
     }
 }


### PR DESCRIPTION
In this PR:
 - the duplicate `static` initializer in `AggregateStateId` is removed;
 - the `AggregateStateIdStringifier` became a singleton.

Since no actual change in the behavior is or public API is performed, we may leave the framework version unchanged.