### PR TITLE
Publish a separate artifact with the Proto definitions

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -35,6 +35,8 @@ apply from: generateDescriptorSetScript
 
 apply from: testArtifactsScript
 
+apply from: "../scripts/assemble-proto.gradle"
+
 apply plugin: spineProtobufPluginId
 
 modelCompiler {

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.9.67-SNAPSHOT'
+def final SPINE_VERSION = '0.9.68-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.9.66-SNAPSHOT'
+def final SPINE_VERSION = '0.9.67-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/scripts/assemble-proto.gradle
+++ b/scripts/assemble-proto.gradle
@@ -69,7 +69,7 @@ buildscript {
  */
 Collection<File> collectProto() {
     final def dependencies = configurations.compile.files
-    final def jarFiles = dependencies.collect { it.name }
+    final def jarFiles = dependencies.collect { JarFileName.ofFile(it) }
     final def result = new HashSet<>()
     for (final File jarFile in dependencies) {
         if (jarFile.name.endsWith(".jar")) {
@@ -89,11 +89,11 @@ Collection<File> collectProto() {
  * Returns the root directory containing a Proto package.
  *
  * @param member the member File of the Proto package
- * @param jars the full listing of the project JAR dependencies
+ * @param jarNames the full listing of the project JAR dependencies
  */
-File getProtoRoot(File member, Collection<String> jars) {
+File getProtoRoot(final File member, final Collection<JarFileName> jarNames) {
     File pkg = member
-    while (!jars.contains(jarName(pkg.parentFile))) {
+    while (!jarNames.contains(jarName(pkg.parentFile))) {
         pkg = pkg.parentFile
     }
     return pkg.parentFile
@@ -111,14 +111,14 @@ File getProtoRoot(File member, Collection<String> jars) {
  *
  * @param jar the folder to get the JAR name for
  */
-String jarName(final File jar) {
+JarFileName jarName(final File jar) {
     final String unpackedJarInfix = ".jar"
     final String name = jar.name
     final int index = name.lastIndexOf(unpackedJarInfix)
     if (index < 0) {
-        return name
+        return null
     } else {
-        return name.substring(0, index + unpackedJarInfix.length())
+        return JarFileName.ofValue(name.substring(0, index + unpackedJarInfix.length()))
     }
 }
 
@@ -150,15 +150,52 @@ publishing {
 }
 
 /**
- * A predicate checking if the given {@link File} is a {@code .proto}
+ * A predicate checking if the given {@link File} is a {@code .proto}.
  */
 enum IsProtoFile implements Predicate<File> {
 
     PREDICATE
 
+    private static final String PROTO_EXT = ".proto"
+
     @Override
     boolean apply(final File input) {
         return (input?.isDirectory() && input.list().length != 0) ||
-                (input?.isFile() && input?.name?.endsWith(".proto"))
+                (input?.isFile() && input?.name?.endsWith(PROTO_EXT))
+    }
+}
+
+/**
+ * The filename of a JAR dependency of the project.
+ */
+final class JarFileName {
+
+    final String value
+
+    private JarFileName(final String value) {
+        this.value = value
+    }
+
+    static JarFileName ofFile(final File jar) {
+        return new JarFileName(jar.name)
+    }
+
+    static JarFileName ofValue(final String value) {
+        return new JarFileName(value)
+    }
+
+    boolean equals(o) {
+        if (this.is(o)) return true
+        if (getClass() != o.class) return false
+
+        JarFileName that = (JarFileName) o
+
+        if (value != that.value) return false
+
+        return true
+    }
+
+    int hashCode() {
+        return (value != null ? value.hashCode() : 0)
     }
 }

--- a/scripts/assemble-proto.gradle
+++ b/scripts/assemble-proto.gradle
@@ -21,6 +21,7 @@ import com.google.common.io.Files
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 buildscript {
     repositories {
         mavenCentral()
@@ -32,7 +33,17 @@ buildscript {
     }
 }
 
-def collectProto() {
+/**
+ * Collects all the directories from current project and its dependencies (including zip tree
+ * directories) which contain {@code .proto} definitions.
+ *
+ * <p>The directories may in practice include files of other extension. The caller should take care
+ * of handling those files respectively.
+ *
+ * <p>It's guaranteed that there are no more Proto definitions in the current project classpath
+ * except those included into the returned {@code Collection}.
+ */
+Collection<File> collectProto() {
     final def dependencies = configurations.compile.files
     final def jarFiles = dependencies.collect { it.name }
     final def result = new HashSet<>()
@@ -40,7 +51,7 @@ def collectProto() {
         final def zipTree = zipTree(jarFile)
         for (final File file in zipTree) {
             if (IsProtoFile.PREDICATE.apply(file)) {
-                result.add(getProtoPackage(file, jarFiles))
+                result.add(getProtoRoot(file, jarFiles))
             }
         }
     }
@@ -48,7 +59,13 @@ def collectProto() {
     return result
 }
 
-File getProtoPackage(File member, Collection<String> jars) {
+/**
+ * Returns the root directory containing a Proto package.
+ *
+ * @param member the member File of the Proto package
+ * @param jars the full listing of the project JAR dependencies
+ */
+File getProtoRoot(File member, Collection<String> jars) {
     File pkg = member
     while (!jars.contains(jarName(pkg.parentFile))) {
         pkg = pkg.parentFile
@@ -56,6 +73,18 @@ File getProtoPackage(File member, Collection<String> jars) {
     return pkg.parentFile
 }
 
+/**
+ * Retrieves the name of the given folder trimmed by {@code ".jar"} suffix.
+ *
+ * <p>More formally, returns the name of the given {@link File} if the name does not contain
+ * {@code ".jar"} substring or the substring of the name containing the characters from the start
+ * to the {@code ".jar"} sequence (inclusively).
+ *
+ * <p>This transformation corresponds to finding the name of a JAR file which was extracted to
+ * the given directory with Gradle {@code zipTree()} API.
+ *
+ * @param jar the folder to get the JAR name for
+ */
 String jarName(final File jar) {
     final String unpackedJarInfix = ".jar"
     final String name = jar.name
@@ -94,6 +123,9 @@ publishing {
     }
 }
 
+/**
+ * A predicate checking if the given {@link File} is a {@code .proto}
+ */
 enum IsProtoFile implements Predicate<File> {
 
     PREDICATE

--- a/scripts/assemble-proto.gradle
+++ b/scripts/assemble-proto.gradle
@@ -40,7 +40,7 @@ buildscript {
  * <p>The directories may in practice include files of other extension. The caller should take care
  * of handling those files respectively.
  *
- * <p>It's guaranteed that there are no more Proto definitions in the current project classpath
+ * <p>It's guaranteed that there are no other Proto definitions in the current project classpath
  * except those included into the returned {@code Collection}.
  */
 Collection<File> collectProto() {
@@ -48,10 +48,12 @@ Collection<File> collectProto() {
     final def jarFiles = dependencies.collect { it.name }
     final def result = new HashSet<>()
     for (final File jarFile in dependencies) {
-        final def zipTree = zipTree(jarFile)
-        for (final File file in zipTree) {
-            if (IsProtoFile.PREDICATE.apply(file)) {
-                result.add(getProtoRoot(file, jarFiles))
+        if (jarFile.name.endsWith(".jar")) {
+            final def zipTree = zipTree(jarFile)
+            for (final File file in zipTree) {
+                if (IsProtoFile.PREDICATE.apply(file)) {
+                    result.add(getProtoRoot(file, jarFiles))
+                }
             }
         }
     }

--- a/scripts/assemble-proto.gradle
+++ b/scripts/assemble-proto.gradle
@@ -1,0 +1,106 @@
+import com.google.common.base.Predicate
+import com.google.common.collect.Iterables
+import com.google.common.io.Files
+
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+buildscript {
+    repositories {
+        mavenCentral()
+        mavenLocal()
+    }
+
+    dependencies {
+        classpath "com.google.guava:guava:$guavaVersion"
+    }
+}
+
+def collectProto() {
+    final def dependencies = configurations.compile.files
+    final def jarFiles = dependencies.collect { it.name }
+    final def result = new HashSet<>()
+    for (final File jarFile in dependencies) {
+        final def zipTree = zipTree(jarFile)
+        for (final File file in zipTree) {
+            if (IsProtoFile.PREDICATE.apply(file)) {
+                result.add(getProtoPackage(file, jarFiles))
+            }
+        }
+    }
+    result.addAll(sourceSets.main.proto.srcDirs)
+    return result
+}
+
+File getProtoPackage(File member, Collection<String> jars) {
+    File pkg = member
+    while (!jars.contains(jarName(pkg.parentFile))) {
+        pkg = pkg.parentFile
+    }
+    return pkg.parentFile
+}
+
+String jarName(final File jar) {
+    final String unpackedJarInfix = ".jar"
+    final String name = jar.name
+    final int index = name.lastIndexOf(unpackedJarInfix)
+    if (index < 0) {
+        return name
+    } else {
+        return name.substring(0, index + unpackedJarInfix.length())
+    }
+}
+
+task assembleProto(type: Jar) {
+    description "Assembles a JAR artifact with all Proto definitions from the classpath."
+    from { collectProto() }
+    include {
+        final File file = it.file
+        return IsProtoFile.PREDICATE.apply(file) ||
+                Iterables.any(Files.fileTreeTraverser().children(file), IsProtoFile.PREDICATE)
+    }
+}
+
+final String artifactIdForPublishing = "spine-${project.name}"
+publishing {
+    publications {
+        mavenProto(MavenPublication) {
+            groupId = "${group}"
+            artifactId = "${artifactIdForPublishing}"
+            version = "${version}"
+
+            from components.java
+
+            artifact assembleProto {
+                classifier = "proto"
+            }
+        }
+    }
+}
+
+enum IsProtoFile implements Predicate<File> {
+
+    PREDICATE
+
+    @Override
+    boolean apply(final File input) {
+        return (input?.isDirectory() && input.list().length != 0) ||
+                (input?.isFile() && input?.name?.endsWith(".proto"))
+    }
+}

--- a/scripts/assemble-proto.gradle
+++ b/scripts/assemble-proto.gradle
@@ -22,6 +22,30 @@ import com.google.common.io.Files
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ * This plugin enables a project to publish a JAR containing all the {@code .proto} definitions
+ * found in the project classpath, which is the definitions from {@code sourceSets.main.proto} and
+ * the proto files extracted from the JAR dependencies of the project.
+ *
+ * <p>The relative file paths are kept.
+ *
+ * <p>To depend onto such artifact of e.g. the client module, use:
+ * <pre>
+ *     {@code
+ *     dependencies {
+ *         compile "io.spine:spine-client:$version@proto"
+ *     }
+ *     }
+ * </pre>
+ *
+ * <p>To enable the artifact publishing for a project, apply this plugin to it:
+ * <pre>
+ *     {@code
+ *     apply from: "../scripts/assemble-proto.gradle"
+ *     }
+ * </pre>
+ */
+
 buildscript {
     repositories {
         mavenCentral()


### PR DESCRIPTION
From now we publish the `.proto` definitions of `client` module in a separate artifact.

The artifact includes all the Protos from the `client` module and its dependencies.

To depend on the artifact:
```groovy
dependencies {
    compile "io.spine:spine-client:$version@proto"
}
```

The artifact itself is a JAR file. It contains all the `.proto` definitions preserving their relative path, i.e. if the file `foo.proto` is declared in the project dependency under `mydependency/foo/foo.proto`, it can be found in the archive under exact `mydependency/foo/foo.proto` path.

There are no files except the `.proto` files in the archive.

_Note:_ the archive may also contain empty directories.

To enable other modules to publish such artifacts, apply `script/assemble-proto.gradle` to the module Gradle project.