### PR TITLE
Fix `Target.type` content

### DIFF
--- a/client/src/main/java/io/spine/client/Queries.java
+++ b/client/src/main/java/io/spine/client/Queries.java
@@ -23,14 +23,15 @@ import com.google.protobuf.FieldMask;
 import com.google.protobuf.Message;
 import io.spine.Identifier;
 import io.spine.annotation.Internal;
-import io.spine.type.TypeName;
 import io.spine.type.TypeUrl;
 
 import javax.annotation.Nullable;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 import static io.spine.client.Targets.composeTarget;
+import static io.spine.type.KnownTypes.getAllUrls;
 import static java.lang.String.format;
 
 /**
@@ -70,9 +71,10 @@ public final class Queries {
         checkNotNull(query);
 
         final Target target = query.getTarget();
-        final TypeName typeName = TypeName.of(target.getType());
-        final TypeUrl type = typeName.toUrl();
-        return type;
+        final String type = target.getType();
+        final TypeUrl typeUrl = TypeUrl.parse(type);
+        checkState(getAllUrls().contains(typeUrl), "Unknown type URL: `%s`.", type);
+        return typeUrl;
     }
 
     static Query.Builder queryBuilderFor(Class<? extends Message> entityClass,

--- a/client/src/main/java/io/spine/client/Targets.java
+++ b/client/src/main/java/io/spine/client/Targets.java
@@ -24,7 +24,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
 import io.spine.protobuf.AnyPacker;
-import io.spine.type.TypeName;
+import io.spine.type.TypeUrl;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -99,10 +99,10 @@ public final class Targets {
                                                    .setIdFilter(idFilter)
                                                    .addAllFilter(entityColumnValues)
                                                    .build();
-        final String typeName = TypeName.of(entityClass)
-                                        .value();
+        final String typeUrl = TypeUrl.of(entityClass)
+                                      .value();
         final Target.Builder builder = Target.newBuilder()
-                                             .setType(typeName);
+                                             .setType(typeUrl);
         if (includeAll) {
             builder.setIncludeAll(true);
         } else {

--- a/client/src/test/java/io/spine/client/QueriesShould.java
+++ b/client/src/test/java/io/spine/client/QueriesShould.java
@@ -61,7 +61,7 @@ public class QueriesShould {
     @Test(expected = IllegalStateException.class)
     public void throw_ISE_for_unknown_type() {
         final Target target = Target.newBuilder()
-                                    .setType("Nonexistent Message Type")
+                                    .setType("nonexistent.org/message.type")
                                     .build();
         final Query query = Query.newBuilder()
                                  .setTarget(target)

--- a/client/src/test/java/io/spine/client/QueriesShould.java
+++ b/client/src/test/java/io/spine/client/QueriesShould.java
@@ -61,7 +61,7 @@ public class QueriesShould {
     @Test(expected = IllegalStateException.class)
     public void throw_ISE_for_unknown_type() {
         final Target target = Target.newBuilder()
-                                    .setType("nonexistent.org/message.type")
+                                    .setType("nonexistent/message.type")
                                     .build();
         final Query query = Query.newBuilder()
                                  .setTarget(target)

--- a/client/src/test/java/io/spine/client/QueryBuilderShould.java
+++ b/client/src/test/java/io/spine/client/QueryBuilderShould.java
@@ -30,7 +30,7 @@ import com.google.protobuf.Timestamp;
 import io.spine.protobuf.AnyPacker;
 import io.spine.test.client.TestEntity;
 import io.spine.test.queries.ProjectId;
-import io.spine.type.TypeName;
+import io.spine.type.TypeUrl;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
@@ -89,8 +89,7 @@ public class QueryBuilderShould extends ActorRequestFactoryShould {
         final Target target = query.getTarget();
         assertTrue(target.getIncludeAll());
 
-        assertEquals(TypeName.of(testEntityClass)
-                             .value(), target.getType());
+        assertEquals(TypeUrl.of(testEntityClass).value(), target.getType());
     }
 
     @Test

--- a/client/src/test/java/io/spine/client/QueryFactoryShould.java
+++ b/client/src/test/java/io/spine/client/QueryFactoryShould.java
@@ -25,7 +25,7 @@ import com.google.protobuf.ProtocolStringList;
 import io.spine.protobuf.AnyPacker;
 import io.spine.test.client.TestEntity;
 import io.spine.test.client.TestEntityId;
-import io.spine.type.TypeName;
+import io.spine.type.TypeUrl;
 import org.junit.Test;
 
 import java.util.Collection;
@@ -306,8 +306,8 @@ public class QueryFactoryShould extends ActorRequestFactoryShould {
         final Target entityTarget = query.getTarget();
         assertNotNull(entityTarget);
 
-        final String expectedTypeName = TypeName.of(targetEntityClass)
-                                                .value();
+        final String expectedTypeName = TypeUrl.of(targetEntityClass)
+                                               .value();
         assertEquals(expectedTypeName, entityTarget.getType());
         return entityTarget;
     }

--- a/client/src/test/java/io/spine/client/TopicFactoryShould.java
+++ b/client/src/test/java/io/spine/client/TopicFactoryShould.java
@@ -25,7 +25,7 @@ import io.spine.core.ActorContext;
 import io.spine.protobuf.AnyPacker;
 import io.spine.test.client.TestEntity;
 import io.spine.test.client.TestEntityId;
-import io.spine.type.TypeName;
+import io.spine.type.TypeUrl;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -45,7 +45,7 @@ public class TopicFactoryShould
 
     // See {@code client_requests.proto} for declaration.
     private static final Class<TestEntity> TARGET_ENTITY_CLASS = TestEntity.class;
-    private static final TypeName TARGET_ENTITY_TYPE_NAME = TypeName.of(TARGET_ENTITY_CLASS);
+    private static final TypeUrl TARGET_ENTITY_TYPE_NAME = TypeUrl.of(TARGET_ENTITY_CLASS);
 
     @Test
     public void create_topic_for_all_entities_of_kind() {

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.7-SNAPSHOT'
+def final SPINE_VERSION = '0.10.8-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/SubscriptionService.java
+++ b/server/src/main/java/io/spine/server/SubscriptionService.java
@@ -34,7 +34,6 @@ import io.spine.core.Response;
 import io.spine.core.Responses;
 import io.spine.grpc.StreamObservers;
 import io.spine.server.stand.Stand;
-import io.spine.type.TypeName;
 import io.spine.type.TypeUrl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -128,17 +127,13 @@ public class SubscriptionService extends SubscriptionServiceGrpc.SubscriptionSer
     }
 
     private BoundedContext selectBoundedContext(Subscription subscription) {
-        final TypeName typeName = TypeName.of(subscription.getTopic()
-                                                          .getTarget()
-                                                          .getType());
-        final TypeUrl type = typeName.toUrl();
-        final BoundedContext result = typeToContextMap.get(type);
-        return result;
+        final Target target = subscription.getTopic().getTarget();
+        final BoundedContext context = selectBoundedContext(target);
+        return context;
     }
 
     private BoundedContext selectBoundedContext(Target target) {
-        final TypeName typeName = TypeName.of(target.getType());
-        final TypeUrl type = typeName.toUrl();
+        final TypeUrl type = TypeUrl.parse(target.getType());
         final BoundedContext result = typeToContextMap.get(type);
         return result;
     }

--- a/server/src/main/java/io/spine/server/stand/AbstractTargetValidator.java
+++ b/server/src/main/java/io/spine/server/stand/AbstractTargetValidator.java
@@ -21,7 +21,6 @@ package io.spine.server.stand;
 
 import com.google.protobuf.Message;
 import io.spine.client.Target;
-import io.spine.type.TypeName;
 import io.spine.type.TypeUrl;
 
 /**
@@ -47,9 +46,7 @@ abstract class AbstractTargetValidator<M extends Message> extends RequestValidat
     }
 
     static TypeUrl getTypeOf(Target target) {
-        final String typeAsString = target
-                .getType();
-        return TypeName.of(typeAsString)
-                       .toUrl();
+        final String typeAsString = target.getType();
+        return TypeUrl.parse(typeAsString);
     }
 }

--- a/server/src/main/java/io/spine/server/stand/MultitenantSubscriptionRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/MultitenantSubscriptionRegistry.java
@@ -26,7 +26,6 @@ import io.spine.client.Target;
 import io.spine.client.Topic;
 import io.spine.core.TenantId;
 import io.spine.server.tenant.TenantFunction;
-import io.spine.type.TypeName;
 import io.spine.type.TypeUrl;
 
 import javax.annotation.Nullable;
@@ -151,10 +150,8 @@ final class MultitenantSubscriptionRegistry implements SubscriptionRegistry {
         public synchronized Subscription add(Topic topic) {
             final SubscriptionId subscriptionId = Subscriptions.generateId();
             final Target target = topic.getTarget();
-            final String typeAsString = target
-                    .getType();
-            final TypeUrl type = TypeName.of(typeAsString)
-                                         .toUrl();
+            final String typeAsString = target.getType();
+            final TypeUrl type = TypeUrl.parse(typeAsString);
             final Subscription subscription = Subscription.newBuilder()
                                                           .setId(subscriptionId)
                                                           .setTopic(topic)

--- a/server/src/test/java/io/spine/server/SubscriptionServiceShould.java
+++ b/server/src/test/java/io/spine/server/SubscriptionServiceShould.java
@@ -156,7 +156,7 @@ public class SubscriptionServiceShould {
                                           .getExposedTypes()
                                           .iterator()
                                           .next()
-                                          .getTypeName();
+                                          .value();
         final Target target = getProjectQueryTarget();
 
         assertEquals(type, target.getType());


### PR DESCRIPTION
This PR fixes the usage of `type` field in `spine.client.Target`. By now we stored Protobuf type name in it instead of type URL.

Updates to the dependant repositories (storage implementations, etc.) may be required.

Fixes #622.