### PR TITLE
Remove an enrichment information from events before storing to `AggregateStorage`

### DIFF
--- a/core/src/main/java/io/spine/core/Events.java
+++ b/core/src/main/java/io/spine/core/Events.java
@@ -262,9 +262,10 @@ public final class Events {
                 throw newIllegalStateException("Unsupported origin case is encountered: %s",
                                                originCase);
         }
-        return event.toBuilder()
-                    .setContext(resultContext)
-                    .build();
+        final Event result = event.toBuilder()
+                                  .setContext(resultContext)
+                                  .build();
+        return result;
     }
 
     /**

--- a/core/src/main/java/io/spine/core/Events.java
+++ b/core/src/main/java/io/spine/core/Events.java
@@ -221,8 +221,7 @@ public final class Events {
     /**
      * Clears enrichments of the specified event.
      *
-     * <p>This method may be helpful to decrease a size of an event,
-     * when enrichments aren't important.
+     * <p>Use this method to decrease a size of an event, if enrichments aren't important.
      *
      * <p>A result won't contain:
      * <ul>

--- a/core/src/main/java/io/spine/core/Events.java
+++ b/core/src/main/java/io/spine/core/Events.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.protobuf.AnyPacker.unpack;
+import static io.spine.util.Exceptions.newIllegalStateException;
 import static io.spine.validate.Validate.checkNotEmptyOrBlank;
 
 /**
@@ -215,6 +216,52 @@ public final class Events {
     public static boolean isExternal(EventContext context) {
         checkNotNull(context);
         return context.getExternal();
+    }
+
+    /**
+     * Obtains the compacted version of the event, which should be used for storing.
+     *
+     * <p>A compacted version doesn't contain:
+     * <ul>
+     *     <li>the enrichment from the event context;</li>
+     *     <li>the enrichment from the origin;</li>
+     *     <li>nested origins if the origin is {@link EventContext}.</li>
+     * </ul>
+     *
+     * @param event the event to compact
+     * @return the compacted event
+     */
+    @Internal
+    public static Event compact(Event event) {
+        final EventContext context = event.getContext();
+        final EventContext.Builder resultContext = context.toBuilder()
+                                                          .clearEnrichment();
+        final EventContext.OriginCase originCase = resultContext.getOriginCase();
+        switch (originCase) {
+            case EVENT_CONTEXT:
+                resultContext.setEventContext(context.getEventContext()
+                                                     .toBuilder()
+                                                     .clearOrigin()
+                                                     .clearEnrichment());
+                break;
+            case REJECTION_CONTEXT:
+                resultContext.setRejectionContext(context.getRejectionContext()
+                                                         .toBuilder()
+                                                         .clearEnrichment());
+                break;
+            case COMMAND_CONTEXT:
+                // Nothing to remove.
+                break;
+            case ORIGIN_NOT_SET:
+                // Does nothing because there is no origin for this event.
+                break;
+            default:
+                throw newIllegalStateException("Unsupported origin case encountered: %s",
+                                               originCase);
+        }
+        return event.toBuilder()
+                    .setContext(resultContext)
+                    .build();
     }
 
     /**

--- a/core/src/main/java/io/spine/core/Events.java
+++ b/core/src/main/java/io/spine/core/Events.java
@@ -256,7 +256,7 @@ public final class Events {
                 // Does nothing because there is no origin for this event.
                 break;
             default:
-                throw newIllegalStateException("Unsupported origin case encountered: %s",
+                throw newIllegalStateException("Unsupported origin case is encountered: %s",
                                                originCase);
         }
         return event.toBuilder()

--- a/core/src/main/java/io/spine/core/Events.java
+++ b/core/src/main/java/io/spine/core/Events.java
@@ -219,22 +219,25 @@ public final class Events {
     }
 
     /**
-     * Obtains the compacted version of the event, which should be used for storing.
+     * Clears enrichments of the specified event.
      *
-     * <p>A compacted version doesn't contain:
+     * <p>This method may be helpful to decrease a size of an event,
+     * when enrichments aren't important.
+     *
+     * <p>A result won't contain:
      * <ul>
      *     <li>the enrichment from the event context;</li>
      *     <li>the enrichment from the first-level origin.</li>
      * </ul>
      *
-     * <p>Enrichments will not be removed from second-level and more deeper origins,
+     * <p>Enrichments will not be removed from second-level and deeper origins,
      * because it's a heavy performance operation.
      *
-     * @param event the event to compact
-     * @return the compacted event
+     * @param event the event to clear enrichments
+     * @return the event without enrichments
      */
     @Internal
-    public static Event compact(Event event) {
+    public static Event clearEnrichments(Event event) {
         final EventContext context = event.getContext();
         final EventContext.Builder resultContext = context.toBuilder()
                                                           .clearEnrichment();

--- a/core/src/main/java/io/spine/core/Events.java
+++ b/core/src/main/java/io/spine/core/Events.java
@@ -224,9 +224,11 @@ public final class Events {
      * <p>A compacted version doesn't contain:
      * <ul>
      *     <li>the enrichment from the event context;</li>
-     *     <li>the enrichment from the origin;</li>
-     *     <li>nested origins if the origin is {@link EventContext}.</li>
+     *     <li>the enrichment from the first-level origin.</li>
      * </ul>
+     *
+     * <p>Enrichments will not be removed from second-level and more deeper origins,
+     * because it's a heavy performance operation.
      *
      * @param event the event to compact
      * @return the compacted event
@@ -241,7 +243,6 @@ public final class Events {
             case EVENT_CONTEXT:
                 resultContext.setEventContext(context.getEventContext()
                                                      .toBuilder()
-                                                     .clearOrigin()
                                                      .clearEnrichment());
                 break;
             case REJECTION_CONTEXT:

--- a/core/src/main/proto/spine/core/enrichment.proto
+++ b/core/src/main/proto/spine/core/enrichment.proto
@@ -34,7 +34,7 @@ import "google/protobuf/any.proto";
 // Attributes with additional information (enrichment) for an outer message.
 //
 // A message can be enriched with one or more messages. For example, an `Event` can be enriched with
-// information for easier building of user interface projections. A `Rejection` can be eriched with
+// information for easier building of user interface projections. A `Rejection` can be enriched with
 // additional information on why the command was rejected.
 //
 // If message enrichment should not be performed (e.g. because of performance or security

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.9.77-SNAPSHOT'
+def final SPINE_VERSION = '0.9.78-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
@@ -38,6 +38,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Lists.newLinkedList;
 import static com.google.protobuf.TextFormat.shortDebugString;
 import static com.google.protobuf.util.Timestamps.checkValid;
+import static io.spine.core.Events.compact;
 import static io.spine.util.Exceptions.newIllegalStateException;
 import static io.spine.validate.Validate.checkNotEmptyOrBlank;
 
@@ -156,13 +157,17 @@ public abstract class AggregateStorage<I>
     /**
      * Writes an event to the storage by an aggregate ID.
      *
+     * <p>Before the storing, an event will be
+     * {@linkplain io.spine.core.Events#compact(Event) compacted}.
+     *
      * @param id    the aggregate ID
      * @param event the event to write
      */
     void writeEvent(I id, Event event) {
         checkNotClosedAndArguments(id, event);
 
-        final AggregateEventRecord record = toStorageRecord(event);
+        final Event compacted = compact(event);
+        final AggregateEventRecord record = toStorageRecord(compacted);
         writeRecord(id, record);
     }
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
@@ -38,7 +38,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Lists.newLinkedList;
 import static com.google.protobuf.TextFormat.shortDebugString;
 import static com.google.protobuf.util.Timestamps.checkValid;
-import static io.spine.core.Events.compact;
+import static io.spine.core.Events.clearEnrichments;
 import static io.spine.util.Exceptions.newIllegalStateException;
 import static io.spine.validate.Validate.checkNotEmptyOrBlank;
 
@@ -157,8 +157,8 @@ public abstract class AggregateStorage<I>
     /**
      * Writes an event to the storage by an aggregate ID.
      *
-     * <p>Before the storing, an event will be
-     * {@linkplain io.spine.core.Events#compact(Event) compacted}.
+     * <p>Before the storing, {@linkplain io.spine.core.Events#clearEnrichments(Event) enrichments}
+     * will be removed from the event.
      *
      * @param id    the aggregate ID
      * @param event the event to write
@@ -166,8 +166,8 @@ public abstract class AggregateStorage<I>
     void writeEvent(I id, Event event) {
         checkNotClosedAndArguments(id, event);
 
-        final Event compacted = compact(event);
-        final AggregateEventRecord record = toStorageRecord(compacted);
+        final Event eventWithoutEnrichments = clearEnrichments(event);
+        final AggregateEventRecord record = toStorageRecord(eventWithoutEnrichments);
         writeRecord(id, record);
     }
 

--- a/server/src/main/java/io/spine/server/event/EEntity.java
+++ b/server/src/main/java/io/spine/server/event/EEntity.java
@@ -33,12 +33,12 @@ import io.spine.type.TypeName;
 import javax.annotation.Nullable;
 import java.util.Comparator;
 
-import static io.spine.core.Events.compact;
+import static io.spine.core.Events.clearEnrichments;
 
 /**
  * An entity for storing an event.
  *
- * <p>The entity {@linkplain Events#compact(Event) compacts} an underlying event.
+ * <p>An underlying event doesn't contain {@linkplain Events#clearEnrichments(Event) enrichments}.
  *
  * @author Alexander Yevsyukov
  * @author Dmytro Dashenkov
@@ -88,8 +88,8 @@ public class EEntity extends AbstractEntity<EventId, Event> {
 
     EEntity(Event event) {
         this(event.getId());
-        final Event compactedEvent = compact(event);
-        updateState(compactedEvent);
+        final Event eventWithoutEnrichments = clearEnrichments(event);
+        updateState(eventWithoutEnrichments);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/event/EEntity.java
+++ b/server/src/main/java/io/spine/server/event/EEntity.java
@@ -36,7 +36,9 @@ import java.util.Comparator;
 import static io.spine.core.Events.compact;
 
 /**
- * Stores an event.
+ * An entity for storing an event.
+ *
+ * <p>The entity {@linkplain Events#compact(Event) compacts} an underlying event.
  *
  * @author Alexander Yevsyukov
  * @author Dmytro Dashenkov

--- a/server/src/main/java/io/spine/server/event/EEntity.java
+++ b/server/src/main/java/io/spine/server/event/EEntity.java
@@ -23,7 +23,6 @@ package io.spine.server.event;
 import com.google.protobuf.Timestamp;
 import io.spine.annotation.Internal;
 import io.spine.core.Event;
-import io.spine.core.EventContext;
 import io.spine.core.EventEnvelope;
 import io.spine.core.EventId;
 import io.spine.core.Events;
@@ -34,7 +33,7 @@ import io.spine.type.TypeName;
 import javax.annotation.Nullable;
 import java.util.Comparator;
 
-import static io.spine.util.Exceptions.newIllegalStateException;
+import static io.spine.core.Events.compact;
 
 /**
  * Stores an event.
@@ -127,50 +126,5 @@ public class EEntity extends AbstractEntity<EventId, Event> {
                                     .getTypeName();
         }
         return typeName.value();
-    }
-
-    /**
-     * Obtains the compacted version of the event.
-     *
-     * <p>A compacted version doesn't contain:
-     * <ul>
-     *     <li>the enrichment from the event context</li>
-     *     <li>the enrichment from the origin</li>
-     *     <li>nested origins if the origin is {@link EventContext}</li>
-     * </ul>
-     *
-     * @param event the event to compact
-     * @return the compacted event
-     */
-    private static Event compact(Event event) {
-        final EventContext context = event.getContext();
-        final EventContext.Builder resultContext = context.toBuilder()
-                                                          .clearEnrichment();
-        final EventContext.OriginCase originCase = resultContext.getOriginCase();
-        switch (originCase) {
-            case EVENT_CONTEXT:
-                resultContext.setEventContext(context.getEventContext()
-                                                     .toBuilder()
-                                                     .clearOrigin()
-                                                     .clearEnrichment());
-                break;
-            case REJECTION_CONTEXT:
-                resultContext.setRejectionContext(context.getRejectionContext()
-                                                         .toBuilder()
-                                                         .clearEnrichment());
-                break;
-            case COMMAND_CONTEXT:
-                // Does nothing.
-                break;
-            case ORIGIN_NOT_SET:
-                // Does nothing because there is no origin for this event.
-                break;
-            default:
-                throw newIllegalStateException("Unsupported origin case encountered: %s",
-                                               originCase);
-        }
-        return event.toBuilder()
-                    .setContext(resultContext)
-                    .build();
     }
 }

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
@@ -54,7 +54,7 @@ import static com.google.protobuf.util.Timestamps.add;
 import static io.spine.Identifier.newUuid;
 import static io.spine.core.Versions.increment;
 import static io.spine.core.Versions.zero;
-import static io.spine.core.given.GivenEnrichment.newEnrichment;
+import static io.spine.core.given.GivenEnrichment.withOneAttribute;
 import static io.spine.server.aggregate.given.Given.StorageRecords.sequenceFor;
 import static io.spine.server.command.TestEventFactory.newInstance;
 import static io.spine.time.Durations2.seconds;
@@ -352,7 +352,7 @@ public abstract class AggregateStorageShould
     @Test
     public void not_store_enrichment_for_EventContext() {
         final EventContext enrichedContext = EventContext.newBuilder()
-                                                         .setEnrichment(newEnrichment())
+                                                         .setEnrichment(withOneAttribute())
                                                          .build();
         final Event event = Event.newBuilder()
                                  .setContext(enrichedContext)
@@ -369,7 +369,7 @@ public abstract class AggregateStorageShould
     @Test
     public void not_store_enrichment_for_origin_of_RejectionContext_type() {
         final RejectionContext origin = RejectionContext.newBuilder()
-                                                        .setEnrichment(newEnrichment())
+                                                        .setEnrichment(withOneAttribute())
                                                         .build();
         final EventContext context = EventContext.newBuilder()
                                                  .setRejectionContext(origin)
@@ -390,7 +390,7 @@ public abstract class AggregateStorageShould
     @Test
     public void not_store_enrichment_for_origin_of_EventContext_type() {
         final EventContext origin = EventContext.newBuilder()
-                                                .setEnrichment(newEnrichment())
+                                                .setEnrichment(withOneAttribute())
                                                 .build();
         final EventContext context = EventContext.newBuilder()
                                                  .setEventContext(origin)

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
@@ -54,7 +54,7 @@ import static com.google.protobuf.util.Timestamps.add;
 import static io.spine.Identifier.newUuid;
 import static io.spine.core.Versions.increment;
 import static io.spine.core.Versions.zero;
-import static io.spine.core.given.GivenEnrichment.enabledEnrichment;
+import static io.spine.core.given.GivenEnrichment.newEnrichment;
 import static io.spine.server.aggregate.given.Given.StorageRecords.sequenceFor;
 import static io.spine.server.command.TestEventFactory.newInstance;
 import static io.spine.time.Durations2.seconds;
@@ -352,7 +352,7 @@ public abstract class AggregateStorageShould
     @Test
     public void not_store_enrichment_for_EventContext() {
         final EventContext enrichedContext = EventContext.newBuilder()
-                                                         .setEnrichment(enabledEnrichment())
+                                                         .setEnrichment(newEnrichment())
                                                          .build();
         final Event event = Event.newBuilder()
                                  .setContext(enrichedContext)
@@ -369,7 +369,7 @@ public abstract class AggregateStorageShould
     @Test
     public void not_store_enrichment_for_origin_of_RejectionContext_type() {
         final RejectionContext origin = RejectionContext.newBuilder()
-                                                        .setEnrichment(enabledEnrichment())
+                                                        .setEnrichment(newEnrichment())
                                                         .build();
         final EventContext context = EventContext.newBuilder()
                                                  .setRejectionContext(origin)
@@ -390,7 +390,7 @@ public abstract class AggregateStorageShould
     @Test
     public void not_store_enrichment_for_origin_of_EventContext_type() {
         final EventContext origin = EventContext.newBuilder()
-                                                .setEnrichment(enabledEnrichment())
+                                                .setEnrichment(newEnrichment())
                                                 .build();
         final EventContext context = EventContext.newBuilder()
                                                  .setEventContext(origin)

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
@@ -408,30 +408,6 @@ public abstract class AggregateStorageShould
         assertTrue(isDefault(loadedOrigin.getEnrichment()));
     }
 
-    @Test
-    public void not_store_nested_origin_for_EventContext_origin() {
-        final EventContext nestedOrigin = EventContext.newBuilder()
-                                                      .setEnrichment(enabledEnrichment())
-                                                      .build();
-        final EventContext origin = EventContext.newBuilder()
-                                                .setEventContext(nestedOrigin)
-                                                .build();
-        final EventContext context = EventContext.newBuilder()
-                                                 .setEventContext(origin)
-                                                 .build();
-        final Event event = Event.newBuilder()
-                                 .setContext(context)
-                                 .setMessage(Any.getDefaultInstance())
-                                 .build();
-        storage.writeEvent(id, event);
-        final EventContext loadedOrigin = storage.read(newReadRequest(id))
-                                                 .get()
-                                                 .getEvent(0)
-                                                 .getContext()
-                                                 .getEventContext();
-        assertTrue(isDefault(loadedOrigin.getEventContext()));
-    }
-
     @Test(expected = IllegalStateException.class)
     public void throw_exception_if_try_to_write_event_count_to_closed_storage() {
         close(storage);

--- a/server/src/test/java/io/spine/server/event/EventStoreShould.java
+++ b/server/src/test/java/io/spine/server/event/EventStoreShould.java
@@ -50,7 +50,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.google.common.collect.Sets.newConcurrentHashSet;
 import static com.google.protobuf.util.Timestamps.add;
 import static com.google.protobuf.util.Timestamps.subtract;
-import static io.spine.core.given.GivenEnrichment.enabledEnrichment;
+import static io.spine.core.given.GivenEnrichment.newEnrichment;
 import static io.spine.grpc.StreamObservers.memoizingObserver;
 import static io.spine.test.Verify.assertContainsAll;
 import static io.spine.test.Verify.assertSize;
@@ -238,7 +238,7 @@ public class EventStoreShould {
         final Event enriched = event.toBuilder()
                                     .setContext(event.getContext()
                                                      .toBuilder()
-                                                     .setEnrichment(enabledEnrichment()))
+                                                     .setEnrichment(newEnrichment()))
                                     .build();
         eventStore.append(enriched);
         final MemoizingObserver<Event> observer = memoizingObserver();
@@ -252,7 +252,7 @@ public class EventStoreShould {
     @Test
     public void not_store_enrichment_for_origin_of_RejectionContext_type() {
         final RejectionContext originContext = RejectionContext.newBuilder()
-                                                               .setEnrichment(enabledEnrichment())
+                                                               .setEnrichment(newEnrichment())
                                                                .build();
         final Event event = projectCreated(Time.getCurrentTime());
         final Event enriched = event.toBuilder()
@@ -273,7 +273,7 @@ public class EventStoreShould {
     @Test
     public void not_store_enrichment_for_origin_of_EventContext_type() {
         final EventContext.Builder originContext = EventContext.newBuilder()
-                                                               .setEnrichment(enabledEnrichment());
+                                                               .setEnrichment(newEnrichment());
         final Event event = projectCreated(Time.getCurrentTime());
         final Event enriched = event.toBuilder()
                                     .setContext(event.getContext()

--- a/server/src/test/java/io/spine/server/event/EventStoreShould.java
+++ b/server/src/test/java/io/spine/server/event/EventStoreShould.java
@@ -290,29 +290,6 @@ public class EventStoreShould {
         assertTrue(isDefault(loadedOriginContext.getEnrichment()));
     }
 
-    @Test
-    public void not_store_nested_origins_for_EventContext_origin() {
-        final EventContext.Builder context = EventContext.newBuilder()
-                                                         .setEnrichment(enabledEnrichment());
-        final EventContext originContext = EventContext.newBuilder()
-                                                       .setEventContext(context)
-                                                       .build();
-        final Event event = projectCreated(Time.getCurrentTime());
-        final Event enriched = event.toBuilder()
-                                    .setContext(event.getContext()
-                                                     .toBuilder()
-                                                     .setEventContext(originContext))
-                                    .build();
-        eventStore.append(enriched);
-        final MemoizingObserver<Event> observer = memoizingObserver();
-        eventStore.read(EventStreamQuery.getDefaultInstance(), observer);
-        final EventContext loadedOriginContext = observer.responses()
-                                                         .get(0)
-                                                         .getContext()
-                                                         .getEventContext();
-        assertTrue(isDefault(loadedOriginContext.getEventContext()));
-    }
-
     /*
      * Test environment
      *********************/

--- a/server/src/test/java/io/spine/server/event/EventStoreShould.java
+++ b/server/src/test/java/io/spine/server/event/EventStoreShould.java
@@ -50,7 +50,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.google.common.collect.Sets.newConcurrentHashSet;
 import static com.google.protobuf.util.Timestamps.add;
 import static com.google.protobuf.util.Timestamps.subtract;
-import static io.spine.core.given.GivenEnrichment.newEnrichment;
+import static io.spine.core.given.GivenEnrichment.withOneAttribute;
 import static io.spine.grpc.StreamObservers.memoizingObserver;
 import static io.spine.test.Verify.assertContainsAll;
 import static io.spine.test.Verify.assertSize;
@@ -238,7 +238,7 @@ public class EventStoreShould {
         final Event enriched = event.toBuilder()
                                     .setContext(event.getContext()
                                                      .toBuilder()
-                                                     .setEnrichment(newEnrichment()))
+                                                     .setEnrichment(withOneAttribute()))
                                     .build();
         eventStore.append(enriched);
         final MemoizingObserver<Event> observer = memoizingObserver();
@@ -252,7 +252,7 @@ public class EventStoreShould {
     @Test
     public void not_store_enrichment_for_origin_of_RejectionContext_type() {
         final RejectionContext originContext = RejectionContext.newBuilder()
-                                                               .setEnrichment(newEnrichment())
+                                                               .setEnrichment(withOneAttribute())
                                                                .build();
         final Event event = projectCreated(Time.getCurrentTime());
         final Event enriched = event.toBuilder()
@@ -273,7 +273,7 @@ public class EventStoreShould {
     @Test
     public void not_store_enrichment_for_origin_of_EventContext_type() {
         final EventContext.Builder originContext = EventContext.newBuilder()
-                                                               .setEnrichment(newEnrichment());
+                                                               .setEnrichment(withOneAttribute());
         final Event event = projectCreated(Time.getCurrentTime());
         final Event enriched = event.toBuilder()
                                     .setContext(event.getContext()

--- a/testutil-core/src/main/java/io/spine/core/given/GivenEnrichment.java
+++ b/testutil-core/src/main/java/io/spine/core/given/GivenEnrichment.java
@@ -34,9 +34,8 @@ import static io.spine.protobuf.TypeConverter.toMessage;
  */
 public class GivenEnrichment {
 
-    private GivenEnrichment() {
-        // Prevent instantiation of this utility class.
-    }
+    /** Prevents instantiation of this utility class. */
+    private GivenEnrichment() {}
 
     /**
      * Creates a new {@link Enrichment} with one {@linkplain Enrichment#getContainer() attribute}.

--- a/testutil-core/src/main/java/io/spine/core/given/GivenEnrichment.java
+++ b/testutil-core/src/main/java/io/spine/core/given/GivenEnrichment.java
@@ -21,7 +21,6 @@
 package io.spine.core.given;
 
 import com.google.protobuf.Any;
-import com.google.protobuf.Message;
 import io.spine.core.Enrichment;
 
 import static com.google.protobuf.Any.pack;
@@ -40,8 +39,8 @@ public class GivenEnrichment {
     }
 
     /**
-     * Creates a non-{@linkplain io.spine.validate.Validate#isDefault(Message) default}
-     * {@link Enrichment}.
+     * Creates a non-{@linkplain io.spine.validate.Validate#isDefault(com.google.protobuf.Message)
+     * default} {@link Enrichment}.
      *
      * @return a new enrichment instance
      */

--- a/testutil-core/src/main/java/io/spine/core/given/GivenEnrichment.java
+++ b/testutil-core/src/main/java/io/spine/core/given/GivenEnrichment.java
@@ -51,10 +51,11 @@ public class GivenEnrichment {
     public static Enrichment enabledEnrichment() {
         final String key = newUuid();
         final Any value = pack(toMessage(newUuid()));
-        return Enrichment.newBuilder()
-                         .setContainer(Enrichment.Container.newBuilder()
-                                                           .putItems(key, value)
-                                                           .build())
-                         .build();
+        final Enrichment result = Enrichment.newBuilder()
+                                            .setContainer(Enrichment.Container.newBuilder()
+                                                                              .putItems(key, value)
+                                                                              .build())
+                                            .build();
+        return result;
     }
 }

--- a/testutil-core/src/main/java/io/spine/core/given/GivenEnrichment.java
+++ b/testutil-core/src/main/java/io/spine/core/given/GivenEnrichment.java
@@ -28,7 +28,7 @@ import static io.spine.Identifier.newUuid;
 import static io.spine.protobuf.TypeConverter.toMessage;
 
 /**
- * Factory methods to create {@code Enrichment} instances for test purposes.
+ * Factory methods to create {@code Enrichment} instances in test purposes.
  *
  * @author Dmytro Grankin
  */
@@ -39,12 +39,13 @@ public class GivenEnrichment {
     }
 
     /**
-     * Creates a non-{@linkplain io.spine.validate.Validate#isDefault(com.google.protobuf.Message)
-     * default} {@link Enrichment}.
+     * Creates a new {@link Enrichment} with one {@linkplain Enrichment#getContainer() attribute}.
+     *
+     * <p>An enrichment attribute is invalid and has random values.
      *
      * @return a new enrichment instance
      */
-    public static Enrichment newEnrichment() {
+    public static Enrichment withOneAttribute() {
         final String key = newUuid();
         final Any value = pack(toMessage(newUuid()));
         final Enrichment result = Enrichment.newBuilder()

--- a/testutil-core/src/main/java/io/spine/core/given/GivenEnrichment.java
+++ b/testutil-core/src/main/java/io/spine/core/given/GivenEnrichment.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.core.given;
+
+import com.google.protobuf.Any;
+import io.spine.core.Enrichment;
+
+import static com.google.protobuf.Any.pack;
+import static io.spine.Identifier.newUuid;
+import static io.spine.protobuf.TypeConverter.toMessage;
+
+/**
+ * Factory methods to create {@code Enrichment} instances for test purposes.
+ *
+ * @author Dmytro Grankin
+ */
+public class GivenEnrichment {
+
+    private GivenEnrichment() {
+        // Prevent instantiation of this utility class.
+    }
+
+    /**
+     * Creates a new enabled {@link Enrichment}.
+     *
+     * <p>A result will contain an enrichment {@linkplain Enrichment#getContainer() instruction}.
+     *
+     * <p>An enrichment instruction is invalid and has random values.
+     *
+     * @return an enabled enrichment
+     * @see Enrichment.ModeCase#getDoNotEnrich()
+     */
+    public static Enrichment enabledEnrichment() {
+        final String key = newUuid();
+        final Any value = pack(toMessage(newUuid()));
+        return Enrichment.newBuilder()
+                         .setContainer(Enrichment.Container.newBuilder()
+                                                           .putItems(key, value)
+                                                           .build())
+                         .build();
+    }
+}

--- a/testutil-core/src/main/java/io/spine/core/given/GivenEnrichment.java
+++ b/testutil-core/src/main/java/io/spine/core/given/GivenEnrichment.java
@@ -21,6 +21,7 @@
 package io.spine.core.given;
 
 import com.google.protobuf.Any;
+import com.google.protobuf.Message;
 import io.spine.core.Enrichment;
 
 import static com.google.protobuf.Any.pack;
@@ -39,16 +40,12 @@ public class GivenEnrichment {
     }
 
     /**
-     * Creates a new enabled {@link Enrichment}.
+     * Creates a non-{@linkplain io.spine.validate.Validate#isDefault(Message) default}
+     * {@link Enrichment}.
      *
-     * <p>A result will contain an enrichment {@linkplain Enrichment#getContainer() instruction}.
-     *
-     * <p>An enrichment instruction is invalid and has random values.
-     *
-     * @return an enabled enrichment
-     * @see Enrichment.ModeCase#getDoNotEnrich()
+     * @return a new enrichment instance
      */
-    public static Enrichment enabledEnrichment() {
+    public static Enrichment newEnrichment() {
         final String key = newUuid();
         final Any value = pack(toMessage(newUuid()));
         final Enrichment result = Enrichment.newBuilder()

--- a/testutil-core/src/test/java/io/spine/core/given/GivenEnrichmentShould.java
+++ b/testutil-core/src/test/java/io/spine/core/given/GivenEnrichmentShould.java
@@ -20,13 +20,15 @@
 
 package io.spine.core.given;
 
+import com.google.protobuf.Any;
 import io.spine.core.Enrichment;
 import org.junit.Test;
 
-import static io.spine.core.given.GivenEnrichment.newEnrichment;
+import java.util.Map;
+
+import static io.spine.core.given.GivenEnrichment.withOneAttribute;
 import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
-import static io.spine.validate.Validate.isDefault;
-import static org.junit.Assert.assertFalse;
+import static io.spine.test.Verify.assertSize;
 
 /**
  * @author Dmytro Grankin
@@ -39,8 +41,10 @@ public class GivenEnrichmentShould {
     }
 
     @Test
-    public void create_non_default_enrichment() {
-        final Enrichment enrichment = newEnrichment();
-        assertFalse(isDefault(enrichment));
+    public void create_enrichment_with_one_attribute() {
+        final Enrichment enrichment = withOneAttribute();
+        final Map<String, Any> enrichmentAttributes = enrichment.getContainer()
+                                                                .getItems();
+        assertSize(1, enrichmentAttributes);
     }
 }

--- a/testutil-core/src/test/java/io/spine/core/given/GivenEnrichmentShould.java
+++ b/testutil-core/src/test/java/io/spine/core/given/GivenEnrichmentShould.java
@@ -23,6 +23,7 @@ package io.spine.core.given;
 import io.spine.core.Enrichment;
 import org.junit.Test;
 
+import static io.spine.core.given.GivenEnrichment.newEnrichment;
 import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
 import static io.spine.validate.Validate.isDefault;
 import static org.junit.Assert.assertFalse;
@@ -39,7 +40,7 @@ public class GivenEnrichmentShould {
 
     @Test
     public void create_non_default_enrichment() {
-        final Enrichment enrichment = enrichment();
+        final Enrichment enrichment = newEnrichment();
         assertFalse(isDefault(enrichment));
     }
 }

--- a/testutil-core/src/test/java/io/spine/core/given/GivenEnrichmentShould.java
+++ b/testutil-core/src/test/java/io/spine/core/given/GivenEnrichmentShould.java
@@ -20,15 +20,11 @@
 
 package io.spine.core.given;
 
-import com.google.protobuf.Any;
 import io.spine.core.Enrichment;
 import org.junit.Test;
 
-import java.util.Map;
-
-import static io.spine.core.given.GivenEnrichment.enabledEnrichment;
 import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
-import static io.spine.test.Verify.assertNotEmpty;
+import static io.spine.validate.Validate.isDefault;
 import static org.junit.Assert.assertFalse;
 
 /**
@@ -42,11 +38,8 @@ public class GivenEnrichmentShould {
     }
 
     @Test
-    public void create_enabled_enrichment() {
-        final Enrichment enrichment = enabledEnrichment();
-        assertFalse(enrichment.getDoNotEnrich());
-        final Map<String, Any> enrichmentInstructions = enrichment.getContainer()
-                                                                  .getItems();
-        assertNotEmpty(enrichmentInstructions);
+    public void create_non_default_enrichment() {
+        final Enrichment enrichment = enrichment();
+        assertFalse(isDefault(enrichment));
     }
 }

--- a/testutil-core/src/test/java/io/spine/core/given/GivenEnrichmentShould.java
+++ b/testutil-core/src/test/java/io/spine/core/given/GivenEnrichmentShould.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.core.given;
+
+import com.google.protobuf.Any;
+import io.spine.core.Enrichment;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static io.spine.core.given.GivenEnrichment.enabledEnrichment;
+import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
+import static io.spine.test.Verify.assertNotEmpty;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author Dmytro Grankin
+ */
+public class GivenEnrichmentShould {
+
+    @Test
+    public void have_private_utility_ctor() {
+        assertHasPrivateParameterlessCtor(GivenEnrichment.class);
+    }
+
+    @Test
+    public void create_enabled_enrichment() {
+        final Enrichment enrichment = enabledEnrichment();
+        assertFalse(enrichment.getDoNotEnrich());
+        final Map<String, Any> enrichmentInstructions = enrichment.getContainer()
+                                                                  .getItems();
+        assertNotEmpty(enrichmentInstructions);
+    }
+}


### PR DESCRIPTION
Storage of `Aggregate` event records stores event enrichments, that aren't needed and take a lot of space.

To fix this behavior, `AggregateStorage.writeEvent(...)` method was changed and now it clears enrichments from the event context and the enrichment from the first-level origin of the specified event. But the event will still contain enrichments from second-level and deeper origins, because their removal is a heavy performance operation.

Other changes:
* `EEntity` was fixed. Now, it removes only enrichments from an event.
* `GivenEnrichment` utility was introduced.
* The framework version was increased to `0.9.78-SNAPSHOT`.
