### PR TITLE
Versioning policy update: # of `Event`s emitted --> # of version increments. Even if state is NOT modified

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.9.73-SNAPSHOT'
+def final SPINE_VERSION = '0.9.74-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/test/java/io/spine/server/aggregate/AggregateShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateShould.java
@@ -740,7 +740,6 @@ public class AggregateShould {
             return Lists.<Message>newArrayList(firstPaused, thenCancelled);
         }
 
-
         @Apply
         private void on(AggProjectPaused event) {
             // do nothing.

--- a/server/src/test/java/io/spine/server/aggregate/given/Given.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/Given.java
@@ -32,9 +32,13 @@ import io.spine.server.aggregate.AggregateEventRecord;
 import io.spine.server.command.TestEventFactory;
 import io.spine.test.aggregate.ProjectId;
 import io.spine.test.aggregate.command.AggAddTask;
+import io.spine.test.aggregate.command.AggCancelProject;
 import io.spine.test.aggregate.command.AggCreateProject;
+import io.spine.test.aggregate.command.AggPauseProject;
 import io.spine.test.aggregate.command.AggStartProject;
+import io.spine.test.aggregate.event.AggProjectCancelled;
 import io.spine.test.aggregate.event.AggProjectCreated;
+import io.spine.test.aggregate.event.AggProjectPaused;
 import io.spine.test.aggregate.event.AggProjectStarted;
 import io.spine.test.aggregate.event.AggTaskAdded;
 import io.spine.testdata.Sample;
@@ -64,6 +68,18 @@ public class Given {
                                     .setProjectId(id)
                                     .setName(projectName)
                                     .build();
+        }
+
+        public static AggProjectPaused projectPaused(ProjectId id) {
+            return AggProjectPaused.newBuilder()
+                                   .setProjectId(id)
+                                   .build();
+        }
+
+        public static AggProjectCancelled projectCancelled(ProjectId id) {
+            return AggProjectCancelled.newBuilder()
+                                      .setProjectId(id)
+                                      .build();
         }
 
         public static AggTaskAdded taskAdded(ProjectId id) {
@@ -135,20 +151,32 @@ public class Given {
 
         public static AggCreateProject createProject(ProjectId id) {
             final AggCreateProject.Builder builder = AggCreateProject.newBuilder()
-                                                               .setProjectId(id)
-                                                               .setName(projectName(id));
+                                                                     .setProjectId(id)
+                                                                     .setName(projectName(id));
+            return builder.build();
+        }
+
+        public static AggPauseProject pauseProject(ProjectId id) {
+            final AggPauseProject.Builder builder = AggPauseProject.newBuilder()
+                                                                   .setProjectId(id);
+            return builder.build();
+        }
+
+        public static AggCancelProject cancelProject(ProjectId id) {
+            final AggCancelProject.Builder builder = AggCancelProject.newBuilder()
+                                                                     .setProjectId(id);
             return builder.build();
         }
 
         public static AggAddTask addTask(ProjectId id) {
             final AggAddTask.Builder builder = AggAddTask.newBuilder()
-                                                   .setProjectId(id);
+                                                         .setProjectId(id);
             return builder.build();
         }
 
         public static AggStartProject startProject(ProjectId id) {
             final AggStartProject.Builder builder = AggStartProject.newBuilder()
-                                                             .setProjectId(id);
+                                                                   .setProjectId(id);
             return builder.build();
         }
     }

--- a/server/src/test/proto/spine/test/aggregate/commands.proto
+++ b/server/src/test/proto/spine/test/aggregate/commands.proto
@@ -62,3 +62,11 @@ message ImportEvents {
     ProjectId project_id = 1;
     repeated core.Event event = 2;
 }
+
+message AggPauseProject {
+    ProjectId project_id = 1;
+}
+
+message AggCancelProject {
+    ProjectId project_id = 1;
+}

--- a/server/src/test/proto/spine/test/aggregate/events.proto
+++ b/server/src/test/proto/spine/test/aggregate/events.proto
@@ -56,3 +56,10 @@ message AggProjectDeleted {
     repeated ProjectId child_project_id = 2;
 }
 
+message AggProjectPaused {
+    ProjectId project_id = 1;
+}
+
+message AggProjectCancelled {
+    ProjectId project_id = 1;
+}


### PR DESCRIPTION
In the lifecycle of `Aggregate` handling a command is always followed by emitting one or more events. In turn they are fed to the `Aggregate`'s event appliers and modify its state. All event appliers are called in scope of a transaction.

When a transaction is committed, there is a check of the state modifications made. If there weren't any, no increment of version is performed.

However, there may be a case when some events are emitted after handling a command, but applying them does not change the `Aggregate` state — perhaps, because the `Aggregate` instance is already in the desired state. In this case events get `N + 1`, `N + 2`, ... version numbers — where `N` is an initial version of this `Aggregate`.  However, an `Aggregate` is left with `N`. 

The problem is that next time we load this `Aggregate` instance from the events, it will get `N + 2` version — as the `Aggregate` version always follows the version of its source event, when loading from `EventStore`. So there's a collision of behavior.

This PR fixes this issue.

From now on emitting any event will lead to a version increment, has the instance been modified or not.

The framework version has been increased  to `0.9.74-SNAPSHOT`.