### PR TITLE
Tenant ID callback

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.8-SNAPSHOT'
+def final SPINE_VERSION = '0.10.9-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/server/src/main/java/io/spine/server/tenant/TenantIndex.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantIndex.java
@@ -47,12 +47,15 @@ public interface TenantIndex extends AutoCloseable {
     Set<TenantId> getAll();
 
     /**
-     * Applies the given {@code operation} onto all the tenant IDs, currently present and added
-     * in future.
+     * Applies the given {@code operation} to all the tenant IDs currently present in the index
+     * and those added in future.
      *
      * <p>The operation is applied to {@linkplain #getAll() all present tenant IDs} at once. When
      * new IDs are {@linkplain #keep(TenantId) added} to the index, the operation is applied
      * to them as well.
+     *
+     * <p>Note that the operation may be applied to a single {@code TenantId} more then once. In
+     * general, the caller may rely on at-least-once behavior.
      *
      * @param operation the operation to apply to all the tenant IDs
      */
@@ -132,7 +135,7 @@ public interface TenantIndex extends AutoCloseable {
     }
 
     /**
-     * A function interface of a operation on {@code TenantId}.
+     * A functional interface of an operation on {@code TenantId}.
      *
      * @see #forEachTenant(TenantIdConsumer)
      */
@@ -140,7 +143,7 @@ public interface TenantIndex extends AutoCloseable {
     interface TenantIdConsumer {
 
         /**
-         * Accepts a {@code TenantId} and performs an operation upon it.
+         * Accepts a {@code TenantId} and performs an operation on it.
          *
          * @param tenantId the operation argument
          */

--- a/server/src/main/java/io/spine/server/tenant/TenantRepository.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantRepository.java
@@ -22,7 +22,6 @@ package io.spine.server.tenant;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import com.google.protobuf.Message;
 import io.spine.core.TenantId;
 import io.spine.server.entity.AbstractEntity;
@@ -34,6 +33,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Sets.newConcurrentHashSet;
 
 /**
  * Abstract base for repositories storing information about tenants.
@@ -45,8 +45,8 @@ public abstract class TenantRepository<T extends Message, E extends TenantReposi
         extends DefaultRecordBasedRepository<TenantId, E, T>
         implements TenantIndex {
 
-    private final Set<TenantId> cache = Sets.newConcurrentHashSet();
-    private final Set<TenantIdConsumer> callbacks = Sets.newConcurrentHashSet();
+    private final Set<TenantId> cache = newConcurrentHashSet();
+    private final Set<TenantIdConsumer> callbacks = newConcurrentHashSet();
 
     @Override
     public void initStorage(StorageFactory factory) {
@@ -66,7 +66,6 @@ public abstract class TenantRepository<T extends Message, E extends TenantReposi
         if (cache.contains(id)) {
             return;
         }
-
         final Optional<E> optional = find(id);
         if (!optional.isPresent()) {
             final E newEntity = create(id);
@@ -117,8 +116,8 @@ public abstract class TenantRepository<T extends Message, E extends TenantReposi
     @Override
     public void forEachTenant(TenantIdConsumer operation) {
         checkNotNull(operation);
-        final Set<TenantId> ids = getAll();
         callbacks.add(operation);
+        final Set<TenantId> ids = getAll();
         for (TenantId tenantId : ids) {
             operation.accept(tenantId);
         }

--- a/server/src/test/java/io/spine/server/tenant/SingleTenantIndexShould.java
+++ b/server/src/test/java/io/spine/server/tenant/SingleTenantIndexShould.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.tenant;
+
+import com.google.common.collect.ImmutableList;
+import io.spine.core.TenantId;
+import org.junit.Test;
+
+import java.util.List;
+
+import static io.spine.core.given.GivenTenantId.newUuid;
+import static java.util.Collections.singleton;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public class SingleTenantIndexShould extends TenantIndexShould {
+
+    @Override
+    protected TenantIndex createIndex() {
+        return TenantIndex.Factory.singleTenant();
+    }
+
+    @Test
+    public void apply_callback_only_once() {
+        final TenantIndex tenantIndex = getIndex();
+        final MemoizingConsumer operation = new MemoizingConsumer();
+        tenantIndex.forEachTenant(operation);
+
+        tenantIndex.keep(newUuid());
+        tenantIndex.keep(newUuid());
+        tenantIndex.keep(newUuid());
+
+        operation.assertContains(singleton(CurrentTenant.singleTenant()));
+    }
+
+    @Test
+    public void provide_tenant_index_for_single_tenant_context() {
+        final TenantIndex index = getIndex();
+
+        final List<TenantId> items = ImmutableList.copyOf(index.getAll());
+
+        assertEquals(1, items.size());
+        assertEquals(CurrentTenant.singleTenant(), items.get(0));
+    }
+}

--- a/server/src/test/java/io/spine/server/tenant/TenantRepositoryShould.java
+++ b/server/src/test/java/io/spine/server/tenant/TenantRepositoryShould.java
@@ -23,11 +23,27 @@ package io.spine.server.tenant;
 import com.google.protobuf.Timestamp;
 import io.spine.core.TenantId;
 import io.spine.server.BoundedContext;
+import io.spine.server.tenant.TenantIndex.TenantIdConsumer;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+import static com.google.common.collect.Lists.newArrayListWithExpectedSize;
 import static io.spine.core.given.GivenTenantId.newUuid;
+import static java.util.Collections.synchronizedList;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -37,6 +53,8 @@ import static org.mockito.Mockito.verify;
  * @author Alexander Yevsyukov
  */
 public class TenantRepositoryShould {
+
+    private static final TenantId[] EMPTY_ARRAY = {};
 
     private TenantRepository<?, ?> repository;
 
@@ -78,6 +96,63 @@ public class TenantRepositoryShould {
         assertFalse(repository.unCache(tenantId));
     }
 
+    @Test
+    public void apply_operation_for_each_tenant() {
+        final MemoizingConsumer operation = new MemoizingConsumer();
+        final Set<TenantId> current = repository.getAll();
+        assertTrue(current.isEmpty());
+
+        final TenantId first = newUuid();
+        final TenantId second = newUuid();
+        repository.keep(first);
+        repository.forEachTenant(operation);
+
+        assertEquals(1, operation.accepted.size());
+        assertThat(operation.accepted, contains(first));
+
+        repository.keep(second);
+        assertEquals(2, operation.accepted.size());
+        assertThat(operation.accepted, contains(first, second));
+    }
+
+    @Test
+    public void apply_operation_for_each_tenant_concurrently() throws InterruptedException {
+        final int parallelism = 5;
+        final Collection<TenantId> tenants = generate(parallelism);
+        final MemoizingConsumer operation = new MemoizingConsumer();
+        repository.forEachTenant(operation);
+        final ExecutorService executor = newFixedThreadPool(parallelism);
+        for (final TenantId tenant : tenants) {
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    repository.keep(tenant);
+                }
+            });
+        }
+        executor.awaitTermination(2, SECONDS);
+        final TenantId[] expected = tenants.toArray(EMPTY_ARRAY);
+        assertThat(operation.accepted, containsInAnyOrder(expected));
+    }
+
+    private static Collection<TenantId> generate(int count) {
+        final Collection<TenantId> tenants = newArrayListWithExpectedSize(count);
+        for (int i = 0; i < count; i++) {
+            tenants.add(newUuid());
+        }
+        return tenants;
+    }
+
+    private static class MemoizingConsumer implements TenantIdConsumer {
+
+        private final List<TenantId> accepted = synchronizedList(new LinkedList<TenantId>());
+
+        @Override
+        public void accept(TenantId tenantId) {
+            assertNotNull(tenantId);
+            accepted.add(tenantId);
+        }
+    }
 
     private static class TenantRepositoryImpl
             extends TenantRepository<Timestamp, DefaultTenantRepository.Entity> {


### PR DESCRIPTION
This PR introduces the API for performing an operation for each tenant in a bounded context.

The `TenantIndex.forEachTenant` method applies the given `TenantIdConsumer` to all the tenants in the index. Also, all the subsequent `TenantIndex.keep` calls will apply the operation on the new `TenantId`s.

`TenantIdConsumer` itself is a functional interface, which is duck-type compatible to Java 8 `Consumer<TenantId>`, therefore can be substituted with the standard interface when migrating to Java 8.

Note that in most cases the consumer is applied only once to a single instance of `TenantId`. Though, in some cases, it may be applied several times. At-least-once invocation is guaranteed.