### PR TITLE
Open AggregateRepository dispatchers 

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.3-SNAPSHOT'
+def final SPINE_VERSION = '0.10.4-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -187,6 +187,9 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * <p>By default, this method returns {@code this} reference.
      *
      * <p>Override this method to change the way the repository acts upon the dispatched commands.
+     * Note that the custom implementations might want to call
+     * {@link #dispatch AggregateRepository.dispatch()}. Otherwise, the basic features of
+     * the framework may not function properly.
      *
      * @return a new instance of {@link CommandDispatcher}
      * @see #dispatch(CommandEnvelope)
@@ -207,6 +210,9 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * <p>By default, this method returns {@code DelegatingEventDispatcher.of(this)}.
      *
      * <p>Override this method to change the way the repository acts upon the dispatched events.
+     * Note that the custom implementations might want to call
+     * {@link #dispatchEvent AggregateRepository.dispatchEvent()}. Otherwise, the basic features of
+     * the framework may not function properly.
      *
      * @return a new instance of {@link io.spine.server.event.EventDispatcher EventDispatcher}
      * @see #dispatchEvent(EventEnvelope)
@@ -228,7 +234,9 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * <p>By default, this method returns {@code DelegatingRejectionDispatcher.of(this)}.
      *
      * <p>Override this method to change the way the repository acts upon the dispatched
-     * rejections.
+     * rejections. Note that the custom implementations might want to call
+     * {@link #dispatchRejection AggregateRepository.dispatchRejection()}. Otherwise, the basic
+     * features of the framework may not function properly.
      *
      * @return a new instance of
      *         {@link io.spine.server.rejection.RejectionDispatcher EventDispatcher}

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -21,16 +21,20 @@ package io.spine.server.aggregate;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
+import com.google.protobuf.Message;
 import io.spine.annotation.SPI;
 import io.spine.core.CommandClass;
 import io.spine.core.CommandEnvelope;
 import io.spine.core.Event;
 import io.spine.core.EventClass;
 import io.spine.core.EventEnvelope;
+import io.spine.core.MessageEnvelope;
 import io.spine.core.RejectionClass;
 import io.spine.core.RejectionEnvelope;
 import io.spine.core.TenantId;
 import io.spine.server.BoundedContext;
+import io.spine.server.bus.Bus;
+import io.spine.server.bus.MessageDispatcher;
 import io.spine.server.commandbus.CommandDispatcher;
 import io.spine.server.commandbus.CommandErrorHandler;
 import io.spine.server.entity.LifecycleFlags;
@@ -38,10 +42,14 @@ import io.spine.server.entity.Repository;
 import io.spine.server.event.DelegatingEventDispatcher;
 import io.spine.server.event.EventBus;
 import io.spine.server.event.EventDispatcherDelegate;
+import io.spine.server.event.ExternalizedEventDispatcher;
 import io.spine.server.integration.ExternalMessageClass;
 import io.spine.server.integration.ExternalMessageDispatcher;
+import io.spine.server.integration.IntegrationBus;
 import io.spine.server.model.Model;
 import io.spine.server.rejection.DelegatingRejectionDispatcher;
+import io.spine.server.rejection.ExternalizedRejectionDispatcher;
+import io.spine.server.rejection.RejectionBus;
 import io.spine.server.rejection.RejectionDispatcherDelegate;
 import io.spine.server.route.CommandRouting;
 import io.spine.server.route.EventProducers;
@@ -51,6 +59,7 @@ import io.spine.server.route.RejectionRouting;
 import io.spine.server.stand.Stand;
 import io.spine.server.storage.Storage;
 import io.spine.server.storage.StorageFactory;
+import io.spine.type.MessageClass;
 
 import javax.annotation.CheckReturnValue;
 import java.util.List;
@@ -133,20 +142,18 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
 
         final Set<CommandClass> commandClasses = getMessageClasses();
 
-        final DelegatingEventDispatcher<I> eventDispatcher;
-        eventDispatcher = DelegatingEventDispatcher.of(this);
+        final ExternalizedEventDispatcher<?> eventDispatcher = createEventDispatcher();
         final Set<EventClass> eventClasses = eventDispatcher.getMessageClasses();
 
-        final ExternalMessageDispatcher<I> extEventDispatcher;
-        extEventDispatcher = eventDispatcher.getExternalDispatcher();
+        final ExternalMessageDispatcher<?> extEventDispatcher =
+                eventDispatcher.getExternalDispatcher();
         final Set<ExternalMessageClass> extEventClasses = extEventDispatcher.getMessageClasses();
 
-        final DelegatingRejectionDispatcher<I> rejectionDispatcher;
-        rejectionDispatcher = DelegatingRejectionDispatcher.of(this);
+        final ExternalizedRejectionDispatcher<?> rejectionDispatcher = createRejectionDispatcher();
         final Set<RejectionClass> rejectionClasses = rejectionDispatcher.getMessageClasses();
 
-        final ExternalMessageDispatcher<I> extRejectionDispatcher;
-        extRejectionDispatcher = rejectionDispatcher.getExternalDispatcher();
+        final ExternalMessageDispatcher<?> extRejectionDispatcher =
+                rejectionDispatcher.getExternalDispatcher();
         final Set<ExternalMessageClass> extRejectionClasses =
                 extRejectionDispatcher.getMessageClasses();
 
@@ -157,48 +164,88 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
                             " nor react on events or rejections.", this);
         }
 
-        registerInCommandBus(boundedContext, commandClasses);
-        registerInEventBus(boundedContext, eventDispatcher, eventClasses);
-        registerInRejectionBus(boundedContext, rejectionDispatcher, rejectionClasses);
+        final CommandDispatcher<?> commandDispatcher = createCommandDispatcher();
+        final RejectionBus rejectionBus = boundedContext.getRejectionBus();
+        registerDispatcher(boundedContext.getCommandBus(), commandDispatcher, commandClasses);
+        registerDispatcher(boundedContext.getEventBus(), eventDispatcher, eventClasses);
+        registerDispatcher(rejectionBus, rejectionDispatcher, rejectionClasses);
 
-        registerExtMessageDispatcher(boundedContext, extEventDispatcher, extEventClasses);
-        registerExtMessageDispatcher(boundedContext, extRejectionDispatcher, extRejectionClasses);
+        final IntegrationBus integrationBus = boundedContext.getIntegrationBus();
+        registerDispatcher(integrationBus, extEventDispatcher, extEventClasses);
+        registerDispatcher(integrationBus, extRejectionDispatcher, extRejectionClasses);
 
-        this.commandErrorHandler = CommandErrorHandler.with(boundedContext.getRejectionBus());
+        this.commandErrorHandler = CommandErrorHandler.with(rejectionBus);
     }
 
-    private void registerExtMessageDispatcher(BoundedContext boundedContext,
-                                              ExternalMessageDispatcher<I> extEventDispatcher,
-                                              Set<ExternalMessageClass> extEventClasses) {
-        if (!extEventClasses.isEmpty()) {
-            boundedContext.getIntegrationBus()
-                          .register(extEventDispatcher);
-        }
+    /**
+     * Creates an instance of {@link CommandDispatcher}.
+     *
+     * <p>The created instance is
+     * {@linkplain io.spine.server.commandbus.CommandBus#register registered} in
+     * the {@code CommandBus} upon the repository {@linkplain #onRegistered() registration}.
+     *
+     * <p>By default, this method returns {@code this} reference.
+     *
+     * <p>Override this method to change the way the repository acts upon the dispatched commands.
+     *
+     * @return a new instance of {@link CommandDispatcher}
+     * @see #dispatch(CommandEnvelope)
+     */
+    @SPI
+    protected CommandDispatcher<?> createCommandDispatcher() {
+        return this;
     }
 
-    private void registerInRejectionBus(BoundedContext boundedContext,
-                                        DelegatingRejectionDispatcher<I> rejectionDispatcher,
-                                        Set<RejectionClass> rejectionClasses) {
-        if (!rejectionClasses.isEmpty()) {
-            boundedContext.getRejectionBus()
-                          .register(rejectionDispatcher);
-        }
+    /**
+     * Creates an instance of {@link io.spine.server.event.EventDispatcher EventDispatcher} capable
+     * of creating {@linkplain ExternalMessageDispatcher external message dispatchers}.
+     *
+     * <p>The created instance is
+     * {@linkplain io.spine.server.event.EventBus#register registered} in
+     * the {@code EventBus} upon the repository {@linkplain #onRegistered() registration}.
+     *
+     * <p>By default, this method returns {@code DelegatingEventDispatcher.of(this)}.
+     *
+     * <p>Override this method to change the way the repository acts upon the dispatched events.
+     *
+     * @return a new instance of {@link io.spine.server.event.EventDispatcher EventDispatcher}
+     * @see #dispatchEvent(EventEnvelope)
+     */
+    @SPI
+    protected ExternalizedEventDispatcher<?> createEventDispatcher() {
+        return DelegatingEventDispatcher.of(this);
     }
 
-    private void registerInEventBus(BoundedContext boundedContext,
-                                    DelegatingEventDispatcher<I> eventDispatcher,
-                                    Set<EventClass> eventClasses) {
-        if (!eventClasses.isEmpty()) {
-            boundedContext.getEventBus()
-                          .register(eventDispatcher);
-        }
+    /**
+     * Creates an instance of
+     * {@link io.spine.server.rejection.RejectionDispatcher RejectionDispatcher} capable of
+     * creating {@linkplain ExternalMessageDispatcher external message dispatchers}.
+     *
+     * <p>The created instance is
+     * {@linkplain io.spine.server.rejection.RejectionBus#register registered} in
+     * the {@code RejectionBus} upon the repository {@linkplain #onRegistered() registration}.
+     *
+     * <p>By default, this method returns {@code DelegatingRejectionDispatcher.of(this)}.
+     *
+     * <p>Override this method to change the way the repository acts upon the dispatched
+     * rejections.
+     *
+     * @return a new instance of
+     *         {@link io.spine.server.rejection.RejectionDispatcher EventDispatcher}
+     * @see #dispatchRejection(RejectionEnvelope)
+     */
+    @SPI
+    protected ExternalizedRejectionDispatcher<?> createRejectionDispatcher() {
+        return DelegatingRejectionDispatcher.of(this);
     }
 
-    private void registerInCommandBus(BoundedContext boundedContext,
-                                      Set<CommandClass> commandClasses) {
-        if (!commandClasses.isEmpty()) {
-            boundedContext.getCommandBus()
-                          .register(this);
+    private static <M extends Message,
+                    E extends MessageEnvelope<?, M, ?>,
+                    D extends MessageDispatcher<C, E, ?>,
+                    C extends MessageClass>
+    void registerDispatcher(Bus<M, E, C, D> bus, D dispatcher, Set<? extends C> msgClasses) {
+        if (!msgClasses.isEmpty()) {
+            bus.register(dispatcher);
         }
     }
 

--- a/server/src/main/java/io/spine/server/bus/ExternalizedMessageDispatcher.java
+++ b/server/src/main/java/io/spine/server/bus/ExternalizedMessageDispatcher.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.bus;
+
+import io.spine.annotation.SPI;
+import io.spine.core.MessageEnvelope;
+import io.spine.server.integration.ExternalMessageDispatcher;
+import io.spine.type.MessageClass;
+
+/**
+ * A {@link MulticastDispatcher} capable of creating {@link ExternalMessageDispatcher} instances.
+ *
+ * @author Dmytro Dashenkov
+ */
+@SPI
+public interface ExternalizedMessageDispatcher<C extends MessageClass,
+                                               E extends MessageEnvelope,
+                                               I>
+        extends MulticastDispatcher<C, E, I> {
+
+    /**
+     * Wraps this dispatcher to an external rejection dispatcher.
+     *
+     * @return an external dispatcher proxying calls to the underlying instance
+     */
+    ExternalMessageDispatcher<I> getExternalDispatcher();
+}

--- a/server/src/main/java/io/spine/server/bus/ExternalizedMulticastDispatcher.java
+++ b/server/src/main/java/io/spine/server/bus/ExternalizedMulticastDispatcher.java
@@ -31,9 +31,9 @@ import io.spine.type.MessageClass;
  * @author Dmytro Dashenkov
  */
 @SPI
-public interface ExternalizedMessageDispatcher<C extends MessageClass,
-                                               E extends MessageEnvelope,
-                                               I>
+public interface ExternalizedMulticastDispatcher<C extends MessageClass,
+                                                 E extends MessageEnvelope,
+                                                 I>
         extends MulticastDispatcher<C, E, I> {
 
     /**

--- a/server/src/main/java/io/spine/server/bus/MulticastDispatcher.java
+++ b/server/src/main/java/io/spine/server/bus/MulticastDispatcher.java
@@ -36,7 +36,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @param <I> the type of IDs of entities to which messages are dispatched
  * @author Alexander Yevsyukov
  */
-public interface MulticastDispatcher <C extends MessageClass, E extends MessageEnvelope, I>
+public interface MulticastDispatcher<C extends MessageClass, E extends MessageEnvelope, I>
         extends MessageDispatcher<C, E, Set<I>> {
 
     class Identity {

--- a/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
+++ b/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
@@ -50,7 +50,7 @@ import static java.lang.String.format;
  * @see EventDispatcherDelegate
  */
 @Internal
-public final class DelegatingEventDispatcher<I> implements EventDispatcher<I> {
+public final class DelegatingEventDispatcher<I> implements ExternalizedEventDispatcher<I> {
 
     /**
      * A target delegate.
@@ -91,11 +91,7 @@ public final class DelegatingEventDispatcher<I> implements EventDispatcher<I> {
         delegate.onError(envelope, exception);
     }
 
-    /**
-     * Wraps this dispatcher to an external event dispatcher.
-     *
-     * @return the external rejection dispatcher proxying calls to the underlying instance
-     */
+    @Override
     public ExternalMessageDispatcher<I> getExternalDispatcher() {
         return new ExternalMessageDispatcher<I>() {
             @Override

--- a/server/src/main/java/io/spine/server/event/ExternalizedEventDispatcher.java
+++ b/server/src/main/java/io/spine/server/event/ExternalizedEventDispatcher.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.event;
+
+import io.spine.annotation.SPI;
+import io.spine.core.EventClass;
+import io.spine.core.EventEnvelope;
+import io.spine.server.bus.ExternalizedMessageDispatcher;
+
+/**
+ * An {@link EventDispatcher} capable of creating instances of
+ * {@link io.spine.server.integration.ExternalMessageDispatcher ExternalMessageDispatcher}.
+ *
+ * @author Dmytro Dashenkov
+ */
+@SPI
+public interface ExternalizedEventDispatcher<I>
+        extends ExternalizedMessageDispatcher<EventClass, EventEnvelope, I>,
+                EventDispatcher<I> {
+}

--- a/server/src/main/java/io/spine/server/event/ExternalizedEventDispatcher.java
+++ b/server/src/main/java/io/spine/server/event/ExternalizedEventDispatcher.java
@@ -23,7 +23,7 @@ package io.spine.server.event;
 import io.spine.annotation.SPI;
 import io.spine.core.EventClass;
 import io.spine.core.EventEnvelope;
-import io.spine.server.bus.ExternalizedMessageDispatcher;
+import io.spine.server.bus.ExternalizedMulticastDispatcher;
 
 /**
  * An {@link EventDispatcher} capable of creating instances of
@@ -33,6 +33,6 @@ import io.spine.server.bus.ExternalizedMessageDispatcher;
  */
 @SPI
 public interface ExternalizedEventDispatcher<I>
-        extends ExternalizedMessageDispatcher<EventClass, EventEnvelope, I>,
+        extends ExternalizedMulticastDispatcher<EventClass, EventEnvelope, I>,
                 EventDispatcher<I> {
 }

--- a/server/src/main/java/io/spine/server/rejection/DelegatingRejectionDispatcher.java
+++ b/server/src/main/java/io/spine/server/rejection/DelegatingRejectionDispatcher.java
@@ -51,7 +51,7 @@ import static java.lang.String.format;
  * @see RejectionDispatcherDelegate
  */
 @Internal
-public final class DelegatingRejectionDispatcher<I> implements RejectionDispatcher<I> {
+public final class DelegatingRejectionDispatcher<I> implements ExternalizedRejectionDispatcher<I> {
 
     /** A target delegate. */
     private final RejectionDispatcherDelegate<I> delegate;
@@ -99,11 +99,7 @@ public final class DelegatingRejectionDispatcher<I> implements RejectionDispatch
                           .toString();
     }
 
-    /**
-     * Wraps this dispatcher to an external rejection dispatcher.
-     *
-     * @return the external rejection dispatcher proxying calls to the underlying instance
-     */
+    @Override
     public ExternalMessageDispatcher<I> getExternalDispatcher() {
         return new ExternalMessageDispatcher<I>() {
             @Override

--- a/server/src/main/java/io/spine/server/rejection/ExternalizedRejectionDispatcher.java
+++ b/server/src/main/java/io/spine/server/rejection/ExternalizedRejectionDispatcher.java
@@ -23,7 +23,7 @@ package io.spine.server.rejection;
 import io.spine.annotation.SPI;
 import io.spine.core.RejectionClass;
 import io.spine.core.RejectionEnvelope;
-import io.spine.server.bus.ExternalizedMessageDispatcher;
+import io.spine.server.bus.ExternalizedMulticastDispatcher;
 
 /**
  * A {@link RejectionDispatcher} capable of creating instances of
@@ -33,6 +33,6 @@ import io.spine.server.bus.ExternalizedMessageDispatcher;
  */
 @SPI
 public interface ExternalizedRejectionDispatcher<I>
-        extends ExternalizedMessageDispatcher<RejectionClass, RejectionEnvelope, I>,
+        extends ExternalizedMulticastDispatcher<RejectionClass, RejectionEnvelope, I>,
                 RejectionDispatcher<I> {
 }

--- a/server/src/main/java/io/spine/server/rejection/ExternalizedRejectionDispatcher.java
+++ b/server/src/main/java/io/spine/server/rejection/ExternalizedRejectionDispatcher.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.rejection;
+
+import io.spine.annotation.SPI;
+import io.spine.core.RejectionClass;
+import io.spine.core.RejectionEnvelope;
+import io.spine.server.bus.ExternalizedMessageDispatcher;
+
+/**
+ * A {@link RejectionDispatcher} capable of creating instances of
+ * {@link io.spine.server.integration.ExternalMessageDispatcher ExternalMessageDispatcher}.
+ *
+ * @author Dmytro Dashenkov
+ */
+@SPI
+public interface ExternalizedRejectionDispatcher<I>
+        extends ExternalizedMessageDispatcher<RejectionClass, RejectionEnvelope, I>,
+                RejectionDispatcher<I> {
+}


### PR DESCRIPTION
From now, `AggregateRepository` exposes 3 new `protected` methods:
 - `createCommandDispatcher(): CommandDispatcher`;
 - `createEventDispatcher(): ExternalizedEventDispatcher`;
 - `createRejectionDispatcher(): ExternalizedRejectionDispatcher`.

Here `Externalized*Dispatcher` is a dispatcher capable of wrapping itself into an `ExternalMessageDispatcher`.

This is done to make it possible to change the repository behavior upon a message dispatching.