### PR TITLE
Improve the API and behavior of `EntityRecordWithColumns` 

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.9.63-SNAPSHOT'
+def final SPINE_VERSION = '0.9.64-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/entity/storage/ColumnRecords.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ColumnRecords.java
@@ -27,7 +27,6 @@ import io.spine.server.entity.storage.EntityColumn.MemoizedValue;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -77,11 +76,10 @@ public final class ColumnRecords {
         checkArgument(recordWithColumns.hasColumns(),
                       "Passed record has no Entity Columns.");
 
-        for (Map.Entry<String, MemoizedValue> column : recordWithColumns.getColumnValues()
-                                                                        .entrySet()) {
-            final I columnIdentifier = mapColumnIdentifier.apply(column.getKey());
+        for (String columnName : recordWithColumns.getColumnNames()) {
+            final I columnIdentifier = mapColumnIdentifier.apply(columnName);
             checkNotNull(columnIdentifier);
-            final MemoizedValue columnValue = column.getValue();
+            final MemoizedValue columnValue = recordWithColumns.getColumnValue(columnName);
             final EntityColumn columnMetadata = columnValue.getSourceColumn();
             @SuppressWarnings("unchecked") // We don't know the exact types of the value
             final ColumnType<Object, Object, D, I> columnType =

--- a/server/src/main/java/io/spine/server/entity/storage/EntityRecordWithColumns.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityRecordWithColumns.java
@@ -22,19 +22,15 @@ package io.spine.server.entity.storage;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.spine.annotation.Internal;
 import io.spine.server.entity.Entity;
 import io.spine.server.entity.EntityRecord;
 
 import java.io.Serializable;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.Lists.newLinkedList;
 import static io.spine.util.Exceptions.newIllegalStateException;
 
 /**
@@ -115,18 +111,12 @@ public final class EntityRecordWithColumns implements Serializable {
     }
 
     /**
-     * Obtains sorted {@linkplain EntityColumn#getStoredName() names}
-     * of entity columns for the record.
+     * Obtains entity column {@linkplain EntityColumn#getStoredName() names} for the record.
      *
-     * <p>The names will be sorted using {@link String#compareTo(String)}.
-     *
-     * @return the sorted entity column names
+     * @return the entity column names
      */
-    public Collection<String> getColumnNames() {
-        final ImmutableSet<String> names = storageFields.keySet();
-        final List<String> list = newLinkedList(names);
-        Collections.sort(list);
-        return list;
+    public Set<String> getColumnNames() {
+        return storageFields.keySet();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/entity/storage/EntityRecordWithColumns.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityRecordWithColumns.java
@@ -56,7 +56,7 @@ public final class EntityRecordWithColumns implements Serializable {
                                     Map<String, EntityColumn.MemoizedValue> columns) {
         this.record = checkNotNull(record);
         this.storageFields = ImmutableMap.copyOf(columns);
-        this.hasStorageFields = true;
+        this.hasStorageFields = !columns.isEmpty();
     }
 
     /**
@@ -133,9 +133,8 @@ public final class EntityRecordWithColumns implements Serializable {
      * <p>If returns {@code false}, the {@linkplain EntityColumn columns} are not considered
      * by the storage.
      *
-     * @return {@code true} if current object was constructed with
-     * {@linkplain #create(EntityRecord, Entity)} and {@code false} if it was
-     * constructed with {@linkplain #of(EntityRecord)}
+     * @return {@code true} if the object was constructed via {@link #create(EntityRecord, Entity)}
+     *         and the entity has columns; {@code false} otherwise
      */
     public boolean hasColumns() {
         return hasStorageFields;

--- a/server/src/main/java/io/spine/server/event/ERepository.java
+++ b/server/src/main/java/io/spine/server/event/ERepository.java
@@ -20,7 +20,9 @@
 
 package io.spine.server.event;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.FieldMask;
@@ -127,17 +129,24 @@ class ERepository extends DefaultRecordBasedRepository<EventId, EEntity, Event> 
      * @param query the source {@link EventStreamQuery} to get the info from
      * @return new instance of {@link EntityFilters} filtering the events
      */
+    @VisibleForTesting
     static EntityFilters toEntityFilters(EventStreamQuery query) {
-        final CompositeColumnFilter timeFilter = timeFilter(query);
-        final CompositeColumnFilter typeFilter = typeFilter(query);
-        final EntityFilters entityFilters = EntityFilters.newBuilder()
-                                                         .addFilter(timeFilter)
-                                                         .addFilter(typeFilter)
-                                                         .build();
-        return entityFilters;
+        final EntityFilters.Builder builder = EntityFilters.newBuilder();
+
+        final Optional<CompositeColumnFilter> timeFilter = timeFilter(query);
+        if (timeFilter.isPresent()) {
+            builder.addFilter(timeFilter.get());
+        }
+
+        final Optional<CompositeColumnFilter> typeFilter = typeFilter(query);
+        if (typeFilter.isPresent()) {
+            builder.addFilter(typeFilter.get());
+        }
+
+        return builder.build();
     }
 
-    private static CompositeColumnFilter timeFilter(EventStreamQuery query) {
+    private static Optional<CompositeColumnFilter> timeFilter(EventStreamQuery query) {
         final CompositeColumnFilter.Builder timeFilter = CompositeColumnFilter.newBuilder()
                                                                               .setOperator(ALL);
         if (query.hasAfter()) {
@@ -150,20 +159,39 @@ class ERepository extends DefaultRecordBasedRepository<EventId, EEntity, Event> 
             final ColumnFilter filter = lt(CREATED_TIME_COLUMN, timestamp);
             timeFilter.addFilter(filter);
         }
-        return timeFilter.build();
+
+        return buildFilter(timeFilter);
     }
 
-    private static CompositeColumnFilter typeFilter(EventStreamQuery query) {
+    private static Optional<CompositeColumnFilter> typeFilter(EventStreamQuery query) {
         final CompositeColumnFilter.Builder typeFilter = CompositeColumnFilter.newBuilder()
                                                                               .setOperator(EITHER);
         for (EventFilter eventFilter : query.getFilterList()) {
-            final String type = eventFilter.getEventType();
+            final String type = eventFilter.getEventType()
+                                           .trim();
             if (!type.isEmpty()) {
                 final ColumnFilter filter = eq(TYPE_COLUMN, type);
                 typeFilter.addFilter(filter);
             }
         }
-        return typeFilter.build();
+
+        return buildFilter(typeFilter);
+    }
+
+    /**
+     * Obtains a {@code CompositeColumnFilter} from the specified builder.
+     *
+     * @param builder the builder of the filter
+     * @return {@code Optional} of the {@code CompositeColumnFilter}, if there are column filters
+     * in the builder; {@code Optional.absent()} otherwise
+     */
+    private static Optional<CompositeColumnFilter> buildFilter(
+            CompositeColumnFilter.Builder builder) {
+        final boolean filterIsEmpty = builder.getFilterList()
+                                             .isEmpty();
+        return filterIsEmpty
+               ? Optional.<CompositeColumnFilter>absent()
+               : Optional.of(builder.build());
     }
 
     private static class EEntityMatchesStreamQuery implements Predicate<EEntity> {

--- a/server/src/main/java/io/spine/server/event/ERepository.java
+++ b/server/src/main/java/io/spine/server/event/ERepository.java
@@ -167,9 +167,9 @@ class ERepository extends DefaultRecordBasedRepository<EventId, EEntity, Event> 
         final CompositeColumnFilter.Builder typeFilter = CompositeColumnFilter.newBuilder()
                                                                               .setOperator(EITHER);
         for (EventFilter eventFilter : query.getFilterList()) {
-            final String type = eventFilter.getEventType()
-                                           .trim();
-            if (!type.isEmpty()) {
+            final String type = eventFilter.getEventType();
+            if (!type.trim()
+                     .isEmpty()) {
                 final ColumnFilter filter = eq(TYPE_COLUMN, type);
                 typeFilter.addFilter(filter);
             }

--- a/server/src/main/java/io/spine/server/storage/memory/EntityQueryMatcher.java
+++ b/server/src/main/java/io/spine/server/storage/memory/EntityQueryMatcher.java
@@ -20,15 +20,16 @@
 
 package io.spine.server.storage.memory;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Multimap;
 import com.google.protobuf.Any;
 import io.spine.Identifier;
 import io.spine.client.ColumnFilter;
 import io.spine.client.CompositeColumnFilter.CompositeOperator;
+import io.spine.server.entity.storage.CompositeQueryParameter;
 import io.spine.server.entity.storage.EntityColumn;
 import io.spine.server.entity.storage.EntityColumn.MemoizedValue;
-import io.spine.server.entity.storage.CompositeQueryParameter;
 import io.spine.server.entity.storage.EntityQuery;
 import io.spine.server.entity.storage.EntityRecordWithColumns;
 import io.spine.server.entity.storage.QueryParameters;
@@ -38,7 +39,6 @@ import java.util.Collection;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.Maps.newHashMap;
 import static io.spine.protobuf.TypeConverter.toObject;
 import static io.spine.server.storage.OperatorEvaluator.eval;
 import static io.spine.util.Exceptions.newIllegalArgumentException;
@@ -86,16 +86,15 @@ final class EntityQueryMatcher<I> implements Predicate<EntityRecordWithColumns> 
 
     @SuppressWarnings("EnumSwitchStatementWhichMissesCases") // Only valuable cases covered
     private boolean columnValuesMatch(EntityRecordWithColumns record) {
-        final Map<String, MemoizedValue> entityColumns = getColumnValues(record);
         boolean match;
         for (CompositeQueryParameter filter : queryParams) {
             final CompositeOperator operator = filter.getOperator();
             switch (operator) {
                 case ALL:
-                    match = checkAll(filter.getFilters(), entityColumns);
+                    match = checkAll(filter.getFilters(), record);
                     break;
                 case EITHER:
-                    match = checkEither(filter.getFilters(), entityColumns);
+                    match = checkEither(filter.getFilters(), record);
                     break;
                 default:
                     throw newIllegalArgumentException("Composite operator %s is invalid.",
@@ -109,12 +108,13 @@ final class EntityQueryMatcher<I> implements Predicate<EntityRecordWithColumns> 
     }
 
     private static boolean checkAll(Multimap<EntityColumn, ColumnFilter> filters,
-                                    Map<String, MemoizedValue> entityColumns) {
+                                    EntityRecordWithColumns record) {
         for (Map.Entry<EntityColumn, ColumnFilter> filter : filters.entries()) {
-            final String columnName = filter.getKey()
-                                            .getName();
-            final MemoizedValue memoizedValue = entityColumns.get(columnName);
-            final boolean matches = checkSingleParameter(filter.getValue(), memoizedValue);
+            final Optional<MemoizedValue> columnValue = getColumnValue(record, filter.getKey());
+            if (!columnValue.isPresent()) {
+                return false;
+            }
+            final boolean matches = checkSingleParameter(filter.getValue(), columnValue.get());
             if (!matches) {
                 return false;
             }
@@ -123,14 +123,14 @@ final class EntityQueryMatcher<I> implements Predicate<EntityRecordWithColumns> 
     }
 
     private static boolean checkEither(Multimap<EntityColumn, ColumnFilter> filters,
-                                       Map<String, MemoizedValue> entityColumns) {
+                                       EntityRecordWithColumns record) {
         for (Map.Entry<EntityColumn, ColumnFilter> filter : filters.entries()) {
-            final String columnName = filter.getKey()
-                                            .getName();
-            final MemoizedValue memoizedValue = entityColumns.get(columnName);
-            final boolean matches = checkSingleParameter(filter.getValue(), memoizedValue);
-            if (matches) {
-                return true;
+            final Optional<MemoizedValue> columnValue = getColumnValue(record, filter.getKey());
+            if (columnValue.isPresent()) {
+                final boolean matches = checkSingleParameter(filter.getValue(), columnValue.get());
+                if (matches) {
+                    return true;
+                }
             }
         }
         return filters.isEmpty();
@@ -154,22 +154,15 @@ final class EntityQueryMatcher<I> implements Predicate<EntityRecordWithColumns> 
         return result;
     }
 
-    /**
-     * Obtains entity column values for the specified record.
-     *
-     * <p>Takes into account particularities of memory-based implementations.
-     *
-     * @param record the record to obtain column values
-     * @return column values suited for memory-based implementations
-     */
-    private static Map<String, MemoizedValue> getColumnValues(EntityRecordWithColumns record) {
-        final Map<String, MemoizedValue> result = newHashMap();
-        final Map<String, MemoizedValue> valuesWithDefaultNames = record.getColumnValues();
-        for (MemoizedValue memoizedValue : valuesWithDefaultNames.values()) {
-            final String columnName = memoizedValue.getSourceColumn()
-                                                   .getName();
-            result.put(columnName, memoizedValue);
+    private static Optional<MemoizedValue> getColumnValue(EntityRecordWithColumns record,
+                                                          EntityColumn column) {
+        final String storedName = column.getStoredName();
+        if (!record.getColumnNames()
+                   .contains(storedName)) {
+            return Optional.absent();
         }
-        return result;
+
+        final MemoizedValue value = record.getColumnValue(storedName);
+        return Optional.of(value);
     }
 }

--- a/server/src/test/java/io/spine/server/entity/storage/EntityRecordWithColumnsShould.java
+++ b/server/src/test/java/io/spine/server/entity/storage/EntityRecordWithColumnsShould.java
@@ -34,20 +34,15 @@ import org.junit.Test;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
-import static com.google.common.collect.Lists.newLinkedList;
-import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.testing.SerializableTester.reserializeAndAssert;
-import static io.spine.Identifier.newUuid;
 import static io.spine.server.entity.storage.EntityColumn.MemoizedValue;
 import static io.spine.server.entity.storage.EntityRecordWithColumns.create;
 import static io.spine.server.entity.storage.EntityRecordWithColumns.of;
 import static io.spine.server.storage.EntityField.version;
 import static io.spine.test.Verify.assertSize;
 import static java.util.Collections.singletonMap;
-import static java.util.Collections.sort;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -121,23 +116,6 @@ public class EntityRecordWithColumnsShould {
         assertFalse(record.hasColumns());
         final Collection<String> names = record.getColumnNames();
         assertTrue(names.isEmpty());
-    }
-
-    @Test
-    public void return_sorted_column_names() {
-        final MemoizedValue value = mock(MemoizedValue.class);
-        final Map<String, MemoizedValue> columns = newHashMap();
-        final int columnSize = 1000;
-        for (int i = 0; i < columnSize; i++) {
-            final String name = newUuid();
-            columns.put(name, value);
-        }
-
-        final List<String> expectedNames = newLinkedList(columns.keySet());
-        sort(expectedNames);
-
-        final EntityRecordWithColumns record = of(EntityRecord.getDefaultInstance(), columns);
-        assertEquals(expectedNames, record.getColumnNames());
     }
 
     @Test(expected = IllegalStateException.class)

--- a/server/src/test/java/io/spine/server/entity/storage/EntityRecordWithColumnsShould.java
+++ b/server/src/test/java/io/spine/server/entity/storage/EntityRecordWithColumnsShould.java
@@ -22,6 +22,8 @@ package io.spine.server.entity.storage;
 
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
+import com.google.protobuf.Any;
+import io.spine.server.entity.AbstractEntity;
 import io.spine.server.entity.AbstractVersionableEntity;
 import io.spine.server.entity.EntityRecord;
 import io.spine.server.entity.VersionableEntity;
@@ -35,6 +37,7 @@ import java.util.Map;
 
 import static com.google.common.testing.SerializableTester.reserializeAndAssert;
 import static io.spine.server.entity.storage.EntityColumn.MemoizedValue;
+import static io.spine.server.entity.storage.EntityRecordWithColumns.create;
 import static io.spine.server.entity.storage.EntityRecordWithColumns.of;
 import static io.spine.server.storage.EntityField.version;
 import static io.spine.test.Verify.assertContainsKeyValue;
@@ -136,6 +139,16 @@ public class EntityRecordWithColumnsShould {
     }
 
     @Test
+    public void not_have_columns_if_values_list_is_empty() {
+        final EntityWithoutColumns entity = new EntityWithoutColumns("ID");
+        final Map<String, MemoizedValue> columnValues = Columns.from(entity);
+        assertTrue(columnValues.isEmpty());
+
+        final EntityRecordWithColumns record = create(EntityRecord.getDefaultInstance(), entity);
+        assertFalse(record.hasColumns());
+    }
+
+    @Test
     public void have_equals() {
         final MemoizedValue mockValue = mock(MemoizedValue.class);
         final EntityRecordWithColumns noFieldsEnvelope =
@@ -149,7 +162,7 @@ public class EntityRecordWithColumnsShould {
         final EntityRecordWithColumns notEmptyFieldsEnvelope =
                 of(
                         EntityRecord.getDefaultInstance(),
-                        Collections.<String, MemoizedValue>singletonMap("key", mockValue)
+                        Collections.singletonMap("key", mockValue)
                 );
         new EqualsTester()
                 .addEqualityGroup(noFieldsEnvelope, emptyFieldsEnvelope, notEmptyFieldsEnvelope)
@@ -166,6 +179,12 @@ public class EntityRecordWithColumnsShould {
     public static class TestEntity extends AbstractVersionableEntity<String, Project> {
 
         protected TestEntity(String id) {
+            super(id);
+        }
+    }
+
+    public static class EntityWithoutColumns extends AbstractEntity<String, Any> {
+        protected EntityWithoutColumns(String id) {
             super(id);
         }
     }

--- a/server/src/test/java/io/spine/server/event/ERepositoryShould.java
+++ b/server/src/test/java/io/spine/server/event/ERepositoryShould.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.event;
+
+import com.google.protobuf.util.Timestamps;
+import io.spine.client.ColumnFilter;
+import io.spine.client.CompositeColumnFilter;
+import io.spine.client.CompositeColumnFilter.CompositeOperator;
+import io.spine.client.EntityFilters;
+import org.junit.Test;
+
+import java.util.List;
+
+import static io.spine.server.event.ERepository.toEntityFilters;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Dmytro Grankin
+ */
+public class ERepositoryShould {
+
+    @Test
+    public void convert_empty_query_to_empty_EntityFilters() {
+        final EventStreamQuery query = EventStreamQuery.newBuilder()
+                                                       .build();
+        final EntityFilters entityFilters = toEntityFilters(query);
+        assertTrue(entityFilters.getFilterList()
+                                .isEmpty());
+    }
+
+    @Test
+    public void convert_time_query_to_EntityFilters() {
+        final EventStreamQuery query = EventStreamQuery.newBuilder()
+                                                       .setAfter(Timestamps.MIN_VALUE)
+                                                       .setBefore(Timestamps.MAX_VALUE)
+                                                       .build();
+        final EntityFilters entityFilters = toEntityFilters(query);
+        assertEquals(1, entityFilters.getFilterCount());
+
+        final CompositeColumnFilter compositeFilter = entityFilters.getFilter(0);
+        final List<ColumnFilter> columnFilters = compositeFilter.getFilterList();
+        assertEquals(CompositeOperator.ALL, compositeFilter.getOperator());
+        assertEquals(2, columnFilters.size());
+    }
+
+    @Test
+    public void convert_type_query_to_EntityFilters() {
+        final EventFilter validFilter = filterForType("com.example.EventType");
+        final EventFilter invalidFilter = filterForType("   ");
+        final EventStreamQuery query = EventStreamQuery.newBuilder()
+                                                       .addFilter(validFilter)
+                                                       .addFilter(invalidFilter)
+                                                       .build();
+        final EntityFilters entityFilters = toEntityFilters(query);
+        assertEquals(1, entityFilters.getFilterCount());
+
+        final CompositeColumnFilter compositeFilter = entityFilters.getFilter(0);
+        final List<ColumnFilter> columnFilters = compositeFilter.getFilterList();
+        assertEquals(CompositeOperator.EITHER, compositeFilter.getOperator());
+        assertEquals(1, columnFilters.size());
+    }
+
+    private static EventFilter filterForType(String typeName) {
+        return EventFilter.newBuilder()
+                          .setEventType(typeName)
+                          .build();
+    }
+}

--- a/server/src/test/java/io/spine/server/event/ERepositoryShould.java
+++ b/server/src/test/java/io/spine/server/event/ERepositoryShould.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.event;
 
+import com.google.protobuf.Any;
 import com.google.protobuf.util.Timestamps;
 import io.spine.client.ColumnFilter;
 import io.spine.client.CompositeColumnFilter;
@@ -29,6 +30,7 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static io.spine.protobuf.TypeConverter.toObject;
 import static io.spine.server.event.ERepository.toEntityFilters;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
@@ -64,7 +66,8 @@ public class ERepositoryShould {
 
     @Test
     public void convert_type_query_to_EntityFilters() {
-        final EventFilter validFilter = filterForType("com.example.EventType");
+        final String typeName = " com.example.EventType ";
+        final EventFilter validFilter = filterForType(typeName);
         final EventFilter invalidFilter = filterForType("   ");
         final EventStreamQuery query = EventStreamQuery.newBuilder()
                                                        .addFilter(validFilter)
@@ -77,6 +80,9 @@ public class ERepositoryShould {
         final List<ColumnFilter> columnFilters = compositeFilter.getFilterList();
         assertEquals(CompositeOperator.EITHER, compositeFilter.getOperator());
         assertEquals(1, columnFilters.size());
+        final Any typeNameAsAny = columnFilters.get(0)
+                                               .getValue();
+        assertEquals(typeName, toObject(typeNameAsAny, String.class));
     }
 
     private static EventFilter filterForType(String typeName) {

--- a/server/src/test/java/io/spine/server/projection/ProjectionStorageShould.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionStorageShould.java
@@ -68,7 +68,8 @@ public abstract class ProjectionStorageShould
 
     @Override
     protected Message newState(ProjectId id) {
-        final Project state = Given.project(id, "Projection name " + id.getId());
+        final String uniqueName = format("Projection_name-%s-%s", id.getId(), System.nanoTime());
+        final Project state = Given.project(id, uniqueName);
         return state;
     }
 

--- a/server/src/test/java/io/spine/server/stand/StandStorageShould.java
+++ b/server/src/test/java/io/spine/server/stand/StandStorageShould.java
@@ -170,9 +170,14 @@ public abstract class StandStorageShould extends RecordStorageShould<AggregateSt
     }
 
     @SuppressWarnings("NoopMethodInAbstractClass") // Overrides the behavior for all the inheritors.
-    @Ignore
     @Override
     public void allow_by_single_id_queries_with_no_columns() {
+        // Stand storage does not support entity columns.
+    }
+
+    @SuppressWarnings("NoopMethodInAbstractClass") // Overrides the behavior for all the inheritors.
+    @Override
+    public void update_entity_column_values() {
         // Stand storage does not support entity columns.
     }
 

--- a/server/src/test/java/io/spine/server/stand/StandStorageShould.java
+++ b/server/src/test/java/io/spine/server/stand/StandStorageShould.java
@@ -76,10 +76,11 @@ public abstract class StandStorageShould extends RecordStorageShould<AggregateSt
 
     @Override
     protected Message newState(AggregateStateId id) {
+        final String uniqueName = format("test-project-%s-%s", id.toString(), System.nanoTime());
         final Project project = Project.newBuilder()
                                        .setId((ProjectId) id.getAggregateId())
                                        .setStatus(Project.Status.CREATED)
-                                       .setName(format("test-project-%s", id.toString()))
+                                       .setName(uniqueName)
                                        .addTask(Task.getDefaultInstance())
                                        .build();
         return project;

--- a/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
@@ -35,6 +35,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
+import static com.google.common.collect.Sets.newHashSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -199,7 +200,7 @@ public abstract class AbstractStorageShould<I,
         }
 
         final Iterator<I> index = storage.index();
-        final Collection<I> indexValues = Sets.newHashSet(index);
+        final Collection<I> indexValues = newHashSet(index);
 
         assertEquals(ids.size(), indexValues.size());
         Verify.assertContainsAll(indexValues, (I[]) ids.toArray());
@@ -275,5 +276,19 @@ public abstract class AbstractStorageShould<I,
     public void throw_exception_if_close_twice() throws Exception {
         storage.close();
         storage.close();
+    }
+
+    @SuppressWarnings("MismatchedQueryAndUpdateOfCollection"/* Storing of generated objects and
+                                                               checking via #contains(Object). */)
+    @Test
+    public void return_unique_ID() {
+        final int checkCount = 10;
+        final Set<I> ids = newHashSet();
+        for (int i = 0; i < checkCount; i++) {
+            final I newId = newId();
+            if (ids.contains(newId)) {
+                fail("AbstractStorageShould.newId() should return unique IDs.");
+            }
+        }
     }
 }

--- a/server/src/test/java/io/spine/server/storage/memory/EntityQueryMatcherShould.java
+++ b/server/src/test/java/io/spine/server/storage/memory/EntityQueryMatcherShould.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import static com.google.common.collect.ImmutableMultimap.of;
 import static io.spine.client.ColumnFilters.eq;
 import static io.spine.client.CompositeColumnFilter.CompositeOperator.ALL;
+import static io.spine.client.CompositeColumnFilter.CompositeOperator.EITHER;
 import static io.spine.server.entity.storage.EntityRecordWithColumns.of;
 import static io.spine.server.entity.storage.TestCompositeQueryParameterFactory.createParams;
 import static io.spine.server.entity.storage.TestEntityQueryFactory.createQuery;
@@ -166,6 +167,27 @@ public class EntityQueryMatcherShould {
 
         final EntityQueryMatcher<?> matcher = new EntityQueryMatcher<>(query);
         assertTrue(matcher.apply(recordWithColumns));
+    }
+
+    @Test
+    public void not_match_by_wrong_field_name() {
+        final String wrongName = "wrong";
+        final EntityColumn target = mock(EntityColumn.class);
+
+        final Multimap<EntityColumn, ColumnFilter> filters = of(target,
+                                                                eq(wrongName, "any"));
+        final CompositeQueryParameter parameter = createParams(filters, EITHER);
+        final QueryParameters params = QueryParameters.newBuilder()
+                                                      .add(parameter)
+                                                      .build();
+        final EntityQuery<?> query = createQuery(Collections.emptyList(), params);
+        final EntityQueryMatcher<?> matcher = new EntityQueryMatcher<>(query);
+
+        final EntityRecord record = EntityRecord.newBuilder()
+                                                .setEntityId(Any.getDefaultInstance())
+                                                .build();
+        final EntityRecordWithColumns recordWithColumns = of(record);
+        assertFalse(matcher.apply(recordWithColumns));
     }
 
     private static QueryParameters defaultQueryParameters() {

--- a/server/src/test/java/io/spine/server/storage/memory/EntityQueryMatcherShould.java
+++ b/server/src/test/java/io/spine/server/storage/memory/EntityQueryMatcherShould.java
@@ -27,8 +27,8 @@ import com.google.protobuf.Message;
 import io.spine.client.ColumnFilter;
 import io.spine.protobuf.AnyPacker;
 import io.spine.server.entity.EntityRecord;
-import io.spine.server.entity.storage.EntityColumn;
 import io.spine.server.entity.storage.CompositeQueryParameter;
+import io.spine.server.entity.storage.EntityColumn;
 import io.spine.server.entity.storage.EntityQuery;
 import io.spine.server.entity.storage.EntityRecordWithColumns;
 import io.spine.server.entity.storage.QueryParameters;
@@ -101,7 +101,7 @@ public class EntityQueryMatcherShould {
         final String targetName = "feature";
         final EntityColumn target = mock(EntityColumn.class);
         when(target.isNullable()).thenReturn(true);
-        when(target.getName()).thenReturn(targetName);
+        when(target.getStoredName()).thenReturn(targetName);
         when(target.getType()).thenReturn(Boolean.class);
         final Serializable acceptedValue = true;
 
@@ -146,7 +146,7 @@ public class EntityQueryMatcherShould {
 
         final EntityColumn column = mock(EntityColumn.class);
         when(column.getType()).thenReturn(Any.class);
-        when(column.getName()).thenReturn(columnName);
+        when(column.getStoredName()).thenReturn(columnName);
 
         final EntityColumn.MemoizedValue value = mock(EntityColumn.MemoizedValue.class);
         when(value.getSourceColumn()).thenReturn(column);

--- a/server/src/test/java/io/spine/server/storage/memory/InMemoryRecordStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/memory/InMemoryRecordStorageShould.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import static io.spine.Identifier.newUuid;
 import static java.lang.String.format;
+import static java.lang.System.nanoTime;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -58,10 +59,11 @@ public class InMemoryRecordStorageShould
 
     @Override
     protected Message newState(ProjectId id) {
+        final String uniqueName = format("record-storage-test-%s-%s", id.getId(), nanoTime());
         final Project project = Project.newBuilder()
                                        .setId(id)
                                        .setStatus(Project.Status.CREATED)
-                                       .setName(format("record-storage-test-%s", id.getId()))
+                                       .setName(uniqueName)
                                        .addTask(Task.getDefaultInstance())
                                        .build();
         return project;


### PR DESCRIPTION
This PR improves `EntityRecordWithColumns` and fixes a bug in `ERepository`.

Summary:
- `EntityRecordWithColumns.hasColumns()` was fixed. Now returns `false` always if an `Entity` does not have columns.
- `Map.Entry` was removed from the API of `EntityRecordWithColumns`.
- Conversion of `EventStreamQuery` to `EntityFilters`  in `ERepository` was fixed.