### PR TITLE
Update `base` dependency

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -32,7 +32,7 @@ ext {
     spineVersion = SPINE_VERSION
 
     // Depend on `base` for the general definitions and a model compiler.
-    spineBaseVersion = '0.9.55-SNAPSHOT'
+    spineBaseVersion = '0.9.79-SNAPSHOT'
 
     // We use Spine tools in the build process.
     spineToolsVersion = '0.9.41-SNAPSHOT'

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.3-SNAPSHOT'
+def final SPINE_VERSION = '0.10.4-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/ext.gradle
+++ b/ext.gradle
@@ -32,7 +32,7 @@ ext {
     spineVersion = SPINE_VERSION
 
     // Depend on `base` for the general definitions and a model compiler.
-    spineBaseVersion = '0.9.79-SNAPSHOT'
+    spineBaseVersion = '0.10.0'
 
     // We use Spine tools in the build process.
     spineToolsVersion = '0.9.41-SNAPSHOT'


### PR DESCRIPTION
In this PR we update dependency on `base` project to the `0.10.0` version.

The framework version is set to `0.10.4-SNAPSHOT`.