### PR TITLE
Projection version advancing fix

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.9.68-SNAPSHOT'
+def final SPINE_VERSION = '0.9.69-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/entity/AbstractVersionableEntity.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractVersionableEntity.java
@@ -174,7 +174,7 @@ public abstract class AbstractVersionableEntity<I, S extends Message>
      *
      * @param newState a new state to set
      */
-    @VisibleForTesting
+    @VisibleForTesting // Used in tests only.
     void incrementState(S newState) {
         updateState(newState, incrementedVersion());
     }

--- a/server/src/main/java/io/spine/server/entity/AbstractVersionableEntity.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractVersionableEntity.java
@@ -172,10 +172,10 @@ public abstract class AbstractVersionableEntity<I, S extends Message>
     /**
      * Updates the state incrementing the version number and recording time of the modification.
      *
-     * <p>This is a test-only method convenience method. Calling this method is equivalent
-     * to calling {@link #updateState(Message, Version)} with the incremented by one version.
+     * <p>This is a test-only convenience method. Calling this method is equivalent to calling
+     * {@link #updateState(Message, Version)} with the incremented by one version.
      *
-     * <p>Please use {@link #updateState(Message, Version)} directly is the production code.
+     * <p>Please use {@link #updateState(Message, Version)} directly in the production code.
      *
      * @param newState a new state to set
      */

--- a/server/src/main/java/io/spine/server/entity/AbstractVersionableEntity.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractVersionableEntity.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.entity;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
@@ -173,6 +174,7 @@ public abstract class AbstractVersionableEntity<I, S extends Message>
      *
      * @param newState a new state to set
      */
+    @VisibleForTesting
     void incrementState(S newState) {
         updateState(newState, incrementedVersion());
     }

--- a/server/src/main/java/io/spine/server/entity/AbstractVersionableEntity.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractVersionableEntity.java
@@ -172,9 +172,14 @@ public abstract class AbstractVersionableEntity<I, S extends Message>
     /**
      * Updates the state incrementing the version number and recording time of the modification.
      *
+     * <p>This is a test-only method convenience method. Calling this method is equivalent
+     * to calling {@link #updateState(Message, Version)} with the incremented by one version.
+     *
+     * <p>Please use {@link #updateState(Message, Version)} directly is the production code.
+     *
      * @param newState a new state to set
      */
-    @VisibleForTesting // Used in tests only.
+    @VisibleForTesting
     void incrementState(S newState) {
         updateState(newState, incrementedVersion());
     }

--- a/server/src/main/java/io/spine/server/entity/EntityVersioning.java
+++ b/server/src/main/java/io/spine/server/entity/EntityVersioning.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.entity;
+
+import io.spine.annotation.Internal;
+import io.spine.core.EventContext;
+import io.spine.core.Version;
+import io.spine.core.Versions;
+
+/**
+ * The strategy of versioning of {@linkplain Entity entities} during a {@link Transaction.Phase} of
+ * a certain {@code Transaction}.
+ */
+@Internal
+public enum EntityVersioning {
+
+    /**
+     * This strategy is applied to the {@link Entity} types which represent a sequence of
+     * events.
+     *
+     * <p>One example of such entity is {@link io.spine.server.aggregate.Aggregate Aggregate}.
+     * As a sequence of events, an {@code Aggregate} has no own versioning system, thus
+     * inherits the versions of the {@linkplain io.spine.server.aggregate.Apply applied}
+     * events. In other words, the current version of an {@code Aggregate} is
+     * the {@linkplain EventContext#getVersion() version} of last applied event.
+     */
+    FROM_EVENT {
+        @Override
+        Version nextVersion(Transaction.Phase<?, ?, ?, ?> phase) {
+            final Version fromEvent = phase.getContext().getVersion();
+            return fromEvent;
+        }
+    },
+
+    /**
+     * This strategy is applied to the {@link Entity} types which are not the pure Event
+     * Sourcing entities, such as {@link io.spine.server.projection.Projection Projection}s.
+     *
+     * <p>A {@code Projection} represents an arbitrary cast of data in a specific moment in
+     * time. The events applied to a {@code Projection} are random, i.e. are produced by
+     * different {@code Entities} and have no common versioning. Thus, a {@code Projection} has
+     * its own versioning system. Each event makes a {@code Projection} <i>increment</i> its
+     * version by one.
+     */
+    AUTO_INCREMENT {
+        @Override
+        Version nextVersion(Transaction.Phase<?, ?, ?, ?> phase) {
+            final Version current = phase.getUnderlyingTransaction().getVersion();
+            final Version newVersion = Versions.increment(current);
+            return newVersion;
+        }
+    };
+
+    /**
+     * Creates the {@link Entity} version which is set after the given {@link Transaction.Phase} is
+     * complete successfully.
+     *
+     * <p>This method has no side effects, i.e. doesn't set the version to the transaction etc.
+     *
+     * @param phase the transaction phase that causes the version change
+     * @return the advanced version
+     */
+    abstract Version nextVersion(Transaction.Phase<?, ?, ?, ?> phase);
+}

--- a/server/src/main/java/io/spine/server/entity/EntityVersioning.java
+++ b/server/src/main/java/io/spine/server/entity/EntityVersioning.java
@@ -70,7 +70,7 @@ public enum EntityVersioning {
 
     /**
      * Creates the {@link Entity} version which is set after the given {@link Transaction.Phase} is
-     * complete successfully.
+     * completed successfully.
      *
      * <p>This method has no side effects, i.e. doesn't set the version to the transaction etc.
      *

--- a/server/src/main/java/io/spine/server/entity/EntityVersioning.java
+++ b/server/src/main/java/io/spine/server/entity/EntityVersioning.java
@@ -51,14 +51,13 @@ public enum EntityVersioning {
     },
 
     /**
-     * This strategy is applied to the {@link Entity} types which are not the pure Event
-     * Sourcing entities, such as {@link io.spine.server.projection.Projection Projection}s.
+     * This strategy is applied to the {@link Entity} types which cannot use the event versions,
+     * such as {@link io.spine.server.projection.Projection Projection}s.
      *
      * <p>A {@code Projection} represents an arbitrary cast of data in a specific moment in
-     * time. The events applied to a {@code Projection} are random, i.e. are produced by
-     * different {@code Entities} and have no common versioning. Thus, a {@code Projection} has
-     * its own versioning system. Each event makes a {@code Projection} <i>increment</i> its
-     * version by one.
+     * time. The events applied to a {@code Projection} are produced by different {@code Entities}
+     * and have no common versioning. Thus, a {@code Projection} has its own versioning system.
+     * Each event <i>increments</i> the {@code Projection} version by one.
      */
     AUTO_INCREMENT {
         @Override

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -232,17 +232,7 @@ public abstract class Transaction<I,
         return entity;
     }
 
-    /**
-     * Retrieves the pending version of the Entity.
-     *
-     * <p>In case of a successful transaction, this version will be set to to the Entity.
-     *
-     * <p>This method is <b>consistent</b>, i.e. the returned value is the same for all
-     * the invocations on a single instance of {@code Transaction}. More formally, for any
-     * {@code Transaction tx}, {@code tx.getValue().equals(tx.getValue())} is always {@code true}.
-     *
-     * @return the pending Entity version
-     */
+    @VisibleForTesting
     Version getVersion() {
         return version;
     }

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -448,12 +448,28 @@ public abstract class Transaction<I,
         lifecycleFlags = lifecycleFlags.toBuilder().setDeleted(deleted).build();
     }
 
+    /**
+     * Retrieves the {@link VersionAdvancementStrategy} of current {@code Transaction}.
+     *
+     * <p>The value should be constant along all the instances of a certain (runtime) type.
+     *
+     * <p>The default value is {@link VersionAdvancementStrategy#INJECT INJECT}.
+     */
     protected VersionAdvancementStrategy versioningStrategy() {
         return INJECT;
     }
 
+    /**
+     * The strategy of advancing the version of a {@code Transaction} upon the given {@link Phase}.
+     */
     protected enum VersionAdvancementStrategy {
 
+        /**
+         * Retrieves the version from the {@linkplain EventContext event}, which caused
+         * the transaction phase.
+         *
+         * @see EventContext#getVersion()
+         */
         INJECT {
             @Override
             Version advanceUpon(Phase<?, ?, ?, ?> phase) {
@@ -461,6 +477,12 @@ public abstract class Transaction<I,
                 return fromEvent;
             }
         },
+
+        /**
+         * Retrieves the current version of the {@code Transaction} incremented by one.
+         *
+         * @see Transaction#getVersion()
+         */
         INCREMENT {
             @Override
             Version advanceUpon(Phase<?, ?, ?, ?> phase) {
@@ -470,6 +492,14 @@ public abstract class Transaction<I,
             }
         };
 
+        /**
+         * Creates an advanced version upon the given {@link Phase}.
+         *
+         * <p>This method has no side effects, i.e. doesn't set the version to the transaction etc.
+         *
+         * @param phase the transaction phase that causes the version change
+         * @return the advanced version
+         */
         abstract Version advanceUpon(Phase<?, ?, ?, ?> phase);
     }
 

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -442,8 +442,8 @@ public abstract class Transaction<I,
      *
      * <p>The value should be constant among all the instances of a certain (runtime) type.
      *
-     * <p>The default value is {@link EntityVersioning#FROM_EVENT FROM_EVENT}, as it works for
-     * most types of {@link Entity}.
+     * <p>The default value is the Event Sourcing-fashioned
+     * {@link EntityVersioning#FROM_EVENT FROM_EVENT} strategy.
      */
     protected EntityVersioning versioningStrategy() {
         return FROM_EVENT;

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -467,7 +467,7 @@ public abstract class Transaction<I,
          */
         FROM_EVENT {
             @Override
-            Version advance(Phase<?, ?, ?, ?> phase) {
+            Version nextVersion(Phase<?, ?, ?, ?> phase) {
                 final Version fromEvent = phase.getContext().getVersion();
                 return fromEvent;
             }
@@ -477,7 +477,7 @@ public abstract class Transaction<I,
          * This strategy is applied to the {@link Entity} types which are not the pure Event
          * Sourcing entities, such as {@link io.spine.server.projection.Projection Projection}s.
          *
-         * <p>A {@code Projection} represents some joined chunk of data in a specific moment in
+         * <p>A {@code Projection} represents an arbitrary cast of data in a specific moment in
          * time. The events applied to a {@code Projection} are random, i.e. are produced by
          * different {@code Entities} and have no common versioning. Thus, a {@code Projection} has
          * its own versioning system. Each event makes a {@code Projection} <i>increment</i> its
@@ -485,7 +485,7 @@ public abstract class Transaction<I,
          */
         AUTO_INCREMENT {
             @Override
-            Version advance(Phase<?, ?, ?, ?> phase) {
+            Version nextVersion(Phase<?, ?, ?, ?> phase) {
                 final Version current = phase.getUnderlyingTransaction().getVersion();
                 final Version newVersion = Versions.increment(current);
                 return newVersion;
@@ -501,7 +501,7 @@ public abstract class Transaction<I,
          * @param phase the transaction phase that causes the version change
          * @return the advanced version
          */
-        abstract Version advance(Phase<?, ?, ?, ?> phase);
+        abstract Version nextVersion(Phase<?, ?, ?, ?> phase);
     }
 
     /**
@@ -547,7 +547,7 @@ public abstract class Transaction<I,
 
         private void advanceVersion() {
             final Version version = underlyingTransaction.versioningStrategy()
-                                                         .advance(this);
+                                                         .nextVersion(this);
             checkIsIncrement(underlyingTransaction.getVersion(), version);
             underlyingTransaction.setVersion(version);
         }

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -506,10 +506,10 @@ public abstract class Transaction<I,
      * @param <S> the type of entity state
      * @param <B> the type of a {@code ValidatingBuilder} for the entity state
      */
-    static class Phase<I,
-                       E extends EventPlayingEntity<I, S, B>,
-                       S extends Message,
-                       B extends ValidatingBuilder<S, ? extends Message.Builder>> {
+    protected static class Phase<I,
+                                 E extends EventPlayingEntity<I, S, B>,
+                                 S extends Message,
+                                 B extends ValidatingBuilder<S, ? extends Message.Builder>> {
 
         private final Transaction<I, E, S, B> underlyingTransaction;
         private final EventEnvelope event;

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -243,7 +243,7 @@ public abstract class Transaction<I,
      *
      * @return the pending Entity version
      */
-    protected Version getVersion() {
+    Version getVersion() {
         return version;
     }
 

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -443,8 +443,8 @@ public abstract class Transaction<I,
      *
      * <p>The value should be constant among all the instances of a certain (runtime) type.
      *
-     * <p>The default value is the Event Sourcing-fashioned
-     * {@link EntityVersioning#FROM_EVENT FROM_EVENT} strategy.
+     * <p>By default the version is taken from
+     * the {@linkplain EntityVersioning#FROM_EVENT latest event applied}.
      */
     protected EntityVersioning versioningStrategy() {
         return FROM_EVENT;

--- a/server/src/main/java/io/spine/server/procman/PmTransaction.java
+++ b/server/src/main/java/io/spine/server/procman/PmTransaction.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Message;
 import io.spine.core.EventEnvelope;
 import io.spine.core.Version;
+import io.spine.server.entity.EntityVersioning;
 import io.spine.server.entity.Transaction;
 import io.spine.server.entity.TransactionListener;
 import io.spine.validate.ValidatingBuilder;
@@ -111,5 +112,10 @@ class PmTransaction<I,
                                      Version version) {
         final PmTransaction<I, S, B> tx = new PmTransaction<>(processManager, state, version);
         return tx;
+    }
+
+    @Override
+    protected EntityVersioning versioningStrategy() {
+        return EntityVersioning.AUTO_INCREMENT;
     }
 }

--- a/server/src/main/java/io/spine/server/procman/ProcessManager.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManager.java
@@ -258,4 +258,25 @@ public abstract class ProcessManager<I,
         return "ProcessManager modification is not available this way. " +
                 "Please modify the state from a command handling or event reacting method.";
     }
+
+    /**
+     * Plays the given events upon the given {@code ProcessManager}.
+     *
+     * <p>Starts an {@link PmTransaction} and plays all the given {@linkplain Event events}
+     * sequentially. Then {@linkplain io.spine.server.entity.Transaction#commit() commits}
+     * the transaction.
+     *
+     * <p>This method is test-only.
+     *
+     * @param entity the entity to apply the events onto
+     * @param events the events to play
+     */
+    @VisibleForTesting
+    static void play(ProcessManager<?, ?, ?> entity, Iterable<Event> events) {
+        checkNotNull(entity);
+        checkNotNull(events);
+        final PmTransaction<?, ?, ?> tx = PmTransaction.start(entity);
+        entity.play(events);
+        tx.commit();
+    }
 }

--- a/server/src/main/java/io/spine/server/procman/ProcessManager.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManager.java
@@ -258,25 +258,4 @@ public abstract class ProcessManager<I,
         return "ProcessManager modification is not available this way. " +
                 "Please modify the state from a command handling or event reacting method.";
     }
-
-    /**
-     * Plays the given events upon the given {@code ProcessManager}.
-     *
-     * <p>Starts an {@link PmTransaction} and plays all the given {@linkplain Event events}
-     * sequentially. Then {@linkplain io.spine.server.entity.Transaction#commit() commits}
-     * the transaction.
-     *
-     * <p>This method is test-only.
-     *
-     * @param entity the entity to apply the events onto
-     * @param events the events to play
-     */
-    @VisibleForTesting
-    static void play(ProcessManager<?, ?, ?> entity, Iterable<Event> events) {
-        checkNotNull(entity);
-        checkNotNull(events);
-        final PmTransaction<?, ?, ?> tx = PmTransaction.start(entity);
-        entity.play(events);
-        tx.commit();
-    }
 }

--- a/server/src/main/java/io/spine/server/projection/ProjectionTransaction.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionTransaction.java
@@ -63,6 +63,13 @@ class ProjectionTransaction<I,
         projection.apply(event.getMessage(), event.getEventContext());
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The {@code ProjectionTransaction} uses the
+     * {@link VersionAdvancementStrategy#INCREMENT INCREMENT} strategy as the event versions are
+     * irrelevant to the projection version.
+     */
     @Override
     protected VersionAdvancementStrategy versioningStrategy() {
         return VersionAdvancementStrategy.INCREMENT;

--- a/server/src/main/java/io/spine/server/projection/ProjectionTransaction.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionTransaction.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Message;
 import io.spine.core.EventEnvelope;
 import io.spine.core.Version;
+import io.spine.server.entity.EntityVersioning;
 import io.spine.server.entity.Transaction;
 import io.spine.server.entity.TransactionListener;
 import io.spine.validate.ValidatingBuilder;

--- a/server/src/main/java/io/spine/server/projection/ProjectionTransaction.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionTransaction.java
@@ -67,12 +67,12 @@ class ProjectionTransaction<I,
      * {@inheritDoc}
      *
      * <p>The {@code ProjectionTransaction} uses the
-     * {@link VersionAdvancementStrategy#INCREMENT INCREMENT} strategy as the event versions are
+     * {@link EntityVersioning#AUTO_INCREMENT AUTO_INCREMENT} strategy as the event versions are
      * irrelevant to the projection version.
      */
     @Override
-    protected VersionAdvancementStrategy versioningStrategy() {
-        return VersionAdvancementStrategy.INCREMENT;
+    protected EntityVersioning versioningStrategy() {
+        return EntityVersioning.AUTO_INCREMENT;
     }
 
     /**

--- a/server/src/main/java/io/spine/server/projection/ProjectionTransaction.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionTransaction.java
@@ -63,6 +63,11 @@ class ProjectionTransaction<I,
         projection.apply(event.getMessage(), event.getEventContext());
     }
 
+    @Override
+    protected VersionAdvancementStrategy versioningStrategy() {
+        return VersionAdvancementStrategy.INCREMENT;
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/server/src/test/java/io/spine/server/entity/TransactionShould.java
+++ b/server/src/test/java/io/spine/server/entity/TransactionShould.java
@@ -371,7 +371,6 @@ public abstract class TransactionShould<I,
     }
 
     private static Version someVersion() {
-        return newVersion(1, getCurrentTime());
+        return newVersion(42, getCurrentTime());
     }
-
 }

--- a/server/src/test/java/io/spine/server/entity/TransactionShould.java
+++ b/server/src/test/java/io/spine/server/entity/TransactionShould.java
@@ -310,6 +310,26 @@ public abstract class TransactionShould<I,
         }
     }
 
+    @Test
+    public void advance_version_from_event() {
+        final E entity = createEntity();
+        final Transaction<I, E, S, B> tx = createTx(entity);
+        assertEquals(entity.getVersion(), tx.getVersion());
+
+        final Event event = createEvent(createEventMessage());
+        final EventEnvelope envelope = EventEnvelope.of(event);
+        tx.apply(envelope);
+
+        assertEquals(event.getContext().getVersion(), tx.getVersion());
+        tx.commit();
+        assertEquals(event.getContext().getVersion(), entity.getVersion());
+    }
+
+    protected final Event createEvent(Message eventMessage) {
+        return eventFactory.createEvent(eventMessage,
+                                        someVersion());
+    }
+
     private static ValidationException validationException() {
         final ValidationException ex = new ValidationException(Lists.<ConstraintViolation>newLinkedList());
         return ex;
@@ -348,11 +368,6 @@ public abstract class TransactionShould<I,
 
     private void applyEvent(Transaction<I, E, S, B> tx, Event event) {
         tx.apply(EventEnvelope.of(event));
-    }
-
-    private Event createEvent(Message eventMessage) {
-        return eventFactory.createEvent(eventMessage,
-                                        someVersion());
     }
 
     private static Version someVersion() {

--- a/server/src/test/java/io/spine/server/procman/PmTransactionShould.java
+++ b/server/src/test/java/io/spine/server/procman/PmTransactionShould.java
@@ -139,5 +139,5 @@ public class PmTransactionShould
     @Ignore // The behavior is changed. The version should be auto incremented.
     @Test
     @Override
-    public void advance_version_from_event() { }
+    public void advance_version_from_event() {}
 }

--- a/server/src/test/java/io/spine/server/procman/PmTransactionShould.java
+++ b/server/src/test/java/io/spine/server/procman/PmTransactionShould.java
@@ -41,6 +41,7 @@ import java.util.List;
 
 import static io.spine.protobuf.AnyPacker.unpack;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -142,9 +143,7 @@ public class PmTransactionShould
     @Ignore // The behavior is changed. See increment_version_on_event
     @Test
     @Override
-    public void advance_version_from_event() {
-        super.advance_version_from_event();
-    }
+    public void advance_version_from_event() { }
 
     @Test
     public void increment_version_on_event() {
@@ -154,5 +153,6 @@ public class PmTransactionShould
         ProcessManager.play(entity, Collections.singleton(event));
         final Version expected = Versions.increment(oldVersion);
         assertEquals(expected.getNumber(), entity.getVersion().getNumber());
+        assertNotEquals(event.getContext().getVersion(), entity.getVersion());
     }
 }

--- a/server/src/test/java/io/spine/server/procman/PmTransactionShould.java
+++ b/server/src/test/java/io/spine/server/procman/PmTransactionShould.java
@@ -22,7 +22,6 @@ package io.spine.server.procman;
 import com.google.protobuf.Message;
 import io.spine.core.Event;
 import io.spine.core.Version;
-import io.spine.core.Versions;
 import io.spine.server.entity.Transaction;
 import io.spine.server.entity.TransactionListener;
 import io.spine.server.entity.TransactionShould;
@@ -36,12 +35,9 @@ import io.spine.validate.ConstraintViolation;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.List;
 
 import static io.spine.protobuf.AnyPacker.unpack;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -140,27 +136,8 @@ public class PmTransactionShould
               .setShouldThrow(toThrow);
     }
 
-    @Ignore // The behavior is changed. See increment_version_on_event for the right behavior test
+    @Ignore // The behavior is changed. The version should be auto incremented.
     @Test
     @Override
     public void advance_version_from_event() { }
-
-    /**
-     * Tests the version advancement strategy for the {@link ProcessManager}s.
-     *
-     * <p>The versioning strategy is for {@link ProcessManager} is
-     * {@link io.spine.server.entity.EntityVersioning#AUTO_INCREMENT AUTO_INCREMENT}. This test
-     * case substitutes {@link #advance_version_from_event()}, which tested the behavior of
-     * {@link io.spine.server.entity.EntityVersioning#FROM_EVENT FROM_EVENT} strategy.
-     */
-    @Test
-    public void increment_version_on_event() {
-        final ProcessManager<ProjectId, Project, PatchedProjectBuilder> entity = createEntity();
-        final Version oldVersion = entity.getVersion();
-        final Event event = createEvent(createEventMessage());
-        ProcessManager.play(entity, Collections.singleton(event));
-        final Version expected = Versions.increment(oldVersion);
-        assertEquals(expected.getNumber(), entity.getVersion().getNumber());
-        assertNotEquals(event.getContext().getVersion(), entity.getVersion());
-    }
 }

--- a/server/src/test/java/io/spine/server/procman/PmTransactionShould.java
+++ b/server/src/test/java/io/spine/server/procman/PmTransactionShould.java
@@ -22,6 +22,7 @@ package io.spine.server.procman;
 import com.google.protobuf.Message;
 import io.spine.core.Event;
 import io.spine.core.Version;
+import io.spine.core.Versions;
 import io.spine.server.entity.Transaction;
 import io.spine.server.entity.TransactionListener;
 import io.spine.server.entity.TransactionShould;
@@ -32,10 +33,14 @@ import io.spine.test.procman.ProjectId;
 import io.spine.test.procman.event.PmProjectCreated;
 import io.spine.test.procman.event.PmTaskAdded;
 import io.spine.validate.ConstraintViolation;
+import org.junit.Ignore;
+import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 import static io.spine.protobuf.AnyPacker.unpack;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -132,5 +137,22 @@ public class PmTransactionShould
             RuntimeException toThrow) {
         entity.getBuilder()
               .setShouldThrow(toThrow);
+    }
+
+    @Ignore // The behavior is changed. See increment_version_on_event
+    @Test
+    @Override
+    public void advance_version_from_event() {
+        super.advance_version_from_event();
+    }
+
+    @Test
+    public void increment_version_on_event() {
+        final ProcessManager<ProjectId, Project, PatchedProjectBuilder> entity = createEntity();
+        final Version oldVersion = entity.getVersion();
+        final Event event = createEvent(createEventMessage());
+        ProcessManager.play(entity, Collections.singleton(event));
+        final Version expected = Versions.increment(oldVersion);
+        assertEquals(expected.getNumber(), entity.getVersion().getNumber());
     }
 }

--- a/server/src/test/java/io/spine/server/procman/PmTransactionShould.java
+++ b/server/src/test/java/io/spine/server/procman/PmTransactionShould.java
@@ -140,11 +140,19 @@ public class PmTransactionShould
               .setShouldThrow(toThrow);
     }
 
-    @Ignore // The behavior is changed. See increment_version_on_event
+    @Ignore // The behavior is changed. See increment_version_on_event for the right behavior test
     @Test
     @Override
     public void advance_version_from_event() { }
 
+    /**
+     * Tests the version advancement strategy for the {@link ProcessManager}s.
+     *
+     * <p>The versioning strategy is for {@link ProcessManager} is
+     * {@link io.spine.server.entity.EntityVersioning#AUTO_INCREMENT AUTO_INCREMENT}. This test
+     * case substitutes {@link #advance_version_from_event()}, which tested the behavior of
+     * {@link io.spine.server.entity.EntityVersioning#FROM_EVENT FROM_EVENT} strategy.
+     */
     @Test
     public void increment_version_on_event() {
         final ProcessManager<ProjectId, Project, PatchedProjectBuilder> entity = createEntity();

--- a/server/src/test/java/io/spine/server/projection/ProjectionTransactionShould.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionTransactionShould.java
@@ -24,6 +24,7 @@ import com.google.protobuf.Message;
 import io.spine.core.Event;
 import io.spine.core.Subscribe;
 import io.spine.core.Version;
+import io.spine.core.Versions;
 import io.spine.server.entity.ThrowingValidatingBuilder;
 import io.spine.server.entity.Transaction;
 import io.spine.server.entity.TransactionListener;
@@ -33,12 +34,16 @@ import io.spine.test.projection.ProjectId;
 import io.spine.test.projection.event.PrjProjectCreated;
 import io.spine.test.projection.event.PrjTaskAdded;
 import io.spine.validate.ConstraintViolation;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
 
 import static com.google.common.collect.Lists.newLinkedList;
 import static io.spine.protobuf.AnyPacker.unpack;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -138,6 +143,23 @@ public class ProjectionTransactionShould
             RuntimeException toThrow) {
         entity.getBuilder()
               .setShouldThrow(toThrow);
+    }
+
+    @Ignore // The behavior is changed. See increment_version_on_event
+    @Test
+    @Override
+    public void advance_version_from_event() {
+        super.advance_version_from_event();
+    }
+
+    @Test
+    public void increment_version_on_event() {
+        final Projection<ProjectId, Project, PatchedProjectBuilder> entity = createEntity();
+        final Version oldVersion = entity.getVersion();
+        final Event event = createEvent(createEventMessage());
+        Projection.play(entity, Collections.singleton(event));
+        final Version expected = Versions.increment(oldVersion);
+        assertEquals(expected.getNumber(), entity.getVersion().getNumber());
     }
 
     @SuppressWarnings({"MethodMayBeStatic", "unused"})  // Methods accessed via reflection.

--- a/server/src/test/java/io/spine/server/projection/ProjectionTransactionShould.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionTransactionShould.java
@@ -146,11 +146,19 @@ public class ProjectionTransactionShould
               .setShouldThrow(toThrow);
     }
 
-    @Ignore // The behavior is changed. See increment_version_on_event
+    @Ignore // The behavior is changed. See increment_version_on_event for the right behavior test
     @Test
     @Override
     public void advance_version_from_event() { }
 
+    /**
+     * Tests the version advancement strategy for the {@link Projection}s.
+     *
+     * <p>The versioning strategy is for {@link Projection} is
+     * {@link io.spine.server.entity.EntityVersioning#AUTO_INCREMENT AUTO_INCREMENT}. This test
+     * case substitutes {@link #advance_version_from_event()}, which tested the behavior of
+     * {@link io.spine.server.entity.EntityVersioning#FROM_EVENT FROM_EVENT} strategy.
+     */
     @Test
     public void increment_version_on_event() {
         final Projection<ProjectId, Project, PatchedProjectBuilder> entity = createEntity();

--- a/server/src/test/java/io/spine/server/projection/ProjectionTransactionShould.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionTransactionShould.java
@@ -146,10 +146,17 @@ public class ProjectionTransactionShould
               .setShouldThrow(toThrow);
     }
 
-    @Ignore // The behavior is changed. See increment_version_on_event for the right behavior test
+    /**
+     * This test is ignored as the expected behavior has been changed for the projection
+     * transactions.
+     *
+     * <p>{@link #increment_version_on_event() Another test method} is created to test the new
+     * behavior. Please refer to it for more details.
+     */
+    @Ignore
     @Test
     @Override
-    public void advance_version_from_event() { }
+    public void advance_version_from_event() {}
 
     /**
      * Tests the version advancement strategy for the {@link Projection}s.

--- a/server/src/test/java/io/spine/server/projection/ProjectionTransactionShould.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionTransactionShould.java
@@ -44,6 +44,7 @@ import java.util.List;
 import static com.google.common.collect.Lists.newLinkedList;
 import static io.spine.protobuf.AnyPacker.unpack;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -148,9 +149,7 @@ public class ProjectionTransactionShould
     @Ignore // The behavior is changed. See increment_version_on_event
     @Test
     @Override
-    public void advance_version_from_event() {
-        super.advance_version_from_event();
-    }
+    public void advance_version_from_event() { }
 
     @Test
     public void increment_version_on_event() {
@@ -160,6 +159,7 @@ public class ProjectionTransactionShould
         Projection.play(entity, Collections.singleton(event));
         final Version expected = Versions.increment(oldVersion);
         assertEquals(expected.getNumber(), entity.getVersion().getNumber());
+        assertNotEquals(event.getContext().getVersion(), entity.getVersion());
     }
 
     @SuppressWarnings({"MethodMayBeStatic", "unused"})  // Methods accessed via reflection.


### PR DESCRIPTION
Fixes #583.

From now there are two strategies of version advancing: `FROM_EVENT` and `AUTO_INCREMENT`.

The `FROM_EVENT` strategy is default, and the `AUTO_INCREMENT` is used for `Projection`s and `ProcessManager`s.