### PR TITLE
Externalize `OperatorEvaluator`

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.9.61-SNAPSHOT'
+def final SPINE_VERSION = '0.9.62-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/storage/OperatorEvaluator.java
+++ b/server/src/main/java/io/spine/server/storage/OperatorEvaluator.java
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.server.storage.memory;
+package io.spine.server.storage;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Timestamp;

--- a/server/src/main/java/io/spine/server/storage/OperatorEvaluator.java
+++ b/server/src/main/java/io/spine/server/storage/OperatorEvaluator.java
@@ -115,7 +115,7 @@ public enum OperatorEvaluator {
      *
      * <p>For example, if operands where {@code 42} and {@code 9} (exactly in that order) and
      * the operator was {@link Operator#GREATER_THAN GREATER_THAN}, then this function could be
-     * expressed as {@code 42 > 8}. The function returns the {@code boolean} result of
+     * expressed as {@code 42 > 9}. The function returns the {@code boolean} result of
      * the evaluation.
      *
      * @param left     the left operand

--- a/server/src/main/java/io/spine/server/storage/memory/EntityQueryMatcher.java
+++ b/server/src/main/java/io/spine/server/storage/memory/EntityQueryMatcher.java
@@ -39,7 +39,7 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.protobuf.TypeConverter.toObject;
-import static io.spine.server.storage.memory.OperatorEvaluator.eval;
+import static io.spine.server.storage.OperatorEvaluator.eval;
 import static io.spine.util.Exceptions.newIllegalArgumentException;
 
 /**

--- a/server/src/main/java/io/spine/server/storage/memory/EntityQueryMatcher.java
+++ b/server/src/main/java/io/spine/server/storage/memory/EntityQueryMatcher.java
@@ -55,7 +55,7 @@ final class EntityQueryMatcher<I> implements Predicate<EntityRecordWithColumns> 
     private final Collection<I> acceptedIds;
     private final QueryParameters queryParams;
 
-    public EntityQueryMatcher(EntityQuery<I> query) {
+    EntityQueryMatcher(EntityQuery<I> query) {
         checkNotNull(query);
         this.acceptedIds = query.getIds();
         this.queryParams = query.getParameters();

--- a/server/src/main/java/io/spine/server/storage/memory/OperatorEvaluator.java
+++ b/server/src/main/java/io/spine/server/storage/memory/OperatorEvaluator.java
@@ -22,6 +22,7 @@ package io.spine.server.storage.memory;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Timestamp;
+import io.spine.annotation.Internal;
 
 import javax.annotation.Nullable;
 import java.util.Objects;
@@ -39,7 +40,8 @@ import static java.lang.String.format;
  * @author Dmytro Dashenkov
  * @see io.spine.client.CompositeColumnFilter.CompositeOperator for the comparison strategies
  */
-enum OperatorEvaluator {
+@Internal
+public enum OperatorEvaluator {
 
     EQUAL {
         @Override
@@ -125,7 +127,7 @@ enum OperatorEvaluator {
      *                                       <a href="supported_types">not supported</a> for
      *                                       the given data types
      */
-    static <T> boolean eval(@Nullable T left, Operator operator, @Nullable T right)
+    public static <T> boolean eval(@Nullable T left, Operator operator, @Nullable T right)
             throws UnsupportedOperationException {
         checkNotNull(operator);
         final OperatorEvaluator evaluator = EVALUATORS.get(operator);
@@ -142,6 +144,4 @@ enum OperatorEvaluator {
      * @return {@code true} if the expression evaluates into {@code true}, {@code false} otherwise
      */
     abstract boolean eval(@Nullable Object left, @Nullable Object right);
-
-
 }

--- a/server/src/test/java/io/spine/server/storage/OperatorEvaluatorShould.java
+++ b/server/src/test/java/io/spine/server/storage/OperatorEvaluatorShould.java
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.server.storage.memory;
+package io.spine.server.storage;
 
 import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Duration;
@@ -34,7 +34,7 @@ import static io.spine.client.ColumnFilter.Operator.GREATER_OR_EQUAL;
 import static io.spine.client.ColumnFilter.Operator.GREATER_THAN;
 import static io.spine.client.ColumnFilter.Operator.LESS_OR_EQUAL;
 import static io.spine.client.ColumnFilter.Operator.LESS_THAN;
-import static io.spine.server.storage.memory.OperatorEvaluator.eval;
+import static io.spine.server.storage.OperatorEvaluator.eval;
 import static io.spine.test.Tests.nullRef;
 import static io.spine.time.Durations2.seconds;
 import static io.spine.time.Time.getCurrentTime;


### PR DESCRIPTION
In this PR we externalize `OperatorEvaluator` class to make it available in `datastore` Storage implementation.