### PR TITLE
Make Command handling repositories post Rejections

### DIFF
--- a/client/src/test/java/io/spine/core/CommandsShould.java
+++ b/client/src/test/java/io/spine/core/CommandsShould.java
@@ -31,14 +31,12 @@ import com.google.protobuf.Int64Value;
 import com.google.protobuf.StringValue;
 import com.google.protobuf.Timestamp;
 import io.spine.Identifier;
-import io.spine.base.ThrowableMessage;
 import io.spine.client.ActorRequestFactory;
 import io.spine.client.TestActorRequestFactory;
 import io.spine.core.given.GivenCommandContext;
 import io.spine.core.given.GivenUserId;
 import io.spine.string.Stringifiers;
 import io.spine.time.Durations2;
-import io.spine.time.Time;
 import io.spine.time.ZoneOffset;
 import io.spine.time.ZoneOffsets;
 import io.spine.type.TypeName;
@@ -49,7 +47,6 @@ import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.protobuf.Descriptors.FileDescriptor;
-import static io.spine.core.Commands.causedByRejection;
 import static io.spine.core.Commands.sameActorAndTenant;
 import static io.spine.core.given.GivenTenantId.newUuid;
 import static io.spine.protobuf.TypeConverter.toMessage;
@@ -64,7 +61,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- * * Tests for {@linkplain Commands Commands utility class}.
+ * Tests for {@linkplain Commands Commands utility class}.
  *
  * <p>The test suite is located under the "client" module since actor request generation
  * is required. So we want to avoid circular dependencies between "core" and "client" modules.
@@ -250,22 +247,5 @@ public class CommandsShould {
                                                .toUrl();
 
         assertEquals(TypeUrl.of(StringValue.class), typeUrl);
-    }
-
-    @SuppressWarnings({
-            "NewExceptionWithoutArguments" /* No need to have a message for this test. */,
-            "SerializableInnerClassWithNonSerializableOuterClass" /* Does not refer anything. */
-    })
-    @Test
-    public void say_if_RuntimeException_was_called_by_command_rejection() {
-        assertFalse(causedByRejection(new RuntimeException()));
-        final ThrowableMessage throwableMessage = new ThrowableMessage(Time.getCurrentTime()) {
-            private static final long serialVersionUID = 0L;
-        };
-        assertTrue(causedByRejection(new IllegalStateException(throwableMessage)));
-
-        // Check that root cause is analyzed.
-        assertTrue(causedByRejection(
-                new RuntimeException(new IllegalStateException(throwableMessage))));
     }
 }

--- a/core/src/main/java/io/spine/core/Commands.java
+++ b/core/src/main/java/io/spine/core/Commands.java
@@ -22,7 +22,6 @@ package io.spine.core;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
-import com.google.common.base.Throwables;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
@@ -226,36 +225,24 @@ public final class Commands {
     }
 
     /**
-     * Verifies if the exception has command rejection as its
-     * {@linkplain Throwables#getRootCause(Throwable) root cause} .
+     * Produces a {@link Rejection} for the given {@link Command} based on the given
+     * {@linkplain ThrowableMessage cause}.
      *
-     * @param exception the exception to analyze
-     * @return {@code true} if the exception was created because of a command rejection thrown,
-     *         {@code false} otherwise
+     * <p>The given {@link Throwable} should be
+     * {@linkplain Rejections#causedByRejection caused by a Rejection} or
+     * an {@link IllegalArgumentException} is thrown.
+     *
+     * @param command the command to reject
+     * @param cause the rejection cause (may be wrapped into other kinds of {@code Throwable})
+     * @return a {@link Rejection} for the given command
+     * @throws IllegalArgumentException upon an invalid rejection cause
      */
-    public static boolean causedByRejection(Throwable exception) {
-        //TODO:2017-07-26:alexander.yevsyukov: Check against CommandRejection
-        // instead of ThrowableMessage when code generation allows customizing a custom
-        // rejection types instead of `ThrowableMessage`.
-        // See: https://github.com/SpineEventEngine/base/issues/20
-        final Throwable rootCause = Throwables.getRootCause(exception);
-        final boolean result = rootCause instanceof ThrowableMessage;
-        return result;
-    }
-
-    public static ThrowableMessage getCauseRejection(Throwable throwable) {
-        checkNotNull(throwable);
-        checkArgument(causedByRejection(throwable));
-        final Throwable cause = Throwables.getRootCause(throwable);
-        return (ThrowableMessage) cause;
-    }
-
     @Internal
-    public static Rejection reject(Command command, Throwable cause) {
+    public static Rejection reject(Command command, Throwable cause) throws IllegalStateException {
         checkNotNull(command);
         checkNotNull(cause);
 
-        final ThrowableMessage rejectionThrowable = getCauseRejection(cause);
+        final ThrowableMessage rejectionThrowable = Rejections.getCauseRejection(cause);
         final Rejection rejection = Rejections.toRejection(rejectionThrowable, command);
         return rejection;
     }

--- a/core/src/main/java/io/spine/core/Commands.java
+++ b/core/src/main/java/io/spine/core/Commands.java
@@ -238,11 +238,12 @@ public final class Commands {
      * @throws IllegalArgumentException upon an invalid rejection cause
      */
     @Internal
-    public static Rejection reject(Command command, Throwable cause) throws IllegalStateException {
+    public static Rejection rejectWithCause(Command command, Throwable cause)
+            throws IllegalArgumentException {
         checkNotNull(command);
         checkNotNull(cause);
 
-        final ThrowableMessage rejectionThrowable = Rejections.getCauseRejection(cause);
+        final ThrowableMessage rejectionThrowable = Rejections.getCause(cause);
         final Rejection rejection = Rejections.toRejection(rejectionThrowable, command);
         return rejection;
     }

--- a/core/src/main/java/io/spine/core/Rejections.java
+++ b/core/src/main/java/io/spine/core/Rejections.java
@@ -29,6 +29,7 @@ import io.spine.Identifier;
 import io.spine.annotation.Internal;
 import io.spine.base.ThrowableMessage;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.protobuf.AnyPacker.pack;
 import static io.spine.protobuf.AnyPacker.unpack;
@@ -191,5 +192,43 @@ public final class Rejections {
     public static boolean isExternal(RejectionContext context) {
         checkNotNull(context);
         return context.getExternal();
+    }
+
+    /**
+     * Verifies if the exception has command rejection as its
+     * {@linkplain Throwables#getRootCause(Throwable) root cause} .
+     *
+     * @param exception the exception to analyze
+     * @return {@code true} if the exception was created because of a command rejection thrown,
+     *         {@code false} otherwise
+     */
+    public static boolean causedByRejection(Throwable exception) {
+        //TODO:2017-07-26:alexander.yevsyukov: Check against CommandRejection
+        // instead of ThrowableMessage when code generation allows customizing a custom
+        // rejection types instead of `ThrowableMessage`.
+        // See: https://github.com/SpineEventEngine/base/issues/20
+        final Throwable rootCause = Throwables.getRootCause(exception);
+        final boolean result = rootCause instanceof ThrowableMessage;
+        return result;
+    }
+
+    /**
+     * Retrieves the {@linkplain Throwables#getRootCause root cause} of the given {@link Throwable}
+     * as a {@link ThrowableMessage}.
+     *
+     * <p>Throws an {@link IllegalArgumentException} if the root cause is not
+     * a {@code ThrowableMessage}.
+     *
+     * @param throwable the {@link Throwable} wrapping a {@link ThrowableMessage}
+     * @return the wrapped {@link ThrowableMessage}
+     * @throws IllegalArgumentException upon an invalid {@link Throwable}
+     *                                  {@linkplain Throwables#getRootCause root cause}
+     */
+    static ThrowableMessage getCauseRejection(Throwable throwable)
+            throws IllegalArgumentException {
+        checkNotNull(throwable);
+        checkArgument(causedByRejection(throwable));
+        final Throwable cause = Throwables.getRootCause(throwable);
+        return (ThrowableMessage) cause;
     }
 }

--- a/core/src/main/java/io/spine/core/Rejections.java
+++ b/core/src/main/java/io/spine/core/Rejections.java
@@ -224,7 +224,7 @@ public final class Rejections {
      * @throws IllegalArgumentException upon an invalid {@link Throwable}
      *                                  {@linkplain Throwables#getRootCause root cause}
      */
-    static ThrowableMessage getCauseRejection(Throwable throwable)
+    static ThrowableMessage getCause(Throwable throwable)
             throws IllegalArgumentException {
         checkNotNull(throwable);
         checkArgument(causedByRejection(throwable));

--- a/core/src/main/java/io/spine/core/Rejections.java
+++ b/core/src/main/java/io/spine/core/Rejections.java
@@ -195,8 +195,8 @@ public final class Rejections {
     }
 
     /**
-     * Verifies if the exception has command rejection as its
-     * {@linkplain Throwables#getRootCause(Throwable) root cause} .
+     * Verifies if the exception was {@linkplain Throwables#getRootCause(Throwable) caused} by
+     * a command rejection.
      *
      * @param exception the exception to analyze
      * @return {@code true} if the exception was created because of a command rejection thrown,

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.2-SNAPSHOT'
+def final SPINE_VERSION = '0.10.4-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.4-SNAPSHOT'
+def final SPINE_VERSION = '0.10.3-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateCommandEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateCommandEndpoint.java
@@ -78,8 +78,6 @@ class AggregateCommandEndpoint<I, A extends Aggregate<I, ?, ?>>
     @Override
     protected void onError(CommandEnvelope envelope, RuntimeException exception) {
         repository().onError(envelope, exception);
-        // Re-throw exception so that unhandled command gets proper status.
-        throw exception;
     }
 
     /**

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -290,7 +290,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
         checkNotNull(envelope);
         checkNotNull(exception);
         if (causedByRejection(exception)) {
-            final Rejection rejection = Commands.reject(envelope.getCommand(), exception);
+            final Rejection rejection = Commands.rejectWithCause(envelope.getCommand(), exception);
             getBoundedContext().getRejectionBus()
                                .post(rejection);
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -59,7 +59,7 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.core.Commands.causedByRejection;
+import static io.spine.core.Rejections.causedByRejection;
 import static io.spine.server.entity.EntityWithLifecycle.Predicates.isEntityVisible;
 import static io.spine.util.Exceptions.newIllegalStateException;
 

--- a/server/src/main/java/io/spine/server/command/CommandDispatchingErrors.java
+++ b/server/src/main/java/io/spine/server/command/CommandDispatchingErrors.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.command;
+
+import io.spine.annotation.Internal;
+import io.spine.core.CommandEnvelope;
+import io.spine.core.Commands;
+import io.spine.core.Rejection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.core.Rejections.causedByRejection;
+import static java.lang.String.format;
+
+/**
+ * A utility for handling the errors which happen while
+ * {@linkplain io.spine.server.commandbus.CommandDispatcher dispatching}
+ * {@linkplain io.spine.core.Command commands}.
+ *
+ * @author Dmytro Dashenkov
+ */
+@Internal
+public final class CommandDispatchingErrors {
+
+    private CommandDispatchingErrors() {
+        // Prevent utility class instantiation.
+    }
+
+    /**
+     * Retrieves the {@linkplain Rejection command rejection} from the passed {@code exception} or
+     * throws the {@code exception} if it is not caused by a {@code Rejection}.
+     *
+     * @param envelope  the command which caused the {@code exception}
+     * @param exception the {@link Exception} thrown while dispatching the given command
+     * @return {@link Rejection} which caused the {@code exception} if any
+     * @throws RuntimeException throws the given {@code exception} if it is not caused by
+     *                          a {@link Rejection}
+     */
+    @SuppressWarnings("ProhibitedExceptionDeclared")
+    public static Rejection onDispatchingError(RuntimeException exception,
+                                               CommandEnvelope envelope) throws RuntimeException {
+        checkNotNull(envelope);
+        checkNotNull(exception);
+        if (causedByRejection(exception)) {
+            final Rejection rejection = Commands.rejectWithCause(envelope.getCommand(), exception);
+            return rejection;
+        } else {
+            log().error(format("Error dispatching command (class: %s id: %s).",
+                               envelope.getMessage().getClass(),
+                               envelope.getId().getUuid()),
+                        exception);
+            throw exception;
+        }
+    }
+
+    private static Logger log() {
+        return LogSingleton.INSTANCE.value;
+    }
+
+    private enum LogSingleton {
+        INSTANCE;
+        @SuppressWarnings("NonSerializableFieldInSerializableClass")
+        private final Logger value = LoggerFactory.getLogger(CommandDispatchingErrors.class);
+    }
+}

--- a/server/src/main/java/io/spine/server/commandbus/CommandBus.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandBus.java
@@ -30,6 +30,7 @@ import io.spine.core.Command;
 import io.spine.core.CommandClass;
 import io.spine.core.CommandEnvelope;
 import io.spine.core.Rejection;
+import io.spine.protobuf.AnyPacker;
 import io.spine.server.ServerEnvironment;
 import io.spine.server.bus.Bus;
 import io.spine.server.bus.BusFilter;
@@ -206,6 +207,9 @@ public class CommandBus extends Bus<Command,
             if (causedByRejection(e)) {
                 final ThrowableMessage throwableMessage = (ThrowableMessage) cause;
                 final Rejection rejection = toRejection(throwableMessage, envelope.getCommand());
+                final Class<?> rejectionClass = AnyPacker.unpack(rejection.getMessage())
+                                                         .getClass();
+                Log.log().info("Posting rejection {} to RejectionBus.", rejectionClass.getName());
                 rejectionBus().post(rejection);
                 result = reject(envelope.getId(), rejection);
             } else {

--- a/server/src/main/java/io/spine/server/commandbus/CommandBus.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandBus.java
@@ -209,7 +209,7 @@ public class CommandBus extends Bus<Command,
                 final Rejection rejection = toRejection(throwableMessage, envelope.getCommand());
                 final Class<?> rejectionClass = AnyPacker.unpack(rejection.getMessage())
                                                          .getClass();
-                Log.log().info("Posting rejection {} to RejectionBus.", rejectionClass.getName());
+                Log.log().trace("Posting rejection {} to RejectionBus.", rejectionClass.getName());
                 rejectionBus().post(rejection);
                 result = reject(envelope.getId(), rejection);
             } else {

--- a/server/src/main/java/io/spine/server/commandbus/CommandBus.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandBus.java
@@ -46,7 +46,7 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.getRootCause;
-import static io.spine.core.Commands.causedByRejection;
+import static io.spine.core.Rejections.causedByRejection;
 import static io.spine.core.Rejections.toRejection;
 import static io.spine.server.bus.Buses.acknowledge;
 import static io.spine.server.bus.Buses.reject;

--- a/server/src/main/java/io/spine/server/commandbus/CommandErrorHandler.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandErrorHandler.java
@@ -18,51 +18,70 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.server.command;
+package io.spine.server.commandbus;
 
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableSet;
 import io.spine.annotation.Internal;
+import io.spine.core.CommandClass;
 import io.spine.core.CommandEnvelope;
 import io.spine.core.Commands;
 import io.spine.core.Rejection;
+import io.spine.server.rejection.RejectionBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.core.Rejections.causedByRejection;
 import static java.lang.String.format;
 
 /**
- * A utility for handling the errors which happen while
- * {@linkplain io.spine.server.commandbus.CommandDispatcher dispatching}
- * {@linkplain io.spine.core.Command commands}.
+ * A {@link CommandDispatcher} which handles the dispatching errors.
  *
  * @author Dmytro Dashenkov
+ * @see #onError(CommandEnvelope, RuntimeException)
  */
 @Internal
-public final class CommandDispatchingErrors {
+public final class CommandErrorHandler<I> implements CommandDispatcher<I> {
 
-    private CommandDispatchingErrors() {
-        // Prevent utility class instantiation.
+    private final Function<CommandEnvelope, I> handler;
+    private final RejectionBus rejectionBus;
+
+    public CommandErrorHandler(Function<CommandEnvelope, I> handler,
+                               RejectionBus rejectionBus) {
+        this.handler = handler;
+        this.rejectionBus = rejectionBus;
+    }
+
+    @SuppressWarnings("ReturnOfCollectionOrArrayField") // Immutable Collection impl.
+    @Override
+    public Set<CommandClass> getMessageClasses() {
+        return ImmutableSet.of();
+    }
+
+    @Override
+    public I dispatch(CommandEnvelope envelope) {
+        checkNotNull(envelope);
+        return handler.apply(envelope);
     }
 
     /**
-     * Retrieves the {@linkplain Rejection command rejection} from the passed {@code exception} or
-     * throws the {@code exception} if it is not caused by a {@code Rejection}.
+     * {@inheritDoc}
      *
-     * @param envelope  the command which caused the {@code exception}
-     * @param exception the {@link Exception} thrown while dispatching the given command
-     * @return {@link Rejection} which caused the {@code exception} if any
-     * @throws RuntimeException throws the given {@code exception} if it is not caused by
-     *                          a {@link Rejection}
+     * <p>If the given {@code exception} has been caused by
+     * a {@linkplain io.spine.base.ThrowableMessage command rejection}, the {@link Rejection} is
+     * {@linkplain RejectionBus#post(Rejection) posted} to the {@code RejectionBus}. Otherwise,
+     * the given {@code exception} is thrown.
      */
-    @SuppressWarnings("ProhibitedExceptionDeclared")
-    public static Rejection onDispatchingError(RuntimeException exception,
-                                               CommandEnvelope envelope) throws RuntimeException {
+    @Override
+    public void onError(CommandEnvelope envelope, RuntimeException exception) {
         checkNotNull(envelope);
         checkNotNull(exception);
         if (causedByRejection(exception)) {
             final Rejection rejection = Commands.rejectWithCause(envelope.getCommand(), exception);
-            return rejection;
+            rejectionBus.post(rejection);
         } else {
             log().error(format("Error dispatching command (class: %s id: %s).",
                                envelope.getMessage().getClass(),
@@ -79,6 +98,6 @@ public final class CommandDispatchingErrors {
     private enum LogSingleton {
         INSTANCE;
         @SuppressWarnings("NonSerializableFieldInSerializableClass")
-        private final Logger value = LoggerFactory.getLogger(CommandDispatchingErrors.class);
+        private final Logger value = LoggerFactory.getLogger(CommandErrorHandler.class);
     }
 }

--- a/server/src/main/java/io/spine/server/commandbus/CommandErrorHandler.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandErrorHandler.java
@@ -33,10 +33,10 @@ import static io.spine.core.Rejections.causedByRejection;
 import static java.lang.String.format;
 
 /**
- * A supervisor watching the command dispatcher process.
+ * The handler of the errors thrown while command dispatching.
  *
  * <p>The {@linkplain CommandDispatcher command dispatchers} may delegate
- * the {@linkplain CommandDispatcher#onError command handling} to an instance of
+ * the {@linkplain CommandDispatcher#onError error handling} to an instance of
  * {@code CommandErrorHandler}.
  *
  * @author Dmytro Dashenkov
@@ -63,7 +63,7 @@ public final class CommandErrorHandler {
     }
 
     /**
-     * Handles an error occurred during dispatching a command.
+     * Handles an error occurred during dispatching of a command.
      *
      * <p>If the given {@code exception} has been caused by
      * a {@linkplain io.spine.base.ThrowableMessage command rejection}, the {@link Rejection} is

--- a/server/src/main/java/io/spine/server/commandbus/CommandErrorHandler.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandErrorHandler.java
@@ -37,18 +37,29 @@ import static java.lang.String.format;
  *
  * <p>The {@linkplain CommandDispatcher command dispatchers} may delegate
  * the {@linkplain CommandDispatcher#onError command handling} to an instance of
- * {@code CommandDispatchingSupervisor}.
+ * {@code CommandErrorHandler}.
  *
  * @author Dmytro Dashenkov
- * @see #onError(CommandEnvelope, RuntimeException)
+ * @see #handleError(CommandEnvelope, RuntimeException)
  */
 @Internal
-public final class CommandDispatchingSupervisor {
+public final class CommandErrorHandler {
 
     private final RejectionBus rejectionBus;
 
-    public CommandDispatchingSupervisor(RejectionBus rejectionBus) {
+    private CommandErrorHandler(RejectionBus rejectionBus) {
         this.rejectionBus = rejectionBus;
+    }
+
+    /**
+     * Creates new instance of {@code CommandErrorHandler} with the given {@link RejectionBus}.
+     *
+     * @param rejectionBus the {@link RejectionBus} to post the command rejections into
+     * @return a new instance of {@code CommandErrorHandler}
+     */
+    public static CommandErrorHandler with(RejectionBus rejectionBus) {
+        checkNotNull(rejectionBus);
+        return new CommandErrorHandler(rejectionBus);
     }
 
     /**
@@ -59,7 +70,7 @@ public final class CommandDispatchingSupervisor {
      * {@linkplain RejectionBus#post(Rejection) posted} to the {@code RejectionBus}. Otherwise,
      * the given {@code exception} is thrown.
      */
-    public void onError(CommandEnvelope envelope, RuntimeException exception) {
+    public void handleError(CommandEnvelope envelope, RuntimeException exception) {
         checkNotNull(envelope);
         checkNotNull(exception);
         if (causedByRejection(exception)) {
@@ -81,6 +92,6 @@ public final class CommandDispatchingSupervisor {
     private enum LogSingleton {
         INSTANCE;
         @SuppressWarnings("NonSerializableFieldInSerializableClass")
-        private final Logger value = LoggerFactory.getLogger(CommandDispatchingSupervisor.class);
+        private final Logger value = LoggerFactory.getLogger(CommandErrorHandler.class);
     }
 }

--- a/server/src/main/java/io/spine/server/commandbus/CommandErrorHandler.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandErrorHandler.java
@@ -24,6 +24,7 @@ import io.spine.annotation.Internal;
 import io.spine.core.CommandEnvelope;
 import io.spine.core.Rejection;
 import io.spine.server.rejection.RejectionBus;
+import io.spine.string.Stringifiers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,7 +80,7 @@ public final class CommandErrorHandler {
         } else {
             log().error(format("Error dispatching command (class: %s id: %s).",
                                envelope.getMessage().getClass(),
-                               envelope.getId().getUuid()),
+                               Stringifiers.toString(envelope.getId())),
                         exception);
             throw exception;
         }

--- a/server/src/main/java/io/spine/server/procman/PmCommandEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmCommandEndpoint.java
@@ -73,7 +73,6 @@ class PmCommandEndpoint<I, P extends ProcessManager<I, ?, ?>>
     @Override
     protected void onError(CommandEnvelope envelope, RuntimeException exception) {
         repository().onError(envelope, exception);
-        throw exception;
     }
 
     /**

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
@@ -290,7 +290,7 @@ public abstract class ProcessManagerRepository<I,
         checkNotNull(envelope);
         checkNotNull(exception);
         if (causedByRejection(exception)) {
-            final Rejection rejection = Commands.reject(envelope.getCommand(), exception);
+            final Rejection rejection = Commands.rejectWithCause(envelope.getCommand(), exception);
             getBoundedContext().getRejectionBus()
                                .post(rejection);
 

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
@@ -56,7 +56,7 @@ import javax.annotation.CheckReturnValue;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.core.Commands.causedByRejection;
+import static io.spine.core.Rejections.causedByRejection;
 import static io.spine.util.Exceptions.newIllegalStateException;
 
 /**

--- a/server/src/test/java/io/spine/core/RejectionsShould.java
+++ b/server/src/test/java/io/spine/core/RejectionsShould.java
@@ -136,7 +136,7 @@ public class RejectionsShould {
             "SerializableInnerClassWithNonSerializableOuterClass" /* Does not refer anything. */
     })
     @Test
-    public void say_if_RuntimeException_was_called_by_command_rejection() {
+    public void tell_if_RuntimeException_was_called_by_command_rejection() {
         assertFalse(causedByRejection(new RuntimeException()));
         final ThrowableMessage throwableMessage = new ThrowableMessage(Time.getCurrentTime()) {
             private static final long serialVersionUID = 0L;

--- a/server/src/test/java/io/spine/server/procman/given/ProcessManagerRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/procman/given/ProcessManagerRepositoryTestEnv.java
@@ -29,8 +29,8 @@ import io.spine.core.EventContext;
 import io.spine.core.React;
 import io.spine.server.command.Assign;
 import io.spine.server.entity.TestEntityWithStringColumn;
-import io.spine.server.entity.rejection.StandardRejections.EntityAlreadyArchived;
-import io.spine.server.entity.rejection.StandardRejections.EntityAlreadyDeleted;
+import io.spine.server.entity.rejection.EntityAlreadyArchived;
+import io.spine.server.entity.rejection.StandardRejections;
 import io.spine.server.procman.CommandRouted;
 import io.spine.server.procman.ProcessManager;
 import io.spine.server.procman.ProcessManagerRepository;
@@ -42,6 +42,7 @@ import io.spine.test.procman.command.PmAddTask;
 import io.spine.test.procman.command.PmCreateProject;
 import io.spine.test.procman.command.PmDoNothing;
 import io.spine.test.procman.command.PmStartProject;
+import io.spine.test.procman.command.PmThrowEntityAlreadyArchived;
 import io.spine.test.procman.event.PmProjectCreated;
 import io.spine.test.procman.event.PmProjectStarted;
 import io.spine.test.procman.event.PmTaskAdded;
@@ -49,6 +50,7 @@ import io.spine.testdata.Sample;
 
 import java.util.List;
 
+import static io.spine.protobuf.AnyPacker.pack;
 import static java.util.Collections.emptyList;
 
 public class ProcessManagerRepositoryTestEnv {
@@ -160,14 +162,20 @@ public class ProcessManagerRepositoryTestEnv {
             return emptyList();
         }
 
+        @Assign
+        Empty handle(PmThrowEntityAlreadyArchived command) throws EntityAlreadyArchived {
+            keep(command);
+            throw new EntityAlreadyArchived(pack(command.getProjectId()));
+        }
+
         @React
-        Empty on(EntityAlreadyArchived rejection) {
+        Empty on(StandardRejections.EntityAlreadyArchived rejection) {
             keep(rejection);
             return withNothing();
         }
 
         @React
-        Empty on(EntityAlreadyDeleted rejection) {
+        Empty on(StandardRejections.EntityAlreadyDeleted rejection) {
             keep(rejection);
             return withNothing();
         }

--- a/server/src/test/java/io/spine/server/procman/given/ProcessManagerRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/procman/given/ProcessManagerRepositoryTestEnv.java
@@ -163,7 +163,7 @@ public class ProcessManagerRepositoryTestEnv {
         }
 
         @Assign
-        Empty handle(PmThrowEntityAlreadyArchived command) throws EntityAlreadyArchived {
+        List<Message> handle(PmThrowEntityAlreadyArchived command) throws EntityAlreadyArchived {
             keep(command);
             throw new EntityAlreadyArchived(pack(command.getProjectId()));
         }

--- a/server/src/test/proto/spine/test/procman/commands.proto
+++ b/server/src/test/proto/spine/test/procman/commands.proto
@@ -47,3 +47,8 @@ message PmStartProject {
 message PmDoNothing {
     ProjectId project_id = 1;
 }
+
+// A command, which always causes StandardRejections.EntityAlreadyArchived to be thrown.
+message PmThrowEntityAlreadyArchived {
+    ProjectId project_id = 1;
+}


### PR DESCRIPTION
Currently, `CommandBus` is the only place where we post rejection into the `RejectionBus`. It catches `Throwable`s from the `CommandDispatcher.dispatch()` invocation and posts the rejections parsed from the `Throwable`.
This approach may not work if the command handling is postponed.

The suggested approach is following:
 - `AggregateRepository` and `ProcessManagerRepository` (which are command dispatchers) post rejections that are thrown upon their dispatching. 
 - `CommandBus` still posts the rejections which arrive back to it in the call stack.
