### PR TITLE
Use `ConsumerID` to pick target envelope consumer

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.9.50-SNAPSHOT'
+def final SPINE_VERSION = '0.9.51-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/commandbus/DelegatingCommandDispatcher.java
+++ b/server/src/main/java/io/spine/server/commandbus/DelegatingCommandDispatcher.java
@@ -70,10 +70,16 @@ public class DelegatingCommandDispatcher<I> implements CommandDispatcher<I> {
         delegate.onError(envelope, exception);
     }
 
+    /**
+     * Returns the string representation of this dispatcher.
+     *
+     * <p>Includes an FQN of the {@code delegate} in order to allow distinguish
+     * {@code DelegatingCommandDispatcher} instances with different delegates.
+     */
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                          .add("delegate", delegate.getClass())
+                          .add("commandDelegate", delegate.getClass())
                           .toString();
     }
 }

--- a/server/src/main/java/io/spine/server/commandbus/DelegatingCommandDispatcher.java
+++ b/server/src/main/java/io/spine/server/commandbus/DelegatingCommandDispatcher.java
@@ -19,6 +19,7 @@
  */
 package io.spine.server.commandbus;
 
+import com.google.common.base.MoreObjects;
 import io.spine.annotation.Internal;
 import io.spine.core.CommandClass;
 import io.spine.core.CommandEnvelope;
@@ -67,5 +68,12 @@ public class DelegatingCommandDispatcher<I> implements CommandDispatcher<I> {
     @Override
     public void onError(CommandEnvelope envelope, RuntimeException exception) {
         delegate.onError(envelope, exception);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("delegate", delegate.getClass())
+                          .toString();
     }
 }

--- a/server/src/main/java/io/spine/server/delivery/Consumers.java
+++ b/server/src/main/java/io/spine/server/delivery/Consumers.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.spine.server.delivery;
+
+import io.spine.server.commandbus.DelegatingCommandDispatcher;
+import io.spine.server.event.DelegatingEventDispatcher;
+import io.spine.server.rejection.DelegatingRejectionDispatcher;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A utility class for working with delivery consumers.
+ *
+ * @author Alex Tymchenko
+ */
+public final class Consumers {
+
+    private Consumers() {
+    }
+
+    /**
+     * Creates an identity for the {@linkplain Delivery} consumer.
+     *
+     * @param consumer the consumer
+     * @return the consumer identity
+     */
+    public static ConsumerId idOf(Object consumer) {
+        checkNotNull(consumer);
+
+        // Delegates are masking the real class.
+        // Using their string identity instead of FQN.
+        if (consumer instanceof DelegatingCommandDispatcher ||
+                consumer instanceof DelegatingEventDispatcher ||
+                consumer instanceof DelegatingRejectionDispatcher) {
+
+            return idOfString(consumer.toString());
+        }
+        return idOfString(consumer.getClass()
+                                  .getName());
+    }
+
+    private static ConsumerId idOfString(String identityString) {
+        return ConsumerId.newBuilder()
+                         .setConsumerIdentity(identityString)
+                         .build();
+    }
+}

--- a/server/src/main/java/io/spine/server/delivery/Consumers.java
+++ b/server/src/main/java/io/spine/server/delivery/Consumers.java
@@ -32,8 +32,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public final class Consumers {
 
-    private Consumers() {
-    }
+    /** Prevents instantiation of this utility class. */
+    private Consumers() {}
 
     /**
      * Creates an identity for the {@linkplain Delivery} consumer.

--- a/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
+++ b/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
@@ -76,10 +76,16 @@ public final class DelegatingEventDispatcher<I> implements EventDispatcher<I> {
         delegate.onError(envelope, exception);
     }
 
+    /**
+     * Returns the string representation of this dispatcher.
+     *
+     * <p>Includes an FQN of the {@code delegate} in order to allow distinguish
+     * {@code DelegatingEventDispatcher} instances with different delegates.
+     */
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                          .add("delegate", delegate.getClass())
+                          .add("eventDelegate", delegate.getClass())
                           .toString();
     }
 }

--- a/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
+++ b/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.event;
 
+import com.google.common.base.MoreObjects;
 import io.spine.annotation.Internal;
 import io.spine.core.EventClass;
 import io.spine.core.EventEnvelope;
@@ -73,5 +74,12 @@ public final class DelegatingEventDispatcher<I> implements EventDispatcher<I> {
     @Override
     public void onError(EventEnvelope envelope, RuntimeException exception) {
         delegate.onError(envelope, exception);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("delegate", delegate.getClass())
+                          .toString();
     }
 }

--- a/server/src/main/java/io/spine/server/rejection/DelegatingRejectionDispatcher.java
+++ b/server/src/main/java/io/spine/server/rejection/DelegatingRejectionDispatcher.java
@@ -70,10 +70,16 @@ public final class DelegatingRejectionDispatcher<I> implements RejectionDispatch
         delegate.onError(envelope, exception);
     }
 
+    /**
+     * Returns the string representation of this dispatcher.
+     *
+     * <p>Includes an FQN of the {@code delegate} in order to allow distinguish
+     * {@code DelegatingRejectionDispatcher} instances with different delegates.
+     */
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                          .add("delegate", delegate.getClass())
+                          .add("rejectionDelegate", delegate.getClass())
                           .toString();
     }
 }

--- a/server/src/main/java/io/spine/server/rejection/DelegatingRejectionDispatcher.java
+++ b/server/src/main/java/io/spine/server/rejection/DelegatingRejectionDispatcher.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.rejection;
 
+import com.google.common.base.MoreObjects;
 import io.spine.annotation.Internal;
 import io.spine.core.RejectionClass;
 import io.spine.core.RejectionEnvelope;
@@ -67,5 +68,12 @@ public final class DelegatingRejectionDispatcher<I> implements RejectionDispatch
         checkNotNull(envelope);
         checkNotNull(exception);
         delegate.onError(envelope, exception);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("delegate", delegate.getClass())
+                          .toString();
     }
 }

--- a/server/src/main/proto/spine/server/delivery/consumer.proto
+++ b/server/src/main/proto/spine/server/delivery/consumer.proto
@@ -1,0 +1,44 @@
+//
+// Copyright 2017, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.server.delivery;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option (SPI_all) = true;
+option java_package = "io.spine.server.delivery";
+option java_multiple_files = true;
+option java_outer_classname = "ConsumerProto";
+option java_generate_equals_and_hash = true;
+
+// An identificator of a consumer for `Delivery`.
+//
+// Used to match the target consumers for the envelope; especially helpful if the delivery
+// is distributed across several nodes.
+message ConsumerId {
+
+    // Typically, the FQN for the consumer class.
+    //
+    // If the consumer is delegate, the FQN of the final destination class
+    // is used as a part of this string.
+    string consumer_identity = 1 [(required) = true];
+}

--- a/server/src/test/java/io/spine/delivery/ConsumersShould.java
+++ b/server/src/test/java/io/spine/delivery/ConsumersShould.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.spine.delivery;
+
+import com.google.common.testing.NullPointerTester;
+import io.spine.server.delivery.Consumers;
+import org.junit.Test;
+
+import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
+
+/**
+ * @author Alex Tymchenko
+ */
+public class ConsumersShould {
+
+    @Test
+    public void have_private_ctor() {
+        assertHasPrivateParameterlessCtor(Consumers.class);
+    }
+
+    @Test
+    public void pass_the_null_tolerance_check() {
+        new NullPointerTester()
+                .testAllPublicStaticMethods(Consumers.class);
+    }
+}

--- a/server/src/test/java/io/spine/server/event/EventBusShould.java
+++ b/server/src/test/java/io/spine/server/event/EventBusShould.java
@@ -30,6 +30,7 @@ import io.spine.core.Events;
 import io.spine.core.Subscribe;
 import io.spine.server.BoundedContext;
 import io.spine.server.bus.EnvelopeValidator;
+import io.spine.server.delivery.Consumers;
 import io.spine.server.event.given.EventBusTestEnv.GivenEvent;
 import io.spine.server.storage.StorageFactory;
 import io.spine.test.event.ProjectCreated;
@@ -243,7 +244,7 @@ public class EventBusShould {
         final EventEnvelope postponedEvent = postponedEvents.iterator()
                                                             .next();
         verify(delegateDispatcherExecutor, never()).execute(any(Runnable.class));
-        postponedDispatcherDelivery.deliverNow(postponedEvent, dispatcher.getClass());
+        postponedDispatcherDelivery.deliverNow(postponedEvent, Consumers.idOf(dispatcher));
         assertTrue(dispatcher.isDispatchCalled());
         verify(delegateDispatcherExecutor).execute(any(Runnable.class));
     }

--- a/server/src/test/java/io/spine/server/event/EventBusShould.java
+++ b/server/src/test/java/io/spine/server/event/EventBusShould.java
@@ -34,7 +34,6 @@ import io.spine.server.delivery.Consumers;
 import io.spine.server.event.given.EventBusTestEnv.GivenEvent;
 import io.spine.server.storage.StorageFactory;
 import io.spine.test.event.ProjectCreated;
-import io.spine.test.event.ProjectStarred;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -251,9 +250,9 @@ public class EventBusShould {
     }
 
     @Test
-    public void deliver_postponed_event_to_delegating_dispatchers_using_configured_executor() {
-        final ProjectCreatedDelegate first = new ProjectCreatedDelegate();
-        final ProjectStartedDelegate second = new ProjectStartedDelegate();
+    public void pick_proper_consumer_by_consumer_id_when_delivering_to_delegates_of_same_event() {
+        final FirstProjectCreatedDelegate first = new FirstProjectCreatedDelegate();
+        final AnotherProjectCreatedDelegate second = new AnotherProjectCreatedDelegate();
 
         final DelegatingEventDispatcher<String> firstDispatcher =
                 DelegatingEventDispatcher.of(first);
@@ -430,7 +429,7 @@ public class EventBusShould {
     /**
      * A delegate, dispatching {@link ProjectCreated} events.
      */
-    private static class ProjectCreatedDelegate implements EventDispatcherDelegate<String> {
+    private static class FirstProjectCreatedDelegate implements EventDispatcherDelegate<String> {
         private boolean dispatchCalled = false;
 
         @Override
@@ -455,14 +454,14 @@ public class EventBusShould {
     }
 
     /**
-     * A delegate, dispatching {@link ProjectStarred} events.
+     * Another delegate, dispatching {@link ProjectCreated} events.
      */
-    private static class ProjectStartedDelegate implements EventDispatcherDelegate<String> {
+    private static class AnotherProjectCreatedDelegate implements EventDispatcherDelegate<String> {
         private boolean dispatchCalled = false;
 
         @Override
         public Set<EventClass> getEventClasses() {
-            return ImmutableSet.of(EventClass.of(ProjectStarred.class));
+            return ImmutableSet.of(EventClass.of(ProjectCreated.class));
         }
 
         @Override

--- a/server/src/test/java/io/spine/server/rejection/RejectionBusShould.java
+++ b/server/src/test/java/io/spine/server/rejection/RejectionBusShould.java
@@ -26,6 +26,7 @@ import io.spine.core.RejectionClass;
 import io.spine.core.RejectionEnvelope;
 import io.spine.grpc.MemoizingObserver;
 import io.spine.server.delivery.Consumers;
+import io.spine.server.rejection.given.AnotherInvalidProjectNameDelegate;
 import io.spine.server.rejection.given.BareDispatcher;
 import io.spine.server.rejection.given.CommandAwareSubscriber;
 import io.spine.server.rejection.given.CommandMessageAwareSubscriber;
@@ -34,7 +35,6 @@ import io.spine.server.rejection.given.FaultySubscriber;
 import io.spine.server.rejection.given.InvalidOrderSubscriber;
 import io.spine.server.rejection.given.InvalidProjectNameDelegate;
 import io.spine.server.rejection.given.InvalidProjectNameSubscriber;
-import io.spine.server.rejection.given.MissingOwnerDelegate;
 import io.spine.server.rejection.given.PostponedDispatcherRejectionDelivery;
 import io.spine.server.rejection.given.RejectionMessageSubscriber;
 import io.spine.server.rejection.given.VerifiableSubscriber;
@@ -250,9 +250,9 @@ public class RejectionBusShould {
     }
 
     @Test
-    public void deliver_postponed_rejection_to_delegating_dispatchers_using_configured_executor() {
+    public void pick_proper_consumer_by_consumer_id_when_delivering_to_delegates_of_same_rejection() {
         final InvalidProjectNameDelegate first = new InvalidProjectNameDelegate();
-        final MissingOwnerDelegate second = new MissingOwnerDelegate();
+        final AnotherInvalidProjectNameDelegate second = new AnotherInvalidProjectNameDelegate();
 
         final DelegatingRejectionDispatcher<String> firstDispatcher =
                 DelegatingRejectionDispatcher.of(first);

--- a/server/src/test/java/io/spine/server/rejection/RejectionBusShould.java
+++ b/server/src/test/java/io/spine/server/rejection/RejectionBusShould.java
@@ -25,6 +25,7 @@ import io.spine.core.Rejection;
 import io.spine.core.RejectionClass;
 import io.spine.core.RejectionEnvelope;
 import io.spine.grpc.MemoizingObserver;
+import io.spine.server.delivery.Consumers;
 import io.spine.server.rejection.given.BareDispatcher;
 import io.spine.server.rejection.given.CommandAwareSubscriber;
 import io.spine.server.rejection.given.CommandMessageAwareSubscriber;
@@ -241,7 +242,7 @@ public class RejectionBusShould {
         final RejectionEnvelope postponedRejection = postponedRejections.iterator()
                                                                         .next();
         verify(delegateDispatcherExecutor, never()).execute(any(Runnable.class));
-        postponedDelivery.deliverNow(postponedRejection, dispatcher.getClass());
+        postponedDelivery.deliverNow(postponedRejection, Consumers.idOf(dispatcher));
         assertTrue(dispatcher.isDispatchCalled());
         verify(delegateDispatcherExecutor).execute(any(Runnable.class));
     }

--- a/server/src/test/java/io/spine/server/rejection/given/AnotherInvalidProjectNameDelegate.java
+++ b/server/src/test/java/io/spine/server/rejection/given/AnotherInvalidProjectNameDelegate.java
@@ -23,22 +23,22 @@ import com.google.common.collect.ImmutableSet;
 import io.spine.core.RejectionClass;
 import io.spine.core.RejectionEnvelope;
 import io.spine.server.rejection.RejectionDispatcherDelegate;
-import io.spine.test.rejection.ProjectRejections.MissingOwner;
+import io.spine.test.rejection.ProjectRejections.InvalidProjectName;
 
 import java.util.Set;
 
 /**
- * A test delegate, which dispatches {@link MissingOwner} rejections.
+ * Another test delegate, which dispatches {@link InvalidProjectName} rejections.
  *
  * @author Alex Tymchenko
  */
-public class MissingOwnerDelegate implements RejectionDispatcherDelegate<String> {
+public class AnotherInvalidProjectNameDelegate implements RejectionDispatcherDelegate<String> {
 
     private boolean dispatchCalled = false;
 
     @Override
     public Set<RejectionClass> getRejectionClasses() {
-        return RejectionClass.setOf(MissingOwner.class);
+        return RejectionClass.setOf(InvalidProjectName.class);
     }
 
     @Override

--- a/server/src/test/java/io/spine/server/rejection/given/InvalidProjectNameDelegate.java
+++ b/server/src/test/java/io/spine/server/rejection/given/InvalidProjectNameDelegate.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.spine.server.rejection.given;
+
+import com.google.common.collect.ImmutableSet;
+import io.spine.core.RejectionClass;
+import io.spine.core.RejectionEnvelope;
+import io.spine.server.rejection.RejectionDispatcherDelegate;
+import io.spine.test.rejection.ProjectRejections.InvalidProjectName;
+
+import java.util.Set;
+
+/**
+ * A test delegate, which dispatches {@link InvalidProjectName} rejections.
+ *
+ * @author Alex Tymchenko
+ */
+public class InvalidProjectNameDelegate implements RejectionDispatcherDelegate<String> {
+
+    private boolean dispatchCalled = false;
+
+    @Override
+    public Set<RejectionClass> getRejectionClasses() {
+        return RejectionClass.setOf(InvalidProjectName.class);
+    }
+
+    @Override
+    public Set<String> dispatchRejection(RejectionEnvelope envelope) {
+        dispatchCalled = true;
+        return ImmutableSet.of(toString());
+    }
+
+    @Override
+    public void onError(RejectionEnvelope envelope, RuntimeException exception) {
+        // do nothing.
+    }
+
+    public boolean isDispatchCalled() {
+        return dispatchCalled;
+    }
+}

--- a/server/src/test/java/io/spine/server/rejection/given/MissingOwnerDelegate.java
+++ b/server/src/test/java/io/spine/server/rejection/given/MissingOwnerDelegate.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.spine.server.rejection.given;
+
+import com.google.common.collect.ImmutableSet;
+import io.spine.core.RejectionClass;
+import io.spine.core.RejectionEnvelope;
+import io.spine.server.rejection.RejectionDispatcherDelegate;
+import io.spine.test.rejection.ProjectRejections.MissingOwner;
+
+import java.util.Set;
+
+/**
+ * A test delegate, which dispatches {@link MissingOwner} rejections.
+ *
+ * @author Alex Tymchenko
+ */
+public class MissingOwnerDelegate implements RejectionDispatcherDelegate<String> {
+
+    private boolean dispatchCalled = false;
+
+    @Override
+    public Set<RejectionClass> getRejectionClasses() {
+        return RejectionClass.setOf(MissingOwner.class);
+    }
+
+    @Override
+    public Set<String> dispatchRejection(RejectionEnvelope envelope) {
+        dispatchCalled = true;
+        return ImmutableSet.of(toString());
+    }
+
+    @Override
+    public void onError(RejectionEnvelope envelope, RuntimeException exception) {
+        // do nothing.
+    }
+
+    public boolean isDispatchCalled() {
+        return dispatchCalled;
+    }
+}

--- a/server/src/test/java/io/spine/server/stand/StandPostShould.java
+++ b/server/src/test/java/io/spine/server/stand/StandPostShould.java
@@ -30,6 +30,7 @@ import io.spine.core.EventEnvelope;
 import io.spine.core.Version;
 import io.spine.server.BoundedContext;
 import io.spine.server.aggregate.AggregateRepository;
+import io.spine.server.delivery.Consumers;
 import io.spine.server.entity.AbstractVersionableEntity;
 import io.spine.server.entity.EntityStateEnvelope;
 import io.spine.server.entity.VersionableEntity;
@@ -139,7 +140,7 @@ public class StandPostShould {
         final EntityStateEnvelope envelope = EntityStateEnvelope.of(entity,
                                                                     context.getActorContext()
                                                                            .getTenantId());
-        verify(delivery).deliverNow(eq(envelope), eq(Stand.class));
+        verify(delivery).deliverNow(eq(envelope), eq(Consumers.idOf(stand)));
     }
 
     // **** Integration scenarios (<source> -> StandFunnel -> Mock Stand) ****


### PR DESCRIPTION
Before this PR the identification of consumers in scope of `Delivery` was built upon the consumer `Class<...>`.

However, as `AggregateRepository`uses delegates (such as `DelegatingEventDispatcher`) to register itself, the class of consumer cannot be used as an identity — as long as several different `AggregateRepository` classes have the consumers with the same class (e.g. `DelegatingEventDispatcher.class`).

This PR introduces `ConsumerId` to identify the target consumer instead of `Class<?>`. The instances of `ConsumerId ` are is built taking into account the real class name. In case of `Delegating...Dispatcher`, an FQN of the real delegate is used.

The framework version is increased to `0.9.51-SNAPSHOT`.