### PR TITLE
Storage test suits improvement

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.4-SNAPSHOT'
+def final SPINE_VERSION = '0.10.5-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
@@ -39,8 +39,6 @@ import io.spine.test.aggregate.ProjectId;
 import io.spine.test.aggregate.ProjectVBuilder;
 import io.spine.testdata.Sample;
 import io.spine.time.Time;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
@@ -80,19 +78,15 @@ public abstract class AggregateStorageShould
 
     private AggregateStorage<ProjectId> storage;
 
-    @Before
-    public void setUpAggregateStorageTest() {
-        storage = newDefaultStorage();
-    }
-
-    @After
-    public void tearDownAggregateStorageTest() {
-        close(storage);
+    @Override
+    public void setUpAbstractStorageTest() {
+        super.setUpAbstractStorageTest();
+        storage = getStorage();
     }
 
     @Override
-    public AggregateStorage<ProjectId> newDefaultStorage() {
-        return newStorage(TestAggregate.class);
+    protected Class<? extends TestAggregate> getDefaultEntityClass() {
+        return TestAggregate.class;
     }
 
     /**
@@ -485,7 +479,7 @@ public abstract class AggregateStorageShould
                        .build();
     }
 
-    private static class TestAggregate extends Aggregate<ProjectId, Project, ProjectVBuilder> {
+    public static class TestAggregate extends Aggregate<ProjectId, Project, ProjectVBuilder> {
         protected TestAggregate(ProjectId id) {
             super(id);
         }

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
@@ -96,16 +96,16 @@ public abstract class AggregateStorageShould
     }
 
     /**
-     * Used to get a storage in tests with different ID types.
+     * Creates the storage for the specified ID and aggregate classes.
      *
-     * <p>NOTE: the storage is closed after each test.
+     * <p>The created storage should be closed manually.
      *
-     * @param idClass        class of aggregate ID
-     * @param aggregateClass aggregate class
+     * @param idClass        the class of aggregate ID
+     * @param aggregateClass the aggregate class
      * @param <I>            the type of aggregate IDs
-     * @return an empty storage instance
+     * @return a new storage instance
      */
-    protected abstract <I> AggregateStorage<I> getStorage(Class<? extends I> idClass,
+    protected abstract <I> AggregateStorage<I> newStorage(Class<? extends I> idClass,
                                                           Class<? extends Aggregate<I, ?, ?>> aggregateClass);
 
     @Override
@@ -176,7 +176,7 @@ public abstract class AggregateStorageShould
 
     @Test
     public void write_and_read_event_by_String_id() {
-        final AggregateStorage<String> storage = getStorage(String.class,
+        final AggregateStorage<String> storage = newStorage(String.class,
                                                             TestAggregateWithIdString.class);
         final String id = newUuid();
         writeAndReadEventTest(id, storage);
@@ -184,7 +184,7 @@ public abstract class AggregateStorageShould
 
     @Test
     public void write_and_read_event_by_Long_id() {
-        final AggregateStorage<Long> storage = getStorage(Long.class,
+        final AggregateStorage<Long> storage = newStorage(Long.class,
                                                           TestAggregateWithIdLong.class);
         final long id = 10L;
         writeAndReadEventTest(id, storage);
@@ -192,7 +192,7 @@ public abstract class AggregateStorageShould
 
     @Test
     public void write_and_read_event_by_Integer_id() {
-        final AggregateStorage<Integer> storage = getStorage(Integer.class,
+        final AggregateStorage<Integer> storage = newStorage(Integer.class,
                                                              TestAggregateWithIdInteger.class);
         final int id = 10;
         writeAndReadEventTest(id, storage);

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
@@ -85,7 +85,7 @@ public abstract class AggregateStorageShould
     }
 
     @Override
-    protected Class<? extends TestAggregate> getDefaultEntityClass() {
+    protected Class<? extends TestAggregate> getTestEntityClass() {
         return TestAggregate.class;
     }
 

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
@@ -92,7 +92,7 @@ public abstract class AggregateStorageShould
 
     @Override
     public AggregateStorage<ProjectId> newDefaultStorage() {
-        return getStorage(ProjectId.class, TestAggregate.class);
+        return newStorage(TestAggregate.class);
     }
 
     /**

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
@@ -82,7 +82,7 @@ public abstract class AggregateStorageShould
 
     @Before
     public void setUpAggregateStorageTest() {
-        storage = getDefaultStorage();
+        storage = newDefaultStorage();
     }
 
     @After
@@ -91,7 +91,7 @@ public abstract class AggregateStorageShould
     }
 
     @Override
-    public AggregateStorage<ProjectId> getDefaultStorage() {
+    public AggregateStorage<ProjectId> newDefaultStorage() {
         return getStorage(ProjectId.class, TestAggregate.class);
     }
 

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
@@ -96,7 +96,7 @@ public abstract class AggregateStorageShould
     }
 
     /**
-     * Creates the storage for the specified ID and aggregate classes.
+     * Creates the storage for the specified ID and aggregate class.
      *
      * <p>The created storage should be closed manually.
      *

--- a/server/src/test/java/io/spine/server/stand/StandStorageShould.java
+++ b/server/src/test/java/io/spine/server/stand/StandStorageShould.java
@@ -30,17 +30,14 @@ import com.google.protobuf.Message;
 import io.spine.Identifier;
 import io.spine.core.given.GivenVersion;
 import io.spine.protobuf.AnyPacker;
-import io.spine.server.entity.Entity;
 import io.spine.server.entity.EntityRecord;
 import io.spine.server.entity.FieldMasks;
-import io.spine.server.storage.RecordStorage;
 import io.spine.server.storage.RecordStorageShould;
 import io.spine.test.storage.Project;
 import io.spine.test.storage.ProjectId;
 import io.spine.test.storage.Task;
 import io.spine.test.storage.TaskId;
 import io.spine.type.TypeUrl;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
@@ -60,7 +57,7 @@ import static java.lang.String.format;
  * @author Dmytro Dashenkov
  */
 public abstract class StandStorageShould extends RecordStorageShould<AggregateStateId,
-                                                                     RecordStorage<AggregateStateId>> {
+                                                                     StandStorage> {
 
     protected static final Supplier<AggregateStateId<ProjectId>> DEFAULT_ID_SUPPLIER
             = new Supplier<AggregateStateId<ProjectId>>() {
@@ -86,12 +83,9 @@ public abstract class StandStorageShould extends RecordStorageShould<AggregateSt
         return project;
     }
 
-    @Override
-    protected abstract StandStorage getStorage(Class<? extends Entity> cls);
-
     @Test
     public void retrieve_all_records() {
-        final StandStorage storage = getStorage(TestCounterEntity.class);
+        final StandStorage storage = newStorage(TestCounterEntity.class);
         final List<AggregateStateId> ids = fill(storage, 10, DEFAULT_ID_SUPPLIER);
 
         final Iterator<EntityRecord> allRecords = storage.readAll();
@@ -100,7 +94,7 @@ public abstract class StandStorageShould extends RecordStorageShould<AggregateSt
 
     @Test
     public void retrieve_records_by_ids() {
-        final StandStorage storage = getStorage(TestCounterEntity.class);
+        final StandStorage storage = newStorage(TestCounterEntity.class);
         // Use a subset of IDs
         final List<AggregateStateId> ids = fill(storage, 10, DEFAULT_ID_SUPPLIER).subList(0, 5);
 
@@ -122,7 +116,7 @@ public abstract class StandStorageShould extends RecordStorageShould<AggregateSt
     @SuppressWarnings({"MethodWithMultipleLoops", "ConstantConditions"}) // OK for this test.
     private void checkByTypeRead(FieldMask fieldMask) {
         final boolean withFieldMask = !fieldMask.equals(FieldMask.getDefaultInstance());
-        final StandStorage storage = getStorage(TestCounterEntity.class);
+        final StandStorage storage = newStorage(TestCounterEntity.class);
         final TypeUrl type = TypeUrl.from(Project.getDescriptor());
 
         final int projectsCount = 4;

--- a/server/src/test/java/io/spine/server/stand/StandStorageShould.java
+++ b/server/src/test/java/io/spine/server/stand/StandStorageShould.java
@@ -85,7 +85,7 @@ public abstract class StandStorageShould extends RecordStorageShould<AggregateSt
 
     @Test
     public void retrieve_all_records() {
-        final StandStorage storage = newStorage(TestCounterEntity.class);
+        final StandStorage storage = getStorage();
         final List<AggregateStateId> ids = fill(storage, 10, DEFAULT_ID_SUPPLIER);
 
         final Iterator<EntityRecord> allRecords = storage.readAll();
@@ -94,7 +94,7 @@ public abstract class StandStorageShould extends RecordStorageShould<AggregateSt
 
     @Test
     public void retrieve_records_by_ids() {
-        final StandStorage storage = newStorage(TestCounterEntity.class);
+        final StandStorage storage = getStorage();
         // Use a subset of IDs
         final List<AggregateStateId> ids = fill(storage, 10, DEFAULT_ID_SUPPLIER).subList(0, 5);
 
@@ -116,7 +116,7 @@ public abstract class StandStorageShould extends RecordStorageShould<AggregateSt
     @SuppressWarnings({"MethodWithMultipleLoops", "ConstantConditions"}) // OK for this test.
     private void checkByTypeRead(FieldMask fieldMask) {
         final boolean withFieldMask = !fieldMask.equals(FieldMask.getDefaultInstance());
-        final StandStorage storage = newStorage(TestCounterEntity.class);
+        final StandStorage storage = getStorage();
         final TypeUrl type = TypeUrl.from(Project.getDescriptor());
 
         final int projectsCount = 4;

--- a/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
@@ -59,7 +59,7 @@ public abstract class AbstractStorageShould<I,
 
     @Before
     public void setUpAbstractStorageTest() {
-        storage = getDefaultStorage();
+        storage = newDefaultStorage();
     }
 
     @After
@@ -77,9 +77,9 @@ public abstract class AbstractStorageShould<I,
      * <p>NOTE: the storage is closed after each test.
      *
      * @return an empty storage instance
-     * @see #getDefaultStorage() for a storage instance for a specific {@link Entity}
+     * @see #newDefaultStorage() for a storage instance for a specific {@link Entity}
      */
-    protected abstract S getDefaultStorage();
+    protected abstract S newDefaultStorage();
 
     /**
      * Used to initialize the storage before each test.
@@ -89,7 +89,7 @@ public abstract class AbstractStorageShould<I,
      * @return an empty storage instance
      * @see AbstractStorage#close()
      */
-    protected abstract S getStorage(Class<? extends Entity> cls);
+    protected abstract S newStorage(Class<? extends Entity> cls);
 
     /** Creates a new storage record. */
     protected abstract M newStorageRecord();

--- a/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
@@ -45,7 +45,7 @@ import static org.junit.Assert.fail;
  * An abstract test suites testing storages.
  *
  * <p>The suit manages creation and closing of the {@linkplain #getStorage() storage}
- * for the {@linkplain #getDefaultEntityClass() entity class}.
+ * for the {@linkplain #getTestEntityClass() test entity class}.
  *
  * <p>In case, if the storage for different entity class should be tested,
  * it can be {@linkplain #newStorage(Class) created} manually, but closing of this storage
@@ -69,7 +69,7 @@ public abstract class AbstractStorageShould<I,
 
     @Before
     public void setUpAbstractStorageTest() {
-        storage = newStorage(getDefaultEntityClass());
+        storage = newStorage(getTestEntityClass());
     }
 
     @After
@@ -78,7 +78,7 @@ public abstract class AbstractStorageShould<I,
     }
 
     /**
-     * Obtains the storage for the {@linkplain #getDefaultEntityClass() default entity class}.
+     * Obtains the storage for the {@linkplain #getTestEntityClass() entity class}.
      *
      * @return the storage, which will be closed automatically after a test
      */
@@ -93,7 +93,7 @@ public abstract class AbstractStorageShould<I,
      * release resources, which may be used by the storage.
      *
      * <p>Use {@linkplain #getStorage() existing storage} if the storage may be tested for
-     * {@linkplain #getDefaultEntityClass() default entity class}.
+     * the {@linkplain #getTestEntityClass() entity class}.
      *
      * @return an empty storage instance
      * @see AbstractStorage#close()
@@ -109,8 +109,8 @@ public abstract class AbstractStorageShould<I,
     /** Creates a new read request with the specified ID. */
     protected abstract R newReadRequest(I id);
 
-    /** Returns the class of the default test {@link Entity}. */
-    protected abstract Class<? extends Entity> getDefaultEntityClass();
+    /** Returns the class of the test entity. */
+    protected abstract Class<? extends Entity> getTestEntityClass();
 
     /**
      * Closes the storage and propagates an exception if any occurs.

--- a/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
@@ -59,7 +59,7 @@ public abstract class AbstractStorageShould<I,
 
     @Before
     public void setUpAbstractStorageTest() {
-        storage = newDefaultStorage();
+        storage = newStorage(getDefaultEntityClass());
     }
 
     @After
@@ -68,24 +68,13 @@ public abstract class AbstractStorageShould<I,
     }
 
     /**
-     * @return the storage, which will be closed after a test automatically
+     * Obtains the storage for the {@linkplain #getDefaultEntityClass() default entity class}.
+     *
+     * @return the storage, which will be closed automatically after a test
      */
     protected final S getStorage() {
         return storage;
     }
-
-    /**
-     * Creates the default instance of {@link Storage} for this test suite.
-     *
-     * <p>This method should be used only for creation of a storage.
-     *
-     * <p>Use {@linkplain #getStorage() existing storage} if the default storage
-     * is required in a test.
-     *
-     * @return an empty storage instance
-     * @see #newDefaultStorage() for a storage instance for a specific {@link Entity}
-     */
-    protected abstract S newDefaultStorage();
 
     /**
      * Creates the storage for the specified entity class.
@@ -93,8 +82,8 @@ public abstract class AbstractStorageShould<I,
      * <p>The resulting storage should be {@linkplain #close(AbstractStorage) closed} manually to
      * release resources, which may be used by the storage.
      *
-     * <p>Use this method to test non-{@linkplain #newDefaultStorage() default storage},
-     * otherwise {@link #getStorage() existing storage} is more appropriate for the usage.
+     * <p>Use {@linkplain #getStorage() existing storage} if the storage may be tested for
+     * {@linkplain #getDefaultEntityClass() default entity class}.
      *
      * @return an empty storage instance
      * @see AbstractStorage#close()
@@ -109,6 +98,9 @@ public abstract class AbstractStorageShould<I,
 
     /** Creates a new read request with the specified ID. */
     protected abstract R newReadRequest(I id);
+
+    /** Returns the class of the default test {@link Entity}. */
+    protected abstract Class<? extends Entity> getDefaultEntityClass();
 
     /**
      * Closes the storage and propagates an exception if any occurs.

--- a/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
@@ -67,6 +67,9 @@ public abstract class AbstractStorageShould<I,
         close(storage);
     }
 
+    /**
+     * @return the storage, which will be closed after a test automatically
+     */
     protected final S getStorage() {
         return storage;
     }
@@ -74,7 +77,10 @@ public abstract class AbstractStorageShould<I,
     /**
      * Creates the default instance of {@link Storage} for this test suite.
      *
-     * <p>NOTE: the storage is closed after each test.
+     * <p>This method should be used only for creation of a storage.
+     *
+     * <p>Use {@linkplain #getStorage() existing storage} if the default storage
+     * is required in a test.
      *
      * @return an empty storage instance
      * @see #newDefaultStorage() for a storage instance for a specific {@link Entity}
@@ -82,9 +88,13 @@ public abstract class AbstractStorageShould<I,
     protected abstract S newDefaultStorage();
 
     /**
-     * Used to initialize the storage before each test.
+     * Creates the storage for the specified entity class.
      *
-     * <p>NOTE: the storage is closed after each test.
+     * <p>The resulting storage should be {@linkplain #close(AbstractStorage) closed} manually to
+     * release resources, which may be used by the storage.
+     *
+     * <p>Use this method to test non-{@linkplain #newDefaultStorage() default storage},
+     * otherwise {@link #getStorage() existing storage} is more appropriate for the usage.
      *
      * @return an empty storage instance
      * @see AbstractStorage#close()

--- a/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
@@ -42,12 +42,12 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * An abstract test suites testing storages.
+ * An abstract base for test suites testing storages.
  *
- * <p>The suit manages creation and closing of the {@linkplain #getStorage() storage}
+ * <p>Manages creation and closing of the {@linkplain #getStorage() storage}
  * for the {@linkplain #getTestEntityClass() test entity class}.
  *
- * <p>In case, if the storage for different entity class should be tested,
+ * <p>In case if the storage for different entity class should be tested,
  * it can be {@linkplain #newStorage(Class) created} manually, but closing of this storage
  * is a responsibility of a caller.
  *

--- a/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/AbstractStorageShould.java
@@ -42,7 +42,17 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * Abstract storage tests.
+ * An abstract test suites testing storages.
+ *
+ * <p>The suit manages creation and closing of the {@linkplain #getStorage() storage}
+ * for the {@linkplain #getDefaultEntityClass() entity class}.
+ *
+ * <p>In case, if the storage for different entity class should be tested,
+ * it can be {@linkplain #newStorage(Class) created} manually, but closing of this storage
+ * is a responsibility of a caller.
+ *
+ * <p>All storages should be {@linkplain #close(AbstractStorage) closed} after a test
+ * to avoid the issues, which may occur due to unreleased resources.
  *
  * @param <I> the type of IDs of storage records
  * @param <M> the type of records kept in the storage

--- a/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
@@ -164,7 +164,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     }
 
     @Override
-    protected Class<? extends TestCounterEntity> getDefaultEntityClass() {
+    protected Class<? extends TestCounterEntity> getTestEntityClass() {
         return TestCounterEntity.class;
     }
 
@@ -430,7 +430,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityFilters filters = EntityFilters.newBuilder()
                                                    .addFilter(aggregatingFilter)
                                                    .build();
-        final EntityQuery<I> query = EntityQueries.from(filters, getDefaultEntityClass());
+        final EntityQuery<I> query = EntityQueries.from(filters, getTestEntityClass());
         final I idMatching = newId();
         final I idWrong1 = newId();
         final I idWrong2 = newId();
@@ -483,7 +483,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityFilters filters = EntityFilters.newBuilder()
                                                    .addFilter(aggregatingFilter)
                                                    .build();
-        final EntityQuery<I> query = EntityQueries.from(filters, getDefaultEntityClass());
+        final EntityQuery<I> query = EntityQueries.from(filters, getTestEntityClass());
 
         final I id = newId();
         final TestCounterEntity<I> entity = new TestCounterEntity<>(id);
@@ -546,7 +546,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityFilters filters = EntityFilters.newBuilder()
                                                    .setIdFilter(idFilter)
                                                    .build();
-        final EntityQuery<I> query = EntityQueries.from(filters, getDefaultEntityClass());
+        final EntityQuery<I> query = EntityQueries.from(filters, getTestEntityClass());
 
         // Perform the query
         final Iterator<EntityRecord> readRecords = storage.readAll(query,

--- a/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
@@ -114,8 +114,8 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     protected abstract Message newState(I id);
 
     @Override
-    protected S getDefaultStorage() {
-        return getStorage(getTestEntityClass());
+    protected S newDefaultStorage() {
+        return newStorage(getTestEntityClass());
     }
 
     @Override
@@ -155,7 +155,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     // Converter nullability issues and Optional getting
     @Test
     public void write_and_read_record_by_Message_id() {
-        final RecordStorage<I> storage = getDefaultStorage();
+        final RecordStorage<I> storage = newDefaultStorage();
         final I id = newId();
         final EntityRecord expected = newStorageRecord(id);
         storage.write(id, expected);
@@ -177,7 +177,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final FieldMask nonEmptyFieldMask = FieldMask.newBuilder()
                                                      .addPaths("invalid-path")
                                                      .build();
-        final RecordStorage storage = getDefaultStorage();
+        final RecordStorage storage = newDefaultStorage();
         final Iterator empty = storage.readAll(nonEmptyFieldMask);
 
         assertNotNull(empty);
@@ -189,7 +189,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     public void read_single_record_with_mask() {
         final I id = newId();
         final EntityRecord record = newStorageRecord(id);
-        final RecordStorage<I> storage = getDefaultStorage();
+        final RecordStorage<I> storage = newDefaultStorage();
         storage.write(id, record);
 
         final Descriptors.Descriptor descriptor = newState(id).getDescriptorForType();
@@ -208,7 +208,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     // Converter nullability issues
     @Test
     public void read_multiple_records_with_field_mask() {
-        final RecordStorage<I> storage = getDefaultStorage();
+        final RecordStorage<I> storage = newDefaultStorage();
         final int count = 10;
         final List<I> ids = new LinkedList<>();
         Descriptors.Descriptor typeDescriptor = null;
@@ -241,7 +241,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     @SuppressWarnings("ConstantConditions") // converter nullability issues
     @Test
     public void delete_record() {
-        final RecordStorage<I> storage = getDefaultStorage();
+        final RecordStorage<I> storage = newDefaultStorage();
         final I id = newId();
         final EntityRecord record = newStorageRecord(id);
 
@@ -259,7 +259,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
 
     @Test
     public void write_none_storage_fields_is_none_passed() {
-        final RecordStorage<I> storage = spy(getDefaultStorage());
+        final RecordStorage<I> storage = spy(newDefaultStorage());
         final I id = newId();
         final Any state = pack(Sample.messageOfType(Project.class));
         final EntityRecord record =
@@ -272,7 +272,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
 
     @Test
     public void write_record_bulk() {
-        final RecordStorage<I> storage = getDefaultStorage();
+        final RecordStorage<I> storage = newDefaultStorage();
         final int bulkSize = 5;
 
         final Map<I, EntityRecordWithColumns> initial = new HashMap<>(bulkSize);
@@ -299,7 +299,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     @Test
     public void rewrite_records_in_bulk() {
         final int recordCount = 3;
-        final RecordStorage<I> storage = getDefaultStorage();
+        final RecordStorage<I> storage = newDefaultStorage();
 
         final Function<EntityRecord, EntityRecordWithColumns> recordPacker =
                 new Function<EntityRecord, EntityRecordWithColumns>() {
@@ -341,7 +341,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     @Test(expected = IllegalStateException.class)
     public void fail_to_write_visibility_to_non_existing_record() {
         final I id = newId();
-        final RecordStorage<I> storage = getDefaultStorage();
+        final RecordStorage<I> storage = newDefaultStorage();
 
         storage.writeLifecycleFlags(id, archived());
     }
@@ -349,7 +349,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     @Test
     public void return_absent_visibility_for_missing_record() {
         final I id = newId();
-        final RecordStorage<I> storage = getDefaultStorage();
+        final RecordStorage<I> storage = newDefaultStorage();
         final Optional<LifecycleFlags> optional = storage.readLifecycleFlags(id);
         assertFalse(optional.isPresent());
     }
@@ -359,7 +359,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     public void return_default_visibility_for_new_record() {
         final I id = newId();
         final EntityRecord record = newStorageRecord(id);
-        final RecordStorage<I> storage = getDefaultStorage();
+        final RecordStorage<I> storage = newDefaultStorage();
         storage.write(id, record);
 
         final Optional<LifecycleFlags> optional = storage.readLifecycleFlags(id);
@@ -372,7 +372,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     public void load_visibility_when_updated() {
         final I id = newId();
         final EntityRecord record = newStorageRecord(id);
-        final RecordStorage<I> storage = getDefaultStorage();
+        final RecordStorage<I> storage = newDefaultStorage();
         storage.write(id, EntityRecordWithColumns.of(record));
 
         storage.writeLifecycleFlags(id, archived());
@@ -389,7 +389,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityRecord record = newStorageRecord(id);
         final EntityRecordWithColumns recordWithStorageFields = EntityRecordWithColumns.of(record);
         assertFalse(recordWithStorageFields.hasColumns());
-        final RecordStorage<I> storage = getDefaultStorage();
+        final RecordStorage<I> storage = newDefaultStorage();
 
         storage.write(id, recordWithStorageFields);
         final RecordReadRequest<I> readRequest = newReadRequest(id);
@@ -404,7 +404,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityRecord record = newStorageRecord(id);
         final TestCounterEntity<?> testEntity = new TestCounterEntity<>(id);
         final EntityRecordWithColumns recordWithColumns = create(record, testEntity);
-        final S storage = getDefaultStorage();
+        final S storage = newDefaultStorage();
         storage.write(id, recordWithColumns);
 
         final RecordReadRequest<I> readRequest = newReadRequest(id);
@@ -461,7 +461,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityRecordWithColumns recordWrong1 = create(notFineRecord1, wrongEntity1);
         final EntityRecordWithColumns recordWrong2 = create(notFineRecord2, wrongEntity2);
 
-        final RecordStorage<I> storage = getDefaultStorage();
+        final RecordStorage<I> storage = newDefaultStorage();
 
         storage.write(idMatching, recordRight);
         storage.write(idWrong1, recordWrong1);
@@ -496,7 +496,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityRecord record = newStorageRecord(id, newState(id));
         final EntityRecordWithColumns recordWithColumns = create(record, entity);
 
-        final RecordStorage<I> storage = getDefaultStorage();
+        final RecordStorage<I> storage = newDefaultStorage();
         final FieldMask fieldMask = FieldMask.getDefaultInstance();
 
         // Create the record.
@@ -532,7 +532,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityRecordWithColumns recordWrong1 = create(notFineRecord1, wrongEntity1);
         final EntityRecordWithColumns recordWrong2 = create(notFineRecord2, wrongEntity2);
 
-        final RecordStorage<I> storage = getDefaultStorage();
+        final RecordStorage<I> storage = newDefaultStorage();
 
         // Fill the storage
         storage.write(idWrong1, recordWrong1);

--- a/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
@@ -155,7 +155,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     // Converter nullability issues and Optional getting
     @Test
     public void write_and_read_record_by_Message_id() {
-        final RecordStorage<I> storage = newDefaultStorage();
+        final RecordStorage<I> storage = getStorage();
         final I id = newId();
         final EntityRecord expected = newStorageRecord(id);
         storage.write(id, expected);
@@ -177,7 +177,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final FieldMask nonEmptyFieldMask = FieldMask.newBuilder()
                                                      .addPaths("invalid-path")
                                                      .build();
-        final RecordStorage storage = newDefaultStorage();
+        final RecordStorage storage = getStorage();
         final Iterator empty = storage.readAll(nonEmptyFieldMask);
 
         assertNotNull(empty);
@@ -189,7 +189,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     public void read_single_record_with_mask() {
         final I id = newId();
         final EntityRecord record = newStorageRecord(id);
-        final RecordStorage<I> storage = newDefaultStorage();
+        final RecordStorage<I> storage = getStorage();
         storage.write(id, record);
 
         final Descriptors.Descriptor descriptor = newState(id).getDescriptorForType();
@@ -208,7 +208,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     // Converter nullability issues
     @Test
     public void read_multiple_records_with_field_mask() {
-        final RecordStorage<I> storage = newDefaultStorage();
+        final RecordStorage<I> storage = getStorage();
         final int count = 10;
         final List<I> ids = new LinkedList<>();
         Descriptors.Descriptor typeDescriptor = null;
@@ -241,7 +241,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     @SuppressWarnings("ConstantConditions") // converter nullability issues
     @Test
     public void delete_record() {
-        final RecordStorage<I> storage = newDefaultStorage();
+        final RecordStorage<I> storage = getStorage();
         final I id = newId();
         final EntityRecord record = newStorageRecord(id);
 
@@ -259,7 +259,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
 
     @Test
     public void write_none_storage_fields_is_none_passed() {
-        final RecordStorage<I> storage = spy(newDefaultStorage());
+        final RecordStorage<I> storage = spy(getStorage());
         final I id = newId();
         final Any state = pack(Sample.messageOfType(Project.class));
         final EntityRecord record =
@@ -272,7 +272,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
 
     @Test
     public void write_record_bulk() {
-        final RecordStorage<I> storage = newDefaultStorage();
+        final RecordStorage<I> storage = getStorage();
         final int bulkSize = 5;
 
         final Map<I, EntityRecordWithColumns> initial = new HashMap<>(bulkSize);
@@ -299,7 +299,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     @Test
     public void rewrite_records_in_bulk() {
         final int recordCount = 3;
-        final RecordStorage<I> storage = newDefaultStorage();
+        final RecordStorage<I> storage = getStorage();
 
         final Function<EntityRecord, EntityRecordWithColumns> recordPacker =
                 new Function<EntityRecord, EntityRecordWithColumns>() {
@@ -341,7 +341,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     @Test(expected = IllegalStateException.class)
     public void fail_to_write_visibility_to_non_existing_record() {
         final I id = newId();
-        final RecordStorage<I> storage = newDefaultStorage();
+        final RecordStorage<I> storage = getStorage();
 
         storage.writeLifecycleFlags(id, archived());
     }
@@ -349,7 +349,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     @Test
     public void return_absent_visibility_for_missing_record() {
         final I id = newId();
-        final RecordStorage<I> storage = newDefaultStorage();
+        final RecordStorage<I> storage = getStorage();
         final Optional<LifecycleFlags> optional = storage.readLifecycleFlags(id);
         assertFalse(optional.isPresent());
     }
@@ -359,7 +359,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     public void return_default_visibility_for_new_record() {
         final I id = newId();
         final EntityRecord record = newStorageRecord(id);
-        final RecordStorage<I> storage = newDefaultStorage();
+        final RecordStorage<I> storage = getStorage();
         storage.write(id, record);
 
         final Optional<LifecycleFlags> optional = storage.readLifecycleFlags(id);
@@ -372,7 +372,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     public void load_visibility_when_updated() {
         final I id = newId();
         final EntityRecord record = newStorageRecord(id);
-        final RecordStorage<I> storage = newDefaultStorage();
+        final RecordStorage<I> storage = getStorage();
         storage.write(id, EntityRecordWithColumns.of(record));
 
         storage.writeLifecycleFlags(id, archived());
@@ -389,7 +389,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityRecord record = newStorageRecord(id);
         final EntityRecordWithColumns recordWithStorageFields = EntityRecordWithColumns.of(record);
         assertFalse(recordWithStorageFields.hasColumns());
-        final RecordStorage<I> storage = newDefaultStorage();
+        final RecordStorage<I> storage = getStorage();
 
         storage.write(id, recordWithStorageFields);
         final RecordReadRequest<I> readRequest = newReadRequest(id);
@@ -404,7 +404,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityRecord record = newStorageRecord(id);
         final TestCounterEntity<?> testEntity = new TestCounterEntity<>(id);
         final EntityRecordWithColumns recordWithColumns = create(record, testEntity);
-        final S storage = newDefaultStorage();
+        final S storage = getStorage();
         storage.write(id, recordWithColumns);
 
         final RecordReadRequest<I> readRequest = newReadRequest(id);
@@ -461,7 +461,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityRecordWithColumns recordWrong1 = create(notFineRecord1, wrongEntity1);
         final EntityRecordWithColumns recordWrong2 = create(notFineRecord2, wrongEntity2);
 
-        final RecordStorage<I> storage = newDefaultStorage();
+        final RecordStorage<I> storage = getStorage();
 
         storage.write(idMatching, recordRight);
         storage.write(idWrong1, recordWrong1);
@@ -496,7 +496,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityRecord record = newStorageRecord(id, newState(id));
         final EntityRecordWithColumns recordWithColumns = create(record, entity);
 
-        final RecordStorage<I> storage = newDefaultStorage();
+        final RecordStorage<I> storage = getStorage();
         final FieldMask fieldMask = FieldMask.getDefaultInstance();
 
         // Create the record.
@@ -532,7 +532,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityRecordWithColumns recordWrong1 = create(notFineRecord1, wrongEntity1);
         final EntityRecordWithColumns recordWrong2 = create(notFineRecord2, wrongEntity2);
 
-        final RecordStorage<I> storage = newDefaultStorage();
+        final RecordStorage<I> storage = getStorage();
 
         // Fill the storage
         storage.write(idWrong1, recordWrong1);

--- a/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
@@ -114,11 +114,6 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     protected abstract Message newState(I id);
 
     @Override
-    protected S newDefaultStorage() {
-        return newStorage(getTestEntityClass());
-    }
-
-    @Override
     protected EntityRecord newStorageRecord() {
         return newStorageRecord(newState(newId()));
     }
@@ -168,7 +163,8 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         close(storage);
     }
 
-    protected Class<? extends TestCounterEntity> getTestEntityClass() {
+    @Override
+    protected Class<? extends TestCounterEntity> getDefaultEntityClass() {
         return TestCounterEntity.class;
     }
 
@@ -434,7 +430,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityFilters filters = EntityFilters.newBuilder()
                                                    .addFilter(aggregatingFilter)
                                                    .build();
-        final EntityQuery<I> query = EntityQueries.from(filters, getTestEntityClass());
+        final EntityQuery<I> query = EntityQueries.from(filters, getDefaultEntityClass());
         final I idMatching = newId();
         final I idWrong1 = newId();
         final I idWrong2 = newId();
@@ -487,7 +483,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityFilters filters = EntityFilters.newBuilder()
                                                    .addFilter(aggregatingFilter)
                                                    .build();
-        final EntityQuery<I> query = EntityQueries.from(filters, getTestEntityClass());
+        final EntityQuery<I> query = EntityQueries.from(filters, getDefaultEntityClass());
 
         final I id = newId();
         final TestCounterEntity<I> entity = new TestCounterEntity<>(id);
@@ -550,7 +546,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         final EntityFilters filters = EntityFilters.newBuilder()
                                                    .setIdFilter(idFilter)
                                                    .build();
-        final EntityQuery<I> query = EntityQueries.from(filters, getTestEntityClass());
+        final EntityQuery<I> query = EntityQueries.from(filters, getDefaultEntityClass());
 
         // Perform the query
         final Iterator<EntityRecord> readRecords = storage.readAll(query,

--- a/server/src/test/java/io/spine/server/storage/memory/InMemoryAggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/memory/InMemoryAggregateStorageShould.java
@@ -34,7 +34,7 @@ import io.spine.validate.ValidatingBuilder;
 public class InMemoryAggregateStorageShould extends AggregateStorageShould {
 
     @Override
-    protected AggregateStorage<ProjectId> getStorage(Class<? extends Entity> cls) {
+    protected AggregateStorage<ProjectId> newStorage(Class<? extends Entity> cls) {
         return InMemoryAggregateStorage.newInstance();
     }
 

--- a/server/src/test/java/io/spine/server/storage/memory/InMemoryAggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/memory/InMemoryAggregateStorageShould.java
@@ -39,7 +39,7 @@ public class InMemoryAggregateStorageShould extends AggregateStorageShould {
     }
 
     @Override
-    protected <I> AggregateStorage<I> getStorage(
+    protected <I> AggregateStorage<I> newStorage(
             Class<? extends I> idClass,
             Class<? extends Aggregate<I,
                                       ? extends Message,

--- a/server/src/test/java/io/spine/server/storage/memory/InMemoryProjectionStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/memory/InMemoryProjectionStorageShould.java
@@ -34,7 +34,7 @@ import static io.spine.server.BoundedContext.newName;
 public class InMemoryProjectionStorageShould extends ProjectionStorageShould {
 
     @Override
-    protected ProjectionStorage<ProjectId> getStorage(Class<? extends Entity> cls) {
+    protected ProjectionStorage<ProjectId> newStorage(Class<? extends Entity> cls) {
         final StorageSpec<ProjectId> spec =
                 StorageSpec.of(newName(getClass().getSimpleName()),
                                TypeUrl.of(io.spine.test.projection.Project.class),

--- a/server/src/test/java/io/spine/server/storage/memory/InMemoryRecordStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/memory/InMemoryRecordStorageShould.java
@@ -43,7 +43,7 @@ public class InMemoryRecordStorageShould
         extends RecordStorageShould<ProjectId, RecordStorage<ProjectId>> {
 
     @Override
-    protected RecordStorage<ProjectId> getStorage(Class<? extends Entity> cls) {
+    protected RecordStorage<ProjectId> newStorage(Class<? extends Entity> cls) {
         final StorageSpec<ProjectId> spec = StorageSpec.of(newName(getClass().getSimpleName()),
                                                            TypeUrl.of(Project.class),
                                                            ProjectId.class);
@@ -72,7 +72,7 @@ public class InMemoryRecordStorageShould
 
     @Test
     public void return_storage_spec() {
-        final StorageSpec spec = ((InMemoryRecordStorage) getStorage(Entity.class)).getSpec();
+        final StorageSpec spec = ((InMemoryRecordStorage) newStorage(Entity.class)).getSpec();
         assertEquals(ProjectId.class, spec.getIdClass());
     }
 }

--- a/server/src/test/java/io/spine/server/storage/memory/InMemoryRecordStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/memory/InMemoryRecordStorageShould.java
@@ -22,7 +22,6 @@ package io.spine.server.storage.memory;
 
 import com.google.protobuf.Message;
 import io.spine.server.entity.Entity;
-import io.spine.server.storage.RecordStorage;
 import io.spine.server.storage.RecordStorageShould;
 import io.spine.test.storage.Project;
 import io.spine.test.storage.ProjectId;
@@ -40,10 +39,10 @@ import static org.junit.Assert.assertEquals;
  * @author Dmytro Dashenkov
  */
 public class InMemoryRecordStorageShould
-        extends RecordStorageShould<ProjectId, RecordStorage<ProjectId>> {
+        extends RecordStorageShould<ProjectId, InMemoryRecordStorage<ProjectId>> {
 
     @Override
-    protected RecordStorage<ProjectId> newStorage(Class<? extends Entity> cls) {
+    protected InMemoryRecordStorage<ProjectId> newStorage(Class<? extends Entity> cls) {
         final StorageSpec<ProjectId> spec = StorageSpec.of(newName(getClass().getSimpleName()),
                                                            TypeUrl.of(Project.class),
                                                            ProjectId.class);
@@ -72,7 +71,7 @@ public class InMemoryRecordStorageShould
 
     @Test
     public void return_storage_spec() {
-        final StorageSpec spec = ((InMemoryRecordStorage) newStorage(Entity.class)).getSpec();
+        final StorageSpec spec = getStorage().getSpec();
         assertEquals(ProjectId.class, spec.getIdClass());
     }
 }

--- a/server/src/test/java/io/spine/server/storage/memory/InMemoryStandStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/memory/InMemoryStandStorageShould.java
@@ -32,7 +32,7 @@ import static io.spine.server.BoundedContext.newName;
 public class InMemoryStandStorageShould extends StandStorageShould {
 
     @Override
-    protected StandStorage getStorage(Class<? extends Entity> cls) {
+    protected StandStorage newStorage(Class<? extends Entity> cls) {
         return InMemoryStandStorage.newBuilder()
                                    .setBoundedContextName(newName(getClass().getSimpleName()))
                                    .setMultitenant(false)


### PR DESCRIPTION
Previously, some tests for storages created instances of storages, which were not closed after execution of a test.

It could lead to issues, when the resources used by the storage were not released. This PR fixes this and improves the documentation.

For now, `AbstractStorageShould` manages creation and closing of the single storage for the test entity class, which is specified by `getTestEntityClass()` method. This storage can be obtained using `getStorage()` method.

In the case, if the storage for different entity class should be tested, it can be created using `newStorage(Class)` method, but closing of this storage is a responsibility of a caller.

All storages should be closed after a test to avoid the issues, which may occur due to unreleased resources. `AbstractStorageShould.close(AbstractStorage) ` simplifies this task.

The version of the framework was increased to `0.10.5-SNAPSHOT`.