### PR TITLE
`ProjectionEndpoint` test improvements

### DIFF
--- a/server/src/main/java/io/spine/server/aggregate/AggregateCommandEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateCommandEndpoint.java
@@ -41,8 +41,7 @@ class AggregateCommandEndpoint<I, A extends Aggregate<I, ?, ?>>
 
     static <I, A extends Aggregate<I, ?, ?>>
     I handle(AggregateRepository<I, A> repository, CommandEnvelope command) {
-        final AggregateCommandEndpoint<I, A> endpoint =
-                new AggregateCommandEndpoint<>(repository, command);
+        final AggregateCommandEndpoint<I, A> endpoint = of(repository, command);
 
         return endpoint.handle();
     }

--- a/server/src/main/java/io/spine/server/aggregate/AggregateEventEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateEventEndpoint.java
@@ -50,8 +50,7 @@ class AggregateEventEndpoint<I, A extends Aggregate<I, ?, ?>>
 
     static <I, A extends Aggregate<I, ?, ?>>
     Set<I> handle(AggregateRepository<I, A> repository, EventEnvelope event) {
-        final AggregateEventEndpoint<I, A> endpoint =
-                new AggregateEventEndpoint<>(repository, event);
+        final AggregateEventEndpoint<I, A> endpoint = of(repository, event);
 
         return endpoint.handle();
     }

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRejectionEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRejectionEndpoint.java
@@ -43,8 +43,7 @@ class AggregateRejectionEndpoint<I, A extends Aggregate<I, ?, ?>>
 
     static <I, A extends Aggregate<I, ?, ?>>
     Set<I> handle(AggregateRepository<I, A> repository, RejectionEnvelope rejection) {
-        final AggregateRejectionEndpoint<I, A> endpoint =
-            new AggregateRejectionEndpoint<>(repository, rejection);
+        final AggregateRejectionEndpoint<I, A> endpoint = of(repository, rejection);
 
         return endpoint.handle();
     }

--- a/server/src/main/java/io/spine/server/procman/PmCommandEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmCommandEndpoint.java
@@ -47,7 +47,7 @@ class PmCommandEndpoint<I, P extends ProcessManager<I, ?, ?>>
 
     static <I, P extends ProcessManager<I, ?, ?>>
     I handle (ProcessManagerRepository<I, P, ?> repository, CommandEnvelope cmd) {
-        final PmCommandEndpoint<I, P> endpoint = new PmCommandEndpoint<>(repository, cmd);
+        final PmCommandEndpoint<I, P> endpoint = of(repository, cmd);
         final I result = endpoint.handle();
         return result;
     }

--- a/server/src/main/java/io/spine/server/procman/PmEventEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmEventEndpoint.java
@@ -47,7 +47,7 @@ class PmEventEndpoint<I, P extends ProcessManager<I, ?, ?>>
 
     static <I, P extends ProcessManager<I, ?, ?>>
     Set<I> handle (ProcessManagerRepository<I, P, ?> repository, EventEnvelope event) {
-        final PmEventEndpoint<I, P> endpoint = new PmEventEndpoint<>(repository, event);
+        final PmEventEndpoint<I, P> endpoint = of(repository, event);
         final Set<I> result = endpoint.handle();
         return result;
     }

--- a/server/src/main/java/io/spine/server/procman/PmRejectionEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmRejectionEndpoint.java
@@ -47,7 +47,7 @@ class PmRejectionEndpoint<I, P extends ProcessManager<I, ?, ?>>
 
     static <I, P extends ProcessManager<I, ?, ?>>
     Set<I> handle(ProcessManagerRepository<I, P, ?> repository, RejectionEnvelope rejection) {
-        final PmRejectionEndpoint<I, P> endpoint = new PmRejectionEndpoint<>(repository, rejection);
+        final PmRejectionEndpoint<I, P> endpoint = of(repository, rejection);
         final Set<I> result = endpoint.handle();
         return result;
     }

--- a/server/src/main/java/io/spine/server/projection/ProjectionEndpoint.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionEndpoint.java
@@ -49,7 +49,7 @@ class ProjectionEndpoint<I, P extends Projection<I, ?, ?>>
 
     static <I, P extends Projection<I, ?, ?>>
     Set<I> handle(ProjectionRepository<I, P, ?> repository, EventEnvelope event) {
-        final ProjectionEndpoint<I, P> endpoint = new ProjectionEndpoint<>(repository, event);
+        final ProjectionEndpoint<I, P> endpoint = of(repository, event);
         final Set<I> result = endpoint.handle();
         return result;
     }

--- a/server/src/test/java/io/spine/server/projection/ProjectionEventDeliveryShould.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionEventDeliveryShould.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.spine.server.projection;
+
+import io.spine.core.Event;
+import io.spine.core.EventEnvelope;
+import io.spine.core.Events;
+import io.spine.server.BoundedContext;
+import io.spine.server.projection.given.ProjectionEventDeliveryTestEnv.PostponingEventDelivery;
+import io.spine.server.projection.given.ProjectionEventDeliveryTestEnv.PostponingRepository;
+import io.spine.server.projection.given.ProjectionEventDeliveryTestEnv.ProjectDetails;
+import io.spine.test.projection.ProjectId;
+import io.spine.test.projection.event.PrjProjectCreated;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static io.spine.server.model.ModelTests.clearModel;
+import static io.spine.server.projection.given.ProjectionEventDeliveryTestEnv.projectCreated;
+import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Alex Tymchenko
+ */
+public class ProjectionEventDeliveryShould {
+
+    private BoundedContext boundedContext;
+    private PostponingRepository repository;
+
+    @Before
+    public void setUp() {
+        clearModel();
+        boundedContext = BoundedContext.newBuilder()
+                                       .build();
+        repository = new PostponingRepository();
+        boundedContext.register(repository);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        repository.close();
+        boundedContext.close();
+    }
+
+    @Test
+    public void postpone_events_dispatched_to_subscriber_method() {
+        assertNull(ProjectDetails.getEventReceived());
+
+        final Event event = projectCreated();
+        boundedContext.getEventBus()
+                      .post(event);
+
+        assertNull(ProjectDetails.getEventReceived());
+
+        final EventEnvelope expectedEnvelope = EventEnvelope.of(event);
+        final PostponingEventDelivery delivery = repository.getEndpointDelivery();
+        final Map<ProjectId, EventEnvelope> postponedEvents = delivery.getPostponedEvents();
+        assertTrue(postponedEvents.size() == 1 &&
+                           postponedEvents.containsValue(expectedEnvelope));
+
+        final ProjectId projectId = postponedEvents.keySet()
+                                                   .iterator()
+                                                   .next();
+
+        delivery.deliverNow(projectId, postponedEvents.get(projectId));
+
+        final PrjProjectCreated deliveredEventMsg = ProjectDetails.getEventReceived();
+        assertNotNull(deliveredEventMsg);
+        assertEquals(Events.getMessage(event), deliveredEventMsg);
+    }
+}

--- a/server/src/test/java/io/spine/server/projection/ProjectionRepositoryShould.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionRepositoryShould.java
@@ -166,7 +166,30 @@ public class ProjectionRepositoryShould
 
     @Test
     public void dispatch_event_and_load_projection() {
-        checkDispatchesEvent(GivenEventMessage.projectStarted());
+        final PrjProjectStarted msg = GivenEventMessage.projectStarted();
+
+        // Ensure no instances are present in the repository now.
+        assertFalse(repository().loadAll()
+                                .hasNext());
+        // And no instances of `TestProjection` processed the event message we are going to post.
+        assertTrue(TestProjection.whoProcessed(msg)
+                                 .isEmpty());
+
+        // Post an event message and grab the ID of the projection, which processed it.
+        checkDispatchesEvent(msg);
+        final Set<ProjectId> projectIds = TestProjection.whoProcessed(msg);
+        assertTrue(projectIds.size() == 1);
+        final ProjectId receiverId = projectIds.iterator()
+                                               .next();
+
+        // Check that the projection item has actually been stored and now can be loaded.
+        final Iterator<TestProjection> allItems = repository().loadAll();
+        assertTrue(allItems.hasNext());
+        final TestProjection storedProjection = allItems.next();
+        assertFalse(allItems.hasNext());
+
+        // Check that the stored instance has the same ID as the instance that handled the event.
+        assertEquals(storedProjection.getId(), receiverId);
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/projection/given/ProjectionEventDeliveryTestEnv.java
+++ b/server/src/test/java/io/spine/server/projection/given/ProjectionEventDeliveryTestEnv.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.spine.server.projection.given;
+
+import com.google.common.collect.ImmutableMap;
+import io.spine.Identifier;
+import io.spine.core.Event;
+import io.spine.core.EventEnvelope;
+import io.spine.core.Subscribe;
+import io.spine.server.command.TestEventFactory;
+import io.spine.server.projection.Projection;
+import io.spine.server.projection.ProjectionEventDelivery;
+import io.spine.server.projection.ProjectionRepository;
+import io.spine.test.projection.Project;
+import io.spine.test.projection.ProjectId;
+import io.spine.test.projection.ProjectVBuilder;
+import io.spine.test.projection.event.PrjProjectCreated;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+import static com.google.common.collect.Maps.newHashMap;
+import static io.spine.protobuf.AnyPacker.pack;
+
+/**
+ * @author Alex Tymchenko
+ */
+public class ProjectionEventDeliveryTestEnv {
+
+    /** Prevents instantiation of this utility class. */
+    private ProjectionEventDeliveryTestEnv() {}
+
+    public static Event projectCreated() {
+        final ProjectId projectId = projectId();
+        final TestEventFactory eventFactory =
+                TestEventFactory.newInstance(
+                        pack(projectId),
+                        ProjectionEventDeliveryTestEnv.class
+                );
+
+        final PrjProjectCreated msg = PrjProjectCreated.newBuilder()
+                                                       .setProjectId(projectId)
+                                                       .build();
+
+        final Event result = eventFactory.createEvent(msg);
+        return result;
+    }
+
+    private static ProjectId projectId() {
+        return ProjectId.newBuilder()
+                        .setId(Identifier.newUuid())
+                        .build();
+    }
+
+    public static class ProjectDetails extends Projection<ProjectId, Project, ProjectVBuilder> {
+
+        private static PrjProjectCreated receivedEvent = null;
+
+        protected ProjectDetails(ProjectId id) {
+            super(id);
+        }
+
+        @SuppressWarnings("AssignmentToStaticFieldFromInstanceMethod") // It's fine in tests.
+        @Subscribe
+        public void on(PrjProjectCreated event) {
+            receivedEvent = event;
+        }
+
+        @Nullable
+        public static PrjProjectCreated getEventReceived() {
+            return receivedEvent;
+        }
+    }
+
+    /**
+     * A repository which overrides the delivery strategy for events postponing their delivery
+     * to projection instances.
+     */
+    public static class PostponingRepository
+            extends ProjectionRepository<ProjectId, ProjectDetails, Project> {
+
+        private PostponingEventDelivery eventDelivery = null;
+
+        @Override
+        public PostponingEventDelivery getEndpointDelivery() {
+            if (eventDelivery == null) {
+                eventDelivery = new PostponingEventDelivery(this);
+            }
+            return eventDelivery;
+        }
+    }
+
+    /**
+     * Event delivery strategy which always postpones the delivery, but remembers the event
+     * along with the target entity ID.
+     */
+    public static class PostponingEventDelivery
+            extends ProjectionEventDelivery<ProjectId, ProjectDetails> {
+
+        private final Map<ProjectId, EventEnvelope> postponedEvents = newHashMap();
+
+        protected PostponingEventDelivery(PostponingRepository repository) {
+            super(repository);
+        }
+
+        @Override
+        public boolean shouldPostpone(ProjectId id, EventEnvelope envelope) {
+            postponedEvents.put(id, envelope);
+            return true;
+        }
+
+        public Map<ProjectId, EventEnvelope> getPostponedEvents() {
+            return ImmutableMap.copyOf(postponedEvents);
+        }
+    }
+}

--- a/server/src/test/java/io/spine/server/projection/given/ProjectionRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/projection/given/ProjectionRepositoryTestEnv.java
@@ -21,6 +21,7 @@
 package io.spine.server.projection.given;
 
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.protobuf.Message;
 import io.spine.core.EventContext;
@@ -39,6 +40,7 @@ import io.spine.test.projection.event.PrjProjectStarted;
 import io.spine.test.projection.event.PrjTaskAdded;
 
 import javax.annotation.Nullable;
+import java.util.Set;
 
 public class ProjectionRepositoryTestEnv {
 
@@ -132,12 +134,27 @@ public class ProjectionRepositoryTestEnv {
             return result;
         }
 
+        /**
+         * Returns the IDs of projection instances, which processed the given message.
+         *
+         * <p>Empty set is returned if no instance processed the given message.
+         */
+        public static Set<ProjectId> whoProcessed(Message eventMessage) {
+            final ImmutableSet.Builder<ProjectId> builder = ImmutableSet.builder();
+            for (ProjectId projectId : eventMessagesDelivered.keySet()) {
+                if(eventMessagesDelivered.get(projectId).contains(eventMessage)) {
+                    builder.add(projectId);
+                }
+            }
+            return builder.build();
+        }
+
         public static void clearMessageDeliveryHistory() {
             eventMessagesDelivered.clear();
         }
 
         private void keep(Message eventMessage) {
-            eventMessagesDelivered.put(getState().getId(), eventMessage);
+            eventMessagesDelivered.put(getId(), eventMessage);
         }
 
         @Subscribe


### PR DESCRIPTION
This PR adds a test for `ProjectionEndpoint` delivery strategy.

Also #570 is addressed: `ProjectionEndpoint.deliverNowTo(..)` is ensured to store the projection instance after an event is successfully delivered.

As a minor addition, it fixes a minor code duplication — all `...Endpoint` classes now use own static `of` method to create new instances instead of explicit `new ...Endpoint<>` calls.

The framework version left intact.