### PR TITLE
Generalize parameter for `Storage.read(...)`

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.9.72-SNAPSHOT'
+def final SPINE_VERSION = '0.9.75-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
@@ -60,7 +60,23 @@ public final class AggregateReadRequest<I> implements ReadRequest<I> {
      *
      * @return the snapshot trigger value
      */
+    @SuppressWarnings("unused")
     public int getSnapshotTrigger() {
         return snapshotTrigger;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        AggregateReadRequest<?> that = (AggregateReadRequest<?>) o;
+
+        return snapshotTrigger == that.snapshotTrigger && id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
     }
 }

--- a/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
@@ -32,14 +32,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * <p>A result of processing this request is a {@linkplain AggregateStateRecord record},
  * which satisfies the request criteria.
  *
- * <p>To restore an aggregate, the last {@link Snapshot} and events occurred after
- * creation of this snapshot are required. So instead of reading all
- * {@linkplain AggregateEventRecord aggregate event records}, it is reasonable to read
- * them by batches, while the last {@link Snapshot} will not be found. The request specifies
- * a size of the batches as a {@linkplain #getSnapshotTrigger snapshot trigger} value.
+ * <p>The request specifies events {@linkplain #getBatchSize() batch size}
+ * to perform an efficient reading in {@link AggregateStorage}.
  *
  * <p>Two requests for the aggregate with the same {@link #id} are considered equal.
- * {@link #snapshotTrigger} is not taken into account, because it should affect only
+ * {@link #batchSize} is not taken into account, because it should affect only
  * process of reading, but resulting records should be the same.
  *
  * @param <I> the type of the record ID
@@ -49,12 +46,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public final class AggregateReadRequest<I> implements ReadRequest<I> {
 
     private final I id;
-    private final int snapshotTrigger;
+    private final int batchSize;
 
-    public AggregateReadRequest(I id, int snapshotTrigger) {
-        checkArgument(snapshotTrigger > 0);
+    public AggregateReadRequest(I id, int batchSize) {
+        checkArgument(batchSize > 0);
         this.id = checkNotNull(id);
-        this.snapshotTrigger = snapshotTrigger;
+        this.batchSize = batchSize;
     }
 
     @Override
@@ -63,18 +60,12 @@ public final class AggregateReadRequest<I> implements ReadRequest<I> {
     }
 
     /**
-     * Obtains the {@linkplain AggregateRepository#snapshotTrigger snapshot trigger}.
+     * Obtains the number of {@linkplain AggregateEventRecord events} to read per a batch.
      *
-     * <p>Use this value for the {@linkplain AggregateStorage#historyBackward(AggregateReadRequest)
-     * history} reading optimization as a batch size.
-     *
-     * <p>The value reflects the current snapshot trigger set for the {@link AggregateRepository},
-     * in which this request is created.
-     *
-     * @return the snapshot trigger value
+     * @return the events batch size
      */
-    public int getSnapshotTrigger() {
-        return snapshotTrigger;
+    public int getBatchSize() {
+        return batchSize;
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.aggregate;
+
+import io.spine.annotation.SPI;
+import io.spine.server.storage.ReadRequest;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A read request for {@link AggregateStorage}.
+ *
+ * @param <I> the type of the target ID
+ * @author dmytro.grankin
+ */
+@SPI
+public final class AggregateReadRequest<I> implements ReadRequest<I> {
+
+    private final I id;
+    private final int snapshotTrigger;
+
+    public AggregateReadRequest(I id, int snapshotTrigger) {
+        this.id = checkNotNull(id);
+        this.snapshotTrigger = snapshotTrigger;
+    }
+
+    @Override
+    public I getId() {
+        return id;
+    }
+
+    public int getSnapshotTrigger() {
+        return snapshotTrigger;
+    }
+}

--- a/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
@@ -32,11 +32,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * <p>A result of processing this request is a {@linkplain AggregateStateRecord record},
  * which satisfies the request criteria.
  *
- * <p>The request specifies events {@linkplain #getBatchSize() batch size}
- * to perform an efficient reading in {@link AggregateStorage}.
+ * <p>In addition to a record identifier, this request implementation requires
+ * the batch size for event reading to be set. Typically that would be a number of
+ * event records to read to encounter the most recent snapshot.
  *
- * <p>Two requests for the aggregate with the same {@link #id} are considered equal.
- * {@link #batchSize} is not taken into account, because it should affect only
+ * <p>Two requests with the same {@linkplain #getRecordId() record ID} are considered equal.
+ * {@linkplain #getBatchSize() Batch size} is not taken into account, because it should affect only
  * process of reading, but resulting records should be the same.
  *
  * @param <I> the type of the record ID
@@ -45,22 +46,22 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Internal
 public final class AggregateReadRequest<I> implements ReadRequest<I> {
 
-    private final I id;
+    private final I recordId;
     private final int batchSize;
 
-    public AggregateReadRequest(I id, int batchSize) {
+    public AggregateReadRequest(I recordId, int batchSize) {
         checkArgument(batchSize > 0);
-        this.id = checkNotNull(id);
+        this.recordId = checkNotNull(recordId);
         this.batchSize = batchSize;
     }
 
     @Override
     public I getRecordId() {
-        return id;
+        return recordId;
     }
 
     /**
-     * Obtains the number of {@linkplain AggregateEventRecord events} to read per a batch.
+     * Obtains the number of {@linkplain AggregateEventRecord events} to read per batch.
      *
      * @return the events batch size
      */
@@ -75,11 +76,11 @@ public final class AggregateReadRequest<I> implements ReadRequest<I> {
 
         AggregateReadRequest<?> that = (AggregateReadRequest<?>) o;
 
-        return id.equals(that.id);
+        return recordId.equals(that.recordId);
     }
 
     @Override
     public int hashCode() {
-        return id.hashCode();
+        return recordId.hashCode();
     }
 }

--- a/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
@@ -27,15 +27,16 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * A read request for {@link AggregateStorage}.
+ * A request to read events for a particular {@code Aggregate} from {@link AggregateStorage}.
  *
- * <p>A result of this request is a record with the specified id.
+ * <p>A result of processing this request is a {@linkplain AggregateStateRecord record},
+ * which satisfies the request criteria.
  *
- * <p>To organize efficient reading of an aggregate history, {@link AggregateStorage} should
- * read {@linkplain AggregateEventRecord aggregate event records} by batches.
- *
- * <p>The request specifies a size of the batches as a
- * {@linkplain #getSnapshotTrigger snapshot trigger} value.
+ * <p>To restore an aggregate, the last {@link Snapshot} and events occurred after
+ * creation of this snapshot are required. So instead of reading all
+ * {@linkplain AggregateEventRecord aggregate event records}, it is reasonable to read
+ * them by batches, while the last {@link Snapshot} will not be found. The request specifies
+ * a size of the batches as a {@linkplain #getSnapshotTrigger snapshot trigger} value.
  *
  * <p>Two requests for the aggregate with the same {@link #id} are considered equal.
  * {@link #snapshotTrigger} is not taken into account, because it should affect only
@@ -65,16 +66,10 @@ public final class AggregateReadRequest<I> implements ReadRequest<I> {
      * Obtains the {@linkplain AggregateRepository#snapshotTrigger snapshot trigger}.
      *
      * <p>Use this value for the {@linkplain AggregateStorage#historyBackward(AggregateReadRequest)
-     * history} reading optimization.
+     * history} reading optimization as a batch size.
      *
-     * <p>To load an aggregate, required only the last {@link Snapshot} and events occurred after
-     * creation of this snapshot. So instead of reading all {@linkplain AggregateEventRecord
-     * aggregate event records}, it is reasonable to read them by batches, size of which is equal
-     * to the snapshot trigger value.
-     *
-     * <p>NOTE: A snapshot trigger can be changed for {@link AggregateRepository}
-     * after the instantiation, so the amount of events between snapshots can be different
-     * in an aggregate history and may look like this: {@code e1, s1, e2, e3, e4, s2, e5, e6, s3}.
+     * <p>The value reflects the current snapshot trigger set for the {@link AggregateRepository},
+     * in which this request is created.
      *
      * @return the snapshot trigger value
      */

--- a/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
@@ -23,6 +23,7 @@ package io.spine.server.aggregate;
 import io.spine.annotation.Internal;
 import io.spine.server.storage.ReadRequest;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -34,6 +35,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * <p>The request specifies a size of the batches as a
  * {@linkplain #getSnapshotTrigger snapshot trigger} value.
  *
+ * <p>Two requests for the aggregate with the same {@link #id} are considered equal.
+ * {@link #snapshotTrigger} is not taken into account, because it should affect only
+ * process of reading, but resulting records should be the same.
+ *
  * @param <I> the type of the record ID
  * @author Dmytro Grankin
  */
@@ -44,6 +49,7 @@ public final class AggregateReadRequest<I> implements ReadRequest<I> {
     private final int snapshotTrigger;
 
     public AggregateReadRequest(I id, int snapshotTrigger) {
+        checkArgument(snapshotTrigger > 0);
         this.id = checkNotNull(id);
         this.snapshotTrigger = snapshotTrigger;
     }
@@ -66,11 +72,10 @@ public final class AggregateReadRequest<I> implements ReadRequest<I> {
      *
      * <p>NOTE: A snapshot trigger can be changed for {@link AggregateRepository}
      * after the instantiation, so the amount of events between snapshots can be different
-     * in an aggregate history and may look like this: {@code e1, s1, e2, e3, e4, s2, e5, s3}.
+     * in an aggregate history and may look like this: {@code e1, s1, e2, e3, e4, s2, e5, e6, s3}.
      *
      * @return the snapshot trigger value
      */
-    @SuppressWarnings("unused")
     public int getSnapshotTrigger() {
         return snapshotTrigger;
     }
@@ -82,7 +87,7 @@ public final class AggregateReadRequest<I> implements ReadRequest<I> {
 
         AggregateReadRequest<?> that = (AggregateReadRequest<?>) o;
 
-        return snapshotTrigger == that.snapshotTrigger && id.equals(that.id);
+        return id.equals(that.id);
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
@@ -20,7 +20,7 @@
 
 package io.spine.server.aggregate;
 
-import io.spine.annotation.SPI;
+import io.spine.annotation.Internal;
 import io.spine.server.storage.ReadRequest;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -28,10 +28,16 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * A read request for {@link AggregateStorage}.
  *
- * @param <I> the type of the target ID
- * @author dmytro.grankin
+ * <p>To organize efficient reading of an aggregate history, {@link AggregateStorage} should
+ * read {@linkplain AggregateEventRecord aggregate event records} by batches.
+ *
+ * <p>The request specifies a size of the batches as a
+ * {@linkplain #getSnapshotTrigger snapshot trigger} value.
+ *
+ * @param <I> the type of the record ID
+ * @author Dmytro Grankin
  */
-@SPI
+@Internal
 public final class AggregateReadRequest<I> implements ReadRequest<I> {
 
     private final I id;
@@ -57,6 +63,10 @@ public final class AggregateReadRequest<I> implements ReadRequest<I> {
      * creation of this snapshot. So instead of reading all {@linkplain AggregateEventRecord
      * aggregate event records}, it is reasonable to read them by batches, size of which is equal
      * to the snapshot trigger value.
+     *
+     * <p>NOTE: A snapshot trigger can be changed for {@link AggregateRepository}
+     * after the instantiation, so the amount of events between snapshots can be different
+     * in an aggregate history and may look like this: {@code e1, s1, e2, e3, e4, s2, e5, s3}.
      *
      * @return the snapshot trigger value
      */

--- a/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
@@ -47,6 +47,19 @@ public final class AggregateReadRequest<I> implements ReadRequest<I> {
         return id;
     }
 
+    /**
+     * Obtains the {@linkplain AggregateRepository#snapshotTrigger snapshot trigger}.
+     *
+     * <p>Use this value for the {@linkplain AggregateStorage#historyBackward(AggregateReadRequest)
+     * history} reading optimization.
+     *
+     * <p>To load an aggregate, required only the last {@link Snapshot} and events occurred after
+     * creation of this snapshot. So instead of reading all {@linkplain AggregateEventRecord
+     * aggregate event records}, it is reasonable to read them by batches, size of which is equal
+     * to the snapshot trigger value.
+     *
+     * @return the snapshot trigger value
+     */
     public int getSnapshotTrigger() {
         return snapshotTrigger;
     }

--- a/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
@@ -29,6 +29,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * A read request for {@link AggregateStorage}.
  *
+ * <p>A result of this request is a record with the specified id.
+ *
  * <p>To organize efficient reading of an aggregate history, {@link AggregateStorage} should
  * read {@linkplain AggregateEventRecord aggregate event records} by batches.
  *

--- a/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
@@ -58,7 +58,7 @@ public final class AggregateReadRequest<I> implements ReadRequest<I> {
     }
 
     @Override
-    public I getId() {
+    public I getRecordId() {
         return id;
     }
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -19,7 +19,6 @@
  */
 package io.spine.server.aggregate;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import io.spine.annotation.SPI;
 import io.spine.core.CommandClass;
@@ -413,7 +412,6 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * @param  id the ID of the aggregate
      * @return loaded or created aggregate instance
      */
-    @VisibleForTesting
     A loadOrCreate(I id) {
         final Optional<A> optional = load(id);
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -396,7 +396,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      *
      * @param snapshotTrigger a positive number of the snapshot trigger
      */
-    protected final void setSnapshotTrigger(int snapshotTrigger) {
+    protected void setSnapshotTrigger(int snapshotTrigger) {
         checkArgument(snapshotTrigger > 0);
         this.snapshotTrigger = snapshotTrigger;
     }

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -429,7 +429,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * Loads an aggregate by the passed ID.
      *
      * <p>To read an {@link AggregateStateRecord} from an {@link AggregateStorage},
-     * a {@linkplain #snapshotTrigger snapshot trigger} is used as a
+     * a {@linkplain #getSnapshotTrigger() snapshot trigger} is used as a
      * {@linkplain AggregateReadRequest#getBatchSize() batch size}.
      *
      * @param id the ID of the aggregate

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -239,6 +239,19 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
     }
 
     /**
+     * {@inheritDoc}
+     *
+     * <p>Sets {@link #snapshotTrigger} for the assigned storage.
+     *
+     * @param factory storage factory
+     */
+    @Override
+    public void initStorage(StorageFactory factory) {
+        super.initStorage(factory);
+        aggregateStorage().setSnapshotTrigger(snapshotTrigger);
+    }
+
+    /**
      * Creates aggregate storage for the repository.
      *
      * @param factory the factory to create the storage
@@ -396,10 +409,12 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      *
      * @param snapshotTrigger a positive number of the snapshot trigger
      */
-    @SuppressWarnings("unused")
-    protected void setSnapshotTrigger(int snapshotTrigger) {
+    protected final void setSnapshotTrigger(int snapshotTrigger) {
         checkArgument(snapshotTrigger > 0);
         this.snapshotTrigger = snapshotTrigger;
+        if (isStorageAssigned()) {
+            aggregateStorage().setSnapshotTrigger(snapshotTrigger);
+        }
     }
 
     AggregateStorage<I> aggregateStorage() {

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -19,6 +19,7 @@
  */
 package io.spine.server.aggregate;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import io.spine.annotation.SPI;
 import io.spine.core.CommandClass;
@@ -400,7 +401,8 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
         this.snapshotTrigger = snapshotTrigger;
     }
 
-    AggregateStorage<I> aggregateStorage() {
+    @VisibleForTesting
+    public AggregateStorage<I> aggregateStorage() {
         @SuppressWarnings("unchecked") // We check the type on initialization.
         final AggregateStorage<I> result = (AggregateStorage<I>) getStorage();
         return result;

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -425,6 +425,16 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
         return result;
     }
 
+    /**
+     * Loads an aggregate by the passed ID.
+     *
+     * <p>To read an {@link AggregateStateRecord} from an {@link AggregateStorage},
+     * a {@linkplain #snapshotTrigger snapshot trigger} is used as a
+     * {@linkplain AggregateReadRequest#getBatchSize() batch size}.
+     *
+     * @param id the ID of the aggregate
+     * @return the loaded instance or {@code Optional.absent()} if there is no record with the ID
+     */
     private Optional<A> load(I id) {
         final AggregateReadRequest<I> request = new AggregateReadRequest<>(id, snapshotTrigger);
         final Optional<AggregateStateRecord> eventsFromStorage = aggregateStorage().read(request);

--- a/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.aggregate;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.protobuf.Timestamp;
 import io.spine.Identifier;
@@ -269,7 +270,8 @@ public abstract class AggregateStorage<I>
      *
      * @return a positive integer value
      */
-    protected int getSnapshotTrigger() {
+    @VisibleForTesting
+    public int getSnapshotTrigger() {
         return snapshotTrigger;
     }
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
@@ -52,6 +52,18 @@ public abstract class AggregateStorage<I>
         extends AbstractStorage<I, AggregateStateRecord>
         implements StorageWithLifecycleFlags<I, AggregateStateRecord> {
 
+    /**
+     * The {@link AggregateRepository#snapshotTrigger snapshot trigger} value
+     * of the repository, to which is assigned this storage.
+     *
+     * <p>This value should be used for the {@link #historyBackward(Object) history reading}
+     * optimization. To load an aggregate in the default scenario, required only
+     * the last {@link Snapshot} and events occurred after creation of this snapshot.
+     * So instead of reading all {@linkplain AggregateEventRecord event records}, it is reasonable
+     * to read by batches equal to the snapshot trigger value.
+     */
+    private int snapshotTrigger = AggregateRepository.DEFAULT_SNAPSHOT_TRIGGER;
+
     protected AggregateStorage(boolean multitenant) {
         super(multitenant);
     }
@@ -251,4 +263,23 @@ public abstract class AggregateStorage<I>
      * @return new iterator instance
      */
     protected abstract Iterator<AggregateEventRecord> historyBackward(I id);
+
+    /**
+     * Returns the number of events until a next {@code Snapshot} is made.
+     *
+     * @return a positive integer value
+     */
+    protected int getSnapshotTrigger() {
+        return snapshotTrigger;
+    }
+
+    /**
+     * Changes the number of events between making aggregate snapshots to the passed value.
+     *
+     * @param snapshotTrigger a positive number of the snapshot trigger
+     */
+    protected void setSnapshotTrigger(int snapshotTrigger) {
+        checkArgument(snapshotTrigger > 0);
+        this.snapshotTrigger = snapshotTrigger;
+    }
 }

--- a/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
@@ -55,12 +55,6 @@ public abstract class AggregateStorage<I>
     /**
      * The {@link AggregateRepository#snapshotTrigger snapshot trigger} value
      * of the repository, to which is assigned this storage.
-     *
-     * <p>This value should be used for the {@link #historyBackward(Object) history reading}
-     * optimization. To load an aggregate in the default scenario, required only
-     * the last {@link Snapshot} and events occurred after creation of this snapshot.
-     * So instead of reading all {@linkplain AggregateEventRecord event records}, it is reasonable
-     * to read by batches equal to the snapshot trigger value.
      */
     private int snapshotTrigger = AggregateRepository.DEFAULT_SNAPSHOT_TRIGGER;
 
@@ -258,6 +252,12 @@ public abstract class AggregateStorage<I>
      *
      * <p>Records are sorted by timestamp descending (from newer to older).
      * The iterator is empty if there's no history for the aggregate with passed ID
+     *
+     * <p>Use {@link #snapshotTrigger} for the history reading optimization.
+     * To load an aggregate in the default scenario, required only
+     * the last {@link Snapshot} and events occurred after creation of this snapshot.
+     * So instead of reading all {@linkplain AggregateEventRecord event records},
+     * it is reasonable to read them by batches equal to the snapshot trigger value.
      *
      * @param id aggregate ID
      * @return new iterator instance

--- a/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
@@ -60,7 +60,7 @@ public abstract class AggregateStorage<I>
      * Forms and returns an {@link AggregateStateRecord} based on the
      * {@linkplain #historyBackward(AggregateReadRequest) aggregate history}.
      *
-     * @param request the aggregate read request for which to form a record
+     * @param request the aggregate read request based on which to form a record
      * @return the record instance or {@code Optional.absent()} if the
      *         {@linkplain #historyBackward(AggregateReadRequest) aggregate history} is empty
      * @throws IllegalStateException if the storage was closed before

--- a/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
+++ b/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
@@ -164,7 +164,7 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
      */
     private Optional<EntityRecord> findRecord(I id) {
         final RecordStorage<I> storage = recordStorage();
-        final RecordReadRequest<I> request = RecordReadRequest.of(id);
+        final RecordReadRequest<I> request = new RecordReadRequest<>(id);
         final Optional<EntityRecord> found = storage.read(request);
         if (!found.isPresent()) {
             return Optional.absent();

--- a/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
+++ b/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
@@ -34,6 +34,7 @@ import io.spine.client.EntityId;
 import io.spine.server.entity.storage.EntityQueries;
 import io.spine.server.entity.storage.EntityQuery;
 import io.spine.server.entity.storage.EntityRecordWithColumns;
+import io.spine.server.storage.RecordReadRequest;
 import io.spine.server.storage.RecordStorage;
 import io.spine.server.storage.StorageFactory;
 import io.spine.type.TypeUrl;
@@ -163,7 +164,8 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
      */
     private Optional<EntityRecord> findRecord(I id) {
         final RecordStorage<I> storage = recordStorage();
-        final Optional<EntityRecord> found = storage.read(id);
+        final RecordReadRequest<I> request = RecordReadRequest.of(id);
+        final Optional<EntityRecord> found = storage.read(request);
         if (!found.isPresent()) {
             return Optional.absent();
         }

--- a/server/src/main/java/io/spine/server/entity/Repository.java
+++ b/server/src/main/java/io/spine/server/entity/Repository.java
@@ -86,7 +86,7 @@ public abstract class Repository<I, E extends Entity<I, ?>>
      * initialized} or the repository was {@linkplain #close() closed}.
      */
     @Nullable
-    private Storage<I, ?> storage;
+    private Storage<I, ?, ?> storage;
 
     /** Lazily initialized logger. */
     private final Supplier<Logger> loggerSupplier = Logging.supplyFor(getClass());
@@ -260,7 +260,7 @@ public abstract class Repository<I, E extends Entity<I, ?>>
      * @throws IllegalStateException if the storage is not assigned
      */
     @CheckReturnValue
-    protected final Storage<I, ?> getStorage() {
+    protected final Storage<I, ?, ?> getStorage() {
         return checkStorage(this.storage);
     }
 
@@ -306,7 +306,7 @@ public abstract class Repository<I, E extends Entity<I, ?>>
      * @param factory the factory to create the storage
      * @return the created storage instance
      */
-    protected abstract Storage<I, ?> createStorage(StorageFactory factory);
+    protected abstract Storage<I, ?, ?> createStorage(StorageFactory factory);
 
     /**
      * Closes the repository by closing the underlying storage.
@@ -328,7 +328,7 @@ public abstract class Repository<I, E extends Entity<I, ?>>
         return storage != null;
     }
 
-    private Storage<I, ?> ensureStorage() {
+    private Storage<I, ?, ?> ensureStorage() {
         checkState(storage != null, "No storage assigned in repository %s", this);
         return storage;
     }

--- a/server/src/main/java/io/spine/server/projection/ProjectionStorage.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionStorage.java
@@ -27,6 +27,7 @@ import io.spine.annotation.SPI;
 import io.spine.server.entity.EntityRecord;
 import io.spine.server.entity.storage.EntityQuery;
 import io.spine.server.entity.storage.EntityRecordWithColumns;
+import io.spine.server.storage.RecordReadRequest;
 import io.spine.server.storage.RecordStorage;
 
 import javax.annotation.Nullable;
@@ -52,7 +53,8 @@ public abstract class ProjectionStorage<I> extends RecordStorage<I> {
     @Override
     protected Optional<EntityRecord> readRecord(I id) {
         final RecordStorage<I> storage = recordStorage();
-        final Optional<EntityRecord> record = storage.read(id);
+        final RecordReadRequest<I> request = RecordReadRequest.of(id);
+        final Optional<EntityRecord> record = storage.read(request);
         return record;
     }
 

--- a/server/src/main/java/io/spine/server/projection/ProjectionStorage.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionStorage.java
@@ -53,7 +53,7 @@ public abstract class ProjectionStorage<I> extends RecordStorage<I> {
     @Override
     protected Optional<EntityRecord> readRecord(I id) {
         final RecordStorage<I> storage = recordStorage();
-        final RecordReadRequest<I> request = RecordReadRequest.of(id);
+        final RecordReadRequest<I> request = new RecordReadRequest<>(id);
         final Optional<EntityRecord> record = storage.read(request);
         return record;
     }

--- a/server/src/main/java/io/spine/server/stand/AggregateQueryProcessor.java
+++ b/server/src/main/java/io/spine/server/stand/AggregateQueryProcessor.java
@@ -125,8 +125,8 @@ class AggregateQueryProcessor implements QueryProcessor {
     }
 
     private Iterator<EntityRecord> readOne(AggregateStateId singleId, FieldMask fieldMask) {
-        final RecordReadRequest<AggregateStateId> request = new RecordReadRequest<>(singleId,
-                                                                                    fieldMask);
+        final RecordReadRequest<AggregateStateId> request = RecordReadRequest.of(singleId,
+                                                                                 fieldMask);
         final Optional<EntityRecord> singleResult = standStorage.read(request);
         Iterator<EntityRecord> result;
         if (!singleResult.isPresent()) {

--- a/server/src/main/java/io/spine/server/stand/AggregateQueryProcessor.java
+++ b/server/src/main/java/io/spine/server/stand/AggregateQueryProcessor.java
@@ -35,6 +35,7 @@ import io.spine.client.Query;
 import io.spine.client.Target;
 import io.spine.protobuf.AnyPacker;
 import io.spine.server.entity.EntityRecord;
+import io.spine.server.storage.RecordReadRequest;
 import io.spine.type.TypeUrl;
 
 import javax.annotation.Nullable;
@@ -124,13 +125,10 @@ class AggregateQueryProcessor implements QueryProcessor {
     }
 
     private Iterator<EntityRecord> readOne(AggregateStateId singleId, FieldMask fieldMask) {
-        final boolean shouldApplyFieldMask = !fieldMask.getPathsList()
-                                                       .isEmpty();
-
+        final RecordReadRequest<AggregateStateId> request = new RecordReadRequest<>(singleId,
+                                                                                    fieldMask);
+        final Optional<EntityRecord> singleResult = standStorage.read(request);
         Iterator<EntityRecord> result;
-        final Optional<EntityRecord> singleResult = shouldApplyFieldMask
-                ? standStorage.read(singleId, fieldMask)
-                : standStorage.read(singleId);
         if (!singleResult.isPresent()) {
             result = Collections.emptyIterator();
         } else {

--- a/server/src/main/java/io/spine/server/stand/AggregateQueryProcessor.java
+++ b/server/src/main/java/io/spine/server/stand/AggregateQueryProcessor.java
@@ -125,9 +125,12 @@ class AggregateQueryProcessor implements QueryProcessor {
     }
 
     private Iterator<EntityRecord> readOne(AggregateStateId singleId, FieldMask fieldMask) {
-        final RecordReadRequest<AggregateStateId> request = RecordReadRequest.of(singleId,
-                                                                                 fieldMask);
-        final Optional<EntityRecord> singleResult = standStorage.read(request);
+        final boolean shouldApplyFieldMask = !fieldMask.getPathsList()
+                                                       .isEmpty();
+        final RecordReadRequest<AggregateStateId> request = new RecordReadRequest<>(singleId);
+        final Optional<EntityRecord> singleResult = shouldApplyFieldMask
+                                                    ? standStorage.read(request, fieldMask)
+                                                    : standStorage.read(request);
         Iterator<EntityRecord> result;
         if (!singleResult.isPresent()) {
             result = Collections.emptyIterator();

--- a/server/src/main/java/io/spine/server/storage/AbstractStorage.java
+++ b/server/src/main/java/io/spine/server/storage/AbstractStorage.java
@@ -28,12 +28,12 @@ import com.google.protobuf.Message;
  * <p>A storage can read and write messages of the given type.
  *
  * @param <I> the type of IDs of storage records
- * @param <R> the type of records kept in the storage
- * @param <Q> the type of {@linkplain ReadRequest read requests} for the storage
+ * @param <M> the type of records kept in the storage
+ * @param <R> the type of {@linkplain ReadRequest read requests} for the storage
  * @author Alexander Yevsyukov
  */
-public abstract class AbstractStorage<I, R extends Message, Q extends ReadRequest<I>>
-                implements Storage<I, R, Q> {
+public abstract class AbstractStorage<I, M extends Message, R extends ReadRequest<I>>
+                implements Storage<I, M, R> {
 
     private final boolean multitenant;
     private boolean open = true;

--- a/server/src/main/java/io/spine/server/storage/AbstractStorage.java
+++ b/server/src/main/java/io/spine/server/storage/AbstractStorage.java
@@ -29,9 +29,11 @@ import com.google.protobuf.Message;
  *
  * @param <I> the type of IDs of storage records
  * @param <R> the type of records kept in the storage
+ * @param <Q> the type of {@linkplain ReadRequest read requests} for the storage
  * @author Alexander Yevsyukov
  */
-public abstract class AbstractStorage<I, R extends Message> implements Storage<I, R> {
+public abstract class AbstractStorage<I, R extends Message, Q extends ReadRequest<I>>
+                implements Storage<I, R, Q> {
 
     private final boolean multitenant;
     private boolean open = true;

--- a/server/src/main/java/io/spine/server/storage/ReadRequest.java
+++ b/server/src/main/java/io/spine/server/storage/ReadRequest.java
@@ -42,5 +42,5 @@ public interface ReadRequest<I> {
      *
      * @return the record ID
      */
-    I getId();
+    I getRecordId();
 }

--- a/server/src/main/java/io/spine/server/storage/ReadRequest.java
+++ b/server/src/main/java/io/spine/server/storage/ReadRequest.java
@@ -25,7 +25,7 @@ import io.spine.annotation.SPI;
 /**
  * A read request for {@link Storage}.
  *
- * @param <I> the type of the target ID
+ * @param <I> the type of the record ID
  * @author Dmytro Grankin
  */
 @SPI

--- a/server/src/main/java/io/spine/server/storage/ReadRequest.java
+++ b/server/src/main/java/io/spine/server/storage/ReadRequest.java
@@ -20,19 +20,30 @@
 
 package io.spine.server.storage;
 
-import io.spine.annotation.SPI;
+import io.spine.annotation.Internal;
 
 /**
  * A read request for {@link Storage}.
  *
+ * <p>Purpose of this interface is generalization of the parameter
+ * for a record {@linkplain Storage#read(ReadRequest) reading}.
+ *
+ * <p>This generalization is required, because {@code ID} is not always sufficient parameter
+ * to read a record. Implementations may specify other filtering parameters or even
+ * configuration for a read execution. E.g. to read a record, reading of which causes
+ * reading of a list of other records, a batch size will be handy and it can be specified as a
+ * parameter of a read request.
+ *
  * @param <I> the type of the record ID
  * @author Dmytro Grankin
  */
-@SPI
+@Internal
 public interface ReadRequest<I> {
 
     /**
      * Obtains the ID of the requested record.
+     *
+     * <p>The result of this request must have this ID.
      *
      * @return the record ID
      */

--- a/server/src/main/java/io/spine/server/storage/ReadRequest.java
+++ b/server/src/main/java/io/spine/server/storage/ReadRequest.java
@@ -23,16 +23,11 @@ package io.spine.server.storage;
 import io.spine.annotation.Internal;
 
 /**
- * A read request for {@link Storage}.
+ * A request to read a particular record from {@link Storage}.
  *
- * <p>Purpose of this interface is generalization of the parameter
- * for a record {@linkplain Storage#read(ReadRequest) reading}.
- *
- * <p>This generalization is required, because {@code ID} is not always sufficient parameter
- * to read a record. Implementations may specify other filtering parameters or even
- * configuration for a read execution. E.g. to read a record, reading of which causes
- * reading of a list of other records, a batch size will be handy and it can be specified as a
- * parameter of a read request.
+ * <p>A purpose of having a general contract for such requests is to allow {@link Storage}
+ * implementations to take some additional parameters, that may help to read a record in
+ * a more optimal way, than just by an ID.
  *
  * @param <I> the type of the record ID
  * @author Dmytro Grankin

--- a/server/src/main/java/io/spine/server/storage/ReadRequest.java
+++ b/server/src/main/java/io/spine/server/storage/ReadRequest.java
@@ -20,34 +20,21 @@
 
 package io.spine.server.storage;
 
-import com.google.common.base.Optional;
-import com.google.protobuf.Message;
-import io.spine.server.entity.LifecycleFlags;
+import io.spine.annotation.SPI;
 
 /**
- * A storage that allows to update {@linkplain LifecycleFlags lifecycle flags} of entities.
+ * A read request for {@link Storage}.
  *
- * @author Alexander Yevsyukov
+ * @param <I> the type of the target ID
+ * @author Dmytro Grankin
  */
-public interface StorageWithLifecycleFlags<I, R extends Message, Q extends ReadRequest<I>>
-        extends Storage<I, R, Q> {
+@SPI
+public interface ReadRequest<I> {
 
     /**
-     * Reads the visibility status for the entity with the passed ID.
+     * Obtains the ID of the requested record.
      *
-     * <p>This method returns {@code Optional.absent()} if none of the
-     * flags of visibility flags were set before.
-     *
-     * @param id the ID of the entity
-     * @return the aggregate visibility or {@code Optional.absent()}
+     * @return the record ID
      */
-    Optional<LifecycleFlags> readLifecycleFlags(I id);
-
-    /**
-     * Writes the visibility status for the entity with the passed ID.
-     *
-     * @param id         the ID of the entity for which to update the status
-     * @param flags the status to write
-     */
-    void writeLifecycleFlags(I id, LifecycleFlags flags);
+    I getId();
 }

--- a/server/src/main/java/io/spine/server/storage/RecordReadRequest.java
+++ b/server/src/main/java/io/spine/server/storage/RecordReadRequest.java
@@ -28,12 +28,13 @@ import java.util.Objects;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * A read request for {@link RecordStorage}.
+ * A request to read a particular record from {@link RecordStorage}.
  *
- * <p>A result of this request is a record with the specified id,
+ * <p>A result of this request is a record with the specified ID,
  * on which was applied the {@link #fieldMask}.
  *
- * <p>Two requests are considered equal if they have the same {@link #id} and {@link #fieldMask}.
+ * <p>Two requests are considered equal if they have the same
+ * {@linkplain #id ID} and {@linkplain #fieldMask field mask}.
  *
  * @param <I> the type of the target ID
  * @author Dmytro Grankin
@@ -44,9 +45,17 @@ public final class RecordReadRequest<I> implements ReadRequest<I> {
     private final I id;
     private final FieldMask fieldMask;
 
-    public RecordReadRequest(I id, FieldMask fieldMask) {
+    private RecordReadRequest(I id, FieldMask fieldMask) {
         this.id = checkNotNull(id);
         this.fieldMask = checkNotNull(fieldMask);
+    }
+
+    public static <I> RecordReadRequest<I> of(I id) {
+        return new RecordReadRequest<>(id, FieldMask.getDefaultInstance());
+    }
+
+    public static <I> RecordReadRequest<I> of(I id, FieldMask fieldMask) {
+        return new RecordReadRequest<>(id, fieldMask);
     }
 
     @Override
@@ -55,7 +64,7 @@ public final class RecordReadRequest<I> implements ReadRequest<I> {
     }
 
     /**
-     * Obtains the field mask to apply on the record with the {@linkplain #getId() ID}.
+     * Obtains the field mask to apply on the record with the {@linkplain #getRecordId() ID}.
      *
      * @return the field mask for the requested record
      */

--- a/server/src/main/java/io/spine/server/storage/RecordReadRequest.java
+++ b/server/src/main/java/io/spine/server/storage/RecordReadRequest.java
@@ -20,34 +20,39 @@
 
 package io.spine.server.storage;
 
-import com.google.common.base.Optional;
-import com.google.protobuf.Message;
-import io.spine.server.entity.LifecycleFlags;
+import com.google.protobuf.FieldMask;
+import io.spine.annotation.SPI;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * A storage that allows to update {@linkplain LifecycleFlags lifecycle flags} of entities.
+ * A read request for {@link RecordStorage}.
  *
- * @author Alexander Yevsyukov
+ * @param <I> the type of the target ID
+ * @author Dmytro Grankin
  */
-public interface StorageWithLifecycleFlags<I, R extends Message, Q extends ReadRequest<I>>
-        extends Storage<I, R, Q> {
+@SPI
+public final class RecordReadRequest<I> implements ReadRequest<I> {
+
+    private final I id;
+    private final FieldMask fieldMask;
+
+    public RecordReadRequest(I id, FieldMask fieldMask) {
+        this.id = checkNotNull(id);
+        this.fieldMask = checkNotNull(fieldMask);
+    }
+
+    @Override
+    public I getId() {
+        return id;
+    }
 
     /**
-     * Reads the visibility status for the entity with the passed ID.
+     * Obtains the field mask to apply on the record with the {@linkplain #getId() ID}.
      *
-     * <p>This method returns {@code Optional.absent()} if none of the
-     * flags of visibility flags were set before.
-     *
-     * @param id the ID of the entity
-     * @return the aggregate visibility or {@code Optional.absent()}
+     * @return the field mask for the requested record
      */
-    Optional<LifecycleFlags> readLifecycleFlags(I id);
-
-    /**
-     * Writes the visibility status for the entity with the passed ID.
-     *
-     * @param id         the ID of the entity for which to update the status
-     * @param flags the status to write
-     */
-    void writeLifecycleFlags(I id, LifecycleFlags flags);
+    public FieldMask getFieldMask() {
+        return fieldMask;
+    }
 }

--- a/server/src/main/java/io/spine/server/storage/RecordReadRequest.java
+++ b/server/src/main/java/io/spine/server/storage/RecordReadRequest.java
@@ -50,7 +50,7 @@ public final class RecordReadRequest<I> implements ReadRequest<I> {
     }
 
     @Override
-    public I getId() {
+    public I getRecordId() {
         return id;
     }
 

--- a/server/src/main/java/io/spine/server/storage/RecordReadRequest.java
+++ b/server/src/main/java/io/spine/server/storage/RecordReadRequest.java
@@ -55,4 +55,19 @@ public final class RecordReadRequest<I> implements ReadRequest<I> {
     public FieldMask getFieldMask() {
         return fieldMask;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        RecordReadRequest<?> that = (RecordReadRequest<?>) o;
+
+        return id.equals(that.id) && fieldMask.equals(that.fieldMask);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
 }

--- a/server/src/main/java/io/spine/server/storage/RecordReadRequest.java
+++ b/server/src/main/java/io/spine/server/storage/RecordReadRequest.java
@@ -29,7 +29,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * <p>A result of this request is a record with the specified ID.
  *
- * <p>Two requests are considered equal if they have the same {@linkplain #id ID}.
+ * <p>Two requests are considered equal if they have the same {@linkplain #getRecordId() record ID}.
  *
  * @param <I> the type of the target ID
  * @author Dmytro Grankin
@@ -37,15 +37,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Internal
 public final class RecordReadRequest<I> implements ReadRequest<I> {
 
-    private final I id;
+    private final I recordId;
 
-    public RecordReadRequest(I id) {
-        this.id = checkNotNull(id);
+    public RecordReadRequest(I recordId) {
+        this.recordId = checkNotNull(recordId);
     }
 
     @Override
     public I getRecordId() {
-        return id;
+        return recordId;
     }
 
     @Override
@@ -55,11 +55,11 @@ public final class RecordReadRequest<I> implements ReadRequest<I> {
 
         RecordReadRequest<?> that = (RecordReadRequest<?>) o;
 
-        return id.equals(that.id);
+        return recordId.equals(that.recordId);
     }
 
     @Override
     public int hashCode() {
-        return id.hashCode();
+        return recordId.hashCode();
     }
 }

--- a/server/src/main/java/io/spine/server/storage/RecordReadRequest.java
+++ b/server/src/main/java/io/spine/server/storage/RecordReadRequest.java
@@ -20,21 +20,16 @@
 
 package io.spine.server.storage;
 
-import com.google.protobuf.FieldMask;
 import io.spine.annotation.Internal;
-
-import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * A request to read a particular record from {@link RecordStorage}.
  *
- * <p>A result of this request is a record with the specified ID,
- * on which was applied the {@link #fieldMask}.
+ * <p>A result of this request is a record with the specified ID.
  *
- * <p>Two requests are considered equal if they have the same
- * {@linkplain #id ID} and {@linkplain #fieldMask field mask}.
+ * <p>Two requests are considered equal if they have the same {@linkplain #id ID}.
  *
  * @param <I> the type of the target ID
  * @author Dmytro Grankin
@@ -43,33 +38,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public final class RecordReadRequest<I> implements ReadRequest<I> {
 
     private final I id;
-    private final FieldMask fieldMask;
 
-    private RecordReadRequest(I id, FieldMask fieldMask) {
+    public RecordReadRequest(I id) {
         this.id = checkNotNull(id);
-        this.fieldMask = checkNotNull(fieldMask);
-    }
-
-    public static <I> RecordReadRequest<I> of(I id) {
-        return new RecordReadRequest<>(id, FieldMask.getDefaultInstance());
-    }
-
-    public static <I> RecordReadRequest<I> of(I id, FieldMask fieldMask) {
-        return new RecordReadRequest<>(id, fieldMask);
     }
 
     @Override
     public I getRecordId() {
         return id;
-    }
-
-    /**
-     * Obtains the field mask to apply on the record with the {@linkplain #getRecordId() ID}.
-     *
-     * @return the field mask for the requested record
-     */
-    public FieldMask getFieldMask() {
-        return fieldMask;
     }
 
     @Override
@@ -79,11 +55,11 @@ public final class RecordReadRequest<I> implements ReadRequest<I> {
 
         RecordReadRequest<?> that = (RecordReadRequest<?>) o;
 
-        return id.equals(that.id) && fieldMask.equals(that.fieldMask);
+        return id.equals(that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, fieldMask);
+        return id.hashCode();
     }
 }

--- a/server/src/main/java/io/spine/server/storage/RecordReadRequest.java
+++ b/server/src/main/java/io/spine/server/storage/RecordReadRequest.java
@@ -21,17 +21,24 @@
 package io.spine.server.storage;
 
 import com.google.protobuf.FieldMask;
-import io.spine.annotation.SPI;
+import io.spine.annotation.Internal;
+
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * A read request for {@link RecordStorage}.
  *
+ * <p>A result of this request is a record with the specified id,
+ * on which was applied the {@link #fieldMask}.
+ *
+ * <p>Two requests are considered equal if they have the same {@link #id} and {@link #fieldMask}.
+ *
  * @param <I> the type of the target ID
  * @author Dmytro Grankin
  */
-@SPI
+@Internal
 public final class RecordReadRequest<I> implements ReadRequest<I> {
 
     private final I id;
@@ -68,6 +75,6 @@ public final class RecordReadRequest<I> implements ReadRequest<I> {
 
     @Override
     public int hashCode() {
-        return id.hashCode();
+        return Objects.hash(id, fieldMask);
     }
 }

--- a/server/src/main/java/io/spine/server/storage/RecordStorage.java
+++ b/server/src/main/java/io/spine/server/storage/RecordStorage.java
@@ -57,32 +57,17 @@ public abstract class RecordStorage<I> extends AbstractStorage<I, EntityRecord, 
     }
 
     /**
-     * Reads a record from the storage using the specified ID.
-     *
-     * @param id the ID of the record to read
-     * @return a record instance or {@code Optional.absent()} if there is no record with this ID
-     */
-    public Optional<EntityRecord> read(I id) {
-        checkNotClosed();
-        checkNotNull(id);
-
-        final Optional<EntityRecord> record = readRecord(id);
-        return record;
-    }
-
-    /**
      * Reads a single item from the storage and applies a {@link FieldMask} to it.
      *
      * @param request the read request to the record
      * @return the record with the applied {@code FieldMask}.
-     * @see #read(Object)
      */
     @Override
     public Optional<EntityRecord> read(RecordReadRequest<I> request) {
         checkNotClosed();
         checkNotNull(request);
 
-        final Optional<EntityRecord> rawResult = read(request.getRecordId());
+        final Optional<EntityRecord> rawResult = readRecord(request.getRecordId());
 
         if (!rawResult.isPresent()) {
             return Optional.absent();
@@ -147,7 +132,8 @@ public abstract class RecordStorage<I> extends AbstractStorage<I, EntityRecord, 
 
     @Override
     public Optional<LifecycleFlags> readLifecycleFlags(I id) {
-        final Optional<EntityRecord> optional = read(id);
+        final RecordReadRequest<I> request = RecordReadRequest.of(id);
+        final Optional<EntityRecord> optional = read(request);
         if (optional.isPresent()) {
             return Optional.of(optional.get()
                                        .getLifecycleFlags());
@@ -157,7 +143,8 @@ public abstract class RecordStorage<I> extends AbstractStorage<I, EntityRecord, 
 
     @Override
     public void writeLifecycleFlags(I id, LifecycleFlags flags) {
-        final Optional<EntityRecord> optional = read(id);
+        final RecordReadRequest<I> request = RecordReadRequest.of(id);
+        final Optional<EntityRecord> optional = read(request);
         if (optional.isPresent()) {
             final EntityRecord record = optional.get();
             final EntityRecord updated = record.toBuilder()

--- a/server/src/main/java/io/spine/server/storage/RecordStorage.java
+++ b/server/src/main/java/io/spine/server/storage/RecordStorage.java
@@ -57,7 +57,10 @@ public abstract class RecordStorage<I> extends AbstractStorage<I, EntityRecord, 
     }
 
     /**
-     * {@inheritDoc}
+     * Reads a record from the storage using the specified ID.
+     *
+     * @param id the ID of the record to read
+     * @return a record instance or {@code Optional.absent()} if there is no record with this ID
      */
     public Optional<EntityRecord> read(I id) {
         checkNotClosed();
@@ -70,7 +73,7 @@ public abstract class RecordStorage<I> extends AbstractStorage<I, EntityRecord, 
     /**
      * Reads a single item from the storage and applies a {@link FieldMask} to it.
      *
-     * @param request ID of the item to read.
+     * @param request the read request to the record
      */
     @Override
     public Optional<EntityRecord> read(RecordReadRequest<I> request) {

--- a/server/src/main/java/io/spine/server/storage/RecordStorage.java
+++ b/server/src/main/java/io/spine/server/storage/RecordStorage.java
@@ -82,7 +82,7 @@ public abstract class RecordStorage<I> extends AbstractStorage<I, EntityRecord, 
         checkNotClosed();
         checkNotNull(request);
 
-        final Optional<EntityRecord> rawResult = read(request.getId());
+        final Optional<EntityRecord> rawResult = read(request.getRecordId());
 
         if (!rawResult.isPresent()) {
             return Optional.absent();

--- a/server/src/main/java/io/spine/server/storage/RecordStorage.java
+++ b/server/src/main/java/io/spine/server/storage/RecordStorage.java
@@ -80,22 +80,18 @@ public abstract class RecordStorage<I> extends AbstractStorage<I, EntityRecord, 
         checkNotClosed();
         checkNotNull(request);
 
-        final Optional<EntityRecord> record = read(request.getId());
+        final Optional<EntityRecord> rawResult = read(request.getId());
 
-        if (!record.isPresent()) {
+        if (!rawResult.isPresent()) {
             return Optional.absent();
         }
 
-        return applyFieldMask(request.getFieldMask(), record.get());
-    }
-
-    protected Optional<EntityRecord> applyFieldMask(FieldMask fieldMask,
-                                                    EntityRecord rawResult) {
-        final EntityRecord.Builder builder = EntityRecord.newBuilder(rawResult);
+        final EntityRecord.Builder builder = EntityRecord.newBuilder(rawResult.get());
         final Any state = builder.getState();
         final TypeUrl type = TypeUrl.parse(state.getTypeUrl());
         final Message stateAsMessage = AnyPacker.unpack(state);
 
+        final FieldMask fieldMask = request.getFieldMask();
         final Message maskedState = FieldMasks.applyMask(fieldMask, stateAsMessage, type);
 
         final Any packedState = AnyPacker.pack(maskedState);

--- a/server/src/main/java/io/spine/server/storage/RecordStorage.java
+++ b/server/src/main/java/io/spine/server/storage/RecordStorage.java
@@ -57,7 +57,7 @@ public abstract class RecordStorage<I> extends AbstractStorage<I, EntityRecord, 
     }
 
     /**
-     * Reads a record from the storage matching the specified request.
+     * Reads a record, which matches the specified {@linkplain RecordReadRequest request}.
      *
      * @param request the request to read the record
      * @return a record instance or {@code Optional.absent()} if there is no record with this ID
@@ -72,7 +72,8 @@ public abstract class RecordStorage<I> extends AbstractStorage<I, EntityRecord, 
     }
 
     /**
-     * Reads a record from the storage matching the request and applies a {@link FieldMask} to it.
+     * Reads a record, which matches the specified {@linkplain RecordReadRequest request}
+     * and applies a {@link FieldMask} to it.
      *
      * @param request   the request to read the record
      * @param fieldMask fields to read.

--- a/server/src/main/java/io/spine/server/storage/RecordStorage.java
+++ b/server/src/main/java/io/spine/server/storage/RecordStorage.java
@@ -74,6 +74,8 @@ public abstract class RecordStorage<I> extends AbstractStorage<I, EntityRecord, 
      * Reads a single item from the storage and applies a {@link FieldMask} to it.
      *
      * @param request the read request to the record
+     * @return the record with the applied {@code FieldMask}.
+     * @see #read(Object)
      */
     @Override
     public Optional<EntityRecord> read(RecordReadRequest<I> request) {

--- a/server/src/main/java/io/spine/server/storage/Storage.java
+++ b/server/src/main/java/io/spine/server/storage/Storage.java
@@ -53,7 +53,7 @@ public interface Storage<I, R extends Message, Q extends ReadRequest<I>> extends
     /**
      * Reads a record from the storage by the specified request.
      *
-     * @param request the read request to the storage
+     * @param request the request to read the record
      * @return a record instance
      *         or {@code Optional.absent()} if there is no record matching this request
      * @throws IllegalStateException if the storage was closed before

--- a/server/src/main/java/io/spine/server/storage/Storage.java
+++ b/server/src/main/java/io/spine/server/storage/Storage.java
@@ -30,12 +30,12 @@ import java.util.Iterator;
  * The base interface for storages.
  *
  * @param <I> the type of identifiers
- * @param <R> the type of records
- * @param <Q> the type of {@linkplain ReadRequest read requests}
+ * @param <M> the type of records
+ * @param <R> the type of {@linkplain ReadRequest read requests}
  * @author Alexander Yevsyukov
  */
 @SPI
-public interface Storage<I, R extends Message, Q extends ReadRequest<I>> extends AutoCloseable {
+public interface Storage<I, M extends Message, R extends ReadRequest<I>> extends AutoCloseable {
 
     /**
      * Verifies whether the storage is multitenant.
@@ -58,7 +58,7 @@ public interface Storage<I, R extends Message, Q extends ReadRequest<I>> extends
      *         or {@code Optional.absent()} if there is no record matching this request
      * @throws IllegalStateException if the storage was closed before
      */
-    Optional<R> read(Q request);
+    Optional<M> read(R request);
 
     /**
      * Writes a record into the storage.
@@ -69,7 +69,7 @@ public interface Storage<I, R extends Message, Q extends ReadRequest<I>> extends
      * @param record a record to store
      * @throws IllegalStateException if the storage is closed
      */
-    void write(I id, R record);
+    void write(I id, M record);
 
     /**
      * Closes the storage.

--- a/server/src/main/java/io/spine/server/storage/Storage.java
+++ b/server/src/main/java/io/spine/server/storage/Storage.java
@@ -51,10 +51,11 @@ public interface Storage<I, R extends Message, Q extends ReadRequest<I>> extends
     Iterator<I> index();
 
     /**
-     * Reads a record from the storage by the passed ID.
+     * Reads a record from the storage by the specified request.
      *
      * @param request the read request to the storage
-     * @return a record instance or {@code Optional.absent()} if there is no record with this ID
+     * @return a record instance
+     *         or {@code Optional.absent()} if there is no record matching this request
      * @throws IllegalStateException if the storage was closed before
      */
     Optional<R> read(Q request);

--- a/server/src/main/java/io/spine/server/storage/Storage.java
+++ b/server/src/main/java/io/spine/server/storage/Storage.java
@@ -31,10 +31,11 @@ import java.util.Iterator;
  *
  * @param <I> the type of identifiers
  * @param <R> the type of records
+ * @param <Q> the type of {@linkplain ReadRequest read requests}
  * @author Alexander Yevsyukov
  */
 @SPI
-public interface Storage<I, R extends Message> extends AutoCloseable {
+public interface Storage<I, R extends Message, Q extends ReadRequest<I>> extends AutoCloseable {
 
     /**
      * Verifies whether the storage is multitenant.
@@ -52,11 +53,11 @@ public interface Storage<I, R extends Message> extends AutoCloseable {
     /**
      * Reads a record from the storage by the passed ID.
      *
-     * @param id the ID of the record to read
+     * @param request the read request to the storage
      * @return a record instance or {@code Optional.absent()} if there is no record with this ID
      * @throws IllegalStateException if the storage was closed before
      */
-    Optional<R> read(I id);
+    Optional<R> read(Q request);
 
     /**
      * Writes a record into the storage.

--- a/server/src/main/java/io/spine/server/storage/StorageWithLifecycleFlags.java
+++ b/server/src/main/java/io/spine/server/storage/StorageWithLifecycleFlags.java
@@ -29,8 +29,8 @@ import io.spine.server.entity.LifecycleFlags;
  *
  * @author Alexander Yevsyukov
  */
-public interface StorageWithLifecycleFlags<I, R extends Message, Q extends ReadRequest<I>>
-        extends Storage<I, R, Q> {
+public interface StorageWithLifecycleFlags<I, M extends Message, R extends ReadRequest<I>>
+        extends Storage<I, M, R> {
 
     /**
      * Reads the visibility status for the entity with the passed ID.

--- a/server/src/main/java/io/spine/server/storage/memory/InMemoryAggregateStorage.java
+++ b/server/src/main/java/io/spine/server/storage/memory/InMemoryAggregateStorage.java
@@ -22,6 +22,7 @@ package io.spine.server.storage.memory;
 
 import com.google.common.base.Optional;
 import io.spine.server.aggregate.AggregateEventRecord;
+import io.spine.server.aggregate.AggregateReadRequest;
 import io.spine.server.aggregate.AggregateStorage;
 import io.spine.server.entity.LifecycleFlags;
 
@@ -98,9 +99,9 @@ class InMemoryAggregateStorage<I> extends AggregateStorage<I> {
     }
 
     @Override
-    protected Iterator<AggregateEventRecord> historyBackward(I id) {
-        checkNotNull(id);
-        final List<AggregateEventRecord> records = getStorage().getHistoryBackward(id);
+    protected Iterator<AggregateEventRecord> historyBackward(AggregateReadRequest<I> request) {
+        checkNotNull(request);
+        final List<AggregateEventRecord> records = getStorage().getHistoryBackward(request);
         return records.iterator();
     }
 }

--- a/server/src/main/java/io/spine/server/storage/memory/InMemoryStandStorage.java
+++ b/server/src/main/java/io/spine/server/storage/memory/InMemoryStandStorage.java
@@ -28,6 +28,7 @@ import io.spine.server.entity.storage.EntityQuery;
 import io.spine.server.entity.storage.EntityRecordWithColumns;
 import io.spine.server.stand.AggregateStateId;
 import io.spine.server.stand.StandStorage;
+import io.spine.server.storage.RecordReadRequest;
 import io.spine.type.TypeUrl;
 
 import javax.annotation.Nullable;
@@ -111,7 +112,8 @@ class InMemoryStandStorage extends StandStorage {
     @Nullable
     @Override
     protected Optional<EntityRecord> readRecord(AggregateStateId id) {
-        return recordStorage.read(id);
+        final RecordReadRequest<AggregateStateId> request = RecordReadRequest.of(id);
+        return recordStorage.read(request);
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/storage/memory/InMemoryStandStorage.java
+++ b/server/src/main/java/io/spine/server/storage/memory/InMemoryStandStorage.java
@@ -112,7 +112,7 @@ class InMemoryStandStorage extends StandStorage {
     @Nullable
     @Override
     protected Optional<EntityRecord> readRecord(AggregateStateId id) {
-        final RecordReadRequest<AggregateStateId> request = RecordReadRequest.of(id);
+        final RecordReadRequest<AggregateStateId> request = new RecordReadRequest<>(id);
         return recordStorage.read(request);
     }
 

--- a/server/src/main/java/io/spine/server/storage/memory/TenantAggregateRecords.java
+++ b/server/src/main/java/io/spine/server/storage/memory/TenantAggregateRecords.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Multimaps;
 import com.google.common.collect.TreeMultimap;
 import io.spine.core.Event;
 import io.spine.server.aggregate.AggregateEventRecord;
+import io.spine.server.aggregate.AggregateReadRequest;
 import io.spine.server.entity.EntityWithLifecycle;
 import io.spine.server.entity.LifecycleFlags;
 import io.spine.time.Timestamps2;
@@ -99,7 +100,8 @@ class TenantAggregateRecords<I> implements TenantStorage<I, AggregateEventRecord
      *
      * @return immutable list
      */
-    List<AggregateEventRecord> getHistoryBackward(I id) {
+    List<AggregateEventRecord> getHistoryBackward(AggregateReadRequest<I> request) {
+        final I id = request.getId();
         return ImmutableList.copyOf(filtered.get(id));
     }
 

--- a/server/src/main/java/io/spine/server/storage/memory/TenantAggregateRecords.java
+++ b/server/src/main/java/io/spine/server/storage/memory/TenantAggregateRecords.java
@@ -101,7 +101,7 @@ class TenantAggregateRecords<I> implements TenantStorage<I, AggregateEventRecord
      * @return immutable list
      */
     List<AggregateEventRecord> getHistoryBackward(AggregateReadRequest<I> request) {
-        final I id = request.getId();
+        final I id = request.getRecordId();
         return ImmutableList.copyOf(filtered.get(id));
     }
 

--- a/server/src/main/java/io/spine/server/tenant/TenantRepository.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantRepository.java
@@ -44,7 +44,7 @@ public abstract class TenantRepository<T extends Message, E extends TenantReposi
         implements TenantIndex {
 
     private final Set<TenantId> cache = Sets.newConcurrentHashSet();
-    
+
     @Override
     public void initStorage(StorageFactory factory) {
         super.initStorage(factory.toSingleTenant());
@@ -81,6 +81,7 @@ public abstract class TenantRepository<T extends Message, E extends TenantReposi
      *
      * <p>Implementations should call this method for removing the cached value
      * for a tenant, which record was removed from the repository.
+     *
      * @param id the ID to remove from the cache
      * @return {@code true} if the value was cached before and removed, {@code false} otherwise
      */
@@ -98,7 +99,7 @@ public abstract class TenantRepository<T extends Message, E extends TenantReposi
 
     @Override
     public Set<TenantId> getAll() {
-        final Storage<TenantId, ?> storage = getStorage();
+        final Storage<TenantId, ?, ?> storage = getStorage();
         final Iterator<TenantId> index = storage != null
                                          ? storage.index()
                                          : null;

--- a/server/src/test/java/io/spine/server/aggregate/AggregateReadRequestShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateReadRequestShould.java
@@ -30,24 +30,24 @@ import org.junit.Test;
 public class AggregateReadRequestShould {
 
     private static final String ID = "ID";
-    private static final int SNAPSHOT_TRIGGER = 10;
+    private static final int BATCH_SIZE = 10;
 
     @Test(expected = NullPointerException.class)
     public void not_accept_null_ID() {
-        new AggregateReadRequest<>(Tests.<String>nullRef(), SNAPSHOT_TRIGGER);
+        new AggregateReadRequest<>(Tests.<String>nullRef(), BATCH_SIZE);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void not_accept_non_positive_snapshot_trigger() {
+    public void not_accept_non_positive_batch_size() {
         new AggregateReadRequest<>(ID, 0);
     }
 
     @Test
     public void consider_request_with_same_ID_equal() {
-        final AggregateReadRequest<String> first = new AggregateReadRequest<>(ID, SNAPSHOT_TRIGGER);
-        final int differentTrigger = first.getSnapshotTrigger() * 2;
+        final AggregateReadRequest<String> first = new AggregateReadRequest<>(ID, BATCH_SIZE);
+        final int differentBatch = first.getBatchSize() * 2;
         final AggregateReadRequest<String> second = new AggregateReadRequest<>(ID,
-                                                                               differentTrigger);
+                                                                               differentBatch);
         new EqualsTester().addEqualityGroup(first, second)
                           .testEquals();
     }

--- a/server/src/test/java/io/spine/server/aggregate/AggregateReadRequestShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateReadRequestShould.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.aggregate;
+
+import com.google.common.testing.EqualsTester;
+import io.spine.test.Tests;
+import org.junit.Test;
+
+public class AggregateReadRequestShould {
+
+    private static final String ID = "id for an aggregate request";
+    private static final int SNAPSHOT_TRIGGER = 10;
+
+    @Test(expected = NullPointerException.class)
+    public void not_accept_null_ID() {
+        new AggregateReadRequest<>(Tests.<String>nullRef(), SNAPSHOT_TRIGGER);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void not_accept_non_positive_snapshot_trigger() {
+        new AggregateReadRequest<>(ID, 0);
+    }
+
+    @Test
+    public void consider_request_with_same_ID_equal() {
+        final AggregateReadRequest<String> first = new AggregateReadRequest<>(ID, SNAPSHOT_TRIGGER);
+        final int differentTrigger = first.getSnapshotTrigger() * 2;
+        final AggregateReadRequest<String> second = new AggregateReadRequest<>(ID,
+                                                                               differentTrigger);
+        new EqualsTester().addEqualityGroup(first, second)
+                          .testEquals();
+    }
+}

--- a/server/src/test/java/io/spine/server/aggregate/AggregateReadRequestShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateReadRequestShould.java
@@ -24,9 +24,12 @@ import com.google.common.testing.EqualsTester;
 import io.spine.test.Tests;
 import org.junit.Test;
 
+/**
+ * @author Dmytro Grankin
+ */
 public class AggregateReadRequestShould {
 
-    private static final String ID = "id for an aggregate request";
+    private static final String ID = "ID";
     private static final int SNAPSHOT_TRIGGER = 10;
 
     @Test(expected = NullPointerException.class)

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryShould.java
@@ -178,7 +178,7 @@ public class AggregateRepositoryShould {
         verify(storageSpy).read(requestCaptor.capture());
 
         final AggregateReadRequest<ProjectId> passedRequest = requestCaptor.getValue();
-        assertEquals(id, passedRequest.getId());
+        assertEquals(id, passedRequest.getRecordId());
         assertEquals(repositorySpy.getSnapshotTrigger(), passedRequest.getSnapshotTrigger());
     }
 
@@ -199,7 +199,7 @@ public class AggregateRepositoryShould {
         verify(storageSpy).read(requestCaptor.capture());
 
         final AggregateReadRequest<ProjectId> passedRequest = requestCaptor.getValue();
-        assertEquals(id, passedRequest.getId());
+        assertEquals(id, passedRequest.getRecordId());
         assertEquals(nonDefaultSnapshotTrigger, passedRequest.getSnapshotTrigger());
     }
 

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryShould.java
@@ -82,6 +82,9 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
+/**
+ * @author Alexander Yevsyukov
+ */
 public class AggregateRepositoryShould {
 
     private final TestActorRequestFactory requestFactory =

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryShould.java
@@ -182,7 +182,7 @@ public class AggregateRepositoryShould {
 
         final AggregateReadRequest<ProjectId> passedRequest = requestCaptor.getValue();
         assertEquals(id, passedRequest.getRecordId());
-        assertEquals(repositorySpy.getSnapshotTrigger(), passedRequest.getSnapshotTrigger());
+        assertEquals(repositorySpy.getSnapshotTrigger(), passedRequest.getBatchSize());
     }
 
     @SuppressWarnings("unchecked")
@@ -203,7 +203,7 @@ public class AggregateRepositoryShould {
 
         final AggregateReadRequest<ProjectId> passedRequest = requestCaptor.getValue();
         assertEquals(id, passedRequest.getRecordId());
-        assertEquals(nonDefaultSnapshotTrigger, passedRequest.getSnapshotTrigger());
+        assertEquals(nonDefaultSnapshotTrigger, passedRequest.getBatchSize());
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryShould.java
@@ -77,6 +77,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 public class AggregateRepositoryShould {
 
@@ -157,6 +160,21 @@ public class AggregateRepositoryShould {
         repository.store(aggregate);
         final AggregateStateRecord record = readRecord(aggregate);
         assertFalse(record.hasSnapshot());
+    }
+
+    @Test
+    public void set_snapshotTrigger_for_ReadAggregateRequest() {
+        final AggregateRepository<ProjectId, ProjectAggregate> repositorySpy = spy(repository);
+        final AggregateStorage<ProjectId> storageSpy = spy(repositorySpy.aggregateStorage());
+        doReturn(storageSpy).when(repositorySpy).aggregateStorage();
+
+        final ProjectId id = Sample.messageOfType(ProjectId.class);
+        repositorySpy.loadOrCreate(id);
+
+        final int expectedSnapshotTrigger = repositorySpy.getSnapshotTrigger();
+        final AggregateReadRequest<ProjectId> expectedRequest =
+                new AggregateReadRequest<>(id, expectedSnapshotTrigger);
+        verify(storageSpy).read(expectedRequest);
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryShould.java
@@ -170,6 +170,8 @@ public class AggregateRepositoryShould {
     @Test
     public void have_default_value_for_snapshot_trigger() {
         assertEquals(AggregateRepository.DEFAULT_SNAPSHOT_TRIGGER, repository.getSnapshotTrigger());
+        assertEquals(AggregateRepository.DEFAULT_SNAPSHOT_TRIGGER, repository.aggregateStorage()
+                                                                             .getSnapshotTrigger());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -189,6 +191,14 @@ public class AggregateRepositoryShould {
         repository.setSnapshotTrigger(newSnapshotTrigger);
 
         assertEquals(newSnapshotTrigger, repository.getSnapshotTrigger());
+        assertEquals(newSnapshotTrigger, repository.aggregateStorage()
+                                                   .getSnapshotTrigger());
+    }
+
+    @Test
+    public void not_update_snapshot_trigger_for_unassigned_storage() {
+        final ProjectAggregateRepository repoWithoutStorage = new ProjectAggregateRepository();
+        repoWithoutStorage.setSnapshotTrigger(10);
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryShould.java
@@ -168,7 +168,7 @@ public class AggregateRepositoryShould {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void set_snapshotTrigger_for_AggregateReadRequest() {
+    public void pass_initial_snapshot_trigger_to_AggregateReadRequest() {
         final AggregateRepository<ProjectId, ProjectAggregate> repositorySpy = spy(repository);
         final AggregateStorage<ProjectId> storageSpy = spy(repositorySpy.aggregateStorage());
         doReturn(storageSpy).when(repositorySpy).aggregateStorage();
@@ -187,7 +187,7 @@ public class AggregateRepositoryShould {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void set_updated_snapshotTrigger_for_AggregateReadRequest() {
+    public void pass_updated_snapshot_trigger_to_AggregateReadRequest() {
         final AggregateRepository<ProjectId, ProjectAggregate> repositorySpy = spy(repository);
         final AggregateStorage<ProjectId> storageSpy = spy(repositorySpy.aggregateStorage());
         doReturn(storageSpy).when(repositorySpy).aggregateStorage();
@@ -233,12 +233,6 @@ public class AggregateRepositoryShould {
         repository.setSnapshotTrigger(newSnapshotTrigger);
 
         assertEquals(newSnapshotTrigger, repository.getSnapshotTrigger());
-    }
-
-    @Test
-    public void not_update_snapshot_trigger_for_unassigned_storage() {
-        final ProjectAggregateRepository repoWithoutStorage = new ProjectAggregateRepository();
-        repoWithoutStorage.setSnapshotTrigger(10);
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
@@ -276,6 +276,11 @@ public abstract class AggregateStorageShould
         storage.readEventCountAfterLastSnapshot(id);
     }
 
+    @Test
+    public void have_default_snapshot_trigger() {
+        assertEquals(AggregateRepository.DEFAULT_SNAPSHOT_TRIGGER, storage.getSnapshotTrigger());
+    }
+
     private static Event generateEvent() {
         final TestEventFactory eventFactory = newInstance(AggregateStorageShould.class);
         final Event result = eventFactory.createEvent(Time.getCurrentTime());

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
@@ -127,7 +127,8 @@ public abstract class AggregateStorageShould
 
     @Test
     public void return_absent_AggregateStateRecord_if_read_history_from_empty_storage() {
-        final Optional<AggregateStateRecord> aggregateStateRecord = readRecord(id);
+        final AggregateReadRequest<ProjectId> readRequest = newReadRequest(id);
+        final Optional<AggregateStateRecord> aggregateStateRecord = storage.read(readRequest);
 
         assertFalse(aggregateStateRecord.isPresent());
     }

--- a/server/src/test/java/io/spine/server/entity/given/RepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/entity/given/RepositoryTestEnv.java
@@ -68,7 +68,7 @@ public class RepositoryTestEnv {
         }
 
         @Override
-        protected Storage<Exception, ?> createStorage(StorageFactory factory) {
+        protected Storage<Exception, ?, ?> createStorage(StorageFactory factory) {
             return null;
         }
     }

--- a/server/src/test/java/io/spine/server/stand/StandShould.java
+++ b/server/src/test/java/io/spine/server/stand/StandShould.java
@@ -338,8 +338,6 @@ public class StandShould extends TenantAwareTest {
                                                      .build();
         when(standStorageMock.readAllByType(any(TypeUrl.class)))
                 .thenReturn(nonEmptyList.iterator());
-        when(standStorageMock.read(any(AggregateStateId.class)))
-                .thenReturn(Optional.of(someRecord));
         when(standStorageMock.readAll())
                 .thenReturn(Collections.<EntityRecord>emptyIterator());
         when(standStorageMock.readMultiple(ArgumentMatchers.<AggregateStateId>anyIterable()))

--- a/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
@@ -128,7 +128,8 @@ public abstract class AbstractStorageShould<I,
     protected void writeAndReadRecordTest(I id) {
         final R expected = writeRecord(id);
 
-        final Optional<R> actual = readRecord(id);
+        final Q readRequest = newReadRequest(id);
+        final Optional<R> actual = storage.read(readRequest);
 
         assertTrue(actual.isPresent());
         assertEquals(expected, actual.get());
@@ -140,14 +141,10 @@ public abstract class AbstractStorageShould<I,
         return expected;
     }
 
-    protected Optional<R> readRecord(I id) {
-        final Q readRequest = newReadRequest(id);
-        return storage.read(readRequest);
-    }
-
     @Test
     public void handle_absence_of_record_with_passed_id() {
-        final Optional<R> record = readRecord(newId());
+        final Q readRequest = newReadRequest(newId());
+        final Optional<R> record = storage.read(readRequest);
 
         assertResultForMissingId(record);
     }
@@ -270,7 +267,8 @@ public abstract class AbstractStorageShould<I,
     public void close_itself_and_throw_exception_if_read_after() throws Exception {
         closeAndFailIfException(storage);
 
-        readRecord(newId());
+        final Q readRequest = newReadRequest(newId());
+        storage.read(readRequest);
     }
 
     @Test(expected = IllegalStateException.class)

--- a/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
@@ -45,14 +45,15 @@ import static org.junit.Assert.fail;
  * Abstract storage tests.
  *
  * @param <I> the type of IDs of storage records
- * @param <R> the type of records kept in the storage
+ * @param <M> the type of records kept in the storage
+ * @param <R> the type of read requests for the storage
  * @author Alexander Litus
  */
 @SuppressWarnings("ClassWithTooManyMethods")
 public abstract class AbstractStorageShould<I,
-                                            R extends Message,
-                                            Q extends ReadRequest<I>,
-                                            S extends AbstractStorage<I, R, Q>> {
+                                            M extends Message,
+                                            R extends ReadRequest<I>,
+                                            S extends AbstractStorage<I, M, R>> {
 
     private S storage;
 
@@ -91,13 +92,13 @@ public abstract class AbstractStorageShould<I,
     protected abstract S getStorage(Class<? extends Entity> cls);
 
     /** Creates a new storage record. */
-    protected abstract R newStorageRecord();
+    protected abstract M newStorageRecord();
 
     /** Creates a new unique storage record ID. */
     protected abstract I newId();
 
     /** Creates a new read request with the specified ID. */
-    protected abstract Q newReadRequest(I id);
+    protected abstract R newReadRequest(I id);
 
     /**
      * Closes the storage and propagates an exception if any occurs.
@@ -114,7 +115,7 @@ public abstract class AbstractStorageShould<I,
 
     /** Closes the storage and fails the test if any exception occurs. */
     @SuppressWarnings("CallToPrintStackTrace")
-    protected void closeAndFailIfException(AbstractStorage<I, R, Q> storage) {
+    protected void closeAndFailIfException(AbstractStorage<I, M, R> storage) {
         try {
             storage.close();
         } catch (Exception e) {
@@ -126,37 +127,37 @@ public abstract class AbstractStorageShould<I,
     /** Writes a record, reads it and asserts it is the same as the expected one. */
     @SuppressWarnings("OptionalGetWithoutIsPresent") // We do check.
     protected void writeAndReadRecordTest(I id) {
-        final R expected = writeRecord(id);
+        final M expected = writeRecord(id);
 
-        final Q readRequest = newReadRequest(id);
-        final Optional<R> actual = storage.read(readRequest);
+        final R readRequest = newReadRequest(id);
+        final Optional<M> actual = storage.read(readRequest);
 
         assertTrue(actual.isPresent());
         assertEquals(expected, actual.get());
     }
 
-    private R writeRecord(I id) {
-        final R expected = newStorageRecord();
+    private M writeRecord(I id) {
+        final M expected = newStorageRecord();
         storage.write(id, expected);
         return expected;
     }
 
     @Test
     public void handle_absence_of_record_with_passed_id() {
-        final Q readRequest = newReadRequest(newId());
-        final Optional<R> record = storage.read(readRequest);
+        final R readRequest = newReadRequest(newId());
+        final Optional<M> record = storage.read(readRequest);
 
         assertResultForMissingId(record);
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType") // This is the purpose of the method.
-    protected void assertResultForMissingId(Optional<R> record) {
+    protected void assertResultForMissingId(Optional<M> record) {
         assertFalse(record.isPresent());
     }
 
     @Test(expected = NullPointerException.class)
     public void throw_exception_if_read_by_null_id() {
-        storage.read(Tests.<Q>nullRef());
+        storage.read(Tests.<R>nullRef());
     }
 
     @Test(expected = NullPointerException.class)
@@ -166,7 +167,7 @@ public abstract class AbstractStorageShould<I,
 
     @Test(expected = NullPointerException.class)
     public void throw_exception_if_write_null_record() {
-        storage.write(newId(), Tests.<R>nullRef());
+        storage.write(newId(), Tests.<M>nullRef());
     }
 
     @Test
@@ -267,7 +268,7 @@ public abstract class AbstractStorageShould<I,
     public void close_itself_and_throw_exception_if_read_after() throws Exception {
         closeAndFailIfException(storage);
 
-        final Q readRequest = newReadRequest(newId());
+        final R readRequest = newReadRequest(newId());
         storage.read(readRequest);
     }
 

--- a/server/src/test/java/io/spine/server/storage/RecordReadRequestShould.java
+++ b/server/src/test/java/io/spine/server/storage/RecordReadRequestShould.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage;
+
+import com.google.common.testing.EqualsTester;
+import com.google.protobuf.FieldMask;
+import io.spine.test.Tests;
+import org.junit.Test;
+
+public class RecordReadRequestShould {
+
+    private static final String ID = "id for a record request";
+    private static final FieldMask FIELD_MASK = FieldMask.getDefaultInstance();
+
+    @Test(expected = NullPointerException.class)
+    public void not_accept_null_ID() {
+        new RecordReadRequest<>(Tests.<String>nullRef(), FIELD_MASK);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void not_accept_null_field_mask() {
+        new RecordReadRequest<>(ID, Tests.<FieldMask>nullRef());
+    }
+
+    @Test
+    public void consider_request_with_same_id_and_field_mask_equal() {
+        final RecordReadRequest<String> first = new RecordReadRequest<>(ID, FIELD_MASK);
+        final RecordReadRequest<String> second = new RecordReadRequest<>(ID, FIELD_MASK);
+        new EqualsTester().addEqualityGroup(first, second)
+                          .testEquals();
+    }
+}

--- a/server/src/test/java/io/spine/server/storage/RecordReadRequestShould.java
+++ b/server/src/test/java/io/spine/server/storage/RecordReadRequestShould.java
@@ -21,7 +21,6 @@
 package io.spine.server.storage;
 
 import com.google.common.testing.EqualsTester;
-import com.google.protobuf.FieldMask;
 import io.spine.test.Tests;
 import org.junit.Test;
 
@@ -30,23 +29,16 @@ import org.junit.Test;
  */
 public class RecordReadRequestShould {
 
-    private static final String ID = "ID";
-    private static final FieldMask FIELD_MASK = FieldMask.getDefaultInstance();
-
     @Test(expected = NullPointerException.class)
     public void not_accept_null_ID() {
-        RecordReadRequest.of(Tests.<String>nullRef());
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void not_accept_null_field_mask() {
-        RecordReadRequest.of(ID, Tests.<FieldMask>nullRef());
+        new RecordReadRequest<>(Tests.nullRef());
     }
 
     @Test
-    public void consider_request_with_same_id_and_field_mask_equal() {
-        final RecordReadRequest<String> first = RecordReadRequest.of(ID, FIELD_MASK);
-        final RecordReadRequest<String> second = RecordReadRequest.of(ID, FIELD_MASK);
+    public void consider_request_with_same_id_equal() {
+        final String id = "ID";
+        final RecordReadRequest<String> first = new RecordReadRequest<>(id);
+        final RecordReadRequest<String> second = new RecordReadRequest<>(id);
         new EqualsTester().addEqualityGroup(first, second)
                           .testEquals();
     }

--- a/server/src/test/java/io/spine/server/storage/RecordReadRequestShould.java
+++ b/server/src/test/java/io/spine/server/storage/RecordReadRequestShould.java
@@ -25,9 +25,12 @@ import com.google.protobuf.FieldMask;
 import io.spine.test.Tests;
 import org.junit.Test;
 
+/**
+ * @author Dmytro Grankin
+ */
 public class RecordReadRequestShould {
 
-    private static final String ID = "id for a record request";
+    private static final String ID = "ID";
     private static final FieldMask FIELD_MASK = FieldMask.getDefaultInstance();
 
     @Test(expected = NullPointerException.class)

--- a/server/src/test/java/io/spine/server/storage/RecordReadRequestShould.java
+++ b/server/src/test/java/io/spine/server/storage/RecordReadRequestShould.java
@@ -35,18 +35,18 @@ public class RecordReadRequestShould {
 
     @Test(expected = NullPointerException.class)
     public void not_accept_null_ID() {
-        new RecordReadRequest<>(Tests.<String>nullRef(), FIELD_MASK);
+        RecordReadRequest.of(Tests.<String>nullRef());
     }
 
     @Test(expected = NullPointerException.class)
     public void not_accept_null_field_mask() {
-        new RecordReadRequest<>(ID, Tests.<FieldMask>nullRef());
+        RecordReadRequest.of(ID, Tests.<FieldMask>nullRef());
     }
 
     @Test
     public void consider_request_with_same_id_and_field_mask_equal() {
-        final RecordReadRequest<String> first = new RecordReadRequest<>(ID, FIELD_MASK);
-        final RecordReadRequest<String> second = new RecordReadRequest<>(ID, FIELD_MASK);
+        final RecordReadRequest<String> first = RecordReadRequest.of(ID, FIELD_MASK);
+        final RecordReadRequest<String> second = RecordReadRequest.of(ID, FIELD_MASK);
         new EqualsTester().addEqualityGroup(first, second)
                           .testEquals();
     }

--- a/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
@@ -125,7 +125,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
 
     @Override
     protected RecordReadRequest<I> newReadRequest(I id) {
-        return RecordReadRequest.of(id);
+        return new RecordReadRequest<>(id);
     }
 
     private EntityRecord newStorageRecord(I id) {
@@ -195,8 +195,8 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final Descriptors.Descriptor descriptor = newState(id).getDescriptorForType();
         final FieldMask idMask = FieldMasks.maskOf(descriptor, 1);
 
-        final RecordReadRequest<I> readRequest = RecordReadRequest.of(id, idMask);
-        final Optional<EntityRecord> optional = storage.read(readRequest);
+        final RecordReadRequest<I> readRequest = new RecordReadRequest<>(id);
+        final Optional<EntityRecord> optional = storage.read(readRequest, idMask);
         assertTrue(optional.isPresent());
         final EntityRecord entityRecord = optional.get();
 

--- a/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
@@ -91,7 +91,7 @@ import static org.mockito.Mockito.verify;
  * @author Dmytro Dashenkov
  */
 public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
-        extends AbstractStorageShould<I, EntityRecord, S> {
+        extends AbstractStorageShould<I, EntityRecord, RecordReadRequest<I>, S> {
 
     private static final Function<EntityRecordWithColumns, EntityRecord> RECORD_EXTRACTOR_FUNCTION =
             new Function<EntityRecordWithColumns, EntityRecord>() {
@@ -121,6 +121,11 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     @Override
     protected EntityRecord newStorageRecord() {
         return newStorageRecord(newState(newId()));
+    }
+
+    @Override
+    protected RecordReadRequest<I> newReadRequest(I id) {
+        return new RecordReadRequest<>(id, FieldMask.getDefaultInstance());
     }
 
     private EntityRecord newStorageRecord(I id) {
@@ -189,7 +194,8 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final Descriptors.Descriptor descriptor = newState(id).getDescriptorForType();
         final FieldMask idMask = FieldMasks.maskOf(descriptor, 1);
 
-        final Optional<EntityRecord> optional = storage.read(id, idMask);
+        final RecordReadRequest<I> readRequest = new RecordReadRequest<>(id, idMask);
+        final Optional<EntityRecord> optional = storage.read(readRequest);
         assertTrue(optional.isPresent());
         final EntityRecord entityRecord = optional.get();
 

--- a/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
@@ -125,7 +125,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
 
     @Override
     protected RecordReadRequest<I> newReadRequest(I id) {
-        return new RecordReadRequest<>(id, FieldMask.getDefaultInstance());
+        return RecordReadRequest.of(id);
     }
 
     private EntityRecord newStorageRecord(I id) {
@@ -160,7 +160,8 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityRecord expected = newStorageRecord(id);
         storage.write(id, expected);
 
-        final EntityRecord actual = storage.read(id)
+        final RecordReadRequest<I> readRequest = newReadRequest(id);
+        final EntityRecord actual = storage.read(readRequest)
                                            .get();
 
         assertEquals(expected, actual);
@@ -194,7 +195,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final Descriptors.Descriptor descriptor = newState(id).getDescriptorForType();
         final FieldMask idMask = FieldMasks.maskOf(descriptor, 1);
 
-        final RecordReadRequest<I> readRequest = new RecordReadRequest<>(id, idMask);
+        final RecordReadRequest<I> readRequest = RecordReadRequest.of(id, idMask);
         final Optional<EntityRecord> optional = storage.read(readRequest);
         assertTrue(optional.isPresent());
         final EntityRecord entityRecord = optional.get();
@@ -251,7 +252,8 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         assertTrue(storage.delete(id));
 
         // There's no record with such ID.
-        assertFalse(storage.read(id)
+        final RecordReadRequest<I> readRequest = newReadRequest(id);
+        assertFalse(storage.read(readRequest)
                            .isPresent());
     }
 
@@ -390,7 +392,8 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final RecordStorage<I> storage = getDefaultStorage();
 
         storage.write(id, recordWithStorageFields);
-        final Optional<EntityRecord> actualRecord = storage.read(id);
+        final RecordReadRequest<I> readRequest = newReadRequest(id);
+        final Optional<EntityRecord> actualRecord = storage.read(readRequest);
         assertTrue(actualRecord.isPresent());
         assertEquals(record, actualRecord.get());
     }
@@ -404,7 +407,8 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final S storage = getDefaultStorage();
         storage.write(id, recordWithColumns);
 
-        final Optional<EntityRecord> readRecord = storage.read(id);
+        final RecordReadRequest<I> readRequest = newReadRequest(id);
+        final Optional<EntityRecord> readRecord = storage.read(readRequest);
         assertTrue(readRecord.isPresent());
         assertEquals(record, readRecord.get());
     }


### PR DESCRIPTION
At the moment `AggregateRepository` is responsible for restoring an `Aggregate` state from its events. To do that each repository instance talks to `AggregateStorage`, which in turn performs all the low-level storage interactions. In particular, it loads up a history of events down to the most recent snapshot for a given `Aggregate` instance.

Up until now `AggregateStorage` was only given with an aggregate identifier, as a parameter for event loading. However, as it turns out, this isn't always enough for a performance-effective implementation.

In order to allow different types of `Repositories` (not just `AggregateRepository`) to pass some specific parameters down to the corresponding `Storage` implementations (again, not just to `AggregateStorage`), this PR generalizes the parameter, passed to `Storage.read(..)` method. Instead of passing just a typed identifier, an instance of `ReadRequest` is now passed.

The design intention here is to have several `Storage`-specific implementations of `ReadRequest`, each wrapping request parameters sufficient for an effective operation of the underlying `Storage`.

Also, in scope of this PR an implementation of such a request is introduced for `AggregateStorage` and `RecordStorage`:

* `AggregateReadRequest`, which brings a notion of the event count to read until the most recent snapshot; repository, in turn, passes a `snapshotTrigger` value as a best guess;
* `RecordReadRequest`, which simply wraps a record identifier for now (in future its functionality may be extended).

Also, see [Datastore-specific performance issue](https://github.com/SpineEventEngine/gae-java/issues/60) on the same matter.

The framework version has been increased to `0.9.75-SNAPSHOT`.