### PR TITLE
`README` updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ or provide custom storage implementations.
 If you need to use API with one of these annotations, please [contact us][email-developers].
 
 [email-developers]: mailto:spine-developers@teamdev.com
-[latest-release]: https://github.com/SpineEventEngine/core-java/releases/tag/0.8.0 
-[spine-site]: https://spine3.org/
+[latest-release]: https://github.com/SpineEventEngine/core-java/releases/tag/0.10.0 
+[spine-site]: https://spine.io/
 [spine-git-book]: https://docs.spine3.org/
 [wiki-home]: https://github.com/SpineEventEngine/core-java/wiki
 [java-code-style]: https://github.com/SpineEventEngine/core-java/wiki/Java-Code-Style 

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.0'
+def final SPINE_VERSION = '0.10.1-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.


### PR DESCRIPTION
This PR fixes markdown variable values to point to the latest release and a new site.

Also, the version is set to `0.10.1-SNAPSHOT` to avoid accidental re-publishing of previously released version.