### PR TITLE
Fix Gradle plugins

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.9.70-SNAPSHOT'
+def final SPINE_VERSION = '0.9.72-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/model/README.MD
+++ b/model/README.MD
@@ -1,0 +1,24 @@
+# Spine model verification tools
+
+This directory contains modules that implement compile time verification of the Spine model.
+
+To enable the verification in a project, apply the following Gradle config to subprojects that may 
+contain Spine model elements:
+ ```groovy
+ buildscript {
+     dependencies {
+         classpath "io.spine.tools:spine-model-verifier:${spineVersion}"
+     }
+ }
+ 
+ apply plugin: 'io.spine.tools.spine-model-verifier'
+ 
+ compileJava {
+     options.compilerArgs += ["-processor", "io.spine.model.assemble.AssignLookup", "-AspineDirRoot=${rootDir}"]
+ }
+ 
+ dependencies {
+     compileOnly group: 'io.spine.tools', name: 'spine-model-assembler', version: spineVersion
+ }
+ ``` 
+The Spine model elements are `Entity` classes, `.proto` definitions, etc.

--- a/model/README.MD
+++ b/model/README.MD
@@ -3,7 +3,7 @@
 This directory contains modules that implement compile time verification of the Spine model.
 
 To enable the verification in a project, apply the following Gradle config to subprojects that may 
-contain Spine model elements:
+contain _Spine model elements_:
  ```groovy
  buildscript {
      dependencies {
@@ -21,4 +21,4 @@ contain Spine model elements:
      compileOnly group: 'io.spine.tools', name: 'spine-model-assembler', version: spineVersion
  }
  ``` 
-The Spine model elements are `Entity` classes, `.proto` definitions, etc.
+The _Spine model elements_ are Java and Protobuf declarations of Entities and the messages handled (i.e. `Command`s, `Event`s and `Rejection`s).

--- a/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifier.java
+++ b/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifier.java
@@ -88,10 +88,9 @@ final class ModelVerifier {
             } catch (ClassNotFoundException e) {
                 log().warn("Failed to load class {}." +
                                    " Consider using io.spine.tools.spine-model-verifier plugin" +
-                                   " only for the modules with the sufficient classpath. " +
-                                   "Finishing model verification now.",
+                                   " only for the modules with the sufficient classpath.",
                            commandHandlingClass);
-                return;
+                continue;
             }
             if (Aggregate.class.isAssignableFrom(cls)) {
                 final Class<? extends Aggregate> aggregateClass =

--- a/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifier.java
+++ b/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifier.java
@@ -86,11 +86,11 @@ final class ModelVerifier {
                 log().debug("Trying to load class \'{}\'", commandHandlingClass);
                 cls = getModelClass(commandHandlingClass);
             } catch (ClassNotFoundException e) {
-                log().warn("Failed to load class %s: %s." +
+                log().warn("Failed to load class {}." +
                                    " Consider using io.spine.tools.spine-model-verifier plugin" +
                                    " only for the modules with the sufficient classpath. " +
                                    "Finishing model verification now.",
-                           e.getMessage());
+                           commandHandlingClass);
                 return;
             }
             if (Aggregate.class.isAssignableFrom(cls)) {

--- a/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifier.java
+++ b/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifier.java
@@ -86,7 +86,12 @@ final class ModelVerifier {
                 log().debug("Trying to load class \'{}\'", commandHandlingClass);
                 cls = getModelClass(commandHandlingClass);
             } catch (ClassNotFoundException e) {
-                throw new IllegalStateException(e);
+                log().warn("Failed to load class %s: %s." +
+                                   " Consider using io.spine.tools.spine-model-verifier plugin" +
+                                   " only for the modules with the sufficient classpath. " +
+                                   "Finishing model verification now.",
+                           e.getMessage());
+                return;
             }
             if (Aggregate.class.isAssignableFrom(cls)) {
                 final Class<? extends Aggregate> aggregateClass =

--- a/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifierPlugin.java
+++ b/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifierPlugin.java
@@ -64,7 +64,7 @@ public final class ModelVerifierPlugin extends SpinePlugin {
     private void createTask(Path rawModelStorage, Project project) {
         log().debug("Adding task {}", VERIFY_MODEL.getValue());
         newTask(VERIFY_MODEL, action(rawModelStorage)).insertBeforeTask(CLASSES)
-                                                      .insertAfterAllTasks(COMPILE_JAVA)
+                                                      .insertAfterTask(COMPILE_JAVA)
                                                       .withInputFiles(rawModelStorage)
                                                       .applyNowTo(project);
     }

--- a/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierShould.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierShould.java
@@ -99,8 +99,8 @@ public class ModelVerifierShould {
         verifier.verify(spineModel);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void not_accept_invalid_class_names() {
+    @Test
+    public void ignore_invalid_class_names() {
         final String invalidClassname = "non.existing.class.Name";
         final CommandHandlers spineModel = CommandHandlers.newBuilder()
                                                 .addCommandHandlingTypes(invalidClassname)

--- a/scripts/assemble-proto.gradle
+++ b/scripts/assemble-proto.gradle
@@ -80,6 +80,14 @@ Collection<File> collectProto() {
                     }
                 }
             } catch (GradleException e) {
+                /*
+                As the :assembleProto task configuration is resolved first upon the project
+                configuration (and we don't have the dependencies there yet) and then upon
+                the execution, the task should complete successfully.
+
+                The message is shown upon `./gradlew clean build` or upon a newly created version
+                of framework build etc.
+                 */
                 logger.error(
                         "${e.message}${System.lineSeparator()}The proto artifact may be corrupted."
                 )

--- a/scripts/assemble-proto.gradle
+++ b/scripts/assemble-proto.gradle
@@ -89,6 +89,9 @@ Collection<File> collectProto() {
                  * thrown by `zipTree()` indicating that the given file, which is a dependency JAR
                  * file does not exist.
                  *
+                 * Though, if this error is thrown on the execution phase, this IS an error. Thus,
+                 * we log an error message.
+                 *
                  * As a side effect, the message is shown upon `./gradlew clean build` or upon
                  * a newly created version of framework build etc.
                  */

--- a/scripts/assemble-proto.gradle
+++ b/scripts/assemble-proto.gradle
@@ -81,12 +81,12 @@ Collection<File> collectProto() {
                 }
             } catch (GradleException e) {
                 /*
-                As the :assembleProto task configuration is resolved first upon the project
-                configuration (and we don't have the dependencies there yet) and then upon
-                the execution, the task should complete successfully.
-
-                The message is shown upon `./gradlew clean build` or upon a newly created version
-                of framework build etc.
+                 * As the :assembleProto task configuration is resolved first upon the project
+                 * configuration (and we don't have the dependencies there yet) and then upon
+                 * the execution, the task should complete successfully.
+                 *
+                 * The message is shown upon `./gradlew clean build` or upon a newly created version
+                 * of framework build etc.
                  */
                 logger.error(
                         "${e.message}${System.lineSeparator()}The proto artifact may be corrupted."

--- a/scripts/assemble-proto.gradle
+++ b/scripts/assemble-proto.gradle
@@ -85,8 +85,12 @@ Collection<File> collectProto() {
                  * configuration (and we don't have the dependencies there yet) and then upon
                  * the execution, the task should complete successfully.
                  *
-                 * The message is shown upon `./gradlew clean build` or upon a newly created version
-                 * of framework build etc.
+                 * To make sure the configuration phase passes, we suppress the GradleException
+                 * thrown by `zipTree()` indicating that the given file, which is a dependency JAR
+                 * file does not exist.
+                 *
+                 * As a side effect, the message is shown upon `./gradlew clean build` or upon
+                 * a newly created version of framework build etc.
                  */
                 logger.error(
                         "${e.message}${System.lineSeparator()}The proto artifact may be corrupted."

--- a/scripts/assemble-proto.gradle
+++ b/scripts/assemble-proto.gradle
@@ -73,10 +73,16 @@ Collection<File> collectProto() {
     for (final File jarFile in dependencies) {
         if (jarFile.name.endsWith(".jar")) {
             final def zipTree = zipTree(jarFile)
-            for (final File file in zipTree) {
-                if (isProtoFile(file)) {
-                    result.add(getProtoRoot(file, jarFiles))
+            try {
+                for (final File file in zipTree) {
+                    if (isProtoFile(file)) {
+                        result.add(getProtoRoot(file, jarFiles))
+                    }
                 }
+            } catch (GradleException e) {
+                logger.error(
+                        "${e.message}${System.lineSeparator()}The proto artifact may be corrupted."
+                )
             }
         }
     }

--- a/server/src/main/java/io/spine/server/entity/EntityClass.java
+++ b/server/src/main/java/io/spine/server/entity/EntityClass.java
@@ -24,8 +24,6 @@ import com.google.protobuf.Message;
 import io.spine.Identifier;
 import io.spine.server.model.ModelClass;
 import io.spine.server.model.ModelError;
-import io.spine.type.ClassName;
-import io.spine.type.KnownTypes;
 import io.spine.type.TypeUrl;
 
 import javax.annotation.Nullable;
@@ -67,8 +65,7 @@ public class EntityClass<E extends Entity> extends ModelClass<E> {
         checkIdClass(idClass);
         this.idClass = idClass;
         this.stateClass = getStateClass(cls);
-        final ClassName stateClassName = ClassName.of(stateClass);
-        this.entityStateType = KnownTypes.getTypeUrl(stateClassName);
+        this.entityStateType = TypeUrl.of(stateClass);
     }
 
     /**


### PR DESCRIPTION
This PR provides two major fixes:
 - `assemble-proto.gradle`  plugin error on building after project `clean`;
 - multi-project build with `model-verifier` plugin (failed due to task cyclic dependencies).

Also, in this PR we add `model/README.MD` file explaining the usage of `model-verifier` plugin.
