### PR TITLE
Exclude empty directories from proto artifact

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.9.69-SNAPSHOT'
+def final SPINE_VERSION = '0.9.70-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/scripts/assemble-proto.gradle
+++ b/scripts/assemble-proto.gradle
@@ -135,7 +135,7 @@ task assembleProto(type: Jar) {
  *
  * @param candidate the {@link File} to check
  * @return {@code true} if the {@code candidate} {@linkplain #isProtoFile is a Protobuf file} or
- * a directory containing at least one Protobuf file
+ *         a directory containing at least one Protobuf file
  */
 boolean isProtoFileOrDir(final File candidate) {
     final Deque<File> filesToCheck = Lists.newLinkedList()

--- a/scripts/assemble-proto.gradle
+++ b/scripts/assemble-proto.gradle
@@ -1,3 +1,6 @@
+import com.google.common.collect.Lists
+
+
 /*
  * Copyright 2017, TeamDev Ltd. All rights reserved.
  *
@@ -135,16 +138,18 @@ task assembleProto(type: Jar) {
  * a directory containing at least one Protobuf file
  */
 boolean isProtoFileOrDir(final File candidate) {
-    if (!candidate.isDirectory()) {
-        return isProtoFile(candidate)
-    }
-    final def children = candidate.listFiles()
-    if (children.length == 0) {
+    final Deque<File> filesToCheck = Lists.newLinkedList()
+    filesToCheck.push(candidate)
+    if (candidate.isDirectory() && candidate.list().length == 0) {
         return false
     }
-    for (final def child in children) {
-        if (isProtoFileOrDir(child)) {
+    while (!filesToCheck.isEmpty()) {
+        final File file = filesToCheck.pop()
+        if (isProtoFile(file)) {
             return true
+        }
+        if (file.isDirectory()) {
+            file.listFiles().each { filesToCheck.push(it) }
         }
     }
     return false

--- a/scripts/assemble-proto.gradle
+++ b/scripts/assemble-proto.gradle
@@ -1,7 +1,3 @@
-import com.google.common.base.Predicate
-import com.google.common.collect.Iterables
-import com.google.common.io.Files
-
 /*
  * Copyright 2017, TeamDev Ltd. All rights reserved.
  *
@@ -75,7 +71,7 @@ Collection<File> collectProto() {
         if (jarFile.name.endsWith(".jar")) {
             final def zipTree = zipTree(jarFile)
             for (final File file in zipTree) {
-                if (IsProtoFile.PREDICATE.apply(file)) {
+                if (isProtoFile(file)) {
                     result.add(getProtoRoot(file, jarFiles))
                 }
             }
@@ -125,11 +121,43 @@ JarFileName jarName(final File jar) {
 task assembleProto(type: Jar) {
     description "Assembles a JAR artifact with all Proto definitions from the classpath."
     from { collectProto() }
-    include {
-        final File file = it.file
-        return IsProtoFile.PREDICATE.apply(file) ||
-                Iterables.any(Files.fileTreeTraverser().children(file), IsProtoFile.PREDICATE)
+    include { isProtoFileOrDir(it.file) }
+}
+
+/**
+ * Checks if the given abstract pathname represents either a {@code .proto} file, or a directory
+ * containing proto files.
+ *
+ * <p>If {@code candidate} is a directory, scans its children recursively.
+ *
+ * @param candidate the {@link File} to check
+ * @return {@code true} if the {@code candidate} {@linkplain #isProtoFile is a Protobuf file} or
+ * a directory containing at least one Protobuf file
+ */
+boolean isProtoFileOrDir(final File candidate) {
+    if (!candidate.isDirectory()) {
+        return isProtoFile(candidate)
     }
+    final def children = candidate.listFiles()
+    if (children.length == 0) {
+        return false
+    }
+    for (final def child in children) {
+        if (isProtoFileOrDir(child)) {
+            return true
+        }
+    }
+    return false
+}
+
+/**
+ * Checks if the given file is a {@code .proto} file.
+ *
+ * @param file the file to check
+ * @return {@code true} if the {@code file} is a Protobuf file, {@code false} otherwise
+ */
+boolean isProtoFile(final File file) {
+    return file.isFile() && file.name.endsWith(".proto")
 }
 
 final String artifactIdForPublishing = "spine-${project.name}"
@@ -146,22 +174,6 @@ publishing {
                 classifier = "proto"
             }
         }
-    }
-}
-
-/**
- * A predicate checking if the given {@link File} is a {@code .proto}.
- */
-enum IsProtoFile implements Predicate<File> {
-
-    PREDICATE
-
-    private static final String PROTO_EXT = ".proto"
-
-    @Override
-    boolean apply(final File input) {
-        return (input?.isDirectory() && input.list().length != 0) ||
-                (input?.isFile() && input?.name?.endsWith(PROTO_EXT))
     }
 }
 


### PR DESCRIPTION
From now the `assemble-proto` Gradle plugin does not include empty directories to the generated JAR artifact.