### PR TITLE
Default state registry thread safety fix

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.9.67-SNAPSHOT'
+def final SPINE_VERSION = '0.9.68-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/entity/AbstractEntity.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractEntity.java
@@ -32,7 +32,6 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.locks.ReentrantLock;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/server/src/main/java/io/spine/server/entity/AbstractEntity.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractEntity.java
@@ -41,6 +41,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @param <I> the type of entity identifiers
  * @param <S> the type of entity state objects
  * @author Alexander Yevsyukov
+ * @author Dmitry Ganzha
  */
 public abstract class AbstractEntity<I, S extends Message> implements Entity<I, S> {
 

--- a/server/src/main/java/io/spine/server/entity/AbstractEntity.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractEntity.java
@@ -32,6 +32,7 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -135,13 +136,10 @@ public abstract class AbstractEntity<I, S extends Message> implements Entity<I, 
     public S getDefaultState() {
         final Class<? extends Entity> entityClass = getClass();
         final DefaultStateRegistry registry = DefaultStateRegistry.getInstance();
-        if (!registry.contains(entityClass)) {
-            final S state = createDefaultState();
-            registry.put(entityClass, state);
-        }
+        final S state = createDefaultState();
         @SuppressWarnings("unchecked")
         // cast is safe because this type of messages is saved to the map
-        final S defaultState = (S) registry.get(entityClass);
+        final S defaultState = (S) registry.putOrGet(entityClass, state);
         return defaultState;
     }
 

--- a/server/src/main/java/io/spine/server/entity/DefaultStateRegistry.java
+++ b/server/src/main/java/io/spine/server/entity/DefaultStateRegistry.java
@@ -33,6 +33,7 @@ import static com.google.common.collect.Maps.newConcurrentMap;
  * A wrapper for the map from entity classes to entity default states.
  *
  * @author Alexander Yevsyukov
+ * @author Dmitry Ganzha
  */
 class DefaultStateRegistry {
 
@@ -69,7 +70,8 @@ class DefaultStateRegistry {
     }
 
     /**
-     * If {@link #defaultStates} does not contain state then save state otherwise return saved state.
+     * If {@link #defaultStates} does not contain state then save state and return it otherwise
+     * return saved state.
      *
      * @param entityClass an entity class
      * @param state a default state of the entity

--- a/server/src/main/java/io/spine/server/entity/DefaultStateRegistry.java
+++ b/server/src/main/java/io/spine/server/entity/DefaultStateRegistry.java
@@ -25,11 +25,9 @@ import com.google.protobuf.Message;
 import javax.annotation.CheckReturnValue;
 import java.util.Map;
 import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.google.common.collect.Maps.newConcurrentMap;
-import static io.spine.util.Exceptions.newIllegalArgumentException;
 
 /**
  * A wrapper for the map from entity classes to entity default states.

--- a/server/src/test/java/io/spine/server/entity/DefaultStateRegistryShould.java
+++ b/server/src/test/java/io/spine/server/entity/DefaultStateRegistryShould.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.verify;
 
 /**
  * @author Alexander Yevsyukov
+ * @author Dmitry Ganzha
  */
 public class DefaultStateRegistryShould {
 
@@ -54,7 +55,7 @@ public class DefaultStateRegistryShould {
         spyMap = spy(newConcurrentMap());
         registry = DefaultStateRegistry.getInstance();
         try {
-            Field defaultStates = registry.getClass()
+            final Field defaultStates = registry.getClass()
                                           .getDeclaredField(DEFAULT_STATES_FIELD_NAME);
             defaultStates.setAccessible(true);
             defaultStates.set(registry, spyMap);


### PR DESCRIPTION
When using _DefaultStateRegistry_ in a multithreaded environment, the following problem occurred in this code:
```java
final DefaultStateRegistry registry = DefaultStateRegistry.getInstance();
if (!registry.contains(entityClass)) {
    final S state = createDefaultState();
    registry.put(entityClass, state);
}
```
Method put code:
```java
void put(Class<? extends Entity> entityClass, Message state) {
     if (contains(entityClass)) {
         throw newIllegalArgumentException("This class is registered already: %s", entityClass);
     }
     defaultStates.put(entityClass, state);
}
```
Actual result: Unpredictable result, can throw exception(This class is registered already) from **DefaultStateRegistry#put**.
Expected result: Don't throw exception and put state only **once** into _defaultStates_.

To solve this problem, it was decided to replace the put method with putOrGet and make it thread safe as well as other methods(**DefaultStateRegistry#get**, **DefaultStateRegistry#contains**), which inserts the value only once, and if the value already exists, it returns the already existing value.

Method **DefaultStateRegistry#putOrGet** code:
```java
Message putOrGet(Class<? extends Entity> entityClass, Message state) {
     lock.writeLock().lock();
     try {
         if (!contains(entityClass)) {
             defaultStates.put(entityClass, state);
         }
         final Message result = get(entityClass);
         return result;
     } finally {
         lock.writeLock().unlock();
     }
}
```

Example how to use new **DefaultStateRegistry#putOrGet** instead of
**DefaultStateRegistry#put** :

Before:
```java
public S getDefaultState() {
     final Class<? extends Entity> entityClass = getClass();
     final DefaultStateRegistry registry = DefaultStateRegistry.getInstance();
     if (!registry.contains(entityClass)) {
         final S state = createDefaultState();
         registry.put(entityClass, state);
     }
     @SuppressWarnings("unchecked")
     // cast is safe because this type of messages is saved to the map
     final S defaultState = (S) registry.get(entityClass);
     return defaultState;
}
```

After:
```java
public S getDefaultState() {
     final Class<? extends Entity> entityClass = getClass();
     final DefaultStateRegistry registry = DefaultStateRegistry.getInstance();
     final S state = createDefaultState();
     @SuppressWarnings("unchecked")
     // cast is safe because this type of messages is saved to the map
     final S defaultState = (S) registry.putOrGet(entityClass, state);
     return defaultState;
}
```