### PR TITLE
Improve storage tests

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.10-SNAPSHOT'
+def final SPINE_VERSION = '0.10.11-SNAPSHOT'
 
 //noinspection GroovyAssignabilityCheck
 ext {

--- a/server/src/main/java/io/spine/server/entity/storage/EntityQuery.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityQuery.java
@@ -25,7 +25,7 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import io.spine.annotation.Internal;
-import io.spine.server.entity.EntityWithLifecycle;
+import io.spine.server.entity.Entity;
 
 import java.io.Serializable;
 import java.util.Collection;
@@ -141,7 +141,7 @@ public final class EntityQuery<I> implements Serializable {
      * @return new instance of {@code EntityQuery}
      */
     @Internal
-    public EntityQuery<I> withLifecycleFlags(Class<? extends EntityWithLifecycle<I, ?>> cls) {
+    public EntityQuery<I> withLifecycleFlags(Class<? extends Entity> cls) {
         checkState(!isLifecycleAttributesSet(),
                    "The query overrides Lifecycle Flags default values.");
         final EntityColumn archivedColumn = findColumn(cls, archived.name());

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
@@ -28,6 +28,7 @@ import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
 import io.spine.core.Event;
 import io.spine.core.EventContext;
+import io.spine.core.EventId;
 import io.spine.core.RejectionContext;
 import io.spine.core.Version;
 import io.spine.server.aggregate.given.Given.StorageRecord;
@@ -349,6 +350,7 @@ public abstract class AggregateStorageShould
                                                          .setEnrichment(withOneAttribute())
                                                          .build();
         final Event event = Event.newBuilder()
+                                 .setId(newEventId())
                                  .setContext(enrichedContext)
                                  .setMessage(Any.getDefaultInstance())
                                  .build();
@@ -369,6 +371,7 @@ public abstract class AggregateStorageShould
                                                  .setRejectionContext(origin)
                                                  .build();
         final Event event = Event.newBuilder()
+                                 .setId(newEventId())
                                  .setContext(context)
                                  .setMessage(Any.getDefaultInstance())
                                  .build();
@@ -390,6 +393,7 @@ public abstract class AggregateStorageShould
                                                  .setEventContext(origin)
                                                  .build();
         final Event event = Event.newBuilder()
+                                 .setId(newEventId())
                                  .setContext(context)
                                  .setMessage(Any.getDefaultInstance())
                                  .build();
@@ -477,6 +481,12 @@ public abstract class AggregateStorageShould
                        .setState(Any.getDefaultInstance())
                        .setTimestamp(time)
                        .build();
+    }
+
+    private static EventId newEventId() {
+        return EventId.newBuilder()
+                      .setValue(newUuid())
+                      .build();
     }
 
     public static class TestAggregate extends Aggregate<ProjectId, Project, ProjectVBuilder> {

--- a/server/src/test/java/io/spine/server/stand/StandStorageShould.java
+++ b/server/src/test/java/io/spine/server/stand/StandStorageShould.java
@@ -187,6 +187,12 @@ public abstract class StandStorageShould extends RecordStorageShould<AggregateSt
         // Stand storage does not support entity columns.
     }
 
+    @SuppressWarnings("NoopMethodInAbstractClass") // Overrides the behavior for all the inheritors.
+    @Override
+    public void read_both_by_columns_and_IDs() {
+        // Stand storage does not support entity columns.
+    }
+
     @Override
     protected AggregateStateId newId() {
         return DEFAULT_ID_SUPPLIER.get();

--- a/server/src/test/java/io/spine/server/stand/StandStorageShould.java
+++ b/server/src/test/java/io/spine/server/stand/StandStorageShould.java
@@ -179,7 +179,7 @@ public abstract class StandStorageShould extends RecordStorageShould<AggregateSt
 
     @SuppressWarnings("NoopMethodInAbstractClass") // Overrides the behavior for all the inheritors.
     @Override
-    public void read_archived_records_if_required() {
+    public void read_archived_records_if_specified() {
         // Stand storage does not support entity columns.
     }
 

--- a/server/src/test/java/io/spine/server/stand/StandStorageShould.java
+++ b/server/src/test/java/io/spine/server/stand/StandStorageShould.java
@@ -171,6 +171,12 @@ public abstract class StandStorageShould extends RecordStorageShould<AggregateSt
 
     @SuppressWarnings("NoopMethodInAbstractClass") // Overrides the behavior for all the inheritors.
     @Override
+    public void read_archived_records_if_required() {
+        // Stand storage does not support entity columns.
+    }
+
+    @SuppressWarnings("NoopMethodInAbstractClass") // Overrides the behavior for all the inheritors.
+    @Override
     public void update_entity_column_values() {
         // Stand storage does not support entity columns.
     }

--- a/server/src/test/java/io/spine/server/stand/StandStorageShould.java
+++ b/server/src/test/java/io/spine/server/stand/StandStorageShould.java
@@ -156,9 +156,17 @@ public abstract class StandStorageShould extends RecordStorageShould<AggregateSt
         }
     }
 
+    /*
+     * Disabled test cases from `RecordStorageShould`.
+     *
+     * These tests check the entity column reads and writes, which are not applicable to
+     * `StandStorage`.
+     *
+     * These checks include the `LifecycleFlags`-related checks (`archived` and `deleted`).
+     */
+
     @SuppressWarnings("NoopMethodInAbstractClass") // Overrides the behavior for all the inheritors.
     @Override
-    @Test
     public void filter_records_by_columns() {
         // Stand storage does not support entity columns.
     }

--- a/server/src/test/java/io/spine/server/stand/StandStorageShould.java
+++ b/server/src/test/java/io/spine/server/stand/StandStorageShould.java
@@ -177,6 +177,12 @@ public abstract class StandStorageShould extends RecordStorageShould<AggregateSt
 
     @SuppressWarnings("NoopMethodInAbstractClass") // Overrides the behavior for all the inheritors.
     @Override
+    public void filter_archived_or_deleted_records_on_by_ID_bulk_read() {
+        // Stand storage does not support entity columns.
+    }
+
+    @SuppressWarnings("NoopMethodInAbstractClass") // Overrides the behavior for all the inheritors.
+    @Override
     public void update_entity_column_values() {
         // Stand storage does not support entity columns.
     }

--- a/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
@@ -562,7 +562,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
     }
 
     @Test
-    public void read_archived_records_if_required() {
+    public void read_archived_records_if_specified() {
         final I activeRecordId = newId();
         final I archivedRecordId = newId();
 


### PR DESCRIPTION
In this PR we improve the storage test coverage.

The `RecordStorage` test suite acquires 3 new test cases for checking the `EntityQuery` reads.