### PR TITLE
Allow to not modify `ProcessManager` state

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.9.66-SNAPSHOT'
+def final SPINE_VERSION = '0.9.67-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateCommandEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateCommandEndpoint.java
@@ -85,6 +85,7 @@ class AggregateCommandEndpoint<I, A extends Aggregate<I, ?, ?>>
     /**
      * Throws {@link IllegalStateException} with the message containing details of the aggregate and
      * the command in response to which the aggregate generated empty set of event messages.
+     *
      * @throws IllegalStateException always
      */
     @Override

--- a/server/src/main/java/io/spine/server/aggregate/AggregateEventEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateEventEndpoint.java
@@ -72,7 +72,8 @@ class AggregateEventEndpoint<I, A extends Aggregate<I, ?, ?>>
     }
 
     /**
-     * Does nothing since an aggregate is not required to produce events in reaction to an event.
+     * Does nothing since a state of an aggregate should not be necessarily
+     * updated during reacting on an event.
      */
     @Override
     protected void onEmptyResult(A aggregate, EventEnvelope envelope) {

--- a/server/src/main/java/io/spine/server/aggregate/AggregateEventEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateEventEndpoint.java
@@ -73,7 +73,7 @@ class AggregateEventEndpoint<I, A extends Aggregate<I, ?, ?>>
 
     /**
      * Does nothing since a state of an aggregate should not be necessarily
-     * updated during reacting on an event.
+     * updated upon reacting on an event.
      */
     @Override
     protected void onEmptyResult(A aggregate, EventEnvelope envelope) {

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRejectionEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRejectionEndpoint.java
@@ -76,7 +76,7 @@ class AggregateRejectionEndpoint<I, A extends Aggregate<I, ?, ?>>
 
     /**
      * Does nothing since a state of an aggregate should not be necessarily
-     * updated during reacting on a rejection.
+     * updated upon reacting on a rejection.
      */
     @Override
     protected void onEmptyResult(A aggregate, RejectionEnvelope envelope) {

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRejectionEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRejectionEndpoint.java
@@ -74,6 +74,10 @@ class AggregateRejectionEndpoint<I, A extends Aggregate<I, ?, ?>>
         return aggregate.reactOn(envelope);
     }
 
+    /**
+     * Does nothing since a state of an aggregate should not be necessarily
+     * updated during reacting on a rejection.
+     */
     @Override
     protected void onEmptyResult(A aggregate, RejectionEnvelope envelope) {
         // Do nothing.

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -160,7 +160,7 @@ public abstract class Transaction<I,
      * Acts similar to
      * {@linkplain Transaction#Transaction(EventPlayingEntity, TransactionListener)
      * Transaction(EventPlayingEntity, TransactionListener)}, but passes an instance of
-     * {@linkplain SilentWitness SilentWitness} as a listener.
+     * {@link SilentWitness} as a listener.
      *
      * @param entity the entity to create the transaction for.
      */
@@ -189,9 +189,8 @@ public abstract class Transaction<I,
 
     /**
      * Acts similar to {@linkplain Transaction#Transaction(EventPlayingEntity,
-     * Message, Version, TransactionListener) an overloaded ctor}
-     * an overloaded ctor}, but passes an instance of
-     * {@linkplain SilentWitness SilentWitness} as a listener.
+     * Message, Version, TransactionListener) an overloaded ctor},
+     * but passes an instance of {@link SilentWitness} as a listener.
      *
      * @param entity  the target entity to modify within this transaction
      * @param state   the entity state to set

--- a/server/src/main/java/io/spine/server/procman/PmCommandEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmCommandEndpoint.java
@@ -46,7 +46,7 @@ class PmCommandEndpoint<I, P extends ProcessManager<I, ?, ?>>
     }
 
     static <I, P extends ProcessManager<I, ?, ?>>
-    I handle (ProcessManagerRepository<I, P, ?> repository, CommandEnvelope cmd) {
+    I handle(ProcessManagerRepository<I, P, ?> repository, CommandEnvelope cmd) {
         final PmCommandEndpoint<I, P> endpoint = of(repository, cmd);
         final I result = endpoint.handle();
         return result;
@@ -77,18 +77,11 @@ class PmCommandEndpoint<I, P extends ProcessManager<I, ?, ?>>
     }
 
     /**
-     * Throws {@link IllegalStateException} with the message containing details of
-     * the process manager and the command in response to which empty set of event messages
-     * was generated.
-     * 
-     * @throws IllegalStateException always
+     * Does nothing since a state of a process manager should not be necessarily
+     * updated during the command handling.
      */
     @Override
-    protected void onEmptyResult(P processManager, CommandEnvelope cmd)
-            throws IllegalStateException {
-        final String format =
-                "The process manager (class: %s, id: %s) produced " +
-                        "empty response for the command (class: %s, id: %s).";
-        onUnhandledCommand(processManager, cmd, format);
+    protected void onEmptyResult(P processManager, CommandEnvelope cmd) {
+        // Do nothing.
     }
 }

--- a/server/src/main/java/io/spine/server/procman/PmEventEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmEventEndpoint.java
@@ -73,7 +73,7 @@ class PmEventEndpoint<I, P extends ProcessManager<I, ?, ?>>
 
     /**
      * Does nothing since a state of a process manager should not be necessarily
-     * updated during reacting on an event.
+     * updated upon reacting on an event.
      */
     @Override
     protected void onEmptyResult(P pm, EventEnvelope envelope) {

--- a/server/src/main/java/io/spine/server/procman/PmEventEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmEventEndpoint.java
@@ -46,7 +46,7 @@ class PmEventEndpoint<I, P extends ProcessManager<I, ?, ?>>
     }
 
     static <I, P extends ProcessManager<I, ?, ?>>
-    Set<I> handle (ProcessManagerRepository<I, P, ?> repository, EventEnvelope event) {
+    Set<I> handle(ProcessManagerRepository<I, P, ?> repository, EventEnvelope event) {
         final PmEventEndpoint<I, P> endpoint = of(repository, event);
         final Set<I> result = endpoint.handle();
         return result;
@@ -71,9 +71,13 @@ class PmEventEndpoint<I, P extends ProcessManager<I, ?, ?>>
         return events;
     }
 
+    /**
+     * Does nothing since a state of a process manager should not be necessarily
+     * updated during reacting on an event.
+     */
     @Override
     protected void onEmptyResult(P pm, EventEnvelope envelope) {
-        // Do nothing. Reacting methods are allowed to return empty results.
+        // Do nothing.
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/procman/PmRejectionEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmRejectionEndpoint.java
@@ -74,7 +74,7 @@ class PmRejectionEndpoint<I, P extends ProcessManager<I, ?, ?>>
 
     /**
      * Does nothing since a state of a process manager should not be necessarily
-     * updated during reacting on a rejection.
+     * updated upon reacting on a rejection.
      */
     @Override
     protected void onEmptyResult(P entity, RejectionEnvelope envelope) {

--- a/server/src/main/java/io/spine/server/procman/PmRejectionEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmRejectionEndpoint.java
@@ -72,6 +72,10 @@ class PmRejectionEndpoint<I, P extends ProcessManager<I, ?, ?>>
         return events;
     }
 
+    /**
+     * Does nothing since a state of a process manager should not be necessarily
+     * updated during reacting on a rejection.
+     */
     @Override
     protected void onEmptyResult(P entity, RejectionEnvelope envelope) {
         // Do nothing. Reacting methods are allowed to return empty results.

--- a/server/src/main/java/io/spine/server/projection/ProjectionEndpoint.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionEndpoint.java
@@ -112,7 +112,7 @@ class ProjectionEndpoint<I, P extends Projection<I, ?, ?>>
 
     /**
      * Does nothing since a state of a projection should not be necessarily
-     * updated during execution of a {@linkplain io.spine.core.Subscribe subscriber} method.
+     * updated upon execution of a {@linkplain io.spine.core.Subscribe subscriber} method.
      */
     @Override
     protected void onEmptyResult(P entity, EventEnvelope event) {

--- a/server/src/main/java/io/spine/server/projection/ProjectionEndpoint.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionEndpoint.java
@@ -110,9 +110,13 @@ class ProjectionEndpoint<I, P extends Projection<I, ?, ?>>
                                     .getTenantId(), projection);
     }
 
+    /**
+     * Does nothing since a state of a projection should not be necessarily
+     * updated during execution of a {@linkplain io.spine.core.Subscribe subscriber} method.
+     */
     @Override
     protected void onEmptyResult(P entity, EventEnvelope event) {
-        // Do nothing. Projections consume events without output.
+        // Do nothing.
     }
 
     @Override

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregateRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregateRepositoryTestEnv.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.BoolValue;
 import com.google.protobuf.FloatValue;
+import com.google.protobuf.Int32Value;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
 import com.google.protobuf.Timestamp;
@@ -79,6 +80,7 @@ import java.util.Set;
 
 import static io.spine.core.Events.nothing;
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
+import static java.util.Collections.emptyList;
 
 /**
  * @author Alexander Yevsyukov
@@ -316,6 +318,7 @@ public class AggregateRepositoryTestEnv {
             return (long) Math.abs(floatValue);
         }
 
+        /** Rejects a negative value via command rejection. */
         @Assign
         Timestamp on(UInt32Value value) {
             if (value.getValue() < 0) {
@@ -331,6 +334,12 @@ public class AggregateRepositoryTestEnv {
                 throw new CannotModifyArchivedEntity(Identifier.pack(getId()));
             }
             return Time.getCurrentTime();
+        }
+
+        /** Invalid command handler, which does not produce events. */
+        @Assign
+        List<Message> on(Int32Value value) {
+            return emptyList();
         }
 
         @Apply

--- a/server/src/test/java/io/spine/server/procman/ProcessManagerRepositoryShould.java
+++ b/server/src/test/java/io/spine/server/procman/ProcessManagerRepositoryShould.java
@@ -198,7 +198,7 @@ public class ProcessManagerRepositoryShould
     }
 
     @Test
-    public void allow_ProcessManager_have_unmodified_state_after_command_handling()
+    public void allow_ProcMan_have_unmodified_state_after_command_handling()
             throws InvocationTargetException {
         testDispatchCommand(doNothing());
     }

--- a/server/src/test/java/io/spine/server/procman/ProcessManagerRepositoryShould.java
+++ b/server/src/test/java/io/spine/server/procman/ProcessManagerRepositoryShould.java
@@ -71,6 +71,7 @@ import static io.spine.server.TestRejectionClasses.assertContains;
 import static io.spine.server.procman.given.ProcessManagerRepositoryTestEnv.GivenCommandMessage.ID;
 import static io.spine.server.procman.given.ProcessManagerRepositoryTestEnv.GivenCommandMessage.addTask;
 import static io.spine.server.procman.given.ProcessManagerRepositoryTestEnv.GivenCommandMessage.createProject;
+import static io.spine.server.procman.given.ProcessManagerRepositoryTestEnv.GivenCommandMessage.doNothing;
 import static io.spine.server.procman.given.ProcessManagerRepositoryTestEnv.GivenCommandMessage.projectCreated;
 import static io.spine.server.procman.given.ProcessManagerRepositoryTestEnv.GivenCommandMessage.projectStarted;
 import static io.spine.server.procman.given.ProcessManagerRepositoryTestEnv.GivenCommandMessage.startProject;
@@ -125,16 +126,16 @@ public class ProcessManagerRepositoryShould
         return procmans;
     }
 
-    /*
-     * Tests
-     *************/
-
     @Override
     protected ProjectId createId(int value) {
         return ProjectId.newBuilder()
                         .setId(format("procman-number-%s", value))
                         .build();
     }
+
+    /*
+     * Tests
+     *************/
 
     @Override
     @Before
@@ -157,6 +158,13 @@ public class ProcessManagerRepositoryShould
 
     ProcessManagerRepository<?, ?, ?> repository() {
         return (ProcessManagerRepository<?, ?, ?>) repository;
+    }
+
+    private void testDispatchCommand(Message cmdMsg) throws InvocationTargetException {
+        final Command cmd = requestFactory.command()
+                                          .create(cmdMsg);
+        repository().dispatchCommand(CommandEnvelope.of(cmd));
+        assertTrue(TestProcessManager.processed(cmdMsg));
     }
 
     private void testDispatchEvent(Message eventMessage) {
@@ -189,12 +197,10 @@ public class ProcessManagerRepositoryShould
         testDispatchCommand(startProject());
     }
 
-    private void testDispatchCommand(Message cmdMsg) throws InvocationTargetException {
-        final Command cmd = requestFactory.command()
-                                          .create(cmdMsg);
-
-        repository().dispatchCommand(CommandEnvelope.of(cmd));
-        assertTrue(TestProcessManager.processed(cmdMsg));
+    @Test
+    public void allow_ProcessManager_have_unmodified_state_after_command_handling()
+            throws InvocationTargetException {
+        testDispatchCommand(doNothing());
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/procman/given/ProcessManagerRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/procman/given/ProcessManagerRepositoryTestEnv.java
@@ -123,7 +123,6 @@ public class ProcessManagerRepositoryTestEnv {
         PmProjectCreated handle(PmCreateProject command, CommandContext ignored) {
             keep(command);
 
-            handleProjectCreated(command.getProjectId());
             final PmProjectCreated event = ((PmProjectCreated.Builder)
                     Sample.builderForType(PmProjectCreated.class))
                           .setProjectId(command.getProjectId())
@@ -135,7 +134,6 @@ public class ProcessManagerRepositoryTestEnv {
         PmTaskAdded handle(PmAddTask command, CommandContext ignored) {
             keep(command);
 
-            handleTaskAdded(command.getTask());
             final PmTaskAdded event = ((PmTaskAdded.Builder)
                     Sample.builderForType(PmTaskAdded.class))
                           .setProjectId(command.getProjectId())
@@ -147,7 +145,6 @@ public class ProcessManagerRepositoryTestEnv {
         CommandRouted handle(PmStartProject command, CommandContext context) {
             keep(command);
 
-            handleProjectStarted();
             final Message addTask = ((PmAddTask.Builder)
                     Sample.builderForType(PmAddTask.class))
                           .setProjectId(command.getProjectId())

--- a/server/src/test/java/io/spine/server/procman/given/ProcessManagerRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/procman/given/ProcessManagerRepositoryTestEnv.java
@@ -40,11 +40,16 @@ import io.spine.test.procman.ProjectVBuilder;
 import io.spine.test.procman.Task;
 import io.spine.test.procman.command.PmAddTask;
 import io.spine.test.procman.command.PmCreateProject;
+import io.spine.test.procman.command.PmDoNothing;
 import io.spine.test.procman.command.PmStartProject;
 import io.spine.test.procman.event.PmProjectCreated;
 import io.spine.test.procman.event.PmProjectStarted;
 import io.spine.test.procman.event.PmTaskAdded;
 import io.spine.testdata.Sample;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
 
 public class ProcessManagerRepositoryTestEnv {
 
@@ -88,14 +93,6 @@ public class ProcessManagerRepositoryTestEnv {
             messagesDelivered.put(getState().getId(), commandOrEventMsg);
         }
 
-        @React
-        public Empty on(PmProjectCreated event, EventContext ignored) {
-            keep(event);
-
-            handleProjectCreated(event.getProjectId());
-            return withNothing();
-        }
-
         private static Empty withNothing() {
             return Empty.getDefaultInstance();
         }
@@ -108,28 +105,11 @@ public class ProcessManagerRepositoryTestEnv {
             getBuilder().mergeFrom(newState);
         }
 
-        @React
-        public Empty on(PmTaskAdded event) {
-            keep(event);
-
-            final Task task = event.getTask();
-            handleTaskAdded(task);
-            return withNothing();
-        }
-
         private void handleTaskAdded(Task task) {
             final Project newState = getState().toBuilder()
                                                .addTask(task)
                                                .build();
             getBuilder().mergeFrom(newState);
-        }
-
-        @React
-        public Empty on(PmProjectStarted event) {
-            keep(event);
-
-            handleProjectStarted();
-            return withNothing();
         }
 
         private void handleProjectStarted() {
@@ -177,6 +157,12 @@ public class ProcessManagerRepositoryTestEnv {
                     .routeAll();
         }
 
+        @Assign
+        List<Message> handle(PmDoNothing command, CommandContext ignored) {
+            keep(command);
+            return emptyList();
+        }
+
         @React
         Empty on(EntityAlreadyArchived rejection) {
             keep(rejection);
@@ -186,6 +172,31 @@ public class ProcessManagerRepositoryTestEnv {
         @React
         Empty on(EntityAlreadyDeleted rejection) {
             keep(rejection);
+            return withNothing();
+        }
+
+        @React
+        public Empty on(PmTaskAdded event) {
+            keep(event);
+
+            final Task task = event.getTask();
+            handleTaskAdded(task);
+            return withNothing();
+        }
+
+        @React
+        public Empty on(PmProjectStarted event) {
+            keep(event);
+
+            handleProjectStarted();
+            return withNothing();
+        }
+
+        @React
+        public Empty on(PmProjectCreated event, EventContext ignored) {
+            keep(event);
+
+            handleProjectCreated(event.getProjectId());
             return withNothing();
         }
 
@@ -216,6 +227,12 @@ public class ProcessManagerRepositoryTestEnv {
 
         public static PmAddTask addTask() {
             return ((PmAddTask.Builder) Sample.builderForType(PmAddTask.class))
+                    .setProjectId(ID)
+                    .build();
+        }
+
+        public static PmDoNothing doNothing() {
+            return ((PmDoNothing.Builder) Sample.builderForType(PmDoNothing.class))
                     .setProjectId(ID)
                     .build();
         }

--- a/server/src/test/proto/spine/test/procman/commands.proto
+++ b/server/src/test/proto/spine/test/procman/commands.proto
@@ -42,3 +42,7 @@ message PmAddTask {
 message PmStartProject {
     ProjectId project_id = 1;
 }
+
+message PmDoNothing {
+    ProjectId project_id = 1;
+}

--- a/server/src/test/proto/spine/test/procman/commands.proto
+++ b/server/src/test/proto/spine/test/procman/commands.proto
@@ -43,6 +43,7 @@ message PmStartProject {
     ProjectId project_id = 1;
 }
 
+// A command, which does not modify a process manager state.
 message PmDoNothing {
     ProjectId project_id = 1;
 }


### PR DESCRIPTION
This PR resolves the [issue](https://github.com/SpineEventEngine/core-java/issues/585). 

Also small issues in the related Javadocs and tests was fixed.