### PR TITLE
Javadoc fix

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.9.41-SNAPSHOT'
+def final SPINE_VERSION = '0.9.43-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/aggregate/React.java
+++ b/server/src/main/java/io/spine/server/aggregate/React.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  *     <li>be annotated with {@link React @React};
  *
  *     <li>accept an event message (derived from {@link com.google.protobuf.Message
- *     Message}) which is <not>generated</not> by this aggregate, as the first parameter;
+ *     Message}) which is <em>generated</em> by this aggregate, as the first parameter;
  *
  *     <li>return an event derived from {@link com.google.protobuf.Message Message}
  *     <strong>or</strong> several event messages returned as a {@link java.util.List List}.

--- a/server/src/main/java/io/spine/server/bus/MulticastDispatcher.java
+++ b/server/src/main/java/io/spine/server/bus/MulticastDispatcher.java
@@ -48,7 +48,7 @@ public interface MulticastDispatcher <C extends MessageClass, E extends MessageE
          * Returns immutable set with one element with the identity of the multicast dispatcher
          * that dispatches messages to itself.
          *
-         * <p>The identity obtained as the result of {@link Object#toString()}
+         * <p>The identity obtained as the result of {@link Object#toString()
          * MulticastDispatcher#toString()}.
          *
          * @param self the instance of the dispatcher

--- a/server/src/main/java/io/spine/server/bus/MulticastDispatcher.java
+++ b/server/src/main/java/io/spine/server/bus/MulticastDispatcher.java
@@ -48,7 +48,8 @@ public interface MulticastDispatcher <C extends MessageClass, E extends MessageE
          * Returns immutable set with one element with the identity of the multicast dispatcher
          * that dispatches messages to itself.
          *
-         * <p>The identity obtained as the result of {@link MulticastDispatcher#toString()}.
+         * <p>The identity obtained as the result of {@link Object#toString()}
+         * MulticastDispatcher#toString()}.
          *
          * @param self the instance of the dispatcher
          * @return immutable set with the dispatcher identity

--- a/server/src/main/java/io/spine/server/entity/storage/EntityQuery.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityQuery.java
@@ -30,6 +30,7 @@ import io.spine.server.entity.EntityWithLifecycle;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -105,10 +106,10 @@ public final class EntityQuery<I> implements Serializable {
     }
 
     /**
-     * @return a set of accepted ID values
+     * @return an immutable set of accepted ID values
      */
     @SuppressWarnings("ReturnOfCollectionOrArrayField") // Immutable structure
-    public ImmutableSet<I> getIds() {
+    public Set<I> getIds() {
         return ids;
     }
 
@@ -141,7 +142,8 @@ public final class EntityQuery<I> implements Serializable {
      */
     @Internal
     public EntityQuery<I> withLifecycleFlags(Class<? extends EntityWithLifecycle<I, ?>> cls) {
-        checkState(!isLifecycleAttributesSet(), "The query overrides Lifecycle Flags default values.");
+        checkState(!isLifecycleAttributesSet(),
+                   "The query overrides Lifecycle Flags default values.");
         final Column archivedColumn = findColumn(cls, archived.name());
         final Column deletedColumn = findColumn(cls, deleted.name());
         final CompositeQueryParameter lifecycleParameter = CompositeQueryParameter.from(


### PR DESCRIPTION
This PR fixes Javadoc errors and makes `EntityQuery` to return `Set` instead of `ImmutableSet`.