### PR TITLE
Reject in command routing

### DIFF
--- a/core/src/main/java/io/spine/core/Commands.java
+++ b/core/src/main/java/io/spine/core/Commands.java
@@ -233,7 +233,7 @@ public final class Commands {
      *         {@code false} otherwise
      */
     public static boolean causedByRejection(RuntimeException exception) {
-        //TODO:2017-07-26:alexander.yevsyukov: Check against CommandRejected
+        //TODO:2017-07-26:alexander.yevsyukov: Check against CommandRejection
         // instead of ThrowableMessage when code generation allows customizing a custom
         // rejection types instead of `ThrowableMessage`.
         // See: https://github.com/SpineEventEngine/base/issues/20

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.9.57-SNAPSHOT'
+def final SPINE_VERSION = '0.9.58-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateCommandEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateCommandEndpoint.java
@@ -90,7 +90,9 @@ class AggregateCommandEndpoint<I, A extends Aggregate<I, ?, ?>>
      */
     @Override
     protected void onEmptyResult(A aggregate, CommandEnvelope cmd) throws IllegalStateException {
-        final String format = "The aggregate (class: %s, id: %s) produced empty response for the command (class: %s, id: %s).";
+        final String format =
+                "The aggregate (class: %s, id: %s) produced empty response for " +
+                "the command (class: %s, id: %s).";
         onUnhandledCommand(aggregate, cmd, format);
     }
 }

--- a/server/src/main/java/io/spine/server/commandbus/CommandBus.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandBus.java
@@ -148,7 +148,8 @@ public class CommandBus extends Bus<Command,
         return isThreadSpawnAllowed;
     }
 
-    CommandStore commandStore() {
+    @VisibleForTesting
+    public CommandStore commandStore() {
         return commandStore;
     }
 

--- a/server/src/main/java/io/spine/server/route/MessageRouting.java
+++ b/server/src/main/java/io/spine/server/route/MessageRouting.java
@@ -150,17 +150,16 @@ abstract class MessageRouting<C extends Message, K extends MessageClass, R>
     }
 
     /**
-     * Finds a route for the passed message and applies it.
+     * Obtains IDs of entities to which the passed message should be delivered.
      *
      * <p>If there is no function for the passed message applies the default function.
      *
-     * @param message the message
-     * @param context the message context
-     * @return the set of entity IDs
-     * @throws IllegalStateException if the route for this message class is already set
+     * @param  message the message
+     * @param  context the message context
+     * @return the set of entity IDs to which the message should be delivered
      */
     @Override
-    public R apply(Message message, C context) throws IllegalStateException {
+    public R apply(Message message, C context) {
         checkNotNull(message);
         checkNotNull(context);
         final K messageClass = toMessageClass(message);

--- a/server/src/main/java/io/spine/server/storage/memory/TenantRecords.java
+++ b/server/src/main/java/io/spine/server/storage/memory/TenantRecords.java
@@ -91,8 +91,8 @@ class TenantRecords<I> implements TenantStorage<I, EntityRecordWithColumns> {
     }
 
     Map<I, EntityRecord> readAllRecords(EntityQuery<I> query, FieldMask fieldMask) {
-        final Map<I, EntityRecordWithColumns> filtered = filterValues(records,
-                                                                      new EntityQueryMatcher<>(query));
+        final Map<I, EntityRecordWithColumns> filtered =
+                filterValues(records, new EntityQueryMatcher<>(query));
         final Map<I, EntityRecord> records = transformValues(filtered,
                                                              EntityRecordUnpacker.INSTANCE);
         final Function<EntityRecord, EntityRecord> fieldMaskApplier =

--- a/server/src/test/java/io/spine/server/route/CommandRoutingRejectionShould.java
+++ b/server/src/test/java/io/spine/server/route/CommandRoutingRejectionShould.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.route;
+
+import com.google.protobuf.Message;
+import io.grpc.stub.StreamObserver;
+import io.spine.client.TestActorRequestFactory;
+import io.spine.core.Ack;
+import io.spine.core.Command;
+import io.spine.core.CommandStatus;
+import io.spine.grpc.StreamObservers;
+import io.spine.protobuf.AnyPacker;
+import io.spine.server.BoundedContext;
+import io.spine.server.commandbus.CommandBus;
+import io.spine.server.commandbus.ProcessingStatus;
+import io.spine.server.commandstore.CommandStore;
+import io.spine.server.rout.given.switchman.SwitchId;
+import io.spine.server.route.given.switchman.Switchman;
+import io.spine.server.route.given.switchman.SwitchmanBureau;
+import io.spine.server.route.given.switchman.command.SetSwitch;
+import io.spine.server.route.given.switchman.rejection.Rejections;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.spine.Identifier.newUuid;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CommandRoutingRejectionShould {
+
+    private final TestActorRequestFactory requestFactory =
+            TestActorRequestFactory.newInstance(getClass());
+    private final StreamObserver<Ack> observer = StreamObservers.noOpObserver();
+
+    private BoundedContext boundedContext;
+    private CommandBus commandBus;
+    private CommandStore commandStore;
+
+    @Before
+    public void setUp() {
+        boundedContext = BoundedContext.newBuilder()
+                                       .setName("Railway Station")
+                                       .setMultitenant(false)
+                                       .build();
+        boundedContext.register(new SwitchmanBureau());
+        commandBus = boundedContext.getCommandBus();
+        commandStore = commandBus.commandStore();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        boundedContext.close();
+    }
+
+    @Test
+    public void result_in_rejected_command() {
+        // Post a successful command to make sure general case works.
+        final Command command =
+                requestFactory.createCommand(SetSwitch.newBuilder()
+                                                      .setSwitchId(generateSwitchId())
+                                                      .setSwitchmanName(Switchman.class.getName())
+                                                      .build());
+        commandBus.post(command, observer);
+        assertEquals(CommandStatus.OK, commandStore.getStatus(command).getCode());
+
+        // Post a command with the argument which causes rejection in routing.
+        final Command commandToReject =
+                requestFactory.createCommand(SetSwitch.newBuilder()
+                .setSwitchId(generateSwitchId())
+                .setSwitchmanName(SwitchmanBureau.MISSING_SWITCHMAN_NAME)
+                .build());
+
+        commandBus.post(commandToReject, observer);
+        final ProcessingStatus status = commandStore.getStatus(commandToReject);
+
+        assertEquals(CommandStatus.REJECTED, status.getCode());
+        final Message rejectionMessage = AnyPacker.unpack(status.getRejection()
+                                                                .getMessage());
+        assertTrue(rejectionMessage instanceof Rejections.SwitchmanUnavailable);
+    }
+
+    private static SwitchId generateSwitchId() {
+        return SwitchId.newBuilder()
+                       .setId(newUuid())
+                       .build();
+    }
+}

--- a/server/src/test/java/io/spine/server/route/CommandRoutingRejectionShould.java
+++ b/server/src/test/java/io/spine/server/route/CommandRoutingRejectionShould.java
@@ -45,6 +45,11 @@ import static io.spine.Identifier.newUuid;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Tests that a command can be rejected within a {@linkplain CommandRoute routing function}.
+ *
+ * @author Alexander Yevsyukov
+ */
 public class CommandRoutingRejectionShould {
 
     private final TestActorRequestFactory requestFactory =
@@ -71,6 +76,15 @@ public class CommandRoutingRejectionShould {
         boundedContext.close();
     }
 
+    /**
+     * Verifies that a command rejected during routing gets rejected status.
+     *
+     * <p>The test initially posts a command which should be processed correctly. This is done to
+     * ensure that basic processing works.
+     *
+     * <p>Then the test posts a command with the argument that should cause rejection in the
+     * routing function.
+     */
     @Test
     public void result_in_rejected_command() {
         // Post a successful command to make sure general case works.

--- a/server/src/test/java/io/spine/server/route/given/switchman/Log.java
+++ b/server/src/test/java/io/spine/server/route/given/switchman/Log.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.route.given.switchman;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.protobuf.Message;
+import io.spine.core.EventContext;
+import io.spine.core.React;
+import io.spine.core.RejectionContext;
+import io.spine.server.aggregate.Aggregate;
+import io.spine.server.aggregate.AggregateRepository;
+import io.spine.server.aggregate.Apply;
+import io.spine.server.rout.given.switchman.LogState;
+import io.spine.server.rout.given.switchman.LogStateVBuilder;
+import io.spine.server.route.EventRoute;
+import io.spine.server.route.RejectionRoute;
+import io.spine.server.route.given.switchman.event.SwitchPositionConfirmed;
+import io.spine.server.route.given.switchman.event.SwitchWorkRecorded;
+import io.spine.server.route.given.switchman.event.SwitchmanAbsenceRecorded;
+import io.spine.server.route.given.switchman.rejection.Rejections;
+import io.spine.time.Time;
+
+import java.util.Set;
+
+/**
+ * The aggregate that accumulates information about switchman work and absence.
+ *
+ * <p>There's only one log per system.
+ *
+ * @author Alexander Yevsyukov
+ */
+public final class Log extends Aggregate<Long, LogState, LogStateVBuilder> {
+
+    /** The ID of the singleton log. */
+    public static final long ID = 42L;
+
+    private Log(Long id) {
+        super(id);
+    }
+
+    @React
+    SwitchmanAbsenceRecorded on(Rejections.SwitchmanUnavailable rejection) {
+        return SwitchmanAbsenceRecorded.newBuilder()
+                                       .setSwitchmanName(rejection.getSwitchmanName())
+                                       .setTimestamp(Time.getCurrentTime())
+                                       .build();
+    }
+
+    @Apply
+    void event(SwitchmanAbsenceRecorded event) {
+        getBuilder().addMissingSwitchman(event.getSwitchmanName());
+    }
+
+    @React
+    SwitchWorkRecorded on(SwitchPositionConfirmed event) {
+        return SwitchWorkRecorded.newBuilder()
+                .setSwitchId(event.getSwitchId())
+                .setSwitchmanName(event.getSwitchmanName())
+                .build();
+    }
+
+    @Apply
+    void event(SwitchWorkRecorded event) {
+        final String switchmanName = event.getSwitchmanName();
+        final Integer currentCount = getState().getCountersMap()
+                                               .get(switchmanName);
+        getBuilder().putCounters(switchmanName,
+                                 currentCount == null ? 1 : currentCount + 1);
+    }
+
+    /**
+     * The repository with default routing functions that route to the singleton aggregate.
+     */
+    @SuppressWarnings("SerializableInnerClassWithNonSerializableOuterClass")
+    public static final class Repository extends AggregateRepository<Long, Log> {
+
+        private static final Set<Long> SINGLETON_ID_SET = ImmutableSet.of(ID);
+
+        public Repository() {
+            super();
+            getEventRouting().replaceDefault(new EventRoute<Long, Message>() {
+                private static final long serialVersionUID = 0L;
+
+                @Override
+                public Set<Long> apply(Message message, EventContext context) {
+                    return SINGLETON_ID_SET;
+                }
+            });
+            getRejectionRouting().replaceDefault(new RejectionRoute<Long, Message>() {
+                private static final long serialVersionUID = 0L;
+
+                @Override
+                public Set<Long> apply(Message message, RejectionContext context) {
+                    return SINGLETON_ID_SET;
+                }
+            });
+        }
+    }
+}

--- a/server/src/test/java/io/spine/server/route/given/switchman/Switchman.java
+++ b/server/src/test/java/io/spine/server/route/given/switchman/Switchman.java
@@ -29,7 +29,7 @@ import io.spine.server.route.given.switchman.event.SwitchPositionConfirmed;
 import io.spine.validate.UInt32ValueVBuilder;
 
 /**
- * The aggregate that handles commands send to a swtichman.
+ * The aggregate that handles commands send to a switchman.
  *
  * @author Alexander Yevsyukov
  */

--- a/server/src/test/java/io/spine/server/route/given/switchman/Switchman.java
+++ b/server/src/test/java/io/spine/server/route/given/switchman/Switchman.java
@@ -33,7 +33,7 @@ import io.spine.validate.UInt32ValueVBuilder;
  *
  * @author Alexander Yevsyukov
  */
-public class Switchman extends Aggregate<String, UInt32Value, UInt32ValueVBuilder> {
+public final class Switchman extends Aggregate<String, UInt32Value, UInt32ValueVBuilder> {
 
     @SuppressWarnings("unused") // invoked by reflection.
     Switchman(String id) {
@@ -43,6 +43,8 @@ public class Switchman extends Aggregate<String, UInt32Value, UInt32ValueVBuilde
     @Assign
     SwitchPositionConfirmed on(SetSwitch cmd) {
         return SwitchPositionConfirmed.newBuilder()
+                                      .setSwitchmanName(getId())
+                                      .setSwitchId(cmd.getSwitchId())
                                       .setPosition(cmd.getPosition())
                                       .build();
     }

--- a/server/src/test/java/io/spine/server/route/given/switchman/Switchman.java
+++ b/server/src/test/java/io/spine/server/route/given/switchman/Switchman.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.route.given.switchman;
+
+import com.google.protobuf.UInt32Value;
+import io.spine.server.aggregate.Aggregate;
+import io.spine.server.aggregate.Apply;
+import io.spine.server.command.Assign;
+import io.spine.server.route.given.switchman.command.SetSwitch;
+import io.spine.server.route.given.switchman.event.SwitchPositionConfirmed;
+import io.spine.validate.UInt32ValueVBuilder;
+
+/**
+ * The aggregate that handles commands send to a swtichman.
+ *
+ * @author Alexander Yevsyukov
+ */
+public class Switchman extends Aggregate<String, UInt32Value, UInt32ValueVBuilder> {
+
+    @SuppressWarnings("unused") // invoked by reflection.
+    Switchman(String id) {
+        super(id);
+    }
+
+    @Assign
+    SwitchPositionConfirmed on(SetSwitch cmd) {
+        return SwitchPositionConfirmed.newBuilder()
+                                      .setPosition(cmd.getPosition())
+                                      .build();
+    }
+
+    @Apply
+    void event(SwitchPositionConfirmed event) {
+        getBuilder().setValue(getState().getValue() + 1);
+    }
+}

--- a/server/src/test/java/io/spine/server/route/given/switchman/SwitchmanBureau.java
+++ b/server/src/test/java/io/spine/server/route/given/switchman/SwitchmanBureau.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.route.given.switchman;
+
+import io.spine.core.CommandContext;
+import io.spine.server.aggregate.AggregateRepository;
+import io.spine.server.route.CommandRoute;
+import io.spine.server.route.given.switchman.command.SetSwitch;
+import io.spine.server.route.given.switchman.rejection.SwitchmanUnavailable;
+
+/**
+ * A repository which fires a rejection in response to a command with a particular value of the
+ * target aggregate ID.
+ */
+@SuppressWarnings("SerializableInnerClassWithNonSerializableOuterClass")
+public class SwitchmanBureau extends AggregateRepository<String, Switchman> {
+
+    /** The ID of the aggregate for which a {@link SetSwitch command} would be rejected. */
+    public static final String MISSING_SWITCHMAN_NAME = "Petrovich";
+
+    public SwitchmanBureau() {
+        super();
+        getCommandRouting().route(SetSwitch.class, new CommandRoute<String, SetSwitch>() {
+            private static final long serialVersionUID = 0L;
+
+            @Override
+            public String apply(SetSwitch cmd, CommandContext context) {
+                final String switchmanName = cmd.getSwitchmanName();
+                if (switchmanName.equals(MISSING_SWITCHMAN_NAME)) {
+                    throw new RuntimeException(new SwitchmanUnavailable(switchmanName));
+                }
+                return switchmanName;
+            }
+        });
+    }
+}

--- a/server/src/test/java/io/spine/server/route/given/switchman/SwitchmanBureau.java
+++ b/server/src/test/java/io/spine/server/route/given/switchman/SwitchmanBureau.java
@@ -31,7 +31,7 @@ import io.spine.server.route.given.switchman.rejection.SwitchmanUnavailable;
  * target aggregate ID.
  */
 @SuppressWarnings("SerializableInnerClassWithNonSerializableOuterClass")
-public class SwitchmanBureau extends AggregateRepository<String, Switchman> {
+public final class SwitchmanBureau extends AggregateRepository<String, Switchman> {
 
     /** The ID of the aggregate for which a {@link SetSwitch command} would be rejected. */
     public static final String MISSING_SWITCHMAN_NAME = "Petrovich";

--- a/server/src/test/java/io/spine/server/route/given/switchman/package-info.java
+++ b/server/src/test/java/io/spine/server/route/given/switchman/package-info.java
@@ -23,6 +23,6 @@
  */
 
 @ParametersAreNonnullByDefault
-package io.spine.test.command.route;
+package io.spine.server.route.given.switchman;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/test/java/io/spine/test/command/route/package-info.java
+++ b/server/src/test/java/io/spine/test/command/route/package-info.java
@@ -19,10 +19,10 @@
  */
 
 /**
- * Test environments for the {@code io.spine.server.route} package.
+ * This package provides test environment for testing rejecting a command during command routing.
  */
 
 @ParametersAreNonnullByDefault
-package io.spine.server.route.given;
+package io.spine.test.command.route;
 
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/test/proto/spine/test/server/route/commands.proto
+++ b/server/src/test/proto/spine/test/server/route/commands.proto
@@ -31,7 +31,7 @@ option java_multiple_files = true;
 import "spine/test/server/route/switchman.proto";
 
 message SetSwitch {
-    string switchman_name = 1;
-    SwitchId switch_id = 2;
-    SwitchPosition position = 3;
+    string switchman_name = 1 [(required) = true];
+    SwitchId switch_id = 2 [(required) = true];
+    SwitchPosition position = 3 [(required) = true];
 }

--- a/server/src/test/proto/spine/test/server/route/commands.proto
+++ b/server/src/test/proto/spine/test/server/route/commands.proto
@@ -1,0 +1,37 @@
+//
+// Copyright 2017, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.test.server.route;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package="io.spine.server.route.given.switchman.command";
+option java_outer_classname = "SwitchmanCommandsProto";
+option java_multiple_files = true;
+
+import "spine/test/server/route/switchman.proto";
+
+message SetSwitch {
+    string switchman_name = 1;
+    SwitchId switch_id = 2;
+    SwitchPosition position = 3;
+}

--- a/server/src/test/proto/spine/test/server/route/events.proto
+++ b/server/src/test/proto/spine/test/server/route/events.proto
@@ -28,11 +28,23 @@ option java_package="io.spine.server.route.given.switchman.event";
 option java_outer_classname = "SwitchmanEventsProto";
 option java_multiple_files = true;
 
+import "google/protobuf/timestamp.proto";
+
 import "spine/test/server/route/switchman.proto";
 
 message SwitchPositionConfirmed {
-    string switchman_name = 1;
-    SwitchId switch_id = 2;
-    SwitchPosition position = 3;
+    string switchman_name = 1 [(required) = true];
+    SwitchId switch_id = 2 [(required) = true];
+    SwitchPosition position = 3 [(required) = true];
     SwitchPosition previous_position = 4;
+}
+
+message SwitchWorkRecorded {
+    string switchman_name = 1 [(required) = true];
+    SwitchId switch_id = 2 [(required) = true];
+}
+
+message SwitchmanAbsenceRecorded {
+    string switchman_name = 1 [(required) = true];
+    google.protobuf.Timestamp timestamp = 2;
 }

--- a/server/src/test/proto/spine/test/server/route/events.proto
+++ b/server/src/test/proto/spine/test/server/route/events.proto
@@ -1,0 +1,38 @@
+//
+// Copyright 2017, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.test.server.route;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package="io.spine.server.route.given.switchman.event";
+option java_outer_classname = "SwitchmanEventsProto";
+option java_multiple_files = true;
+
+import "spine/test/server/route/switchman.proto";
+
+message SwitchPositionConfirmed {
+    string switchman_name = 1;
+    SwitchId switch_id = 2;
+    SwitchPosition position = 3;
+    SwitchPosition previous_position = 4;
+}

--- a/server/src/test/proto/spine/test/server/route/rejections.proto
+++ b/server/src/test/proto/spine/test/server/route/rejections.proto
@@ -1,0 +1,34 @@
+//
+// Copyright 2017, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.test.server.route;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package="io.spine.server.route.given.switchman.rejection";
+option java_generate_equals_and_hash = true;
+
+import "spine/test/aggregate/project.proto";
+
+message SwitchmanUnavailable {
+    string switchman_name = 1;
+}

--- a/server/src/test/proto/spine/test/server/route/switchman.proto
+++ b/server/src/test/proto/spine/test/server/route/switchman.proto
@@ -38,3 +38,9 @@ enum SwitchPosition {
     LEFT = 1;
     RIGHT = 2;
 }
+
+// A log with counters of operations per switchman, and list of missing switchman.
+message LogState {
+    map<string, int32> counters = 1;
+    repeated string missing_switchman = 2;
+}

--- a/server/src/test/proto/spine/test/server/route/switchman.proto
+++ b/server/src/test/proto/spine/test/server/route/switchman.proto
@@ -1,0 +1,45 @@
+//
+// Copyright 2017, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.test.server.route;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package="io.spine.server.rout.given.switchman";
+option java_multiple_files = true;
+
+// A switch identifier.
+message SwitchId {
+    string id = 1;
+}
+
+// A position of a switch.
+enum SwitchPosition {
+    SWITCH_POSITION_UNDEFINED = 0;
+    LEFT = 1;
+    RIGHT = 2;
+}
+
+// A person who switches a switch.
+message Switchman {
+    string name = 1;
+}

--- a/server/src/test/proto/spine/test/server/route/switchman.proto
+++ b/server/src/test/proto/spine/test/server/route/switchman.proto
@@ -38,8 +38,3 @@ enum SwitchPosition {
     LEFT = 1;
     RIGHT = 2;
 }
-
-// A person who switches a switch.
-message Switchman {
-    string name = 1;
-}


### PR DESCRIPTION
This PR adds a test of correct processing of a command which is rejected in a command routing function.

Also an ability to get a command status by command instance was introduced. `CommandStore` was also made visible via a `CommandBus` instance.