### PR TITLE
Remove `IdConverter`

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.9.39-SNAPSHOT'
+def final SPINE_VERSION = '0.9.40-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/bus/Bus.java
+++ b/server/src/main/java/io/spine/server/bus/Bus.java
@@ -28,7 +28,6 @@ import io.spine.core.Ack;
 import io.spine.core.MessageEnvelope;
 import io.spine.type.MessageClass;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Deque;
@@ -196,11 +195,9 @@ public abstract class Bus<T extends Message,
     private BusFilter<E> filterChain() {
         if (filterChain == null) {
             final Deque<BusFilter<E>> filters = createFilterChain();
-            final BusFilter<E> deadMsgFilter = new DeadMessageFilter<>(getIdConverter(),
-                                                                       getDeadMessageHandler(),
+            final BusFilter<E> deadMsgFilter = new DeadMessageFilter<>(getDeadMessageHandler(),
                                                                        registry());
-            final BusFilter<E> validatingFilter = new ValidatingFilter<>(getIdConverter(),
-                                                                         getValidator());
+            final BusFilter<E> validatingFilter = new ValidatingFilter<>(getValidator());
             filters.push(deadMsgFilter);
             filters.push(validatingFilter);
             filterChain = new FilterChain<>(filters);
@@ -223,13 +220,6 @@ public abstract class Bus<T extends Message,
      * @return a dequeue of the bus custom filters
      */
     protected abstract Deque<BusFilter<E>> createFilterChain();
-
-    /**
-     * Obtains the {@link IdConverter} for this type of {@code Bus}.
-     *
-     * @return a function converting a {@link MessageEnvelope} to an ID
-     */
-    protected abstract IdConverter<E> getIdConverter();
 
     /**
      * Filters the given messages.
@@ -422,20 +412,5 @@ public abstract class Bus<T extends Message,
             final E result = toEnvelope(message);
             return result;
         }
-    }
-
-    /**
-     * The function which receives a {@link MessageEnvelope} as a parameter and returns the ID of
-     * the message enclosed in that parameter.
-     *
-     * @param <E> the type of the envelope
-     */
-    public interface IdConverter<E extends MessageEnvelope<?, ?>> extends Function<E, Message> {
-
-        @SuppressWarnings({"AbstractMethodOverridesAbstractMethod", "NullableProblems"})
-            // Changes nullability contract.
-        @Nonnull
-        @Override
-        Message apply(@Nullable E input);
     }
 }

--- a/server/src/main/java/io/spine/server/bus/ValidatingFilter.java
+++ b/server/src/main/java/io/spine/server/bus/ValidatingFilter.java
@@ -21,7 +21,9 @@
 package io.spine.server.bus;
 
 import com.google.common.base.Optional;
+import com.google.protobuf.Any;
 import com.google.protobuf.Message;
+import io.spine.Identifier;
 import io.spine.base.Error;
 import io.spine.core.Ack;
 import io.spine.core.MessageEnvelope;
@@ -39,12 +41,10 @@ import static io.spine.server.bus.Buses.reject;
 final class ValidatingFilter<E extends MessageEnvelope<?, T>, T extends Message>
         extends AbstractBusFilter<E> {
 
-    private final Bus.IdConverter<E> idConverter;
     private final EnvelopeValidator<E> validator;
 
-    ValidatingFilter(Bus.IdConverter<E> idConverter, EnvelopeValidator<E> validator) {
+    ValidatingFilter(EnvelopeValidator<E> validator) {
         super();
-        this.idConverter = checkNotNull(idConverter);
         this.validator = checkNotNull(validator);
     }
 
@@ -54,7 +54,8 @@ final class ValidatingFilter<E extends MessageEnvelope<?, T>, T extends Message>
         final Optional<MessageInvalid> violation = validator.validate(envelope);
         if (violation.isPresent()) {
             final Error error = violation.get().asError();
-            final Ack result = reject(idConverter.apply(envelope), error);
+            final Any packedId = Identifier.pack(envelope.getId());
+            final Ack result = reject(packedId, error);
             return Optional.of(result);
         } else {
             return Optional.absent();

--- a/server/src/main/java/io/spine/server/commandbus/CommandBus.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandBus.java
@@ -30,7 +30,6 @@ import io.spine.core.Ack;
 import io.spine.core.Command;
 import io.spine.core.CommandClass;
 import io.spine.core.CommandEnvelope;
-import io.spine.core.CommandId;
 import io.spine.core.Failure;
 import io.spine.server.ServerEnvironment;
 import io.spine.server.bus.Bus;
@@ -40,7 +39,6 @@ import io.spine.server.bus.EnvelopeValidator;
 import io.spine.server.commandstore.CommandStore;
 import io.spine.server.failure.FailureBus;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Deque;
 import java.util.Set;
@@ -185,11 +183,6 @@ public class CommandBus extends Bus<Command,
     protected Deque<BusFilter<CommandEnvelope>> createFilterChain() {
         filterChain.push(scheduler);
         return filterChain;
-    }
-
-    @Override
-    protected Bus.IdConverter<CommandEnvelope> getIdConverter() {
-        return CommandIdConverter.INSTANCE;
     }
 
     @Override
@@ -512,17 +505,6 @@ public class CommandBus extends Bus<Command,
             final UnsupportedCommandException exception = new UnsupportedCommandException(command);
             commandStore().storeWithError(command, exception);
             return exception;
-        }
-    }
-
-    private enum CommandIdConverter implements Bus.IdConverter<CommandEnvelope> {
-        INSTANCE;
-
-        @Nonnull
-        @Override
-        public CommandId apply(@Nullable CommandEnvelope input) {
-            checkNotNull(input);
-            return input.getId();
         }
     }
 }

--- a/server/src/main/java/io/spine/server/event/EventBus.java
+++ b/server/src/main/java/io/spine/server/event/EventBus.java
@@ -31,10 +31,8 @@ import io.spine.core.Event;
 import io.spine.core.EventClass;
 import io.spine.core.EventContext;
 import io.spine.core.EventEnvelope;
-import io.spine.core.EventId;
 import io.spine.grpc.LoggingObserver;
 import io.spine.grpc.LoggingObserver.Level;
-import io.spine.server.bus.Bus;
 import io.spine.server.bus.BusFilter;
 import io.spine.server.bus.DeadMessageTap;
 import io.spine.server.bus.EnvelopeValidator;
@@ -44,7 +42,6 @@ import io.spine.server.outbus.OutputDispatcherRegistry;
 import io.spine.server.storage.StorageFactory;
 import io.spine.validate.MessageValidator;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Deque;
 import java.util.Set;
@@ -176,11 +173,6 @@ public class EventBus extends CommandOutputBus<Event,
     @Override
     protected Deque<BusFilter<EventEnvelope>> createFilterChain() {
         return filterChain;
-    }
-
-    @Override
-    protected IdConverter<EventEnvelope> getIdConverter() {
-        return EventIdConverter.INSTANCE;
     }
 
     @Override
@@ -532,17 +524,6 @@ public class EventBus extends CommandOutputBus<Event,
             final Message message = envelope.getMessage();
             final UnsupportedEventException exception = new UnsupportedEventException(message);
             return exception;
-        }
-    }
-
-    private enum EventIdConverter implements Bus.IdConverter<EventEnvelope> {
-        INSTANCE;
-
-        @Nonnull
-        @Override
-        public EventId apply(@Nullable EventEnvelope input) {
-            checkNotNull(input);
-            return input.getId();
         }
     }
 }

--- a/server/src/main/java/io/spine/server/failure/FailureBus.java
+++ b/server/src/main/java/io/spine/server/failure/FailureBus.java
@@ -27,10 +27,8 @@ import io.spine.core.Ack;
 import io.spine.core.Failure;
 import io.spine.core.FailureClass;
 import io.spine.core.FailureEnvelope;
-import io.spine.core.FailureId;
 import io.spine.core.MessageInvalid;
 import io.spine.grpc.StreamObservers;
-import io.spine.server.bus.Bus;
 import io.spine.server.bus.BusFilter;
 import io.spine.server.bus.DeadMessageTap;
 import io.spine.server.bus.EnvelopeValidator;
@@ -39,7 +37,6 @@ import io.spine.server.outbus.OutputDispatcherRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Deque;
 import java.util.Set;
@@ -110,11 +107,6 @@ public class FailureBus extends CommandOutputBus<Failure,
     @Override
     protected Deque<BusFilter<FailureEnvelope>> createFilterChain() {
         return filterChain;
-    }
-
-    @Override
-    protected IdConverter<FailureEnvelope> getIdConverter() {
-        return FailureIdConverter.INSTANCE;
     }
 
     @Override
@@ -248,17 +240,6 @@ public class FailureBus extends CommandOutputBus<Failure,
         public Optional<MessageInvalid> validate(FailureEnvelope envelope) {
             checkNotNull(envelope);
             return absent();
-        }
-    }
-
-    private enum FailureIdConverter implements Bus.IdConverter<FailureEnvelope> {
-        INSTANCE;
-
-        @Nonnull
-        @Override
-        public FailureId apply(@Nullable FailureEnvelope input) {
-            checkNotNull(input);
-            return input.getId();
         }
     }
 

--- a/server/src/main/java/io/spine/server/outbus/CommandOutputBus.java
+++ b/server/src/main/java/io/spine/server/outbus/CommandOutputBus.java
@@ -20,7 +20,9 @@
 package io.spine.server.outbus;
 
 import com.google.common.base.Function;
+import com.google.protobuf.Any;
 import com.google.protobuf.Message;
+import io.spine.Identifier;
 import io.spine.annotation.Internal;
 import io.spine.core.Ack;
 import io.spine.core.Event;
@@ -124,10 +126,10 @@ public abstract class CommandOutputBus<M extends Message,
         final E enrichedEnvelope = toEnvelope(enriched);
         final int dispatchersCalled = callDispatchers(enrichedEnvelope);
 
-        final Message id = getIdConverter().apply(envelope);
+        final Any packedId = Identifier.pack(envelope.getId());
         checkState(dispatchersCalled != 0,
                    format("Message %s has no dispatchers.", envelope.getMessage()));
-        final Ack result = acknowledge(id);
+        final Ack result = acknowledge(packedId);
         return result;
     }
 


### PR DESCRIPTION
This PR eliminates the hierarchy of `IdConverter` in favor of using `Identifier`.