### PR TITLE
Update the `SubscriptionUpdate` to contain both IDs and states of updated Entities

### DIFF
--- a/client/src/main/proto/spine/client/subscription.proto
+++ b/client/src/main/proto/spine/client/subscription.proto
@@ -97,11 +97,11 @@ message SubscriptionUpdate {
     //
     repeated EntityStateUpdate entity_state_updates = 9 [(valid) = true];
 
-    // Deprecated field for the entity state updates.
+    // Deleted field `updates`.
     //
     // Use `entity_state_updates` instead.
     //
-    repeated google.protobuf.Any OBSOLETE_updates = 10 [deprecated = true];
+    reserved 10;
 }
 
 // The pair of the entity ID and the entity state both packed as Any.

--- a/client/src/main/proto/spine/client/subscription.proto
+++ b/client/src/main/proto/spine/client/subscription.proto
@@ -86,7 +86,13 @@ message SubscriptionUpdate {
     core.Response response = 2 [(required) = true];
 
     // Reserved for more subscription update attributes.
-    reserved 3 to 8;
+    reserved 3 to 9;
+
+    // Deleted field `updates`.
+    //
+    // Use `entity_state_updates` instead.
+    //
+    reserved 10;
 
     // The updates of the entity states.
     //
@@ -95,13 +101,7 @@ message SubscriptionUpdate {
     // Each of the update state messages is affected by the field mask set for the current
     // subscription.
     //
-    repeated EntityStateUpdate entity_state_updates = 9 [(valid) = true];
-
-    // Deleted field `updates`.
-    //
-    // Use `entity_state_updates` instead.
-    //
-    reserved 10;
+    repeated EntityStateUpdate entity_state_updates = 11 [(valid) = true];
 }
 
 // The pair of the entity ID and the entity state both packed as Any.

--- a/client/src/main/proto/spine/client/subscription.proto
+++ b/client/src/main/proto/spine/client/subscription.proto
@@ -86,12 +86,35 @@ message SubscriptionUpdate {
     core.Response response = 2 [(required) = true];
 
     // Reserved for more subscription update attributes.
-    reserved 3 to 9;
+    reserved 3 to 8;
 
-    // Entity updates packed as Any.
+    // The updates of the Entity states.
     //
-    // Each of the update messages is affected by the field mask set for the current subscription.
-    repeated google.protobuf.Any updates = 10;
+    // Each update is a pair of an Entity ID and state.
+    //
+    // Each of the update state messages is affected by the field mask set for the current
+    // subscription.
+    //
+    repeated EntityStateUpdate entity_state_updates = 9 [(valid) = true];
+
+    // Deprecated field for the Entity state updates.
+    //
+    // Use `entity_state_updates` instead.
+    //
+    repeated google.protobuf.Any OBSOLETE_updates = 10 [deprecated = true];
+}
+
+// The pair of the entity ID and the Entity state both packed as Any.
+message EntityStateUpdate {
+
+    // The Entity ID packed as Any.
+    google.protobuf.Any id = 1 [(required) = true];
+
+    // The Entity state packed as Any.
+    //
+    // May be affected by a field mask specified in the subscription Topic.
+    //
+    google.protobuf.Any state = 2 [(required) = true];
 }
 
 

--- a/client/src/main/proto/spine/client/subscription.proto
+++ b/client/src/main/proto/spine/client/subscription.proto
@@ -88,29 +88,29 @@ message SubscriptionUpdate {
     // Reserved for more subscription update attributes.
     reserved 3 to 8;
 
-    // The updates of the Entity states.
+    // The updates of the entity states.
     //
-    // Each update is a pair of an Entity ID and state.
+    // Each update is a pair of an entity ID and state.
     //
     // Each of the update state messages is affected by the field mask set for the current
     // subscription.
     //
     repeated EntityStateUpdate entity_state_updates = 9 [(valid) = true];
 
-    // Deprecated field for the Entity state updates.
+    // Deprecated field for the entity state updates.
     //
     // Use `entity_state_updates` instead.
     //
     repeated google.protobuf.Any OBSOLETE_updates = 10 [deprecated = true];
 }
 
-// The pair of the entity ID and the Entity state both packed as Any.
+// The pair of the entity ID and the entity state both packed as Any.
 message EntityStateUpdate {
 
-    // The Entity ID packed as Any.
+    // The entity ID packed as Any.
     google.protobuf.Any id = 1 [(required) = true];
 
-    // The Entity state packed as Any.
+    // The entity state packed as Any.
     //
     // May be affected by a field mask specified in the subscription Topic.
     //

--- a/client/src/main/proto/spine/client/subscription.proto
+++ b/client/src/main/proto/spine/client/subscription.proto
@@ -117,7 +117,6 @@ message EntityStateUpdate {
     google.protobuf.Any state = 2 [(required) = true];
 }
 
-
 // Subscription identifier.
 message SubscriptionId {
 

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.5-SNAPSHOT'
+def final SPINE_VERSION = '0.10.6-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/SubscriptionService.java
+++ b/server/src/main/java/io/spine/server/SubscriptionService.java
@@ -23,8 +23,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import com.google.protobuf.Any;
 import io.grpc.stub.StreamObserver;
+import io.spine.client.EntityStateUpdate;
 import io.spine.client.Subscription;
 import io.spine.client.SubscriptionUpdate;
 import io.spine.client.Target;
@@ -92,13 +92,13 @@ public class SubscriptionService extends SubscriptionServiceGrpc.SubscriptionSer
 
             final Stand.EntityUpdateCallback updateCallback = new Stand.EntityUpdateCallback() {
                 @Override
-                public void onStateChanged(Any newEntityState) {
+                public void onStateChanged(EntityStateUpdate stateUpdate) {
                     checkNotNull(subscription);
                     final SubscriptionUpdate update =
                             SubscriptionUpdate.newBuilder()
                                               .setSubscription(subscription)
                                               .setResponse(Responses.ok())
-                                              .addUpdates(newEntityState)
+                                              .addEntityStateUpdates(stateUpdate)
                                               .build();
                     responseObserver.onNext(update);
                 }

--- a/server/src/main/java/io/spine/server/stand/Stand.java
+++ b/server/src/main/java/io/spine/server/stand/Stand.java
@@ -506,14 +506,14 @@ public class Stand implements AutoCloseable {
             @Override
             public void run() {
                 final EntityUpdateCallback callback = subscriptionRecord.getCallback();
-                if (callback != null) {
-                    final Any entityId = toAny(id);
-                    final EntityStateUpdate stateUpdate = EntityStateUpdate.newBuilder()
-                                                                           .setId(entityId)
-                                                                           .setState(entityState)
-                                                                           .build();
-                    callback.onStateChanged(stateUpdate);
-                }
+                checkNotNull(callback, "Notifying by a non-activated subscription.");
+                final Any entityId = toAny(id);
+                final EntityStateUpdate stateUpdate = EntityStateUpdate.newBuilder()
+                                                                       .setId(entityId)
+                                                                       .setState(entityState)
+                                                                       .build();
+                callback.onStateChanged(stateUpdate);
+
             }
         };
         return result;

--- a/server/src/main/java/io/spine/server/stand/Stand.java
+++ b/server/src/main/java/io/spine/server/stand/Stand.java
@@ -395,8 +395,8 @@ public class Stand implements AutoCloseable {
                 final boolean subscriptionIsActive = subscriptionRecord.isActive();
                 final boolean stateMatches = subscriptionRecord.matches(typeUrl, id, entityState);
                 if (subscriptionIsActive && stateMatches) {
-                    final Runnable action = subscribersNotificationAction(subscriptionRecord,
-                                                                          id, entityState);
+                    final Runnable action = notifySubscriberAction(subscriptionRecord,
+                                                                   id, entityState);
                     callbackExecutor.execute(action);
                 }
             }
@@ -500,9 +500,8 @@ public class Stand implements AutoCloseable {
      * @param entityState        the new state of the updated Entity
      * @return a routine delivering the subscription update to the target subscriber
      */
-    private static Runnable subscribersNotificationAction(
-            final SubscriptionRecord subscriptionRecord,
-            final Object id, final Any entityState) {
+    private static Runnable notifySubscriberAction(final SubscriptionRecord subscriptionRecord,
+                                                   final Object id, final Any entityState) {
         final Runnable result = new Runnable() {
             @Override
             public void run() {

--- a/server/src/main/java/io/spine/server/stand/Stand.java
+++ b/server/src/main/java/io/spine/server/stand/Stand.java
@@ -395,8 +395,8 @@ public class Stand implements AutoCloseable {
                 final boolean subscriptionIsActive = subscriptionRecord.isActive();
                 final boolean stateMatches = subscriptionRecord.matches(typeUrl, id, entityState);
                 if (subscriptionIsActive && stateMatches) {
-                    final Runnable action = notifySubscriberAction(subscriptionRecord,
-                                                                   id, entityState);
+                    final Runnable action = notifySubscriptionAction(subscriptionRecord,
+                                                                     id, entityState);
                     callbackExecutor.execute(action);
                 }
             }
@@ -500,8 +500,8 @@ public class Stand implements AutoCloseable {
      * @param entityState        the new state of the updated Entity
      * @return a routine delivering the subscription update to the target subscriber
      */
-    private static Runnable notifySubscriberAction(final SubscriptionRecord subscriptionRecord,
-                                                   final Object id, final Any entityState) {
+    private static Runnable notifySubscriptionAction(final SubscriptionRecord subscriptionRecord,
+                                                     final Object id, final Any entityState) {
         final Runnable result = new Runnable() {
             @Override
             public void run() {
@@ -513,7 +513,6 @@ public class Stand implements AutoCloseable {
                                                                        .setState(entityState)
                                                                        .build();
                 callback.onStateChanged(stateUpdate);
-
             }
         };
         return result;

--- a/server/src/test/java/io/spine/server/stand/StandShould.java
+++ b/server/src/test/java/io/spine/server/stand/StandShould.java
@@ -34,6 +34,7 @@ import io.grpc.stub.StreamObserver;
 import io.spine.client.ActorRequestFactory;
 import io.spine.client.EntityFilters;
 import io.spine.client.EntityId;
+import io.spine.client.EntityStateUpdate;
 import io.spine.client.Query;
 import io.spine.client.QueryResponse;
 import io.spine.client.Subscription;
@@ -490,7 +491,7 @@ public class StandShould extends TenantAwareTest {
         final Any packedState = AnyPacker.pack(customer);
         for (MemoizeEntityUpdateCallback callback : callbacks) {
             assertEquals(packedState, callback.newEntityState);
-            verify(callback, times(1)).onStateChanged(any(Any.class));
+            verify(callback, times(1)).onStateChanged(any(EntityStateUpdate.class));
         }
     }
 
@@ -508,7 +509,7 @@ public class StandShould extends TenantAwareTest {
         final Version stateVersion = GivenVersion.withNumber(1);
         stand.update(asEnvelope(customerId, customer, stateVersion));
 
-        verify(callback, never()).onStateChanged(any(Any.class));
+        verify(callback, never()).onStateChanged(any(EntityStateUpdate.class));
     }
 
     @Test
@@ -521,9 +522,9 @@ public class StandShould extends TenantAwareTest {
         final Set<Customer> callbackStates = newHashSet();
         final MemoizeEntityUpdateCallback callback = new MemoizeEntityUpdateCallback() {
             @Override
-            public void onStateChanged(Any newEntityState) {
+            public void onStateChanged(EntityStateUpdate newEntityState) {
                 super.onStateChanged(newEntityState);
-                final Customer customerInCallback = AnyPacker.unpack(newEntityState);
+                final Customer customerInCallback = AnyPacker.unpack(newEntityState.getState());
                 callbackStates.add(customerInCallback);
             }
         };
@@ -1444,7 +1445,7 @@ public class StandShould extends TenantAwareTest {
     private static Stand.EntityUpdateCallback emptyUpdateCallback() {
         return new Stand.EntityUpdateCallback() {
             @Override
-            public void onStateChanged(Any newEntityState) {
+            public void onStateChanged(EntityStateUpdate newEntityState) {
                 //do nothing
             }
         };
@@ -1515,8 +1516,8 @@ public class StandShould extends TenantAwareTest {
         private Any newEntityState = null;
 
         @Override
-        public void onStateChanged(Any newEntityState) {
-            this.newEntityState = newEntityState;
+        public void onStateChanged(EntityStateUpdate newEntityState) {
+            this.newEntityState = newEntityState.getState();
         }
 
         @Nullable


### PR DESCRIPTION
In this PR we change the `SubscriptionUpdate` message model:
```diff
- repeated google.protobuf.Any updates;
+ repeated EntityStateUpdate entity_state_updates;
```
Here `EntityStateUpdate` is the message containing both Entity ID and entity state.

The `updates` field has been deleted and its number has been [marked as `reserved`](https://developers.google.com/protocol-buffers/docs/proto3#updating) for the serialized format compatibility.

This change is required to make the subscribers aware of the ID of the received updates.