### PR TITLE
Ensure that `Projection`s and `ProcessManager`s declare at least one message handler during repository registration

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.9.76-SNAPSHOT'
+def final SPINE_VERSION = '0.9.77-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
@@ -154,9 +154,8 @@ public abstract class ProcessManagerRepository<I,
      * @param bus        the bus to register dispatchers in
      * @param dispatcher the dispatcher to register
      * @param <D>        the type of dispatcher
-     * @return
-     * {@code true} if there are message classes to dispatch by the given dispatchers,
-     * {@code false} otherwise
+     * @return {@code true} if there are message classes to dispatch by the given dispatchers,
+     *         {@code false} otherwise
      */
     @SuppressWarnings("unchecked")  // To avoid a long "train" of generic parameter definitions.
     private static <D extends MessageDispatcher<?, ?, ?>> boolean register(Bus<?, ?, ?, D> bus,

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
@@ -134,7 +134,7 @@ public abstract class ProcessManagerRepository<I,
                                                            rejDispatcher.getExternalDispatcher());
         final boolean handlesDomesticEvents = !getMessageClasses().isEmpty();
         final boolean handlesExternalEvents = !getExternalEventDispatcher().getMessageClasses()
-                                                                          .isEmpty();
+                                                                           .isEmpty();
 
         final boolean subscribesToEvents = handlesDomesticEvents || handlesExternalEvents;
         final boolean reactsUponRejections = handlesDomesticRejections || handlesExternalRejections;

--- a/server/src/test/java/io/spine/server/procman/ProcessManagerRepositoryShould.java
+++ b/server/src/test/java/io/spine/server/procman/ProcessManagerRepositoryShould.java
@@ -45,6 +45,7 @@ import io.spine.server.entity.rejection.StandardRejections.EntityAlreadyArchived
 import io.spine.server.entity.rejection.StandardRejections.EntityAlreadyDeleted;
 import io.spine.server.event.EventSubscriber;
 import io.spine.server.procman.given.ProcessManagerRepositoryTestEnv;
+import io.spine.server.procman.given.ProcessManagerRepositoryTestEnv.SensoryDeprivedPmRepository;
 import io.spine.server.procman.given.ProcessManagerRepositoryTestEnv.TestProcessManager;
 import io.spine.server.procman.given.ProcessManagerRepositoryTestEnv.TestProcessManagerRepository;
 import io.spine.test.procman.Project;
@@ -270,6 +271,16 @@ public class ProcessManagerRepositoryShould
         assertTrue(delivered.contains(id));
 
         assertTrue(TestProcessManager.processed(rejectionMessage));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void throw_exception_on_attempt_to_register_in_bc_with_no_messages_handled() {
+        final SensoryDeprivedPmRepository repo = new SensoryDeprivedPmRepository();
+        final BoundedContext boundedContext = BoundedContext.newBuilder()
+                                                   .setMultitenant(false)
+                                                   .build();
+        repo.setBoundedContext(boundedContext);
+        repo.onRegistered();
     }
 
     /**

--- a/server/src/test/java/io/spine/server/procman/given/ProcessManagerRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/procman/given/ProcessManagerRepositoryTestEnv.java
@@ -252,4 +252,25 @@ public class ProcessManagerRepositoryTestEnv {
                     .build();
         }
     }
+
+    /**
+     * A process manager, that handles no messages.
+     *
+     * <p>It should not be able to register repositories for such classes.
+     */
+    public static class SensoryDeprivedProcessManager
+            extends ProcessManager<ProjectId, Project, ProjectVBuilder> {
+
+        protected SensoryDeprivedProcessManager(ProjectId id) {
+            super(id);
+        }
+    }
+
+    /**
+     * A repository, that cannot be registered in {@code BoundedContext},
+     * since no messages are declared to handle by the {@linkplain SensoryDeprivedProcessManager
+     * process manager class}.
+     */
+    public static class SensoryDeprivedPmRepository
+            extends ProcessManagerRepository<ProjectId, SensoryDeprivedProcessManager, Project> {}
 }

--- a/server/src/test/java/io/spine/server/projection/ProjectionRepositoryShould.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionRepositoryShould.java
@@ -42,6 +42,7 @@ import io.spine.server.entity.RecordBasedRepositoryShould;
 import io.spine.server.entity.given.Given;
 import io.spine.server.projection.given.ProjectionRepositoryTestEnv.GivenEventMessage;
 import io.spine.server.projection.given.ProjectionRepositoryTestEnv.NoOpTaskNamesRepository;
+import io.spine.server.projection.given.ProjectionRepositoryTestEnv.SensoryDeprivedProjectionRepository;
 import io.spine.server.projection.given.ProjectionRepositoryTestEnv.TestProjection;
 import io.spine.server.projection.given.ProjectionRepositoryTestEnv.TestProjectionRepository;
 import io.spine.server.storage.RecordStorage;
@@ -320,5 +321,15 @@ public class ProjectionRepositoryShould
     @Test
     public void expose_bounded_context_to_package() {
         assertNotNull(repository().boundedContext());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void throw_exception_on_attempt_to_register_in_bc_with_no_messages_handled() {
+        final SensoryDeprivedProjectionRepository repo = new SensoryDeprivedProjectionRepository();
+        final BoundedContext boundedContext = BoundedContext.newBuilder()
+                                                            .setMultitenant(false)
+                                                            .build();
+        repo.setBoundedContext(boundedContext);
+        repo.onRegistered();
     }
 }

--- a/server/src/test/java/io/spine/server/projection/given/ProjectionRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/projection/given/ProjectionRepositoryTestEnv.java
@@ -229,4 +229,25 @@ public class ProjectionRepositoryTestEnv {
                                .build();
         }
     }
+
+    /**
+     * A projection, that handles no messages.
+     *
+     * <p>It should not be able to register repositories for such classes.
+     */
+    public static class SensoryDeprivedProjection
+            extends Projection<ProjectId, Project, ProjectVBuilder> {
+
+        protected SensoryDeprivedProjection(ProjectId id) {
+            super(id);
+        }
+    }
+
+    /**
+     * A repository, that cannot be registered in {@code BoundedContext},
+     * since no messages are declared to handle by the {@linkplain SensoryDeprivedProjection
+     * projection class}.
+     */
+    public static class SensoryDeprivedProjectionRepository
+            extends ProjectionRepository<ProjectId, SensoryDeprivedProjection, Project> {}
 }


### PR DESCRIPTION
Before this PR it was possible to register `ProjectionRepository` and `ProcessManagerRepository` instances  in `BoundedContext`, even if the managed entity did not declare any handler methods (i.e. nothing marked with `@Subscribe` or `@React`).

At the same time such a check was already implemented for `AggregateRepository`.

This changeset addresses this behavior inconsistency and prevents Spine users from such a mistake.

Now, mandatory checks for the proper entity declaration are implemented. They are performed upon a repository registration in the `BoundedContext`. If an entity has no message handler methods, an `IllegalStateException` is raised — similar to the behavior implemented for `AggregateRepository`.

The version of the framework has been set to `0.9.77-SNAPSHOT`.