### PR TITLE
Minor fix of Javadoc formatting

### DIFF
--- a/server/src/main/java/io/spine/server/outbus/enrich/Enricher.java
+++ b/server/src/main/java/io/spine/server/outbus/enrich/Enricher.java
@@ -136,7 +136,7 @@ public abstract class Enricher<M extends EnrichableMessageEnvelope<?, ?, C>, C e
      *         the envelope with the source message
      * @throws IllegalArgumentException
      *         if the passed message cannot be enriched
-     * @see    #canBeEnriched(M)
+     * @see    Enricher#canBeEnriched(EnrichableMessageEnvelope)
      */
     public M enrich(M source) {
         checkTypeRegistered(source);


### PR DESCRIPTION
This PR addresses a minor issue in Javadoc formatting. This issue prevented the previous Spine version from being published to the repository (see #558).

Summary:

* format the reference to `Enricher`'s own method without using a generic parameter.

The library version left intact.