### PR TITLE
Fix  `Queries.typeOf(Query)` doc

### DIFF
--- a/client/src/main/java/io/spine/client/Queries.java
+++ b/client/src/main/java/io/spine/client/Queries.java
@@ -62,7 +62,8 @@ public final class Queries {
     /**
      * Extract the type of {@link Target} for the given {@link Query}.
      *
-     * <p>Returns null if the {@code Target} type is unknown to the application.
+     * <p>Throws an {@link IllegalStateException} if the {@code Target} type is unknown to
+     * the application.
      *
      * @param query the query of interest.
      * @return the URL of the type of the query {@linkplain Query#getTarget() target}


### PR DESCRIPTION
In this PR we make the `Queries.typeOf(Querry)` doc consistent with the implementation.

Before, the doc stated that the method returns `null` if the type is unknown.
Now, the doc states the truth — the method throws `ISE` upon such event (since an unknown type is an illegal state for a system).
  
The framework version is _not_ changed in this PR.