### PR TITLE
Update dependencies

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,49 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <option name="RIGHT_MARGIN" value="100" />
+    <JavaCodeStyleSettings>
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1000" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1000" />
+      <option name="JD_P_AT_EMPTY_LINES" value="false" />
+      <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
+    </JavaCodeStyleSettings>
+    <XML>
+      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+    </XML>
+    <codeStyleSettings language="JAVA">
+      <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+      <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
+      <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+      <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
+      <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
+      <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
+      <option name="CALL_PARAMETERS_WRAP" value="1" />
+      <option name="METHOD_PARAMETERS_WRAP" value="1" />
+      <option name="RESOURCE_LIST_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="THROWS_LIST_WRAP" value="1" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="2" />
+      <option name="BINARY_OPERATION_WRAP" value="1" />
+      <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+      <option name="KEEP_SIMPLE_BLOCKS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_MULTIPLE_EXPRESSIONS_IN_ONE_LINE" value="true" />
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+      <arrangement>
+        <groups>
+          <group>
+            <type>GETTERS_AND_SETTERS</type>
+            <order>KEEP</order>
+          </group>
+          <group>
+            <type>OVERRIDDEN_METHODS</type>
+            <order>KEEP</order>
+          </group>
+        </groups>
+      </arrangement>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/ext.gradle
+++ b/ext.gradle
@@ -48,7 +48,11 @@ ext {
     gRpcVersion = '1.8.0'
     slf4JVersion = '1.7.25'
     jUnitVersion = '4.12'
-    mockitoVersion = '2.12.0'
+
+    // Note that this Mockito version is not the latest one.
+    // When migrating to the further versions, side effects may happen, like mocks persisting
+    // throughout a test suite. We leave this version as is ('2.7.22') for now.
+    mockitoVersion = '2.7.22'
 
     protobufGradlePluginVerison = '0.8.3'
 }

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,29 +25,30 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.9-SNAPSHOT'
+def final SPINE_VERSION = '0.10.10-SNAPSHOT'
 
+//noinspection GroovyAssignabilityCheck
 ext {
     // The version of the modules in this project.
     spineVersion = SPINE_VERSION
 
     // Depend on `base` for the general definitions and a model compiler.
-    spineBaseVersion = '0.10.0'
+    spineBaseVersion = '0.10.1-SNAPSHOT'
 
     // We use Spine tools in the build process.
-    spineToolsVersion = '0.9.41-SNAPSHOT'
+    spineToolsVersion = '0.9.51-SNAPSHOT'
 
     guavaVersion = '20.0'
 
     // NOTE: when updating Protobuf dependency, please check that
     // `KnownTypes.addStandardProtobufTypes()` method is updated with new Message types that may be
     // introduced in the new version of Protobuf.
-    protobufVersion = '3.3.0'
+    protobufVersion = '3.5.0'
     
-    gRpcVersion = '1.4.0'
+    gRpcVersion = '1.8.0'
     slf4JVersion = '1.7.25'
     jUnitVersion = '4.12'
-    mockitoVersion = '2.7.22'
+    mockitoVersion = '2.12.0'
 
     protobufGradlePluginVerison = '0.8.3'
 }

--- a/ext.gradle
+++ b/ext.gradle
@@ -36,7 +36,7 @@ ext {
     spineBaseVersion = '0.10.1-SNAPSHOT'
 
     // We use Spine tools in the build process.
-    spineToolsVersion = '0.9.51-SNAPSHOT'
+    spineToolsVersion = '0.10.0'
 
     guavaVersion = '20.0'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip

--- a/model/model-verifier/build.gradle
+++ b/model/model-verifier/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile project(':server')
     compile project(':model-assembler')
 
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'junit', name: 'junit', version: jUnitVersion
     testCompile gradleTestKit()
     testCompile group: 'io.spine.tools', name: 'spine-plugin-base', version: spineBaseVersion, classifier: 'test'
 }


### PR DESCRIPTION
In this PR we update the third-party dependencies.

| Dependency | Before | After |
|-----|----------|---------| 
| Protobuf | `3.3.0` | `3.5.0` |
| gRPC | `1.5.0` | `1.8.0` |
| Mockito | `2.7.22` | `2.12.0` |
| Spine Base | `0.10.0` | `0.10.1-SNAPSHOT` |
| Spine Tools | `0.9.41-SNAPSHOT` | `0.10.0` |

The Gradle version was migrated from `4.1` to `4.3.1`.

The framework version is advanced to `0.10.10-SNAPSHOT`.