### PR TITLE
Fix inconsistency of storing commands in `CommandStore` in case of concurrent access

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.9.70-SNAPSHOT'
+def final SPINE_VERSION = '0.9.71-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/storage/memory/MultitenantStorage.java
+++ b/server/src/main/java/io/spine/server/storage/memory/MultitenantStorage.java
@@ -64,8 +64,6 @@ abstract class MultitenantStorage<S extends TenantStorage<?, ?>> {
             @Override
             public S apply(@Nullable TenantId tenantId) {
                 checkNotNull(tenantId);
-                //TODO:2017-09-29:dmitry.ganzha: Replace lock with Map#putIfAbsent
-                // when spine will be migrated to Java 8
                 lock.lock();
                 try {
                     S storage = tenantSlices.get(tenantId);

--- a/server/src/main/java/io/spine/server/storage/memory/MultitenantStorage.java
+++ b/server/src/main/java/io/spine/server/storage/memory/MultitenantStorage.java
@@ -40,7 +40,7 @@ import static com.google.common.collect.Maps.newConcurrentMap;
  */
 abstract class MultitenantStorage<S extends TenantStorage<?, ?>> {
 
-    /** The lock for MultitenantStorage's accessor methods. */
+    /** The lock for {@code MultitenantStorage} accessor methods. */
     private final Lock lock = new ReentrantLock();
 
     /** The map from {@code TenantId} to its slice of data. */
@@ -64,7 +64,8 @@ abstract class MultitenantStorage<S extends TenantStorage<?, ?>> {
             @Override
             public S apply(@Nullable TenantId tenantId) {
                 checkNotNull(tenantId);
-                //TODO: replace lock with Map#putIfAbsent when spine will be migrated to Java 8
+                //TODO:2017-09-29:dmitry.ganzha: Replace lock with Map#putIfAbsent
+                // when spine will be migrated to Java 8
                 lock.lock();
                 try {
                     S storage = tenantSlices.get(tenantId);

--- a/server/src/main/java/io/spine/server/storage/memory/MultitenantStorage.java
+++ b/server/src/main/java/io/spine/server/storage/memory/MultitenantStorage.java
@@ -36,6 +36,7 @@ import static com.google.common.collect.Maps.newConcurrentMap;
  *
  * @param <S> the type of the storage "slice" for each tenant
  * @author Alexander Yevsyukov
+ * @author Dmitry Ganzha
  */
 abstract class MultitenantStorage<S extends TenantStorage<?, ?>> {
 

--- a/server/src/main/java/io/spine/server/storage/memory/MultitenantStorage.java
+++ b/server/src/main/java/io/spine/server/storage/memory/MultitenantStorage.java
@@ -25,6 +25,8 @@ import io.spine.server.tenant.TenantFunction;
 
 import javax.annotation.Nullable;
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Maps.newConcurrentMap;
@@ -36,6 +38,9 @@ import static com.google.common.collect.Maps.newConcurrentMap;
  * @author Alexander Yevsyukov
  */
 abstract class MultitenantStorage<S extends TenantStorage<?, ?>> {
+
+    /** The lock for MultitenantStorage's accessor methods. */
+    private final Lock lock = new ReentrantLock();
 
     /** The map from {@code TenantId} to its slice of data. */
     private final Map<TenantId, S> tenantSlices = newConcurrentMap();
@@ -58,12 +63,18 @@ abstract class MultitenantStorage<S extends TenantStorage<?, ?>> {
             @Override
             public S apply(@Nullable TenantId tenantId) {
                 checkNotNull(tenantId);
-                S storage = tenantSlices.get(tenantId);
-                if (storage == null) {
-                    storage = createSlice();
-                    tenantSlices.put(tenantId, storage);
+                //TODO: replace lock with Map#putIfAbsent when spine will be migrated to Java 8
+                lock.lock();
+                try {
+                    S storage = tenantSlices.get(tenantId);
+                    if (storage == null) {
+                        storage = createSlice();
+                        tenantSlices.put(tenantId, storage);
+                    }
+                    return storage;
+                } finally {
+                    lock.unlock();
                 }
-                return storage;
             }
         };
         final S result = func.execute();

--- a/server/src/main/java/io/spine/server/storage/memory/TenantRecords.java
+++ b/server/src/main/java/io/spine/server/storage/memory/TenantRecords.java
@@ -37,7 +37,7 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Maps.filterValues;
-import static com.google.common.collect.Maps.newHashMap;
+import static com.google.common.collect.Maps.newConcurrentMap;
 import static com.google.common.collect.Maps.transformValues;
 import static io.spine.protobuf.AnyPacker.pack;
 import static io.spine.protobuf.AnyPacker.unpack;
@@ -49,10 +49,11 @@ import static io.spine.server.entity.FieldMasks.applyMask;
  * all storage operations available for data of a single tenant.
  *
  * @author Alexander Yevsyukov
+ * @author Dmitry Ganzha
  */
 class TenantRecords<I> implements TenantStorage<I, EntityRecordWithColumns> {
 
-    private final Map<I, EntityRecordWithColumns> records = newHashMap();
+    private final Map<I, EntityRecordWithColumns> records = newConcurrentMap();
     private final Map<I, EntityRecordWithColumns> filtered =
             filterValues(records, isRecordWithColumnsVisible());
 

--- a/server/src/test/java/io/spine/server/storage/memory/MultitenantStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/memory/MultitenantStorageShould.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage.memory;
+
+import io.spine.test.storage.ProjectId;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static com.google.common.collect.Lists.newArrayListWithExpectedSize;
+import static com.google.common.collect.Sets.newHashSetWithExpectedSize;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Dmytry Ganzha
+ */
+public class MultitenantStorageShould {
+
+    private static final boolean IS_MULTITENANT = false;
+
+    private MultitenantStorage<TenantRecords<ProjectId>> multitenantStorage;
+
+    @Before
+    public void setUp() {
+        multitenantStorage = new MultitenantStorage<TenantRecords<ProjectId>>(IS_MULTITENANT) {
+            @Override
+            TenantRecords<ProjectId> createSlice() {
+                return new TenantRecords<>();
+            }
+        };
+    }
+
+    @Test
+    public void should_return_same_slice_when_single_tenant_and_multithreaded_environment()
+            throws InterruptedException, ExecutionException {
+        final int numberOfTasks = 1000;
+        final Collection<Callable<TenantRecords>> tasks = newArrayListWithExpectedSize(numberOfTasks);
+
+        for (int i = 0; i < numberOfTasks; i++) {
+            tasks.add(new Callable<TenantRecords>() {
+                @Override
+                public TenantRecords call() throws Exception {
+                    final TenantRecords<ProjectId> storage = multitenantStorage.getStorage();
+                    return storage;
+                }
+            });
+        }
+
+        final List<Future<TenantRecords>> futures = executeInMultithreadedEnvironment(tasks);
+        final Set<TenantRecords> tenantRecords = convertFuturesToSetOfCompletedResults(futures);
+
+        final int expected = 1;
+        assertEquals(expected, tenantRecords.size());
+    }
+
+    private <R> Set<R> convertFuturesToSetOfCompletedResults(List<Future<R>> futures)
+            throws ExecutionException, InterruptedException {
+        final Set<R> tenantRecords = newHashSetWithExpectedSize(futures.size());
+        for (Future<R> future : futures) {
+            tenantRecords.add(future.get());
+        }
+        return tenantRecords;
+    }
+
+    private <R> List<Future<R>> executeInMultithreadedEnvironment(Collection<Callable<R>> tasks)
+            throws InterruptedException {
+        final ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime()
+                                                                             .availableProcessors() *
+                                                                              2);
+        final List<Future<R>> futures = executor.invokeAll(tasks);
+        return futures;
+    }
+}


### PR DESCRIPTION
**Issue Summary**

At the moment `MultitenantStorage` is used as an abstract base for in-memory storages, that Spine provides for a multitenant bounded contexts. However, even if the context is single-tenant, the same abstract base class is used.

The issue is that a single-tenant `BoundedContext`, which is being accessed from outside from within several threads, fails to use this storage properly. In particular, sending several commands simultaneously leads to data loss on a `CommandStore` level.

In scope of such a scenario, `MultitenantStorage.getStorage()` is called to obtain the data slice for a single tenant configured. First call to this storage leads to creation of a storage slice for a single tenant. All subsequent calls to `getStorage()` read the previously created slice from tenant-ID-to-slice map and re-use the stored value.

**Expected Result** 

`MultitenantStorage.getStorage()` returns the same result in every thread.

**Actual Result**

`MultitenantStorage.getStorage()` creates and returns different instances of storage slices — one per calling thread. In this way only the last slice created and returned by `getStorage()` is actually used for further execution. This leads to data corruption.

**Proposed Solution**

Within this PR the `getStorage()` method is made thread-safe.

Additionally, similar concurrency-related issues were found in the related `TenantRecords` storage slice implementation. In particular, a `HashMap` was used to manage the data in multithreaded environment. This issue has also been addressed.


The framework version has been updated to `0.9.71-SNAPSHOT`.