### PR TITLE
`ExternalMessageEnvelope`: documentation and improved coverage

### DIFF
--- a/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
+++ b/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
@@ -106,24 +106,25 @@ public final class DelegatingEventDispatcher<I> implements EventDispatcher<I> {
 
             @Override
             public Set<I> dispatch(ExternalMessageEnvelope envelope) {
-                final ExternalMessage externalMessage = envelope.getOuterObject();
-                final Event event = unpack(externalMessage.getOriginalMessage());
-                final Set<I> ids = delegate.dispatchEvent(EventEnvelope.of(event));
+                final EventEnvelope eventEnvelope = asEventEnvelope(envelope);
+                final Set<I> ids = delegate.dispatchEvent(eventEnvelope);
                 return ids;
             }
 
             @Override
             public void onError(ExternalMessageEnvelope envelope, RuntimeException exception) {
-
-                final MessageClass messageClass = envelope.getMessageClass();
-                final String messageId = Stringifiers.toString(envelope.getId());
-                final String errorMessage =
-                        format("Error dispatching external event (class: %s, id: %s)",
-                               messageClass, messageId);
-                log().error(errorMessage, exception);
+                final EventEnvelope eventEnvelope = asEventEnvelope(envelope);
+                delegate.onError(eventEnvelope, exception);
             }
         };
     }
+
+    private static EventEnvelope asEventEnvelope(ExternalMessageEnvelope envelope) {
+        final ExternalMessage externalMessage = envelope.getOuterObject();
+        final Event event = unpack(externalMessage.getOriginalMessage());
+        return EventEnvelope.of(event);
+    }
+
 
     private Logger log() {
         return loggerSupplier.get();

--- a/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
+++ b/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
@@ -30,8 +30,6 @@ import io.spine.server.integration.ExternalMessage;
 import io.spine.server.integration.ExternalMessageClass;
 import io.spine.server.integration.ExternalMessageDispatcher;
 import io.spine.server.integration.ExternalMessageEnvelope;
-import io.spine.string.Stringifiers;
-import io.spine.type.MessageClass;
 import io.spine.util.Logging;
 import org.slf4j.Logger;
 
@@ -39,7 +37,6 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.protobuf.AnyPacker.unpack;
-import static java.lang.String.format;
 
 /**
  * A {@link EventDispatcher} which delegates the responsibilities to an aggregated {@link
@@ -123,11 +120,6 @@ public final class DelegatingEventDispatcher<I> implements EventDispatcher<I> {
         final ExternalMessage externalMessage = envelope.getOuterObject();
         final Event event = unpack(externalMessage.getOriginalMessage());
         return EventEnvelope.of(event);
-    }
-
-
-    private Logger log() {
-        return loggerSupplier.get();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
+++ b/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
@@ -21,7 +21,6 @@
 package io.spine.server.event;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Supplier;
 import io.spine.annotation.Internal;
 import io.spine.core.Event;
 import io.spine.core.EventClass;
@@ -30,8 +29,6 @@ import io.spine.server.integration.ExternalMessage;
 import io.spine.server.integration.ExternalMessageClass;
 import io.spine.server.integration.ExternalMessageDispatcher;
 import io.spine.server.integration.ExternalMessageEnvelope;
-import io.spine.util.Logging;
-import org.slf4j.Logger;
 
 import java.util.Set;
 
@@ -53,9 +50,6 @@ public final class DelegatingEventDispatcher<I> implements EventDispatcher<I> {
      * A target delegate.
      */
     private final EventDispatcherDelegate<I> delegate;
-
-    /** Lazily initialized logger. */
-    private final Supplier<Logger> loggerSupplier = Logging.supplyFor(getClass());
 
     /**
      * Creates a new instance of {@code DelegatingCommandDispatcher}, proxying the calls

--- a/server/src/main/java/io/spine/server/integration/ExternalMessageEnvelope.java
+++ b/server/src/main/java/io/spine/server/integration/ExternalMessageEnvelope.java
@@ -59,6 +59,20 @@ public final class ExternalMessageEnvelope
 
     }
 
+    /**
+     * Creates a new instance of {@code ExternalMessageEnvelope} from the {@link ExternalMessage}
+     * instance and the message transferred inside the {@code ExternalMessage}, such as
+     * a {@code io.spine.sample.TaskCreated} event message.
+     *
+     * <p>This factory method provides an optimal performance of
+     * the {@code ExternalMessageEnvelope} creation. It allows to avoid unpacking the original
+     * message from the {@code ExternalMessage} instance.
+     *
+     * @param externalMessage the instance of {@code ExternalMessage} to wrap into an envelope
+     * @param originalMessage the message instance, which was originally transferred inside the
+     *                        {@code externalMessage}
+     * @return the new instance of external message envelope.
+     */
     public static ExternalMessageEnvelope of(ExternalMessage externalMessage,
                                              Message originalMessage) {
         checkNotNull(externalMessage);

--- a/server/src/main/java/io/spine/server/integration/ExternalMessageEnvelope.java
+++ b/server/src/main/java/io/spine/server/integration/ExternalMessageEnvelope.java
@@ -70,7 +70,8 @@ public final class ExternalMessageEnvelope
      *
      * @param externalMessage the instance of {@code ExternalMessage} to wrap into an envelope
      * @param originalMessage the message instance, which was originally transferred inside the
-     *                        {@code externalMessage}
+     *                        {@code externalMessage}, such as a {@code io.spine.sample.TaskCreated}
+     *                        event message.
      * @return the new instance of external message envelope.
      */
     public static ExternalMessageEnvelope of(ExternalMessage externalMessage,
@@ -84,11 +85,26 @@ public final class ExternalMessageEnvelope
         return id;
     }
 
+    /**
+     * Obtains an originally transferred message. For instance, {@code io.spine.sample.TaskCreated}
+     * event message may returned for an external event, transferred inside
+     * of this envelope instance.
+     *
+     * @return the instance of origin message
+     */
     @Override
     public Message getMessage() {
         return message;
     }
 
+    /**
+     * Obtains a message class of an originally transferred message, such as
+     * {@code io.spine.sample.TaskCreated} class.
+     *
+     * @return the event message
+     * @see #getMessage()
+     * @see #of(ExternalMessage, Message)
+     */
     @Override
     public MessageClass getMessageClass() {
         return messageClass;

--- a/server/src/main/java/io/spine/server/integration/ExternalMessages.java
+++ b/server/src/main/java/io/spine/server/integration/ExternalMessages.java
@@ -23,6 +23,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
 import io.spine.Identifier;
+import io.spine.annotation.Internal;
 import io.spine.core.BoundedContextName;
 import io.spine.core.Event;
 import io.spine.core.Rejection;
@@ -35,7 +36,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @author Alex Tymchenko
  */
-final class ExternalMessages {
+@Internal
+public final class ExternalMessages {
 
     /** Prevents instantiation on this utility class. */
     private ExternalMessages() {}
@@ -47,7 +49,7 @@ final class ExternalMessages {
      * @param boundedContextName the name of the bounded context in which the event was created
      * @return the external message wrapping the given event
      */
-    static ExternalMessage of(Event event, BoundedContextName boundedContextName) {
+    public static ExternalMessage of(Event event, BoundedContextName boundedContextName) {
         checkNotNull(event);
 
         final ExternalMessage result = of(event.getId(), event, boundedContextName);

--- a/server/src/main/java/io/spine/server/rejection/RejectionHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/rejection/RejectionHandlerMethod.java
@@ -152,11 +152,18 @@ class RejectionHandlerMethod extends HandlerMethod<RejectionContext> {
          * A rejection handler method which receives a rejection message
          * as a single parameter.
          *
-         * <p>The signature of such a method is following:
+         * <p>The signature of such a method is as follows, if used in {@link RejectionSubscriber}:
          * <pre>
-         * [{@literal @}HandlerAnnotation]
+         * [{@literal @}Subscribe]
          * public void on(RejectionMessage rejection);
          * </pre>
+         *
+         * Or if it is an {@code Entity} reactor method, it is declared as:
+         * <pre>
+         * [{@literal @}React]
+         * public void on(RejectionMessage rejection);
+         * </pre>
+         *
          * where {@code RejectionMessage} is a specific generated rejection message class.
          */
         REJECTION_MESSAGE_AWARE,
@@ -165,11 +172,18 @@ class RejectionHandlerMethod extends HandlerMethod<RejectionContext> {
          * A rejection handler method which receives a rejection message as the first parameter,
          * and {@link io.spine.core.RejectionContext RejectionContext} as the second.
          *
-         * <p>The signature of such a method is following:
+         * <p>The signature of such a method is as follows, if used in {@link RejectionSubscriber}:
          * <pre>
-         * [{@literal @}HandlerAnnotation]
+         * [{@literal @}Subscribe]
          * public void on(RejectionMessage rejection, RejectionContext context);
          * </pre>
+         *
+         * Or if it is an {@code Entity} reactor method, it is declared as:
+         * <pre>
+         * [{@literal @}React]
+         * public void on(RejectionMessage rejection, RejectionContext context);
+         * </pre>
+         *
          * where {@code RejectionMessage} is a specific generated rejection message class.
          */
         REJECTION_CONTEXT_AWARE,
@@ -177,11 +191,18 @@ class RejectionHandlerMethod extends HandlerMethod<RejectionContext> {
         /**
          * A rejection handler method aware of the {@link CommandContext}.
          *
-         * <p>The signature of such a method is following:
+         * <p>The signature of such a method is as follows, if used in {@link RejectionSubscriber}:
          * <pre>
-         * [{@literal @}HandlerAnnotation]
+         * [{@literal @}Subscribe]
          * public void on(RejectionMessage rejection, CommandContext context);
          * </pre>
+         *
+         * Or if it is an {@code Entity} reactor method, it is declared as:
+         * <pre>
+         * [{@literal @}React]
+         * public void on(RejectionMessage rejection, CommandContext context);
+         * </pre>
+         *
          * where {@code RejectionMessage} is a specific generated rejection message class.
          */
         COMMAND_CONTEXT_AWARE,
@@ -189,11 +210,18 @@ class RejectionHandlerMethod extends HandlerMethod<RejectionContext> {
         /**
          * A rejection handler method aware of the command message.
          *
-         * <p>The signature of such a method is following:
+         * <p>The signature of such a method is as follows, if used in {@link RejectionSubscriber}:
          * <pre>
-         * [{@literal @}HandlerAnnotation]
+         * [{@literal @}Subscribe]
          * public void on(RejectionMessage rejection, CommandMessage command);
          * </pre>
+         *
+         * Or if it is an {@code Entity} reactor method, it is declared as:
+         * <pre>
+         * [{@literal @}React]
+         * public void on(RejectionMessage rejection, CommandMessage command);
+         * </pre>
+         *
          * where {@code RejectionMessage} is a specific generated rejection message class, and
          * {@code CommandMessage} is a specific generated command message class.
          */
@@ -203,11 +231,18 @@ class RejectionHandlerMethod extends HandlerMethod<RejectionContext> {
          * A rejection handler method aware of both the command message and
          * the {@link CommandContext}.
          *
-         * <p>The signature of such a method is following:
+         * <p>The signature of such a method is as follows, if used in {@link RejectionSubscriber}:
          * <pre>
-         * [{@literal @}HandlerAnnotation]
-         * public void on(RejectionMessage rejection, CommandMessage command, CommandContext context);
+         * [{@literal @}Subscribe]
+         * public void on(RejectionMessage rejection, CommandMessage command, CommandContext ctx);
          * </pre>
+         *
+         * Or if it is an {@code Entity} reactor method, it is declared as:
+         * <pre>
+         * [{@literal @}React]
+         * public void on(RejectionMessage rejection, CommandMessage command, CommandContext ctx);
+         * </pre>
+         *
          * where {@code RejectionMessage} is a specific generated rejection message class, and
          * {@code CommandMessage} is a specific generated command message class.
          */

--- a/server/src/main/java/io/spine/server/rejection/RejectionHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/rejection/RejectionHandlerMethod.java
@@ -154,13 +154,13 @@ class RejectionHandlerMethod extends HandlerMethod<RejectionContext> {
          *
          * <p>The signature of such a method is as follows, if used in {@link RejectionSubscriber}:
          * <pre>
-         * [{@literal @}Subscribe]
+         * {@literal @}Subscribe
          * public void on(RejectionMessage rejection);
          * </pre>
          *
          * Or if it is an {@code Entity} reactor method, it is declared as:
          * <pre>
-         * [{@literal @}React]
+         * {@literal @}React
          * public void on(RejectionMessage rejection);
          * </pre>
          *
@@ -174,13 +174,13 @@ class RejectionHandlerMethod extends HandlerMethod<RejectionContext> {
          *
          * <p>The signature of such a method is as follows, if used in {@link RejectionSubscriber}:
          * <pre>
-         * [{@literal @}Subscribe]
+         * {@literal @}Subscribe
          * public void on(RejectionMessage rejection, RejectionContext context);
          * </pre>
          *
          * Or if it is an {@code Entity} reactor method, it is declared as:
          * <pre>
-         * [{@literal @}React]
+         * {@literal @}React
          * public void on(RejectionMessage rejection, RejectionContext context);
          * </pre>
          *
@@ -193,13 +193,13 @@ class RejectionHandlerMethod extends HandlerMethod<RejectionContext> {
          *
          * <p>The signature of such a method is as follows, if used in {@link RejectionSubscriber}:
          * <pre>
-         * [{@literal @}Subscribe]
+         * {@literal @}Subscribe
          * public void on(RejectionMessage rejection, CommandContext context);
          * </pre>
          *
          * Or if it is an {@code Entity} reactor method, it is declared as:
          * <pre>
-         * [{@literal @}React]
+         * {@literal @}React
          * public void on(RejectionMessage rejection, CommandContext context);
          * </pre>
          *
@@ -212,13 +212,13 @@ class RejectionHandlerMethod extends HandlerMethod<RejectionContext> {
          *
          * <p>The signature of such a method is as follows, if used in {@link RejectionSubscriber}:
          * <pre>
-         * [{@literal @}Subscribe]
+         * {@literal @}Subscribe
          * public void on(RejectionMessage rejection, CommandMessage command);
          * </pre>
          *
          * Or if it is an {@code Entity} reactor method, it is declared as:
          * <pre>
-         * [{@literal @}React]
+         * {@literal @}React
          * public void on(RejectionMessage rejection, CommandMessage command);
          * </pre>
          *
@@ -233,13 +233,13 @@ class RejectionHandlerMethod extends HandlerMethod<RejectionContext> {
          *
          * <p>The signature of such a method is as follows, if used in {@link RejectionSubscriber}:
          * <pre>
-         * [{@literal @}Subscribe]
+         * {@literal @}Subscribe
          * public void on(RejectionMessage rejection, CommandMessage command, CommandContext ctx);
          * </pre>
          *
          * Or if it is an {@code Entity} reactor method, it is declared as:
          * <pre>
-         * [{@literal @}React]
+         * {@literal @}React
          * public void on(RejectionMessage rejection, CommandMessage command, CommandContext ctx);
          * </pre>
          *

--- a/server/src/test/java/io/spine/server/event/DelegatingEventDispatcherShould.java
+++ b/server/src/test/java/io/spine/server/event/DelegatingEventDispatcherShould.java
@@ -77,10 +77,8 @@ public class DelegatingEventDispatcherShould {
 
     @Test
     public void expose_external_dispatcher_that_delegates_onError() {
-        final EmptyEventDispatcherDelegate delegate = new EmptyEventDispatcherDelegate();
         final ExternalMessageDispatcher<String> extMessageDispatcher =
-                DelegatingEventDispatcher.of(delegate)
-                                         .getExternalDispatcher();
+                delegatingDispatcher.getExternalDispatcher();
 
         final TestEventFactory factory = TestEventFactory.newInstance(getClass());
         final StringValue eventMsg = newUuidValue();

--- a/server/src/test/java/io/spine/server/event/DelegatingEventDispatcherShould.java
+++ b/server/src/test/java/io/spine/server/event/DelegatingEventDispatcherShould.java
@@ -96,7 +96,6 @@ public class DelegatingEventDispatcherShould {
         assertTrue(delegate.onErrorCalled());
     }
 
-
     /*
      * Test environment
      ********************/


### PR DESCRIPTION
This PR addresses #638 and #639.

In particular it clarifies the API of `ExternalMessageEnvelope`. 

Also it improves the test coverage of `DelegatingEventDispatcher` behavior, that dispatches `ExternalMessageEnvelope` instances.

As a bonus, `RejectionHandlerMethod` documentation was improved with explicit mentioning of `@React` and `@Subscribe` in different cases.