### PR TITLE
Uni- and multi-cast dispatchers

### DIFF
--- a/client/src/main/proto/spine/client/command_service.proto
+++ b/client/src/main/proto/spine/client/command_service.proto
@@ -38,5 +38,5 @@ import "spine/core/ack.proto";
 service CommandService {
 
     // Request to handle a command.
-    rpc Post(core.Command) returns (core.IsSent);
+    rpc Post(core.Command) returns (core.Ack);
 }

--- a/client/src/main/proto/spine/client/command_service.proto
+++ b/client/src/main/proto/spine/client/command_service.proto
@@ -32,7 +32,7 @@ option java_outer_classname = "CommandServiceProto";
 option java_generate_equals_and_hash = true;
 
 import "spine/core/command.proto";
-import "spine/core/bus.proto";
+import "spine/core/ack.proto";
 
 // A service for sending commands from clients.
 service CommandService {

--- a/core/src/main/proto/spine/core/ack.proto
+++ b/core/src/main/proto/spine/core/ack.proto
@@ -33,18 +33,18 @@ import "google/protobuf/any.proto";
 
 import "spine/core/response.proto";
 
-// The result of posting a message to a bus.
+// An acknowledgement of posting a message to a bus.
 //
-// The response message brings the ID of the message which has been acknowledged or rejected.
+// This response means that a message was either accepted for further processing, or rejected
+// (e.g. because of a validation error).
 //
-message IsSent {
+// The acknowledgement does not mean that the message was handled or even delivered to recipients.
+//
+message Ack {
 
-    // The correlation ID of the message, i.e. the ID of the message which has been posted.
+    // The ID of the message which has been posted.
     google.protobuf.Any message_id = 1 [(required) = true];
 
-    // The ID of the consumer of the message.
-    google.protobuf.Any consumer_id = 2 [(required) = true];
-
     // The response status.
-    Status status = 3 [(required) = true];
+    Status status = 2 [(required) = true];
 }

--- a/core/src/main/proto/spine/core/ack.proto
+++ b/core/src/main/proto/spine/core/ack.proto
@@ -33,7 +33,7 @@ import "google/protobuf/any.proto";
 
 import "spine/core/response.proto";
 
-// The result of sending a message to a bus.
+// The result of posting a message to a bus.
 //
 // The response message brings the ID of the message which has been acknowledged or rejected.
 //

--- a/core/src/main/proto/spine/core/bus.proto
+++ b/core/src/main/proto/spine/core/bus.proto
@@ -42,6 +42,9 @@ message IsSent {
     // The correlation ID of the message, i.e. the ID of the message which has been posted.
     google.protobuf.Any message_id = 1 [(required) = true];
 
+    // The ID of the consumer of the message.
+    google.protobuf.Any consumer_id = 2 [(required) = true];
+
     // The response status.
-    Status status = 2 [(required) = true];
+    Status status = 3 [(required) = true];
 }

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.9.38-SNAPSHOT'
+def final SPINE_VERSION = '0.9.39-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/BoundedContext.java
+++ b/server/src/main/java/io/spine/server/BoundedContext.java
@@ -26,8 +26,8 @@ import com.google.protobuf.Message;
 import io.grpc.stub.StreamObserver;
 import io.spine.annotation.Experimental;
 import io.spine.annotation.Internal;
+import io.spine.core.Ack;
 import io.spine.core.Event;
-import io.spine.core.IsSent;
 import io.spine.option.EntityOption.Visibility;
 import io.spine.server.commandbus.CommandBus;
 import io.spine.server.commandstore.CommandStore;
@@ -237,7 +237,7 @@ public final class BoundedContext
      */
     @Experimental
     @Override
-    public void notify(IntegrationEvent integrationEvent, StreamObserver<IsSent> observer) {
+    public void notify(IntegrationEvent integrationEvent, StreamObserver<Ack> observer) {
         final Event event = EventFactory.toEvent(integrationEvent);
         eventBus.post(event, observer);
     }

--- a/server/src/main/java/io/spine/server/CommandService.java
+++ b/server/src/main/java/io/spine/server/CommandService.java
@@ -25,9 +25,9 @@ import com.google.common.collect.Sets;
 import io.grpc.stub.StreamObserver;
 import io.spine.base.Error;
 import io.spine.client.grpc.CommandServiceGrpc;
+import io.spine.core.Ack;
 import io.spine.core.Command;
 import io.spine.core.CommandClass;
-import io.spine.core.IsSent;
 import io.spine.server.commandbus.CommandBus;
 import io.spine.server.commandbus.UnsupportedCommandException;
 import org.slf4j.Logger;
@@ -67,7 +67,7 @@ public class CommandService extends CommandServiceGrpc.CommandServiceImplBase {
     @SuppressWarnings("MethodDoesntCallSuperMethod")
     // as we override default implementation with `unimplemented` status.
     @Override
-    public void post(Command request, StreamObserver<IsSent> responseObserver) {
+    public void post(Command request, StreamObserver<Ack> responseObserver) {
         final CommandClass commandClass = CommandClass.of(request);
         final BoundedContext boundedContext = boundedContextMap.get(commandClass);
         if (boundedContext == null) {
@@ -79,11 +79,11 @@ public class CommandService extends CommandServiceGrpc.CommandServiceImplBase {
     }
 
     private static void handleUnsupported(Command request,
-                                          StreamObserver<IsSent> responseObserver) {
+                                          StreamObserver<Ack> responseObserver) {
         final UnsupportedCommandException unsupported = new UnsupportedCommandException(request);
         log().error("Unsupported command posted to CommandService", unsupported);
         final Error error = unsupported.asError();
-        final IsSent response = reject(request.getId(), error);
+        final Ack response = reject(request.getId(), error);
         responseObserver.onNext(response);
         responseObserver.onCompleted();
     }

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -79,7 +79,7 @@ import static io.spine.server.entity.EntityWithLifecycle.Predicates.isEntityVisi
  */
 public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
                 extends Repository<I, A>
-                implements CommandDispatcher, EventDispatcherDelegate {
+                implements CommandDispatcher<I>, EventDispatcherDelegate<I> {
 
     /** The default number of events to be stored before a next snapshot is made. */
     static final int DEFAULT_SNAPSHOT_TRIGGER = 100;
@@ -125,7 +125,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
                       .register(this);
 
         // If there are any events on which aggregates react, register via delegating dispatcher.
-        final DelegatingEventDispatcher delegatingDispatcher = DelegatingEventDispatcher.of(this);
+        final DelegatingEventDispatcher<I> delegatingDispatcher = DelegatingEventDispatcher.of(this);
         if (!delegatingDispatcher.getMessageClasses()
                                  .isEmpty()) {
             boundedContext.getEventBus()
@@ -228,13 +228,13 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * @param envelope the envelope of the command to dispatch
      */
     @Override
-    public void dispatch(final CommandEnvelope envelope) {
-        AggregateCommandEndpoint.handle(this, envelope);
+    public I dispatch(final CommandEnvelope envelope) {
+        return AggregateCommandEndpoint.handle(this, envelope);
     }
 
     @Override
-    public void dispatchEvent(EventEnvelope envelope) {
-        AggregateEventEndpoint.handle(this, envelope);
+    public Set<I> dispatchEvent(EventEnvelope envelope) {
+        return AggregateEventEndpoint.handle(this, envelope);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/bus/Bus.java
+++ b/server/src/main/java/io/spine/server/bus/Bus.java
@@ -24,7 +24,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.protobuf.Message;
 import io.grpc.stub.StreamObserver;
-import io.spine.core.IsSent;
+import io.spine.core.Ack;
 import io.spine.core.MessageEnvelope;
 import io.spine.type.MessageClass;
 
@@ -100,7 +100,7 @@ public abstract class Bus<T extends Message,
      * @param observer the observer to receive outcome of the operation
      * @see #post(Iterable, StreamObserver) for posing multiple messages at once
      */
-    public final void post(T message, StreamObserver<IsSent> observer) {
+    public final void post(T message, StreamObserver<Ack> observer) {
         checkNotNull(message);
         checkNotNull(observer);
         checkArgument(isNotDefault(message));
@@ -115,7 +115,7 @@ public abstract class Bus<T extends Message,
      * of the call. The {@link StreamObserver#onNext StreamObserver.onNext()} is called for each
      * message posted to the bus.
      *
-     * <p>In case the message is accepted by the bus, {@linkplain IsSent IsSent} with the
+     * <p>In case the message is accepted by the bus, {@linkplain Ack IsSent} with the
      * {@link io.spine.core.Status.StatusCase#OK OK} status is passed to the observer.
      *
      * <p>If the message cannot be sent due to some issues, a corresponding
@@ -123,7 +123,7 @@ public abstract class Bus<T extends Message,
      *
      * <p>Depending on the underlying {@link MessageDispatcher}, a message which causes a business
      * {@link io.spine.core.Failure} may result ether a {@link io.spine.core.Failure} status or
-     * an {@link io.spine.core.Status.StatusCase#OK OK} status {@link IsSent} instance. Usually,
+     * an {@link io.spine.core.Status.StatusCase#OK OK} status {@link Ack} instance. Usually,
      * the {@link io.spine.core.Failure} status may only pop up if the {@link MessageDispatcher}
      * processes the message sequentially and throws the failure (wrapped in a
      * the {@linkplain io.spine.base.ThrowableMessage ThrowableMessages}) instead of handling them.
@@ -135,7 +135,7 @@ public abstract class Bus<T extends Message,
      * @param messages the messages to post
      * @param observer the observer to receive outcome of the operation
      */
-    public final void post(Iterable<T> messages, StreamObserver<IsSent> observer) {
+    public final void post(Iterable<T> messages, StreamObserver<Ack> observer) {
         checkNotNull(messages);
         checkNotNull(observer);
 
@@ -248,12 +248,12 @@ public abstract class Bus<T extends Message,
      * @return the message itself if it passes the filtering or
      * {@link Optional#absent() Optional.absent()} otherwise
      */
-    private Iterable<T> filter(Iterable<T> messages, StreamObserver<IsSent> observer) {
+    private Iterable<T> filter(Iterable<T> messages, StreamObserver<Ack> observer) {
         checkNotNull(messages);
         checkNotNull(observer);
         final Collection<T> result = newLinkedList();
         for (T message : messages) {
-            final Optional<IsSent> response = filter(toEnvelope(message));
+            final Optional<Ack> response = filter(toEnvelope(message));
             if (response.isPresent()) {
                 observer.onNext(response.get());
             } else {
@@ -277,8 +277,8 @@ public abstract class Bus<T extends Message,
      * @return the result of message processing by this bus if any, or
      * {@link Optional#absent() Optional.absent()} otherwise
      */
-    private Optional<IsSent> filter(E message) {
-        final Optional<IsSent> filterOutput = filterChain().accept(message);
+    private Optional<Ack> filter(E message) {
+        final Optional<Ack> filterOutput = filterChain().accept(message);
         return filterOutput;
     }
 
@@ -310,7 +310,7 @@ public abstract class Bus<T extends Message,
      *         </ul>
      * @see #post(Message, StreamObserver) for the public API
      */
-    protected abstract IsSent doPost(E envelope);
+    protected abstract Ack doPost(E envelope);
 
     /**
      * Posts each of the given envelopes into the bus and notifies the given observer.
@@ -319,9 +319,9 @@ public abstract class Bus<T extends Message,
      * @param observer  the observer to be notified of the operation result
      * @see #doPost(MessageEnvelope)
      */
-    private void doPost(Iterable<E> envelopes, StreamObserver<IsSent> observer) {
+    private void doPost(Iterable<E> envelopes, StreamObserver<Ack> observer) {
         for (E message : envelopes) {
-            final IsSent result = doPost(message);
+            final Ack result = doPost(message);
             observer.onNext(result);
         }
     }

--- a/server/src/main/java/io/spine/server/bus/Bus.java
+++ b/server/src/main/java/io/spine/server/bus/Bus.java
@@ -55,7 +55,7 @@ import static java.util.Collections.singleton;
 public abstract class Bus<T extends Message,
                           E extends MessageEnvelope<?, T>,
                           C extends MessageClass,
-                          D extends MessageDispatcher<C, E>> implements AutoCloseable {
+                          D extends MessageDispatcher<C>> implements AutoCloseable {
 
     private final Function<T, E> messageConverter = new MessageToEnvelope();
 

--- a/server/src/main/java/io/spine/server/bus/Bus.java
+++ b/server/src/main/java/io/spine/server/bus/Bus.java
@@ -55,7 +55,7 @@ import static java.util.Collections.singleton;
 public abstract class Bus<T extends Message,
                           E extends MessageEnvelope<?, T>,
                           C extends MessageClass,
-                          D extends MessageDispatcher<C>> implements AutoCloseable {
+                          D extends MessageDispatcher<C, E, ?>> implements AutoCloseable {
 
     private final Function<T, E> messageConverter = new MessageToEnvelope();
 

--- a/server/src/main/java/io/spine/server/bus/BusFilter.java
+++ b/server/src/main/java/io/spine/server/bus/BusFilter.java
@@ -22,7 +22,7 @@ package io.spine.server.bus;
 
 import com.google.common.base.Optional;
 import io.spine.annotation.SPI;
-import io.spine.core.IsSent;
+import io.spine.core.Ack;
 import io.spine.core.MessageEnvelope;
 
 /**
@@ -49,7 +49,7 @@ public interface BusFilter<E extends MessageEnvelope<?, ?>> extends AutoCloseabl
      *
      * @param envelope the envelope with the message to filter
      * @return {@code Optional.absent()} if the message passes the filter,
-     *         {@linkplain IsSent posting result} with either status otherwise
+     *         {@linkplain Ack posting result} with either status otherwise
      */
-    Optional<IsSent> accept(E envelope);
+    Optional<Ack> accept(E envelope);
 }

--- a/server/src/main/java/io/spine/server/bus/Buses.java
+++ b/server/src/main/java/io/spine/server/bus/Buses.java
@@ -24,8 +24,8 @@ import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
 import io.spine.base.Error;
+import io.spine.core.Ack;
 import io.spine.core.Failure;
-import io.spine.core.IsSent;
 import io.spine.core.Responses;
 import io.spine.core.Status;
 
@@ -52,7 +52,7 @@ public class Buses {
      * @param id the ID of the message to acknowledge
      * @return {@code IsSent} with an {@code OK} status
      */
-    public static IsSent acknowledge(Message id) {
+    public static Ack acknowledge(Message id) {
         return setStatus(id, Responses.statusOk());
     }
 
@@ -63,7 +63,7 @@ public class Buses {
      * @param cause the cause of the message rejection
      * @return the {@code IsSent} response with the given message ID
      */
-    public static IsSent reject(Message id, Error cause) {
+    public static Ack reject(Message id, Error cause) {
         checkNotNull(cause);
         checkArgument(isNotDefault(cause));
         final Status status = Status.newBuilder()
@@ -79,7 +79,7 @@ public class Buses {
      * @param cause the cause of the message rejection
      * @return the {@code IsSent} response with the given message ID
      */
-    public static IsSent reject(Message id, Failure cause) {
+    public static Ack reject(Message id, Failure cause) {
         checkNotNull(cause);
         checkArgument(isNotDefault(cause));
         final Status status = Status.newBuilder()
@@ -88,14 +88,14 @@ public class Buses {
         return setStatus(id, status);
     }
 
-    private static IsSent setStatus(Message id, Status status) {
+    private static Ack setStatus(Message id, Status status) {
         checkNotNull(id);
 
         final Any packedId = pack(id);
-        final IsSent result = IsSent.newBuilder()
-                                    .setMessageId(packedId)
-                                    .setStatus(status)
-                                    .build();
+        final Ack result = Ack.newBuilder()
+                              .setMessageId(packedId)
+                              .setStatus(status)
+                              .build();
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/bus/DeadMessageFilter.java
+++ b/server/src/main/java/io/spine/server/bus/DeadMessageFilter.java
@@ -23,7 +23,7 @@ package io.spine.server.bus;
 import com.google.common.base.Optional;
 import com.google.protobuf.Message;
 import io.spine.base.Error;
-import io.spine.core.IsSent;
+import io.spine.core.Ack;
 import io.spine.core.MessageEnvelope;
 import io.spine.type.MessageClass;
 
@@ -58,14 +58,14 @@ final class DeadMessageFilter<T extends Message,
     }
 
     @Override
-    public Optional<IsSent> accept(E envelope) {
+    public Optional<Ack> accept(E envelope) {
         @SuppressWarnings("unchecked")
         final C cls = (C) envelope.getMessageClass();
         final Collection<D> dispatchers = registry.getDispatchers(cls);
         if (dispatchers.isEmpty()) {
             final MessageUnhandled report = deadMessageTap.capture(envelope);
             final Error error = report.asError();
-            final IsSent result = reject(idConverter.apply(envelope), error);
+            final Ack result = reject(idConverter.apply(envelope), error);
             return Optional.of(result);
         } else {
             return Optional.absent();

--- a/server/src/main/java/io/spine/server/bus/DeadMessageFilter.java
+++ b/server/src/main/java/io/spine/server/bus/DeadMessageFilter.java
@@ -41,7 +41,7 @@ import static io.spine.server.bus.Buses.reject;
 final class DeadMessageFilter<T extends Message,
                               E extends MessageEnvelope<?, T>,
                               C extends MessageClass,
-                              D extends MessageDispatcher<C, E>>
+                              D extends MessageDispatcher<C>>
         extends AbstractBusFilter<E> {
 
     private final Bus.IdConverter<E> idConverter;

--- a/server/src/main/java/io/spine/server/bus/DeadMessageFilter.java
+++ b/server/src/main/java/io/spine/server/bus/DeadMessageFilter.java
@@ -41,7 +41,7 @@ import static io.spine.server.bus.Buses.reject;
 final class DeadMessageFilter<T extends Message,
                               E extends MessageEnvelope<?, T>,
                               C extends MessageClass,
-                              D extends MessageDispatcher<C>>
+                              D extends MessageDispatcher<C, E, ?>>
         extends AbstractBusFilter<E> {
 
     private final Bus.IdConverter<E> idConverter;

--- a/server/src/main/java/io/spine/server/bus/DispatcherRegistry.java
+++ b/server/src/main/java/io/spine/server/bus/DispatcherRegistry.java
@@ -39,7 +39,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @author Alex Tymchenko
  */
 public class DispatcherRegistry<C extends MessageClass,
-                                D extends MessageDispatcher<C>> {
+                                D extends MessageDispatcher<C, ?, ?>> {
 
     /**
      * The map from a message class to one or more dispatchers of

--- a/server/src/main/java/io/spine/server/bus/DispatcherRegistry.java
+++ b/server/src/main/java/io/spine/server/bus/DispatcherRegistry.java
@@ -39,7 +39,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @author Alex Tymchenko
  */
 public class DispatcherRegistry<C extends MessageClass,
-                                D extends MessageDispatcher<C, ?>> {
+                                D extends MessageDispatcher<C>> {
 
     /**
      * The map from a message class to one or more dispatchers of

--- a/server/src/main/java/io/spine/server/bus/FilterChain.java
+++ b/server/src/main/java/io/spine/server/bus/FilterChain.java
@@ -21,7 +21,7 @@
 package io.spine.server.bus;
 
 import com.google.common.base.Optional;
-import io.spine.core.IsSent;
+import io.spine.core.Ack;
 import io.spine.core.MessageEnvelope;
 
 import java.util.Deque;
@@ -51,10 +51,10 @@ final class FilterChain<E extends MessageEnvelope<?, ?>> implements BusFilter<E>
     }
 
     @Override
-    public Optional<IsSent> accept(E envelope) {
+    public Optional<Ack> accept(E envelope) {
         checkNotNull(envelope);
         for (BusFilter<E> filter : chain) {
-            final Optional<IsSent> output = filter.accept(envelope);
+            final Optional<Ack> output = filter.accept(envelope);
             if (output.isPresent()) {
                 return output;
             }

--- a/server/src/main/java/io/spine/server/bus/MessageDispatcher.java
+++ b/server/src/main/java/io/spine/server/bus/MessageDispatcher.java
@@ -20,7 +20,6 @@
 
 package io.spine.server.bus;
 
-import io.spine.core.MessageEnvelope;
 import io.spine.type.MessageClass;
 
 import java.util.Set;
@@ -28,24 +27,16 @@ import java.util.Set;
 /**
  * A dispatcher of a message.
  *
- * @param <C> the type of dispatched messages
- * @param <E> the type of envelopes for dispatched objects that contain messages
+ * @param <C> the type of class of the dispatched messages
  * @author Alex Tymchenko
  * @author Alexander Yevsyukov
  */
-public interface MessageDispatcher<C extends MessageClass,
-                                   E extends MessageEnvelope> {
+public interface MessageDispatcher<C extends MessageClass> {
+
     /**
      * Obtains a set of message classes that can be processed by this dispatcher.
      *
      * @return non-empty set of message classes
      */
     Set<C> getMessageClasses();
-
-    /**
-     * Dispatches the message contained in the passed envelope.
-     *
-     * @param envelope the envelope with the message
-     */
-    void dispatch(E envelope);
 }

--- a/server/src/main/java/io/spine/server/bus/MessageDispatcher.java
+++ b/server/src/main/java/io/spine/server/bus/MessageDispatcher.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.bus;
 
+import io.spine.core.MessageEnvelope;
 import io.spine.type.MessageClass;
 
 import java.util.Set;
@@ -28,10 +29,16 @@ import java.util.Set;
  * A dispatcher of a message.
  *
  * @param <C> the type of class of the dispatched messages
+ * @param <E> the type of the message envelopes
+ * @param <R> the type of the result of the {@linkplain #dispatch(MessageEnvelope) dispatching
+ *            function}. For {@linkplain UnicastDispatcher unicast dispatching} is the type of
+ *            the IDs of entity that receives a dispatched message.
+ *            For {@linkplain MulticastDispatcher multicast dispatching} is the type of the set
+ *            of entity IDs.
  * @author Alex Tymchenko
  * @author Alexander Yevsyukov
  */
-public interface MessageDispatcher<C extends MessageClass> {
+public interface MessageDispatcher<C extends MessageClass, E extends MessageEnvelope, R> {
 
     /**
      * Obtains a set of message classes that can be processed by this dispatcher.
@@ -39,4 +46,12 @@ public interface MessageDispatcher<C extends MessageClass> {
      * @return non-empty set of message classes
      */
     Set<C> getMessageClasses();
+
+    /**
+     * Dispatches the message contained in the passed envelope.
+     *
+     * @param envelope the envelope with the message
+     * @return ID(s) of entities to which the message was dispatched
+     */
+    R dispatch(E envelope);
 }

--- a/server/src/main/java/io/spine/server/bus/MulticastDispatcher.java
+++ b/server/src/main/java/io/spine/server/bus/MulticastDispatcher.java
@@ -29,7 +29,7 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Dispatches a message to several entities.
+ * Dispatches a message to several entities of the same type.
  *
  * @param <C> the type of dispatched messages
  * @param <E> the type of envelopes for dispatched objects that contain messages

--- a/server/src/main/java/io/spine/server/bus/MulticastDispatcher.java
+++ b/server/src/main/java/io/spine/server/bus/MulticastDispatcher.java
@@ -17,16 +17,27 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package io.spine.server.failure;
 
-import io.spine.core.FailureClass;
-import io.spine.core.FailureEnvelope;
-import io.spine.server.bus.MulticastDispatcher;
+package io.spine.server.bus;
+
+import io.spine.core.MessageEnvelope;
+import io.spine.type.MessageClass;
 
 /**
- * Responsible for delivering the business failures to the corresponding subscribers.
+ * Dispatches a message to several entities.
  *
- * @author Alex Tymchenko
+ * @param <C> the type of dispatched messages
+ * @param <E> the type of envelopes for dispatched objects that contain messages
+ * @author Alexander Yevsyukov
  */
-public interface FailureDispatcher extends MulticastDispatcher<FailureClass, FailureEnvelope> {
+public interface MulticastDispatcher <C extends MessageClass, E extends MessageEnvelope>
+        extends MessageDispatcher<C> {
+
+    /**
+     * Dispatches the message contained in the passed envelope.
+     *
+     * @param envelope the envelope with the message
+     */
+    void dispatch(E envelope);
+
 }

--- a/server/src/main/java/io/spine/server/bus/MulticastDispatcher.java
+++ b/server/src/main/java/io/spine/server/bus/MulticastDispatcher.java
@@ -23,21 +23,16 @@ package io.spine.server.bus;
 import io.spine.core.MessageEnvelope;
 import io.spine.type.MessageClass;
 
+import java.util.Set;
+
 /**
  * Dispatches a message to several entities.
  *
  * @param <C> the type of dispatched messages
  * @param <E> the type of envelopes for dispatched objects that contain messages
+ * @param <I> the type of IDs of entities to which messages are dispatched
  * @author Alexander Yevsyukov
  */
-public interface MulticastDispatcher <C extends MessageClass, E extends MessageEnvelope>
-        extends MessageDispatcher<C> {
-
-    /**
-     * Dispatches the message contained in the passed envelope.
-     *
-     * @param envelope the envelope with the message
-     */
-    void dispatch(E envelope);
-
+public interface MulticastDispatcher <C extends MessageClass, E extends MessageEnvelope, I>
+        extends MessageDispatcher<C, E, Set<I>> {
 }

--- a/server/src/main/java/io/spine/server/bus/UnicastDispatcher.java
+++ b/server/src/main/java/io/spine/server/bus/UnicastDispatcher.java
@@ -28,15 +28,9 @@ import io.spine.type.MessageClass;
  *
  * @param <C> the type of dispatched messages
  * @param <E> the type of envelopes for dispatched objects that contain messages
+ * @param <I> the type of the entity ID
  * @author Alexander Yevsyukov
  */
-public interface UnicastDispatcher<C extends MessageClass, E extends MessageEnvelope>
-        extends MessageDispatcher<C> {
-
-    /**
-     * Dispatches the message contained in the passed envelope.
-     *
-     * @param envelope the envelope with the message
-     */
-    void dispatch(E envelope);
+public interface UnicastDispatcher<C extends MessageClass, E extends MessageEnvelope, I>
+        extends MessageDispatcher<C, E, I> {
 }

--- a/server/src/main/java/io/spine/server/bus/UnicastDispatcher.java
+++ b/server/src/main/java/io/spine/server/bus/UnicastDispatcher.java
@@ -17,16 +17,26 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package io.spine.server.failure;
 
-import io.spine.core.FailureClass;
-import io.spine.core.FailureEnvelope;
-import io.spine.server.bus.MulticastDispatcher;
+package io.spine.server.bus;
+
+import io.spine.core.MessageEnvelope;
+import io.spine.type.MessageClass;
 
 /**
- * Responsible for delivering the business failures to the corresponding subscribers.
+ * Dispatches a message to one entity.
  *
- * @author Alex Tymchenko
+ * @param <C> the type of dispatched messages
+ * @param <E> the type of envelopes for dispatched objects that contain messages
+ * @author Alexander Yevsyukov
  */
-public interface FailureDispatcher extends MulticastDispatcher<FailureClass, FailureEnvelope> {
+public interface UnicastDispatcher<C extends MessageClass, E extends MessageEnvelope>
+        extends MessageDispatcher<C> {
+
+    /**
+     * Dispatches the message contained in the passed envelope.
+     *
+     * @param envelope the envelope with the message
+     */
+    void dispatch(E envelope);
 }

--- a/server/src/main/java/io/spine/server/bus/ValidatingFilter.java
+++ b/server/src/main/java/io/spine/server/bus/ValidatingFilter.java
@@ -23,7 +23,7 @@ package io.spine.server.bus;
 import com.google.common.base.Optional;
 import com.google.protobuf.Message;
 import io.spine.base.Error;
-import io.spine.core.IsSent;
+import io.spine.core.Ack;
 import io.spine.core.MessageEnvelope;
 import io.spine.core.MessageInvalid;
 
@@ -49,12 +49,12 @@ final class ValidatingFilter<E extends MessageEnvelope<?, T>, T extends Message>
     }
 
     @Override
-    public Optional<IsSent> accept(E envelope) {
+    public Optional<Ack> accept(E envelope) {
         checkNotNull(envelope);
         final Optional<MessageInvalid> violation = validator.validate(envelope);
         if (violation.isPresent()) {
             final Error error = violation.get().asError();
-            final IsSent result = reject(idConverter.apply(envelope), error);
+            final Ack result = reject(idConverter.apply(envelope), error);
             return Optional.of(result);
         } else {
             return Optional.absent();

--- a/server/src/main/java/io/spine/server/command/CommandHandler.java
+++ b/server/src/main/java/io/spine/server/command/CommandHandler.java
@@ -65,7 +65,7 @@ import static io.spine.protobuf.TypeConverter.toMessage;
  * @see io.spine.server.aggregate.Aggregate Aggregate
  * @see CommandDispatcher
  */
-public abstract class CommandHandler implements CommandDispatcher {
+public abstract class CommandHandler implements CommandDispatcher<String> {
 
     /**
      * The {@code EventBut} to which the handler posts events it produces.
@@ -99,17 +99,19 @@ public abstract class CommandHandler implements CommandDispatcher {
      * posts resulting events to the {@link EventBus}.
      *
      * @param envelope the command to dispatch
+     * @return the handler identity as the result of {@link #toString()}
      * @throws IllegalStateException if an exception occurred during command dispatching
      *                               with this exception as the cause
      */
     @Override
-    public void dispatch(CommandEnvelope envelope) {
+    public String dispatch(CommandEnvelope envelope) {
         final List<? extends Message> eventMessages =
                 CommandHandlerMethod.invokeFor(this,
                                                envelope.getMessage(),
                                                envelope.getCommandContext());
         final List<Event> events = toEvents(eventMessages, envelope);
         postEvents(events);
+        return toString();
     }
 
     @SuppressWarnings("ReturnOfCollectionOrArrayField") // OK as we return immutable impl.
@@ -122,9 +124,8 @@ public abstract class CommandHandler implements CommandDispatcher {
         return commandClasses;
     }
 
-    private List<Event> toEvents(List<? extends Message> eventMessages,
-                                 CommandEnvelope envelope) {
-        return CommandHandlerMethod.toEvents(producerId, null, eventMessages, envelope);
+    private List<Event> toEvents(List<? extends Message> eventMessages, CommandEnvelope ce) {
+        return CommandHandlerMethod.toEvents(producerId, null, eventMessages, ce);
     }
 
     /** Posts passed events to {@link EventBus}. */

--- a/server/src/main/java/io/spine/server/command/CommandHandler.java
+++ b/server/src/main/java/io/spine/server/command/CommandHandler.java
@@ -95,6 +95,17 @@ public abstract class CommandHandler implements CommandDispatcher<String> {
     }
 
     /**
+     * Obtains identity string of the handler.
+     *
+     * <p>Default implementation returns the result of {@link #toString()}.
+     *
+     * @return the string with the handler identity
+     */
+    protected String getId() {
+        return toString();
+    }
+
+    /**
      * Dispatches the command to the handler method and
      * posts resulting events to the {@link EventBus}.
      *
@@ -111,7 +122,7 @@ public abstract class CommandHandler implements CommandDispatcher<String> {
                                                envelope.getCommandContext());
         final List<Event> events = toEvents(eventMessages, envelope);
         postEvents(events);
-        return toString();
+        return getId();
     }
 
     @SuppressWarnings("ReturnOfCollectionOrArrayField") // OK as we return immutable impl.

--- a/server/src/main/java/io/spine/server/commandbus/CommandBus.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandBus.java
@@ -66,7 +66,7 @@ import static java.lang.String.format;
 public class CommandBus extends Bus<Command,
                                     CommandEnvelope,
                                     CommandClass,
-                                    CommandDispatcher> {
+                                    CommandDispatcher<?>> {
 
     private final CommandStore commandStore;
 
@@ -199,7 +199,7 @@ public class CommandBus extends Bus<Command,
 
     @Override
     protected IsSent doPost(CommandEnvelope envelope) {
-        final CommandDispatcher dispatcher = getDispatcher(envelope);
+        final CommandDispatcher<?> dispatcher = getDispatcher(envelope);
         IsSent result;
         try {
             dispatcher.dispatch(envelope);
@@ -233,7 +233,7 @@ public class CommandBus extends Bus<Command,
         return registry().getRegisteredMessageClasses();
     }
 
-    private Optional<CommandDispatcher> getDispatcher(CommandClass commandClass) {
+    private Optional<? extends CommandDispatcher<?>> getDispatcher(CommandClass commandClass) {
         return registry().getDispatcher(commandClass);
     }
 
@@ -274,8 +274,8 @@ public class CommandBus extends Bus<Command,
         }
     }
 
-    private CommandDispatcher getDispatcher(CommandEnvelope commandEnvelope) {
-        final Optional<CommandDispatcher> dispatcher = getDispatcher(
+    private CommandDispatcher<?> getDispatcher(CommandEnvelope commandEnvelope) {
+        final Optional<? extends CommandDispatcher<?>> dispatcher = getDispatcher(
                 commandEnvelope.getMessageClass()
         );
         if (!dispatcher.isPresent()) {

--- a/server/src/main/java/io/spine/server/commandbus/CommandBus.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandBus.java
@@ -26,12 +26,12 @@ import io.spine.Identifier;
 import io.spine.annotation.Internal;
 import io.spine.base.Error;
 import io.spine.base.ThrowableMessage;
+import io.spine.core.Ack;
 import io.spine.core.Command;
 import io.spine.core.CommandClass;
 import io.spine.core.CommandEnvelope;
 import io.spine.core.CommandId;
 import io.spine.core.Failure;
-import io.spine.core.IsSent;
 import io.spine.server.ServerEnvironment;
 import io.spine.server.bus.Bus;
 import io.spine.server.bus.BusFilter;
@@ -198,9 +198,9 @@ public class CommandBus extends Bus<Command,
     }
 
     @Override
-    protected IsSent doPost(CommandEnvelope envelope) {
+    protected Ack doPost(CommandEnvelope envelope) {
         final CommandDispatcher<?> dispatcher = getDispatcher(envelope);
-        IsSent result;
+        Ack result;
         try {
             dispatcher.dispatch(envelope);
             commandStore.setCommandStatusOk(envelope);

--- a/server/src/main/java/io/spine/server/commandbus/CommandDispatcher.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandDispatcher.java
@@ -22,7 +22,7 @@ package io.spine.server.commandbus;
 
 import io.spine.core.CommandClass;
 import io.spine.core.CommandEnvelope;
-import io.spine.server.bus.MessageDispatcher;
+import io.spine.server.bus.UnicastDispatcher;
 
 import static io.spine.util.Exceptions.newIllegalArgumentException;
 
@@ -33,7 +33,7 @@ import static io.spine.util.Exceptions.newIllegalArgumentException;
  *
  * @author Alexander Yevsyukov
  */
-public interface CommandDispatcher extends MessageDispatcher<CommandClass, CommandEnvelope> {
+public interface CommandDispatcher extends UnicastDispatcher<CommandClass, CommandEnvelope> {
 
     /**
      * Utility class for reporting command dispatching errors.

--- a/server/src/main/java/io/spine/server/commandbus/CommandDispatcher.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandDispatcher.java
@@ -33,7 +33,7 @@ import static io.spine.util.Exceptions.newIllegalArgumentException;
  *
  * @author Alexander Yevsyukov
  */
-public interface CommandDispatcher extends UnicastDispatcher<CommandClass, CommandEnvelope> {
+public interface CommandDispatcher<I> extends UnicastDispatcher<CommandClass, CommandEnvelope, I> {
 
     /**
      * Utility class for reporting command dispatching errors.

--- a/server/src/main/java/io/spine/server/commandbus/CommandDispatcherDelegate.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandDispatcherDelegate.java
@@ -44,8 +44,8 @@ import java.util.Set;
  * returned.
  *
  * <p>The same interference takes place in attempt to implement
- * {@link io.spine.server.bus.MessageDispatcher#dispatch(MessageEnvelope)
- * MessageDispatcher.dispatch(MessageEnvelope)} method with the different types of
+ * {@link io.spine.server.bus.UnicastDispatcher#dispatch(MessageEnvelope)
+ * UnicastDispatcher.dispatch(MessageEnvelope)} method with the different types of
  * {@code MessageEnvelope}s dispatches simultaneously.
  *
  * <p>That's why unlike {@linkplain io.spine.server.bus.MessageDispatcher MessageDispatcher},
@@ -54,12 +54,13 @@ import java.util.Set;
  * {@code MessageDispatcher} API.
  *
  * @author Alex Tymchenko
+ * @param <I> the type of IDs of entities that handle the commands dispatched by the delegate
  * @see DelegatingCommandDispatcher
  */
 @Internal
-public interface CommandDispatcherDelegate {
+public interface CommandDispatcherDelegate<I> {
 
     Set<CommandClass> getCommandClasses();
 
-    void dispatchCommand(CommandEnvelope envelope);
+    I dispatchCommand(CommandEnvelope envelope);
 }

--- a/server/src/main/java/io/spine/server/commandbus/CommandScheduler.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandScheduler.java
@@ -23,11 +23,11 @@ package io.spine.server.commandbus;
 import com.google.common.base.Optional;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
+import io.spine.core.Ack;
 import io.spine.core.Command;
 import io.spine.core.CommandContext;
 import io.spine.core.CommandEnvelope;
 import io.spine.core.CommandId;
-import io.spine.core.IsSent;
 import io.spine.server.bus.BusFilter;
 
 import javax.annotation.CheckReturnValue;
@@ -81,7 +81,7 @@ public abstract class CommandScheduler implements BusFilter<CommandEnvelope> {
     }
 
     @Override
-    public Optional<IsSent> accept(CommandEnvelope envelope) {
+    public Optional<Ack> accept(CommandEnvelope envelope) {
         final Command command = envelope.getCommand();
         if (isScheduled(command)) {
             scheduleAndStore(envelope);

--- a/server/src/main/java/io/spine/server/commandbus/DelegatingCommandDispatcher.java
+++ b/server/src/main/java/io/spine/server/commandbus/DelegatingCommandDispatcher.java
@@ -33,14 +33,14 @@ import java.util.Set;
  * @see CommandDispatcherDelegate
  */
 @Internal
-public class DelegatingCommandDispatcher implements CommandDispatcher {
+public class DelegatingCommandDispatcher<I> implements CommandDispatcher<I> {
 
     /**
      * A target delegate.
      */
-    private final CommandDispatcherDelegate delegate;
+    private final CommandDispatcherDelegate<I> delegate;
 
-    private DelegatingCommandDispatcher(CommandDispatcherDelegate delegate) {
+    private DelegatingCommandDispatcher(CommandDispatcherDelegate<I> delegate) {
         this.delegate = delegate;
     }
 
@@ -50,8 +50,8 @@ public class DelegatingCommandDispatcher implements CommandDispatcher {
      *
      * @param delegate a delegate to pass the dispatching duties to
      */
-    public static DelegatingCommandDispatcher of(CommandDispatcherDelegate delegate) {
-        return new DelegatingCommandDispatcher(delegate);
+    public static <I> DelegatingCommandDispatcher<I> of(CommandDispatcherDelegate<I> delegate) {
+        return new DelegatingCommandDispatcher<>(delegate);
     }
 
     @Override
@@ -60,7 +60,7 @@ public class DelegatingCommandDispatcher implements CommandDispatcher {
     }
 
     @Override
-    public final void dispatch(CommandEnvelope envelope) {
-        delegate.dispatchCommand(envelope);
+    public final I dispatch(CommandEnvelope envelope) {
+        return delegate.dispatchCommand(envelope);
     }
 }

--- a/server/src/main/java/io/spine/server/entity/EntityEventDispatcher.java
+++ b/server/src/main/java/io/spine/server/entity/EntityEventDispatcher.java
@@ -32,7 +32,7 @@ import java.util.Set;
  * @author Alexander Litus
  * @see EventDispatcher
  */
-public interface EntityEventDispatcher<I> extends EventDispatcher {
+public interface EntityEventDispatcher<I> extends EventDispatcher<I> {
 
     /**
      * Obtains a set of entity identifiers to which dispatch the passed event.

--- a/server/src/main/java/io/spine/server/entity/EventDispatchingRepository.java
+++ b/server/src/main/java/io/spine/server/entity/EventDispatchingRepository.java
@@ -89,7 +89,7 @@ public abstract class EventDispatchingRepository<I,
      * @param envelope the event envelope to dispatch
      */
     @Override
-    public void dispatch(EventEnvelope envelope) {
+    public Set<I> dispatch(EventEnvelope envelope) {
         final Message eventMessage = envelope.getMessage();
         final EventContext context = envelope.getEventContext();
         final Set<I> ids = getTargets(envelope);
@@ -102,6 +102,7 @@ public abstract class EventDispatchingRepository<I,
             }
         };
         op.execute();
+        return ids;
     }
 
     /**

--- a/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
+++ b/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
@@ -32,16 +32,17 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * A {@link EventDispatcher} which delegates the responsibilities to an aggregated {@link
  * EventDispatcherDelegate delegate instance}.
  *
+ * @param <I> the type of entity IDs
  * @author Alexander Yevsyukov
  * @see EventDispatcherDelegate
  */
 @Internal
-public final class DelegatingEventDispatcher implements EventDispatcher {
+public final class DelegatingEventDispatcher<I> implements EventDispatcher<I> {
 
     /**
      * A target delegate.
      */
-    private final EventDispatcherDelegate delegate;
+    private final EventDispatcherDelegate<I> delegate;
 
     /**
      * Creates a new instance of {@code DelegatingCommandDispatcher}, proxying the calls
@@ -50,12 +51,12 @@ public final class DelegatingEventDispatcher implements EventDispatcher {
      * @param delegate a delegate to pass the dispatching duties to
      * @return new instance
      */
-    public static DelegatingEventDispatcher of(EventDispatcherDelegate delegate) {
+    public static <I> DelegatingEventDispatcher<I> of(EventDispatcherDelegate<I> delegate) {
         checkNotNull(delegate);
-        return new DelegatingEventDispatcher(delegate);
+        return new DelegatingEventDispatcher<>(delegate);
     }
 
-    private DelegatingEventDispatcher(EventDispatcherDelegate delegate) {
+    private DelegatingEventDispatcher(EventDispatcherDelegate<I> delegate) {
         this.delegate = delegate;
     }
 
@@ -65,7 +66,7 @@ public final class DelegatingEventDispatcher implements EventDispatcher {
     }
 
     @Override
-    public void dispatch(EventEnvelope envelope) {
-        delegate.dispatchEvent(envelope);
+    public Set<I> dispatch(EventEnvelope envelope) {
+        return delegate.dispatchEvent(envelope);
     }
 }

--- a/server/src/main/java/io/spine/server/event/DispatcherEventDelivery.java
+++ b/server/src/main/java/io/spine/server/event/DispatcherEventDelivery.java
@@ -39,7 +39,7 @@ import java.util.concurrent.Executor;
 @SuppressWarnings("WeakerAccess")   // Part of API.
 public abstract class DispatcherEventDelivery extends CommandOutputDelivery<EventEnvelope,
                                                                             EventClass,
-                                                                            EventDispatcher> {
+                                                                            EventDispatcher<?>> {
 
     /**
      * Create a dispatcher event delivery with an {@link Executor} used for the operation.
@@ -63,7 +63,7 @@ public abstract class DispatcherEventDelivery extends CommandOutputDelivery<Even
     }
 
     @Override
-    protected Runnable getDeliveryAction(final EventDispatcher consumer,
+    protected Runnable getDeliveryAction(final EventDispatcher<?> consumer,
                                          final EventEnvelope envelope) {
         return new Runnable() {
             @Override

--- a/server/src/main/java/io/spine/server/event/EventBus.java
+++ b/server/src/main/java/io/spine/server/event/EventBus.java
@@ -26,12 +26,12 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.Message;
 import io.grpc.stub.StreamObserver;
 import io.spine.annotation.Internal;
+import io.spine.core.Ack;
 import io.spine.core.Event;
 import io.spine.core.EventClass;
 import io.spine.core.EventContext;
 import io.spine.core.EventEnvelope;
 import io.spine.core.EventId;
-import io.spine.core.IsSent;
 import io.spine.grpc.LoggingObserver;
 import io.spine.grpc.LoggingObserver.Level;
 import io.spine.server.bus.Bus;
@@ -114,8 +114,8 @@ public class EventBus extends CommandOutputBus<Event,
     private final MessageValidator eventMessageValidator;
 
     private final Deque<BusFilter<EventEnvelope>> filterChain;
-    private final StreamObserver<IsSent> streamObserver = LoggingObserver.forClass(getClass(),
-                                                                                   Level.TRACE);
+    private final StreamObserver<Ack> streamObserver = LoggingObserver.forClass(getClass(),
+                                                                                Level.TRACE);
     /** The validator for events posted to the bus. */
     @Nullable
     private EventValidator eventValidator;

--- a/server/src/main/java/io/spine/server/event/EventBus.java
+++ b/server/src/main/java/io/spine/server/event/EventBus.java
@@ -99,7 +99,7 @@ import static com.google.common.base.Preconditions.checkState;
 public class EventBus extends CommandOutputBus<Event,
                                                EventEnvelope,
                                                EventClass,
-                                               EventDispatcher> {
+                                               EventDispatcher<?>> {
 
     /*
      * NOTE: Even though, the EventBus has a private constructor and
@@ -145,7 +145,7 @@ public class EventBus extends CommandOutputBus<Event,
     }
 
     @VisibleForTesting
-    Set<EventDispatcher> getDispatchers(EventClass eventClass) {
+    Set<? extends EventDispatcher<?>> getDispatchers(EventClass eventClass) {
         return registry().getDispatchers(eventClass);
     }
 
@@ -168,7 +168,7 @@ public class EventBus extends CommandOutputBus<Event,
     }
 
     @Override
-    protected OutputDispatcherRegistry<EventClass, EventDispatcher> createRegistry() {
+    protected OutputDispatcherRegistry<EventClass, EventDispatcher<?>> createRegistry() {
         return new EventDispatcherRegistry();
     }
 

--- a/server/src/main/java/io/spine/server/event/EventDispatcher.java
+++ b/server/src/main/java/io/spine/server/event/EventDispatcher.java
@@ -29,9 +29,10 @@ import static io.spine.util.Exceptions.newIllegalArgumentException;
 /**
  * {@code EventDispatcher} delivers events to subscribers.
  *
+ * @param <I> the type of entity IDs
  * @author Alexander Yevsyukov
  */
-public interface EventDispatcher extends MulticastDispatcher<EventClass, EventEnvelope> {
+public interface EventDispatcher<I> extends MulticastDispatcher<EventClass, EventEnvelope, I> {
 
     /**
      * Utility class for reporting event dispatching errors.

--- a/server/src/main/java/io/spine/server/event/EventDispatcher.java
+++ b/server/src/main/java/io/spine/server/event/EventDispatcher.java
@@ -22,7 +22,7 @@ package io.spine.server.event;
 
 import io.spine.core.EventClass;
 import io.spine.core.EventEnvelope;
-import io.spine.server.bus.MessageDispatcher;
+import io.spine.server.bus.MulticastDispatcher;
 
 import static io.spine.util.Exceptions.newIllegalArgumentException;
 
@@ -31,7 +31,7 @@ import static io.spine.util.Exceptions.newIllegalArgumentException;
  *
  * @author Alexander Yevsyukov
  */
-public interface EventDispatcher extends MessageDispatcher<EventClass, EventEnvelope> {
+public interface EventDispatcher extends MulticastDispatcher<EventClass, EventEnvelope> {
 
     /**
      * Utility class for reporting event dispatching errors.

--- a/server/src/main/java/io/spine/server/event/EventDispatcherDelegate.java
+++ b/server/src/main/java/io/spine/server/event/EventDispatcherDelegate.java
@@ -39,7 +39,7 @@ import java.util.Set;
  * @see DelegatingEventDispatcher
  */
 @Internal
-public interface EventDispatcherDelegate {
+public interface EventDispatcherDelegate<I> {
 
     /**
      * Obtains event classes dispatched by this delegate.
@@ -49,5 +49,5 @@ public interface EventDispatcherDelegate {
     /**
      * Dispatches the event.
      */
-    void dispatchEvent(EventEnvelope envelope);
+    Set<I> dispatchEvent(EventEnvelope envelope);
 }

--- a/server/src/main/java/io/spine/server/event/EventDispatcherRegistry.java
+++ b/server/src/main/java/io/spine/server/event/EventDispatcherRegistry.java
@@ -33,7 +33,7 @@ import java.util.Set;
  * @author Alexander Yevsyukov
  * @author Alex Tymchenko
  */
-class EventDispatcherRegistry extends OutputDispatcherRegistry<EventClass, EventDispatcher> {
+class EventDispatcherRegistry extends OutputDispatcherRegistry<EventClass, EventDispatcher<?>> {
 
     /**
      * {@inheritDoc}
@@ -53,7 +53,7 @@ class EventDispatcherRegistry extends OutputDispatcherRegistry<EventClass, Event
      * {@linkplain EventBus#getDispatchers(EventClass)}) EventBus}.
      */
     @Override
-    protected Set<EventDispatcher> getDispatchers(EventClass eventClass) {
+    protected Set<EventDispatcher<?>> getDispatchers(EventClass eventClass) {
         return super.getDispatchers(eventClass);
     }
 }

--- a/server/src/main/java/io/spine/server/event/EventSubscriber.java
+++ b/server/src/main/java/io/spine/server/event/EventSubscriber.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.event;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Message;
 import io.spine.core.EventClass;
 import io.spine.core.EventContext;
@@ -41,7 +42,7 @@ import java.util.Set;
  * @author Alex Tymchenko
  * @see EventBus#register(MessageDispatcher)
  */
-public abstract class EventSubscriber implements EventDispatcher {
+public abstract class EventSubscriber implements EventDispatcher<String> {
 
     /**
      * Cached set of the event classes this subscriber is subscribed to.
@@ -49,8 +50,15 @@ public abstract class EventSubscriber implements EventDispatcher {
     @Nullable
     private Set<EventClass> eventClasses;
 
+    /**
+     * {@inheritDoc}
+     *
+     * @param envelope the envelope with the message
+     * @return a one element set with the result of {@link #toString()}
+     * as the identify of the subscriber
+     */
     @Override
-    public void dispatch(final EventEnvelope envelope) {
+    public Set<String> dispatch(final EventEnvelope envelope) {
         final EventOperation op = new EventOperation(envelope.getOuterObject()) {
             @Override
             public void run() {
@@ -58,6 +66,7 @@ public abstract class EventSubscriber implements EventDispatcher {
             }
         };
         op.execute();
+        return ImmutableSet.of(toString());
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/event/EventSubscriber.java
+++ b/server/src/main/java/io/spine/server/event/EventSubscriber.java
@@ -20,7 +20,6 @@
 
 package io.spine.server.event;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Message;
 import io.spine.core.EventClass;
 import io.spine.core.EventContext;
@@ -66,7 +65,7 @@ public abstract class EventSubscriber implements EventDispatcher<String> {
             }
         };
         op.execute();
-        return ImmutableSet.of(toString());
+        return Identity.of(this);
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/failure/DispatcherFailureDelivery.java
+++ b/server/src/main/java/io/spine/server/failure/DispatcherFailureDelivery.java
@@ -37,9 +37,8 @@ import java.util.concurrent.Executor;
  */
 @SPI
 @SuppressWarnings("WeakerAccess")   // Part of API.
-public abstract class DispatcherFailureDelivery extends CommandOutputDelivery<FailureEnvelope,
-                                                                              FailureClass,
-                                                                              FailureDispatcher> {
+public abstract class DispatcherFailureDelivery
+        extends CommandOutputDelivery<FailureEnvelope, FailureClass, FailureDispatcher<?>> {
 
     /**
      * Create a dispatcher failure delivery with an {@link Executor} used for the operation.
@@ -63,7 +62,7 @@ public abstract class DispatcherFailureDelivery extends CommandOutputDelivery<Fa
     }
 
     @Override
-    protected Runnable getDeliveryAction(final FailureDispatcher consumer,
+    protected Runnable getDeliveryAction(final FailureDispatcher<?> consumer,
                                          final FailureEnvelope deliverable) {
         return new Runnable() {
             @Override
@@ -94,7 +93,7 @@ public abstract class DispatcherFailureDelivery extends CommandOutputDelivery<Fa
     static final class DirectDelivery extends DispatcherFailureDelivery {
         @Override
         public boolean shouldPostponeDelivery(FailureEnvelope envelope,
-                                              FailureDispatcher dispatcher) {
+                                              FailureDispatcher<?> dispatcher) {
             return false;
         }
     }

--- a/server/src/main/java/io/spine/server/failure/FailureBus.java
+++ b/server/src/main/java/io/spine/server/failure/FailureBus.java
@@ -23,11 +23,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.protobuf.Message;
 import io.grpc.stub.StreamObserver;
+import io.spine.core.Ack;
 import io.spine.core.Failure;
 import io.spine.core.FailureClass;
 import io.spine.core.FailureEnvelope;
 import io.spine.core.FailureId;
-import io.spine.core.IsSent;
 import io.spine.core.MessageInvalid;
 import io.spine.grpc.StreamObservers;
 import io.spine.server.bus.Bus;
@@ -173,7 +173,7 @@ public class FailureBus extends CommandOutputBus<Failure,
      * @see #post(Message, StreamObserver)
      */
     public final void post(Failure failure) {
-        post(failure, StreamObservers.<IsSent>noOpObserver());
+        post(failure, StreamObservers.<Ack>noOpObserver());
     }
 
     /** The {@code Builder} for {@code FailureBus}. */

--- a/server/src/main/java/io/spine/server/failure/FailureBus.java
+++ b/server/src/main/java/io/spine/server/failure/FailureBus.java
@@ -28,6 +28,7 @@ import io.spine.core.FailureClass;
 import io.spine.core.FailureEnvelope;
 import io.spine.core.FailureId;
 import io.spine.core.IsSent;
+import io.spine.core.MessageInvalid;
 import io.spine.grpc.StreamObservers;
 import io.spine.server.bus.Bus;
 import io.spine.server.bus.BusFilter;
@@ -35,7 +36,6 @@ import io.spine.server.bus.DeadMessageTap;
 import io.spine.server.bus.EnvelopeValidator;
 import io.spine.server.outbus.CommandOutputBus;
 import io.spine.server.outbus.OutputDispatcherRegistry;
-import io.spine.core.MessageInvalid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +60,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class FailureBus extends CommandOutputBus<Failure,
                                                  FailureEnvelope,
                                                  FailureClass,
-                                                 FailureDispatcher> {
+                                                 FailureDispatcher<?>> {
 
     private final Deque<BusFilter<FailureEnvelope>> filterChain;
 
@@ -102,7 +102,7 @@ public class FailureBus extends CommandOutputBus<Failure,
     }
 
     @Override
-    protected OutputDispatcherRegistry<FailureClass, FailureDispatcher> createRegistry() {
+    protected OutputDispatcherRegistry<FailureClass, FailureDispatcher<?>> createRegistry() {
         return new FailureDispatcherRegistry();
     }
 
@@ -144,7 +144,7 @@ public class FailureBus extends CommandOutputBus<Failure,
     }
 
     @VisibleForTesting
-    Set<FailureDispatcher> getDispatchers(FailureClass failureClass) {
+    Set<FailureDispatcher<?>> getDispatchers(FailureClass failureClass) {
         return registry().getDispatchers(failureClass);
     }
 

--- a/server/src/main/java/io/spine/server/failure/FailureDispatcher.java
+++ b/server/src/main/java/io/spine/server/failure/FailureDispatcher.java
@@ -26,7 +26,9 @@ import io.spine.server.bus.MulticastDispatcher;
 /**
  * Responsible for delivering the business failures to the corresponding subscribers.
  *
+ * @param <I> the type of entities to which deliver failures
  * @author Alex Tymchenko
  */
-public interface FailureDispatcher extends MulticastDispatcher<FailureClass, FailureEnvelope> {
+public interface FailureDispatcher<I>
+        extends MulticastDispatcher<FailureClass, FailureEnvelope, I> {
 }

--- a/server/src/main/java/io/spine/server/failure/FailureDispatcherRegistry.java
+++ b/server/src/main/java/io/spine/server/failure/FailureDispatcherRegistry.java
@@ -32,7 +32,7 @@ import java.util.Set;
  * @author Alex Tymchenko
  */
 public class FailureDispatcherRegistry extends OutputDispatcherRegistry<FailureClass,
-                                                                        FailureDispatcher> {
+                                                                        FailureDispatcher<?>> {
     /**
      * {@inheritDoc}
      *
@@ -40,7 +40,7 @@ public class FailureDispatcherRegistry extends OutputDispatcherRegistry<FailureC
      * {@linkplain FailureBus#getDispatchers(FailureClass) failureBus}.
      */
     @Override
-    protected Set<FailureDispatcher> getDispatchers(FailureClass messageClass) {
+    protected Set<FailureDispatcher<?>> getDispatchers(FailureClass messageClass) {
         return super.getDispatchers(messageClass);
     }
 

--- a/server/src/main/java/io/spine/server/failure/FailureSubscriber.java
+++ b/server/src/main/java/io/spine/server/failure/FailureSubscriber.java
@@ -62,7 +62,7 @@ public class FailureSubscriber implements FailureDispatcher<String> {
             }
         };
         op.execute();
-        return ImmutableSet.of(toString());
+        return Identity.of(this);
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/failure/FailureSubscriber.java
+++ b/server/src/main/java/io/spine/server/failure/FailureSubscriber.java
@@ -39,7 +39,7 @@ import java.util.Set;
  * @author Alexander Yevsyukov
  * @see FailureBus#register(io.spine.server.bus.MessageDispatcher)
  */
-public class FailureSubscriber implements FailureDispatcher {
+public class FailureSubscriber implements FailureDispatcher<String> {
 
     /**
      * Cached set of the failure classes this subscriber is subscribed to.
@@ -48,7 +48,7 @@ public class FailureSubscriber implements FailureDispatcher {
     private Set<FailureClass> failureClasses;
 
     @Override
-    public void dispatch(final FailureEnvelope envelope) {
+    public Set<String> dispatch(final FailureEnvelope envelope) {
         final Command originCommand = envelope.getOuterObject()
                                               .getContext()
                                               .getCommand();
@@ -62,6 +62,7 @@ public class FailureSubscriber implements FailureDispatcher {
             }
         };
         op.execute();
+        return ImmutableSet.of(toString());
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/outbus/CommandOutputBus.java
+++ b/server/src/main/java/io/spine/server/outbus/CommandOutputBus.java
@@ -60,7 +60,7 @@ import static java.lang.String.format;
 public abstract class CommandOutputBus<M extends Message,
                                        E extends MessageEnvelope<?, M>,
                                        C extends MessageClass,
-                                       D extends MessageDispatcher<C,E>>
+                                       D extends MessageDispatcher<C>>
                 extends Bus<M, E, C, D> {
 
     /**

--- a/server/src/main/java/io/spine/server/outbus/CommandOutputBus.java
+++ b/server/src/main/java/io/spine/server/outbus/CommandOutputBus.java
@@ -60,7 +60,7 @@ import static java.lang.String.format;
 public abstract class CommandOutputBus<M extends Message,
                                        E extends MessageEnvelope<?, M>,
                                        C extends MessageClass,
-                                       D extends MessageDispatcher<C>>
+                                       D extends MessageDispatcher<C, E, ?>>
                 extends Bus<M, E, C, D> {
 
     /**

--- a/server/src/main/java/io/spine/server/outbus/OutputDispatcherRegistry.java
+++ b/server/src/main/java/io/spine/server/outbus/OutputDispatcherRegistry.java
@@ -42,7 +42,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 @Internal
 public class OutputDispatcherRegistry<C extends MessageClass,
-                                      D extends MessageDispatcher<C, ?>>
+                                      D extends MessageDispatcher<C>>
                                 extends DispatcherRegistry<C, D> {
     /**
      * {@inheritDoc}

--- a/server/src/main/java/io/spine/server/outbus/OutputDispatcherRegistry.java
+++ b/server/src/main/java/io/spine/server/outbus/OutputDispatcherRegistry.java
@@ -42,7 +42,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 @Internal
 public class OutputDispatcherRegistry<C extends MessageClass,
-                                      D extends MessageDispatcher<C>>
+                                      D extends MessageDispatcher<C, ?, ?>>
                                 extends DispatcherRegistry<C, D> {
     /**
      * {@inheritDoc}
@@ -96,10 +96,9 @@ public class OutputDispatcherRegistry<C extends MessageClass,
      *
      * <p>Overrides in order to expose itself to {@link CommandOutputBus#close() CommandOutputBus}.
      */
+    @SuppressWarnings("RedundantMethodOverride")
     @Override
     protected void unregisterAll() {
         super.unregisterAll();
     }
-
-
 }

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
@@ -57,7 +57,7 @@ public abstract class ProcessManagerRepository<I,
                                                P extends ProcessManager<I, S, ?>,
                                                S extends Message>
                 extends EventDispatchingRepository<I, P, S>
-                implements CommandDispatcherDelegate {
+                implements CommandDispatcherDelegate<I> {
 
     /** The command routing schema used by this repository. */
     private final CommandRouting<I> commandRouting = CommandRouting.newInstance();
@@ -124,7 +124,7 @@ public abstract class ProcessManagerRepository<I,
      * @see CommandHandlingEntity#dispatchCommand(CommandEnvelope)
      */
     @Override
-    public void dispatchCommand(CommandEnvelope envelope) {
+    public I dispatchCommand(CommandEnvelope envelope) {
         final Message commandMessage = envelope.getMessage();
         final CommandContext context = envelope.getCommandContext();
         final CommandClass commandClass = envelope.getMessageClass();
@@ -138,6 +138,7 @@ public abstract class ProcessManagerRepository<I,
         tx.commit();
 
         postEvents(events);
+        return id;
     }
 
     private ProcManTransaction<?, ?, ?> beginTransactionFor(P manager) {
@@ -166,9 +167,9 @@ public abstract class ProcessManagerRepository<I,
      * @see ProcessManager#dispatchEvent(Message, EventContext)
      */
     @Override
-    public void dispatch(EventEnvelope event) throws IllegalArgumentException {
+    public Set<I> dispatch(EventEnvelope event) throws IllegalArgumentException {
         checkEventClass(event.getMessageClass());
-        super.dispatch(event);
+        return super.dispatch(event);
     }
 
     @Override

--- a/server/src/main/proto/spine/server/integration/grpc/integration_event_subscriber.proto
+++ b/server/src/main/proto/spine/server/integration/grpc/integration_event_subscriber.proto
@@ -29,7 +29,7 @@ option java_multiple_files = true;
 option java_outer_classname = "IntegrationEventSubscriberProto";
 option java_generate_equals_and_hash = true;
 
-import "spine/core/bus.proto";
+import "spine/core/ack.proto";
 import "spine/server/integration/integration_event.proto";
 
 // A service for notifying integration event subscribers.

--- a/server/src/main/proto/spine/server/integration/grpc/integration_event_subscriber.proto
+++ b/server/src/main/proto/spine/server/integration/grpc/integration_event_subscriber.proto
@@ -39,5 +39,5 @@ service IntegrationEventSubscriber {
     // The response is `ok` if the event is successfully received by the subscriber.
     // If the event is not handled because of a technical error, the response is `error`.
     // If the event cannot be handled because of business conditions, the response is `failure`.
-    rpc Notify(server.integration.IntegrationEvent) returns (spine.core.IsSent);
+    rpc Notify(server.integration.IntegrationEvent) returns (core.Ack);
 }

--- a/server/src/test/java/io/spine/server/CommandServiceShould.java
+++ b/server/src/test/java/io/spine/server/CommandServiceShould.java
@@ -24,10 +24,10 @@ import com.google.common.collect.Sets;
 import com.google.protobuf.StringValue;
 import io.spine.base.Error;
 import io.spine.client.TestActorRequestFactory;
+import io.spine.core.Ack;
 import io.spine.core.Command;
 import io.spine.core.CommandId;
 import io.spine.core.CommandValidationError;
-import io.spine.core.IsSent;
 import io.spine.core.Status;
 import io.spine.grpc.MemoizingObserver;
 import io.spine.protobuf.AnyPacker;
@@ -57,7 +57,7 @@ public class CommandServiceShould {
     private BoundedContext projectsContext;
 
     private BoundedContext customersContext;
-    private final MemoizingObserver<IsSent> responseObserver = memoizingObserver();
+    private final MemoizingObserver<Ack> responseObserver = memoizingObserver();
 
     @Before
     public void setUp() {
@@ -115,12 +115,12 @@ public class CommandServiceShould {
     }
 
     private void verifyPostsCommand(Command cmd) {
-        final MemoizingObserver<IsSent> observer = memoizingObserver();
+        final MemoizingObserver<Ack> observer = memoizingObserver();
         service.post(cmd, observer);
 
         assertNull(observer.getError());
         assertTrue(observer.isCompleted());
-        final IsSent acked = observer.firstResponse();
+        final Ack acked = observer.firstResponse();
         final CommandId id = AnyPacker.unpack(acked.getMessageId());
         assertEquals(cmd.getId(), id);
     }
@@ -134,7 +134,7 @@ public class CommandServiceShould {
         service.post(unsupportedCmd, responseObserver);
 
         assertTrue(responseObserver.isCompleted());
-        final IsSent result = responseObserver.firstResponse();
+        final Ack result = responseObserver.firstResponse();
         assertNotNull(result);
         assertTrue(isNotDefault(result));
         final Status status = result.getStatus();

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryViewsShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryViewsShould.java
@@ -23,8 +23,8 @@ package io.spine.server.aggregate;
 import com.google.common.base.Optional;
 import io.spine.client.ActorRequestFactory;
 import io.spine.client.TestActorRequestFactory;
+import io.spine.core.Ack;
 import io.spine.core.Command;
-import io.spine.core.IsSent;
 import io.spine.grpc.StreamObservers;
 import io.spine.server.BoundedContext;
 import io.spine.server.aggregate.given.AggregateRepositoryViewTestEnv.AggregateWithLifecycle;
@@ -72,7 +72,7 @@ public class AggregateRepositoryViewsShould {
                 requestFactory.command()
                               .create(RepoOfAggregateWithLifecycle.createCommandMessage(id, cmd));
         boundedContext.getCommandBus()
-                      .post(command, StreamObservers.<IsSent>noOpObserver());
+                      .post(command, StreamObservers.<Ack>noOpObserver());
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/bc/BoundedContextShould.java
+++ b/server/src/test/java/io/spine/server/bc/BoundedContextShould.java
@@ -22,7 +22,7 @@ package io.spine.server.bc;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
-import io.spine.core.IsSent;
+import io.spine.core.Ack;
 import io.spine.core.Responses;
 import io.spine.grpc.MemoizingObserver;
 import io.spine.option.EntityOption;
@@ -154,7 +154,7 @@ public class BoundedContextShould {
     @Test
     public void notify_integration_event_subscriber() {
         registerAll();
-        final MemoizingObserver<IsSent> observer = memoizingObserver();
+        final MemoizingObserver<Ack> observer = memoizingObserver();
         final IntegrationEvent event = Given.AnIntegrationEvent.projectCreated();
         final Message msg = unpack(event.getMessage());
 
@@ -178,7 +178,7 @@ public class BoundedContextShould {
                                         .setMessage(invalidMsg)
                                         .build();
 
-        final MemoizingObserver<IsSent> observer = memoizingObserver();
+        final MemoizingObserver<Ack> observer = memoizingObserver();
         boundedContext.notify(event, observer);
 
         assertEquals(ERROR, observer.firstResponse().getStatus().getStatusCase());

--- a/server/src/test/java/io/spine/server/bus/MulticastDispatcherIdentityShould.java
+++ b/server/src/test/java/io/spine/server/bus/MulticastDispatcherIdentityShould.java
@@ -22,40 +22,52 @@ package io.spine.server.bus;
 
 import com.google.common.collect.ImmutableSet;
 import io.spine.core.MessageEnvelope;
+import io.spine.test.Tests;
 import io.spine.type.MessageClass;
+import org.junit.Test;
 
 import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.Identifier.newUuid;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
- * Dispatches a message to several entities.
- *
- * @param <C> the type of dispatched messages
- * @param <E> the type of envelopes for dispatched objects that contain messages
- * @param <I> the type of IDs of entities to which messages are dispatched
  * @author Alexander Yevsyukov
  */
-public interface MulticastDispatcher <C extends MessageClass, E extends MessageEnvelope, I>
-        extends MessageDispatcher<C, E, Set<I>> {
+public class MulticastDispatcherIdentityShould {
 
-    class Identity {
+    @Test
+    public void have_utility_ctor() {
+        Tests.assertHasPrivateParameterlessCtor(MulticastDispatcher.Identity.class);
+    }
 
-        /** Prevent instantiation of this utility class. */
-        private Identity() {}
+    @Test
+    public void return_dispatcher_identity() throws Exception {
+        final Set<String> set = MulticastDispatcher.Identity.of(new IdentityTest());
 
-        /**
-         * Returns immutable set with one element with the identity of the multicast dispatcher
-         * that dispatches messages to itself.
-         *
-         * <p>The identity obtained as the result of {@link MulticastDispatcher#toString()}.
-         *
-         * @param self the instance of the dispatcher
-         * @return immutable set with the dispatcher identity
-         */
-        public static Set<String> of(MulticastDispatcher self) {
-            checkNotNull(self);
-            return ImmutableSet.of(self.toString());
+        assertTrue(set.contains(IdentityTest.ID));
+        assertEquals(1, set.size());
+    }
+
+    private static class IdentityTest
+            implements MulticastDispatcher<MessageClass, MessageEnvelope, String> {
+
+        private static final String ID = newUuid();
+
+        @Override
+        public Set<MessageClass> getMessageClasses() {
+            return ImmutableSet.of();
+        }
+
+        @Override
+        public Set<String> dispatch(MessageEnvelope envelope) {
+            return Identity.of(this);
+        }
+
+        @Override
+        public String toString() {
+            return ID;
         }
     }
 }

--- a/server/src/test/java/io/spine/server/commandbus/AbstractCommandBusTestSuite.java
+++ b/server/src/test/java/io/spine/server/commandbus/AbstractCommandBusTestSuite.java
@@ -25,13 +25,13 @@ import com.google.protobuf.Timestamp;
 import io.spine.base.Error;
 import io.spine.client.ActorRequestFactory;
 import io.spine.client.TestActorRequestFactory;
+import io.spine.core.Ack;
 import io.spine.core.ActorContext;
 import io.spine.core.Command;
 import io.spine.core.CommandContext;
 import io.spine.core.CommandEnvelope;
 import io.spine.core.CommandId;
 import io.spine.core.CommandValidationError;
-import io.spine.core.IsSent;
 import io.spine.core.Status;
 import io.spine.core.TenantId;
 import io.spine.grpc.MemoizingObserver;
@@ -90,7 +90,7 @@ public abstract class AbstractCommandBusTestSuite {
     protected FailureBus failureBus;
     protected ExecutorCommandScheduler scheduler;
     protected CreateProjectHandler createProjectHandler;
-    protected MemoizingObserver<IsSent> observer;
+    protected MemoizingObserver<Ack> observer;
 
     /**
      * A public constructor for derived test cases.
@@ -109,7 +109,7 @@ public abstract class AbstractCommandBusTestSuite {
         return invalidCmd;
     }
 
-    static void checkCommandError(IsSent sendingResult,
+    static void checkCommandError(Ack sendingResult,
                                   CommandValidationError validationError,
                                   Class<? extends CommandException> exceptionClass,
                                   Command cmd) {
@@ -119,7 +119,7 @@ public abstract class AbstractCommandBusTestSuite {
                           cmd);
     }
 
-    static void checkCommandError(IsSent sendingResult,
+    static void checkCommandError(Ack sendingResult,
                                   CommandValidationError validationError,
                                   String errorType,
                                   Command cmd) {
@@ -217,7 +217,7 @@ public abstract class AbstractCommandBusTestSuite {
         commandBus.register(createProjectHandler);
 
         final CommandBus spy = spy(commandBus);
-        spy.post(commands, StreamObservers.<IsSent>memoizingObserver());
+        spy.post(commands, StreamObservers.<Ack>memoizingObserver());
 
         @SuppressWarnings("unchecked")
         final ArgumentCaptor<Iterable<Command>> storingCaptor = forClass(Iterable.class);

--- a/server/src/test/java/io/spine/server/commandbus/CommandDispatcherRegistryShould.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandDispatcherRegistryShould.java
@@ -118,7 +118,7 @@ public class CommandDispatcherRegistryShould {
 
     @Test
     public void unregister_command_dispatcher() {
-        final CommandDispatcher dispatcher = new AllCommandDispatcher();
+        final CommandDispatcher<Message> dispatcher = new AllCommandDispatcher();
 
         registry.register(dispatcher);
         registry.unregister(dispatcher);

--- a/server/src/test/java/io/spine/server/commandbus/CommandHandlerShould.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandHandlerShould.java
@@ -217,7 +217,7 @@ public class CommandHandlerShould {
         @Override
         public Set<String> dispatch(EventEnvelope envelope) {
             dispatched.add(envelope);
-            return ImmutableSet.of(toString());
+            return Identity.of(this);
         }
 
         @SuppressWarnings("ReturnOfCollectionOrArrayField") // OK for tests.

--- a/server/src/test/java/io/spine/server/commandbus/CommandHandlerShould.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandHandlerShould.java
@@ -204,7 +204,7 @@ public class CommandHandlerShould {
         }
     }
 
-    private static class EventCatcher implements EventDispatcher {
+    private static class EventCatcher implements EventDispatcher<String> {
 
         private final List<EventEnvelope> dispatched = new LinkedList<>();
 
@@ -215,8 +215,9 @@ public class CommandHandlerShould {
         }
 
         @Override
-        public void dispatch(EventEnvelope envelope) {
+        public Set<String> dispatch(EventEnvelope envelope) {
             dispatched.add(envelope);
+            return ImmutableSet.of(toString());
         }
 
         @SuppressWarnings("ReturnOfCollectionOrArrayField") // OK for tests.

--- a/server/src/test/java/io/spine/server/commandbus/CommandStoreShould.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandStoreShould.java
@@ -285,7 +285,7 @@ public abstract class CommandStoreShould extends AbstractCommandBusTestSuite {
         }
     }
 
-    private static class ThrowingDispatcher implements CommandDispatcher {
+    private static class ThrowingDispatcher implements CommandDispatcher<Message> {
 
         @SuppressWarnings("ThrowableInstanceNeverThrown")
         private final RuntimeException exception = new RuntimeException("Dispatching exception.");
@@ -296,7 +296,7 @@ public abstract class CommandStoreShould extends AbstractCommandBusTestSuite {
         }
 
         @Override
-        public void dispatch(CommandEnvelope envelope) {
+        public Message dispatch(CommandEnvelope envelope) {
             throw exception;
         }
     }

--- a/server/src/test/java/io/spine/server/commandbus/MultiTenantCommandBusShould.java
+++ b/server/src/test/java/io/spine/server/commandbus/MultiTenantCommandBusShould.java
@@ -21,6 +21,8 @@
 package io.spine.server.commandbus;
 
 import com.google.common.testing.NullPointerTester;
+import com.google.protobuf.Empty;
+import com.google.protobuf.Message;
 import io.grpc.stub.StreamObserver;
 import io.spine.base.Error;
 import io.spine.core.Command;
@@ -145,7 +147,7 @@ public class MultiTenantCommandBusShould extends AbstractCommandBusTestSuite {
 
     @Test
     public void unregister_command_dispatcher() {
-        final CommandDispatcher dispatcher = new AddTaskDispatcher();
+        final CommandDispatcher<Message> dispatcher = new AddTaskDispatcher();
         commandBus.register(dispatcher);
         commandBus.unregister(dispatcher);
 
@@ -273,7 +275,7 @@ public class MultiTenantCommandBusShould extends AbstractCommandBusTestSuite {
      * {@link CommandDispatcher#dispatch(MessageEnvelope) dispatch()}
      * was called.
      */
-    private static class AddTaskDispatcher implements CommandDispatcher {
+    private static class AddTaskDispatcher implements CommandDispatcher<Message> {
 
         private boolean dispatcherInvoked = false;
 
@@ -283,8 +285,9 @@ public class MultiTenantCommandBusShould extends AbstractCommandBusTestSuite {
         }
 
         @Override
-        public void dispatch(CommandEnvelope envelope) {
+        public Message dispatch(CommandEnvelope envelope) {
             dispatcherInvoked = true;
+            return Empty.getDefaultInstance();
         }
 
         public boolean wasDispatcherInvoked() {

--- a/server/src/test/java/io/spine/server/commandbus/SingleTenantCommandBusShould.java
+++ b/server/src/test/java/io/spine/server/commandbus/SingleTenantCommandBusShould.java
@@ -22,12 +22,12 @@ package io.spine.server.commandbus;
 
 import com.google.protobuf.Message;
 import io.spine.client.TestActorRequestFactory;
+import io.spine.core.Ack;
 import io.spine.core.Command;
 import io.spine.core.CommandContext;
 import io.spine.core.CommandEnvelope;
 import io.spine.core.CommandValidationError;
 import io.spine.core.Failure;
-import io.spine.core.IsSent;
 import io.spine.grpc.MemoizingObserver;
 import io.spine.server.bus.EnvelopeValidator;
 import io.spine.server.command.Assign;
@@ -108,13 +108,13 @@ public class SingleTenantCommandBusShould extends AbstractCommandBusTestSuite {
         commandBus.register(faultyHandler);
 
         final Command addTaskCommand = clearTenantId(addTask());
-        final MemoizingObserver<IsSent> observer = memoizingObserver();
+        final MemoizingObserver<Ack> observer = memoizingObserver();
         commandBus.post(addTaskCommand, observer);
 
         final InvalidProjectName throwable = faultyHandler.getThrowable();
         final Failure expectedFailure = toFailure(throwable, addTaskCommand);
-        final IsSent isSent = observer.firstResponse();
-        final Failure actualFailure = isSent.getStatus().getFailure();
+        final Ack ack = observer.firstResponse();
+        final Failure actualFailure = ack.getStatus().getFailure();
         assertTrue(isNotDefault(actualFailure));
         assertEquals(unpack(expectedFailure.getMessage()), unpack(actualFailure.getMessage()));
     }

--- a/server/src/test/java/io/spine/server/commandbus/given/CommandDispatcherRegistryTestEnv.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/CommandDispatcherRegistryTestEnv.java
@@ -23,6 +23,7 @@ package io.spine.server.commandbus.given;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
+import com.google.protobuf.Empty;
 import com.google.protobuf.Message;
 import io.spine.core.CommandClass;
 import io.spine.core.CommandContext;
@@ -129,14 +130,15 @@ public class CommandDispatcherRegistryTestEnv {
         }
     }
 
-    public static class EmptyDispatcher implements CommandDispatcher {
+    public static class EmptyDispatcher implements CommandDispatcher<Message> {
         @Override
         public Set<CommandClass> getMessageClasses() {
             return Collections.emptySet();
         }
 
         @Override
-        public void dispatch(CommandEnvelope envelope) {
+        public Message dispatch(CommandEnvelope envelope) {
+            return Empty.getDefaultInstance();
         }
     }
 
@@ -144,7 +146,7 @@ public class CommandDispatcherRegistryTestEnv {
             extends ProcessManagerRepository<ProjectId, NoCommandsProcessManager, Project> {
     }
 
-    public static class AllCommandDispatcher implements CommandDispatcher {
+    public static class AllCommandDispatcher implements CommandDispatcher<Message> {
         @Override
         public Set<CommandClass> getMessageClasses() {
             return CommandClass.setOf(CreateProject.class,
@@ -153,22 +155,24 @@ public class CommandDispatcherRegistryTestEnv {
         }
 
         @Override
-        public void dispatch(CommandEnvelope envelope) {
+        public Message dispatch(CommandEnvelope envelope) {
+            return Empty.getDefaultInstance();
         }
     }
 
-    public static class CreateProjectDispatcher implements CommandDispatcher {
+    public static class CreateProjectDispatcher implements CommandDispatcher<Message> {
         @Override
         public Set<CommandClass> getMessageClasses() {
             return CommandClass.setOf(CreateProject.class);
         }
 
         @Override
-        public void dispatch(CommandEnvelope envelope) {
+        public Message dispatch(CommandEnvelope envelope) {
+            return Empty.getDefaultInstance();
         }
     }
 
-    public static class AddTaskDispatcher implements CommandDispatcher {
+    public static class AddTaskDispatcher implements CommandDispatcher<Message> {
 
         @Override
         public Set<CommandClass> getMessageClasses() {
@@ -176,8 +180,9 @@ public class CommandDispatcherRegistryTestEnv {
         }
 
         @Override
-        public void dispatch(CommandEnvelope envelope) {
+        public Message dispatch(CommandEnvelope envelope) {
             // Do nothing.
+            return Empty.getDefaultInstance();
         }
     }
 

--- a/server/src/test/java/io/spine/server/event/DelegatingEventDispatcherShould.java
+++ b/server/src/test/java/io/spine/server/event/DelegatingEventDispatcherShould.java
@@ -40,7 +40,8 @@ public class DelegatingEventDispatcherShould {
                 .testAllPublicStaticMethods(DelegatingEventDispatcher.class);
     }
 
-    private static final class EmptyEventDispatcherDelegate implements EventDispatcherDelegate {
+    private static final class EmptyEventDispatcherDelegate
+            implements EventDispatcherDelegate<String> {
 
         @Override
         public Set<EventClass> getEventClasses() {
@@ -48,8 +49,9 @@ public class DelegatingEventDispatcherShould {
         }
 
         @Override
-        public void dispatchEvent(EventEnvelope envelope) {
+        public Set<String> dispatchEvent(EventEnvelope envelope) {
             // Do nothing.
+            return ImmutableSet.of();
         }
     }
 }

--- a/server/src/test/java/io/spine/server/event/EventBusShould.java
+++ b/server/src/test/java/io/spine/server/event/EventBusShould.java
@@ -456,7 +456,7 @@ public class EventBusShould {
         @Override
         public Set<String> dispatch(EventEnvelope event) {
             dispatchCalled = true;
-            return ImmutableSet.of(toString());
+            return Identity.of(this);
         }
 
         private boolean isDispatchCalled() {

--- a/server/src/test/java/io/spine/server/event/EventBusShould.java
+++ b/server/src/test/java/io/spine/server/event/EventBusShould.java
@@ -154,7 +154,8 @@ public class EventBusShould {
         final EventClass eventClass = EventClass.of(ProjectCreated.class);
         assertTrue(eventBus.hasDispatchers(eventClass));
 
-        final Collection<EventDispatcher> dispatchers = eventBus.getDispatchers(eventClass);
+        final Collection<? extends EventDispatcher<?>> dispatchers =
+                eventBus.getDispatchers(eventClass);
         assertTrue(dispatchers.contains(subscriberOne));
         assertTrue(dispatchers.contains(subscriberTwo));
     }
@@ -171,7 +172,8 @@ public class EventBusShould {
 
         // Check that the 2nd subscriber with the same event subscriber method remains
         // after the 1st subscriber unregisters.
-        final Collection<EventDispatcher> subscribers = eventBus.getDispatchers(eventClass);
+        final Collection<? extends EventDispatcher<?>> subscribers =
+                eventBus.getDispatchers(eventClass);
         assertFalse(subscribers.contains(subscriberOne));
         assertTrue(subscribers.contains(subscriberTwo));
 
@@ -262,7 +264,7 @@ public class EventBusShould {
         eventBus.register(dispatcherTwo);
 
         eventBus.unregister(dispatcherOne);
-        final Set<EventDispatcher> dispatchers = eventBus.getDispatchers(eventClass);
+        final Set<? extends EventDispatcher<?>> dispatchers = eventBus.getDispatchers(eventClass);
 
         // Check we don't have 1st dispatcher, but have 2nd.
         assertFalse(dispatchers.contains(dispatcherOne));
@@ -442,7 +444,7 @@ public class EventBusShould {
      * A simple dispatcher class, which only dispatch and does not have own event
      * subscribing methods.
      */
-    private static class BareDispatcher implements EventDispatcher {
+    private static class BareDispatcher implements EventDispatcher<String> {
 
         private boolean dispatchCalled = false;
 
@@ -452,8 +454,9 @@ public class EventBusShould {
         }
 
         @Override
-        public void dispatch(EventEnvelope event) {
+        public Set<String> dispatch(EventEnvelope event) {
             dispatchCalled = true;
+            return ImmutableSet.of(toString());
         }
 
         private boolean isDispatchCalled() {

--- a/server/src/test/java/io/spine/server/failure/FailureBusBuilderShould.java
+++ b/server/src/test/java/io/spine/server/failure/FailureBusBuilderShould.java
@@ -57,7 +57,7 @@ public class FailureBusBuilderShould extends BusBuilderShould<FailureBus.Builder
         return new DispatcherFailureDelivery() {
             @Override
             protected boolean shouldPostponeDelivery(FailureEnvelope deliverable,
-                                                     FailureDispatcher consumer) {
+                                                     FailureDispatcher<?> consumer) {
                 return false;   // Does not really matter for tests.
             }
         };

--- a/server/src/test/java/io/spine/server/failure/FailureBusShould.java
+++ b/server/src/test/java/io/spine/server/failure/FailureBusShould.java
@@ -19,7 +19,6 @@
  */
 package io.spine.server.failure;
 
-import com.google.common.collect.ImmutableSet;
 import io.spine.base.Error;
 import io.spine.change.StringChange;
 import io.spine.client.CommandFactory;
@@ -412,7 +411,7 @@ public class FailureBusShould {
         @Override
         public Set<String> dispatch(FailureEnvelope failure) {
             dispatchCalled = true;
-            return ImmutableSet.of(toString());
+            return Identity.of(this);
         }
 
         private boolean isDispatchCalled() {

--- a/server/src/test/java/io/spine/server/failure/FailureBusShould.java
+++ b/server/src/test/java/io/spine/server/failure/FailureBusShould.java
@@ -23,6 +23,7 @@ import io.spine.base.Error;
 import io.spine.change.StringChange;
 import io.spine.client.CommandFactory;
 import io.spine.client.TestActorRequestFactory;
+import io.spine.core.Ack;
 import io.spine.core.Command;
 import io.spine.core.CommandContext;
 import io.spine.core.Commands;
@@ -30,7 +31,6 @@ import io.spine.core.Failure;
 import io.spine.core.FailureClass;
 import io.spine.core.FailureEnvelope;
 import io.spine.core.Failures;
-import io.spine.core.IsSent;
 import io.spine.core.Subscribe;
 import io.spine.core.TenantId;
 import io.spine.grpc.MemoizingObserver;
@@ -332,10 +332,10 @@ public class FailureBusShould {
 
     @Test
     public void report_dead_messages() {
-        final MemoizingObserver<IsSent> observer = memoizingObserver();
+        final MemoizingObserver<Ack> observer = memoizingObserver();
         failureBus.post(missingOwnerFailure(), observer);
         assertTrue(observer.isCompleted());
-        final IsSent result = observer.firstResponse();
+        final Ack result = observer.firstResponse();
         assertNotNull(result);
         assertEquals(ERROR, result.getStatus().getStatusCase());
         final Error error = result.getStatus().getError();

--- a/server/src/test/java/io/spine/server/procman/AbstractCommandRouterShould.java
+++ b/server/src/test/java/io/spine/server/procman/AbstractCommandRouterShould.java
@@ -99,15 +99,16 @@ public abstract class AbstractCommandRouterShould<T extends AbstractCommandRoute
 
         // Register dispatcher for `StringValue` message type.
         // Otherwise we won't be able to post.
-        commandBus.register(new CommandDispatcher() {
+        commandBus.register(new CommandDispatcher<String>() {
             @Override
             public Set<CommandClass> getMessageClasses() {
                 return CommandClass.setOf(StringValue.class);
             }
 
             @Override
-            public void dispatch(CommandEnvelope envelope) {
+            public String dispatch(CommandEnvelope envelope) {
                 // Do nothing.
+                return "Anonymous";
             }
         });
 

--- a/server/src/test/java/io/spine/server/procman/CommandRouterOnErrorShould.java
+++ b/server/src/test/java/io/spine/server/procman/CommandRouterOnErrorShould.java
@@ -60,14 +60,14 @@ public class CommandRouterOnErrorShould extends AbstractCommandRouterShould<Comm
 
         // Register dispatcher for `StringValue` message type.
         // Fails each time of dispatch().
-        commandBus.register(new CommandDispatcher() {
+        commandBus.register(new CommandDispatcher<Message>() {
             @Override
             public Set<CommandClass> getMessageClasses() {
                 return CommandClass.setOf(StringValue.class);
             }
 
             @Override
-            public void dispatch(CommandEnvelope envelope) {
+            public Message dispatch(CommandEnvelope envelope) {
                 throw new IllegalStateException("I am faulty!");
             }
         });

--- a/server/src/test/java/io/spine/server/procman/ProcessManagerShould.java
+++ b/server/src/test/java/io/spine/server/procman/ProcessManagerShould.java
@@ -21,6 +21,7 @@
 package io.spine.server.procman;
 
 import com.google.protobuf.Any;
+import com.google.protobuf.Empty;
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
@@ -344,7 +345,7 @@ public class ProcessManagerShould {
         assertHasPrivateParameterlessCtor(ProcessManager.TypeInfo.class);
     }
 
-    private static class AddTaskDispatcher implements CommandDispatcher {
+    private static class AddTaskDispatcher implements CommandDispatcher<Message> {
 
         private final List<CommandEnvelope> commands = new LinkedList<>();
 
@@ -354,8 +355,9 @@ public class ProcessManagerShould {
         }
 
         @Override
-        public void dispatch(CommandEnvelope envelope) {
+        public Message dispatch(CommandEnvelope envelope) {
             commands.add(envelope);
+            return Empty.getDefaultInstance();
         }
 
         @SuppressWarnings("ReturnOfCollectionOrArrayField") // OK for tests.


### PR DESCRIPTION
This PR allows dispatchers to return IDs of entities to which a message was dispatched.

Also, `IsSent` was renamed to `Ack`.