### PR TITLE
Fix in-memory read of an aggregate history

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.14-SNAPSHOT'
+def final SPINE_VERSION = '0.10.15-SNAPSHOT'
 
 //noinspection GroovyAssignabilityCheck
 ext {

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -58,7 +58,6 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.server.entity.EntityWithLifecycle.Predicates.isEntityVisible;
 import static io.spine.util.Exceptions.newIllegalStateException;
 
 /**
@@ -443,7 +442,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * @return the loaded instance or {@code Optional.absent()} if there is no {@code Aggregate}
      *         with the ID
      */
-    public Optional<A> load(I id) {
+    private Optional<A> load(I id) {
         final Optional<AggregateStateRecord> eventsFromStorage = fetchHistory(id);
         if (eventsFromStorage.isPresent()) {
             final A result = play(id, eventsFromStorage.get());
@@ -501,14 +500,14 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
     /**
      * Loads an aggregate by the passed ID.
      *
-     * <p>The method returns {@link Optional#absent()} if:
-     * <ul>
-     *     <li>there are no events stored for the aggregate with the passed ID, or
-     *     <li>the aggregate has at least one {@linkplain LifecycleFlags lifecycle flag} set.
-     * </ul>
+     * <p>An aggregate will be loaded despite its {@linkplain LifecycleFlags visibility}.
+     * I.e. even if the aggregate is either
+     * {@linkplain io.spine.server.entity.EntityWithLifecycle#isArchived() archived}
+     * or {@linkplain io.spine.server.entity.EntityWithLifecycle#isDeleted() deleted},
+     * it is loaded and returned.
      *
      * @param  id the ID of the aggregate to load
-     * @return the loaded object or {@link Optional#absent()}
+     * @return the loaded object or {@link Optional#absent()} if there are no events for the aggregate
      * @throws IllegalStateException
      *         if the storage of the repository is not {@linkplain #initStorage(StorageFactory)
      *         initialized} prior to this call
@@ -516,14 +515,6 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      */
     @Override
     public Optional<A> find(I id) throws IllegalStateException {
-        final Optional<LifecycleFlags> loadedFlags = aggregateStorage().readLifecycleFlags(id);
-        if (loadedFlags.isPresent()) {
-            final boolean isVisible = isEntityVisible().apply(loadedFlags.get());
-            // If there is a flag that hides the aggregate, return nothing.
-            if (!isVisible) {
-                return Optional.absent();
-            }
-        }
         final Optional<A> result = load(id);
         return result;
     }

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -443,7 +443,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * @return the loaded instance or {@code Optional.absent()} if there is no {@code Aggregate}
      *         with the ID
      */
-    private Optional<A> load(I id) {
+    public Optional<A> load(I id) {
         final Optional<AggregateStateRecord> eventsFromStorage = fetchHistory(id);
         if (eventsFromStorage.isPresent()) {
             final A result = play(id, eventsFromStorage.get());

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -501,7 +501,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * Loads an aggregate by the passed ID.
      *
      * <p>An aggregate will be loaded despite its {@linkplain LifecycleFlags visibility}.
-     * I.e. even if the aggregate is either
+     * I.e. even if the aggregate is
      * {@linkplain io.spine.server.entity.EntityWithLifecycle#isArchived() archived}
      * or {@linkplain io.spine.server.entity.EntityWithLifecycle#isDeleted() deleted},
      * it is loaded and returned.

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryShould.java
@@ -328,8 +328,8 @@ public class AggregateRepositoryShould {
         // child aggregates from the `ProjectArchived` event.
         final Optional<ProjectAggregate> parentAfterArchive = repository.find(parent.getId());
         assertTrue(parentAfterArchive.isPresent());
-        assertFalse(childAfterArchive.get()
-                                     .isArchived());
+        assertFalse(parentAfterArchive.get()
+                                      .isArchived());
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryShould.java
@@ -245,7 +245,7 @@ public class AggregateRepositoryShould {
     }
 
     @Test
-    public void not_find_archived_aggregates() {
+    public void find_archived_aggregates() {
         final ProjectAggregate aggregate = givenStoredAggregate();
 
         final AggregateTransaction tx = AggregateTransaction.start(aggregate);
@@ -253,12 +253,12 @@ public class AggregateRepositoryShould {
         tx.commit();
         repository.store(aggregate);
 
-        assertFalse(repository.find(aggregate.getId())
+        assertTrue(repository.find(aggregate.getId())
                               .isPresent());
     }
 
     @Test
-    public void not_find_deleted_aggregates() {
+    public void find_deleted_aggregates() {
         final ProjectAggregate aggregate = givenStoredAggregate();
 
         final AggregateTransaction tx = AggregateTransaction.start(aggregate);
@@ -267,7 +267,7 @@ public class AggregateRepositoryShould {
 
         repository.store(aggregate);
 
-        assertFalse(repository.find(aggregate.getId())
+        assertTrue(repository.find(aggregate.getId())
                               .isPresent());
     }
 
@@ -320,13 +320,16 @@ public class AggregateRepositoryShould {
                       .post(event);
 
         // Check that the child aggregate was archived.
-        assertFalse(repository.find(child.getId())
-                              .isPresent());
-
+        final Optional<ProjectAggregate> childAfterArchive = repository.find(child.getId());
+        assertTrue(childAfterArchive.isPresent());
+        assertTrue(childAfterArchive.get()
+                                    .isArchived());
         // The parent should not be archived since the dispatch route uses only
         // child aggregates from the `ProjectArchived` event.
-        assertTrue(repository.find(parent.getId())
-                             .isPresent());
+        final Optional<ProjectAggregate> parentAfterArchive = repository.find(parent.getId());
+        assertTrue(parentAfterArchive.isPresent());
+        assertFalse(childAfterArchive.get()
+                                     .isArchived());
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryViewsShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryViewsShould.java
@@ -40,6 +40,9 @@ import static org.junit.Assert.assertTrue;
  */
 public class AggregateRepositoryViewsShould {
 
+    private static final String ARCHIVE_COMMAND = "archive";
+    private static final String DELETE_COMMAND = "delete";
+
     /** The Aggregate ID used in all tests */
     private static final Long id = 100L;
     private final ActorRequestFactory requestFactory =
@@ -76,7 +79,7 @@ public class AggregateRepositoryViewsShould {
     }
 
     @Test
-    public void load_aggregate_if_no_status_flags_set() {
+    public void find_aggregate_if_no_status_flags_set() {
         aggregate = repository.find(id);
 
         assertTrue(aggregate.isPresent());
@@ -86,8 +89,8 @@ public class AggregateRepositoryViewsShould {
     }
 
     @Test
-    public void not_load_aggregates_with_archived_status() {
-        postCommand("archive");
+    public void not_find_aggregates_with_archived_status() {
+        postCommand(ARCHIVE_COMMAND);
 
         aggregate = repository.find(id);
 
@@ -95,11 +98,45 @@ public class AggregateRepositoryViewsShould {
     }
 
     @Test
-    public void not_load_aggregates_with_deleted_status() {
-        postCommand("delete");
+    public void not_find_aggregates_with_deleted_status() {
+        postCommand(DELETE_COMMAND);
 
         aggregate = repository.find(id);
 
         assertFalse(aggregate.isPresent());
+    }
+
+    @Test
+    public void load_aggregate_if_no_status_flags_set() {
+        aggregate = repository.load(id);
+
+        assertTrue(aggregate.isPresent());
+        final AggregateWithLifecycle agg = aggregate.get();
+        assertFalse(agg.isArchived());
+        assertFalse(agg.isDeleted());
+    }
+
+    @Test
+    public void load_aggregates_with_archived_status() {
+        postCommand(ARCHIVE_COMMAND);
+
+        aggregate = repository.load(id);
+
+        assertTrue(aggregate.isPresent());
+        final AggregateWithLifecycle agg = aggregate.get();
+        assertTrue(agg.isArchived());
+        assertFalse(agg.isDeleted());
+    }
+
+    @Test
+    public void load_aggregates_with_deleted_status() {
+        postCommand(DELETE_COMMAND);
+
+        aggregate = repository.load(id);
+
+        assertTrue(aggregate.isPresent());
+        final AggregateWithLifecycle agg = aggregate.get();
+        assertFalse(agg.isArchived());
+        assertTrue(agg.isDeleted());
     }
 }

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryViewsShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryViewsShould.java
@@ -40,9 +40,6 @@ import static org.junit.Assert.assertTrue;
  */
 public class AggregateRepositoryViewsShould {
 
-    private static final String ARCHIVE_COMMAND = "archive";
-    private static final String DELETE_COMMAND = "delete";
-
     /** The Aggregate ID used in all tests */
     private static final Long id = 100L;
     private final ActorRequestFactory requestFactory =
@@ -89,38 +86,10 @@ public class AggregateRepositoryViewsShould {
     }
 
     @Test
-    public void not_find_aggregates_with_archived_status() {
-        postCommand(ARCHIVE_COMMAND);
+    public void find_aggregates_with_archived_status() {
+        postCommand("archive");
 
         aggregate = repository.find(id);
-
-        assertFalse(aggregate.isPresent());
-    }
-
-    @Test
-    public void not_find_aggregates_with_deleted_status() {
-        postCommand(DELETE_COMMAND);
-
-        aggregate = repository.find(id);
-
-        assertFalse(aggregate.isPresent());
-    }
-
-    @Test
-    public void load_aggregate_if_no_status_flags_set() {
-        aggregate = repository.load(id);
-
-        assertTrue(aggregate.isPresent());
-        final AggregateWithLifecycle agg = aggregate.get();
-        assertFalse(agg.isArchived());
-        assertFalse(agg.isDeleted());
-    }
-
-    @Test
-    public void load_aggregates_with_archived_status() {
-        postCommand(ARCHIVE_COMMAND);
-
-        aggregate = repository.load(id);
 
         assertTrue(aggregate.isPresent());
         final AggregateWithLifecycle agg = aggregate.get();
@@ -129,10 +98,10 @@ public class AggregateRepositoryViewsShould {
     }
 
     @Test
-    public void load_aggregates_with_deleted_status() {
-        postCommand(DELETE_COMMAND);
+    public void find_aggregates_with_deleted_status() {
+        postCommand("delete");
 
-        aggregate = repository.load(id);
+        aggregate = repository.find(id);
 
         assertTrue(aggregate.isPresent());
         final AggregateWithLifecycle agg = aggregate.get();

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
@@ -196,10 +196,6 @@ public abstract class AggregateStorageShould
 
     @Test
     public void write_and_read_one_record() {
-        assertWrittenRecordWasRead(id, storage);
-    }
-
-    private <I> void assertWrittenRecordWasRead(I id, AggregateStorage<I> storage) {
         final AggregateEventRecord expected = StorageRecord.create(getCurrentTime());
 
         storage.writeRecord(id, expected);


### PR DESCRIPTION
Previously, it was not possible to read a history of an archived or deleted aggregate using `InMemoryAggregateStorage`. Also, receiving of aggregate IDs was not correct and only IDs of aggregates with default `LifecycleFlags` were returned.

This PR fixes the issues and now behavior for `InMemoryAggregateStorage` and for `DsAggregateStorage` is consistent.

Also, the behavior of `AggregateRepository.find(ID)` was changed and now it returns archived and deleted aggregates either. Such a behavior is correct because the repository should provide an ability to load archived/deleted aggregates during enrichment and in fact, this method is used only for this purpose.

The Spine version was increased to `0.10.15-SNAPSHOT`.