### PR TITLE
Fix javadoc warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ build/
 out/
 
 # Spine temporary artifact storage
+.spine/
 */.spine/
 model/*/.spine/
 

--- a/server/src/main/java/io/spine/server/BoundedContext.java
+++ b/server/src/main/java/io/spine/server/BoundedContext.java
@@ -239,7 +239,8 @@ public final class BoundedContext
      * Obtains a tenant index of this Bounded Context.
      *
      * <p>If the Bounded Context is single-tenant returns
-     * {@linkplain TenantIndex.Factory#singleTenant() null-object} implementation.
+     * {@linkplain io.spine.server.tenant.TenantIndex.Factory#singleTenant() null-object}
+     * implementation.
      */
     @Internal
     public TenantIndex getTenantIndex() {

--- a/server/src/main/java/io/spine/server/aggregate/AggregatePart.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregatePart.java
@@ -61,7 +61,9 @@ public abstract class AggregatePart<I,
     private final R root;
 
     /**
-     * {@inheritDoc}
+     * Creates a new instance of the aggregate part.
+     *
+     * @param root a root of the aggregate to which this part belongs
      */
     protected AggregatePart(R root) {
         super(root.getId());

--- a/server/src/main/java/io/spine/server/aggregate/AggregatePartRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregatePartRepository.java
@@ -36,7 +36,7 @@ public abstract class AggregatePartRepository<I,
                       extends AggregateRepository<I, A> {
 
     /**
-     * {@inheritDoc}
+     * Creates a new instance.
      */
     protected AggregatePartRepository() {
         super();

--- a/server/src/main/java/io/spine/server/command/CommandHandlingEntity.java
+++ b/server/src/main/java/io/spine/server/command/CommandHandlingEntity.java
@@ -54,8 +54,6 @@ import java.util.List;
  * because of a {@linkplain Rejections#toRejection(ThrowableMessage, io.spine.core.Command)
  * rejection}.
  *
- * {@inheritDoc}
- *
  * @author Alexander Yevsyukov
  */
 public abstract
@@ -68,7 +66,7 @@ class CommandHandlingEntity<I,
     private final Any idAsAny;
 
     /**
-     * {@inheritDoc}
+     * Creates a new entity with the passed ID.
      */
     protected CommandHandlingEntity(I id) {
         super(id);

--- a/server/src/main/java/io/spine/server/delivery/MulticastDelivery.java
+++ b/server/src/main/java/io/spine/server/delivery/MulticastDelivery.java
@@ -55,12 +55,15 @@ public abstract class MulticastDelivery<E extends MessageEnvelope,
     @Nullable
     private Function<T, Set<C>> consumerProvider;
 
-    /** {@inheritDoc} */
+    /**
+     * Creates a new delivery instance which performs its actions using
+     * the passed {@code Executor}.
+     */
     protected MulticastDelivery(Executor delegate) {
         super(delegate);
     }
 
-    /** {@inheritDoc} */
+    /** Creates a new direct delivery instance. */
     protected MulticastDelivery() {
         super();
     }

--- a/server/src/main/java/io/spine/server/entity/DefaultRecordBasedRepository.java
+++ b/server/src/main/java/io/spine/server/entity/DefaultRecordBasedRepository.java
@@ -40,11 +40,16 @@ public abstract class DefaultRecordBasedRepository<I,
     private final EntityFactory<I, E> entityFactory;
     private final EntityStorageConverter<I, E, S> storageConverter;
 
-    /** {@inheritDoc} */
-    @SuppressWarnings("OverriddenMethodCallDuringObjectConstruction") // for getting generic params
+    /**
+     * Creates a new instance with the {@linkplain #entityFactory() factory} of entities of class
+     * specified as the {@code <E>} generic parameter, and with the default
+     * {@linkplain #entityConverter() entity storage converter}.
+     */
     protected DefaultRecordBasedRepository() {
         super();
-        this.entityFactory = new DefaultEntityFactory<>(getEntityClass());
+        @SuppressWarnings("OverridableMethodCallDuringObjectConstruction") // get generic param
+        final Class<E> entityClass = getEntityClass();
+        this.entityFactory = new DefaultEntityFactory<>(entityClass);
         final TypeUrl stateType = entityClass().getStateType();
         this.storageConverter = DefaultEntityStorageConverter.forAllFields(stateType,
                                                                            this.entityFactory);

--- a/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
+++ b/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
@@ -67,7 +67,7 @@ import static io.spine.util.Exceptions.newIllegalStateException;
 public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends Message>
                 extends Repository<I, E> {
 
-    /** {@inheritDoc} */
+    /** Creates a new instance. */
     protected RecordBasedRepository() {
         super();
     }

--- a/server/src/main/java/io/spine/server/event/EventBus.java
+++ b/server/src/main/java/io/spine/server/event/EventBus.java
@@ -444,7 +444,8 @@ public class EventBus
         /**
          * Sets logging level for post operations.
          *
-         * <p>If not set directly, {@link LoggingObserver.Level#TRACE} will be used.
+         * <p>If not set directly, {@link io.spine.grpc.LoggingObserver.Level#TRACE Level.TRACE}
+         * will be used.
          */
         public Builder setLogLevelForPost(Level level) {
             this.logLevelForPost = level;

--- a/server/src/main/java/io/spine/server/event/EventStore.java
+++ b/server/src/main/java/io/spine/server/event/EventStore.java
@@ -334,7 +334,8 @@ public class EventStore implements AutoCloseable {
     /**
      * The builder of {@code EventStore} instance exposed as gRPC service.
      *
-     * @see EventStoreGrpc.EventStoreImplBase
+     * @see io.spine.server.event.grpc.EventStoreGrpc.EventStoreImplBase
+     *      EventStoreGrpc.EventStoreImplBase
      */
     public static class ServiceBuilder
             extends AbstractBuilder<ServerServiceDefinition, ServiceBuilder> {

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
@@ -89,7 +89,9 @@ public abstract class ProcessManagerRepository<I,
      */
     private CommandErrorHandler commandErrorHandler;
 
-    /** {@inheritDoc} */
+    /**
+     * Creates a new instance with the event routing by the first message field.
+     */
     protected ProcessManagerRepository() {
         super(EventProducers.<I>fromFirstMessageField());
     }

--- a/server/src/main/java/io/spine/server/storage/LifecycleFlagField.java
+++ b/server/src/main/java/io/spine/server/storage/LifecycleFlagField.java
@@ -30,13 +30,13 @@ package io.spine.server.storage;
 public enum LifecycleFlagField implements StorageField {
 
     /**
-     * A {@linkplain boolean} field representing whether
+     * A {@code boolean} field representing whether
      * the relevant record is {@code archived} or not.
      */
     archived,
 
     /**
-     * A {@linkplain boolean} field representing whether
+     * A {@code boolean} field representing whether
      * the relevant record is {@code deleted} or not.
      */
     deleted


### PR DESCRIPTION
This PR fixes all but one Javadoc warnings.

The remaining warning

```
core-java/server/src/main/java/io/spine/server/entity/storage/ColumnType.java:96: warning - Tag @link: reference not found: java.sql.PreparedStatement PreparedStatement
```
seems to be a [bug in Javadoc](https://bugs.openjdk.java.net/browse/JDK-8006642), which is fixed in Java 8.
