### PR TITLE
Allow to customize `AggregateRepository.load()` behavior

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.3-SNAPSHOT'
+def final SPINE_VERSION = '0.10.2-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.1-SNAPSHOT'
+def final SPINE_VERSION = '0.10.3-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -428,8 +428,8 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
     /**
      * Loads an aggregate by the passed ID.
      *
-     * <p>This method defines the basic flow of an {@code Aggregate} loading. First
-     * the {@linkplain AggregateStateRecord Aggregate State} is {@linkplain #loadOrCreate loaded}
+     * <p>This method defines the basic flow of an {@code Aggregate} loading. First,
+     * the {@linkplain AggregateStateRecord Aggregate state} is {@linkplain #loadOrCreate loaded}
      * from the storage. Then the {@code Aggregate} is {@linkplain #reify reified} from it's state.
      *
      * @param id the ID of the aggregate

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -429,54 +429,56 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * Loads an aggregate by the passed ID.
      *
      * <p>This method defines the basic flow of an {@code Aggregate} loading. First,
-     * the {@linkplain AggregateStateRecord Aggregate state} is {@linkplain #loadOrCreate loaded}
-     * from the storage. Then the {@code Aggregate} is {@linkplain #reify reified} from it's state.
+     * the {@linkplain AggregateStateRecord Aggregate history} is
+     * {@linkplain #fetchHistory fetched} from the storage. Then the {@code Aggregate} is
+     * {@linkplain #play restored} from its state history.
      *
      * @param id the ID of the aggregate
      * @return the loaded instance or {@code Optional.absent()} if there is no {@code Aggregate}
      *         with the ID
      */
     private Optional<A> load(I id) {
-        final Optional<AggregateStateRecord> eventsFromStorage = loadState(id);
+        final Optional<AggregateStateRecord> eventsFromStorage = fetchHistory(id);
         if (eventsFromStorage.isPresent()) {
-            final A result = reify(id, eventsFromStorage.get());
+            final A result = play(id, eventsFromStorage.get());
             return Optional.of(result);
         }
         return Optional.absent();
     }
 
     /**
-     * Loads the state of the {@code Aggregate} with the given ID.
+     * Fetches the history of the {@code Aggregate} with the given ID.
      *
      * <p>To read an {@link AggregateStateRecord} from an {@link AggregateStorage},
      * a {@linkplain #getSnapshotTrigger() snapshot trigger} is used as a
      * {@linkplain AggregateReadRequest#getBatchSize() batch size}.
      *
-     * @param id the ID of the {@code Aggregate} to load
+     * @param id the ID of the {@code Aggregate} to fetch
      * @return the {@link AggregateStateRecord} for the {@code Aggregate} or
      *         {@code Optional.absent()} if there is no record with the ID
      */
-    protected Optional<AggregateStateRecord> loadState(I id) {
+    protected Optional<AggregateStateRecord> fetchHistory(I id) {
         final AggregateReadRequest<I> request = new AggregateReadRequest<>(id, snapshotTrigger);
         final Optional<AggregateStateRecord> eventsFromStorage = aggregateStorage().read(request);
         return eventsFromStorage;
     }
 
     /**
-     * Materializes the given {@linkplain AggregateStateRecord Aggregate state} into an instance
-     * of {@link Aggregate}.
+     * Plays the given {@linkplain AggregateStateRecord Aggregate history} onto an instance
+     * of {@link Aggregate} with the given ID.
      *
-     * <p>Loads the instance from the ID, (optionally) snapshot and events from the
-     * {@code AggregateStateRecord}.
+     * <p>Creates an instance of {@code Aggregate} with the given ID, restores its state from
+     * the {@link Snapshot} present in the {@code history} and applies the events from
+     * the {@code history}.
      *
-     * @param id          the ID of the {@code Aggregate} to load
-     * @param stateRecord the state record of the {@code Aggregate} to load
+     * @param id      the ID of the {@code Aggregate} to load
+     * @param history the state record of the {@code Aggregate} to load
      * @return an instance of {@link Aggregate}
      */
-    protected A reify(I id, AggregateStateRecord stateRecord) {
+    protected A play(I id, AggregateStateRecord history) {
         final A result = create(id);
         final AggregateTransaction tx = AggregateTransaction.start(result);
-        result.play(stateRecord);
+        result.play(history);
         tx.commit();
         return result;
     }

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -435,7 +435,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * @param id the ID of the aggregate
      * @return the loaded instance or {@code Optional.absent()} if there is no record with the ID
      */
-    private Optional<A> load(I id) {
+    Optional<A> load(I id) {
         final AggregateReadRequest<I> request = new AggregateReadRequest<>(id, snapshotTrigger);
         final Optional<AggregateStateRecord> eventsFromStorage = aggregateStorage().read(request);
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -464,12 +464,8 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
     }
 
     /**
-     * Plays the given {@linkplain AggregateStateRecord Aggregate history} onto an instance
+     * Plays the given {@linkplain AggregateStateRecord Aggregate history} for an instance
      * of {@link Aggregate} with the given ID.
-     *
-     * <p>Creates an instance of {@code Aggregate} with the given ID, restores its state from
-     * the {@link Snapshot} present in the {@code history} and applies the events from
-     * the {@code history}.
      *
      * @param id      the ID of the {@code Aggregate} to load
      * @param history the state record of the {@code Aggregate} to load

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -432,6 +432,10 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * a {@linkplain #getSnapshotTrigger() snapshot trigger} is used as a
      * {@linkplain AggregateReadRequest#getBatchSize() batch size}.
      *
+     * <p>This method is exposed into the {@code io.spine.server.aggregate} package for the only
+     * reason of making it overridable. Consider calling {@link #loadOrCreate loadOrCreate()} or
+     * {@link #find find()} instead.
+     *
      * @param id the ID of the aggregate
      * @return the loaded instance or {@code Optional.absent()} if there is no record with the ID
      */


### PR DESCRIPTION
In this small PR we make `AggregateRepository.load(id)` extendable by introducing phases of the `Aggregate` loading:
 1. `fetchHistory`
 2. `play`

 This is done to be able to change the method behavior in custom implementations of `AggregateRepository` (e.g. based on Kafka).

The framework version is advanced to `0.10.2-SNAPSHOT`.