### PR TITLE
Quartet, Either param for Pair, and better Triplet

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.20-SNAPSHOT'
+def final SPINE_VERSION = '0.10.21-SNAPSHOT'
 
 //noinspection GroovyAssignabilityCheck
 ext {

--- a/server/src/main/java/io/spine/server/tuple/Element.java
+++ b/server/src/main/java/io/spine/server/tuple/Element.java
@@ -170,4 +170,11 @@ class Element implements Serializable {
          */
         T getC();
     }
+
+    interface DValue<T> extends OptionalValue {
+        /**
+         * Obtains the fourth element of the tuple.
+         */
+        T getD();
+    }
 }

--- a/server/src/main/java/io/spine/server/tuple/Pair.java
+++ b/server/src/main/java/io/spine/server/tuple/Pair.java
@@ -28,6 +28,7 @@ import io.spine.server.tuple.Element.BValue;
 import javax.annotation.Nullable;
 
 import static com.google.common.base.Optional.fromNullable;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.server.tuple.Element.value;
 
 /**
@@ -67,6 +68,16 @@ public final class Pair<A extends Message, B>
         checkNotNullOrEmpty(Pair.class, a);
         checkNotEmpty(Pair.class, b);
         final Pair<A, Optional<B>> result = new Pair<>(a, fromNullable(b));
+        return result;
+    }
+
+    /**
+     * Creates a pair with the second element of a type descending from {@link Either}.
+     */
+    public static <A extends Message, B extends Either> Pair<A, B> withEither(A a, B b) {
+        checkNotNullOrEmpty(Pair.class, a);
+        checkNotNull(b);
+        final Pair<A, B> result = new Pair<>(a, b);
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/tuple/Pair.java
+++ b/server/src/main/java/io/spine/server/tuple/Pair.java
@@ -27,6 +27,7 @@ import io.spine.server.tuple.Element.BValue;
 
 import javax.annotation.Nullable;
 
+import static com.google.common.base.Optional.fromNullable;
 import static io.spine.server.tuple.Element.value;
 
 /**
@@ -65,7 +66,7 @@ public final class Pair<A extends Message, B>
     Pair<A, Optional<B>> withNullable(A a, @Nullable B b) {
         checkNotNullOrEmpty(Pair.class, a);
         checkNotEmpty(Pair.class, b);
-        final Pair<A, Optional<B>> result = new Pair<>(a, Optional.fromNullable(b));
+        final Pair<A, Optional<B>> result = new Pair<>(a, fromNullable(b));
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/tuple/Quartet.java
+++ b/server/src/main/java/io/spine/server/tuple/Quartet.java
@@ -25,6 +25,7 @@ import com.google.protobuf.Message;
 import io.spine.server.tuple.Element.AValue;
 import io.spine.server.tuple.Element.BValue;
 import io.spine.server.tuple.Element.CValue;
+import io.spine.server.tuple.Element.DValue;
 
 import javax.annotation.Nullable;
 
@@ -32,45 +33,43 @@ import static com.google.common.base.Optional.fromNullable;
 import static io.spine.server.tuple.Element.value;
 
 /**
- * A tuple with three elements.
+ * A tuple with four elements.
  *
  * <p>The second and third elements are optional.
  *
  * @param <A> the type of the first element
  * @param <B> the type of the second element
  * @param <C> the type of the third element
+ * @param <D> the type of the fourth element
  *
  * @author Alexander Yevsyukov
  */
-public final class Triplet<A extends Message, B, C>
+public final class Quartet<A extends Message, B, C, D>
         extends Tuple
-        implements AValue<A>, BValue<B>, CValue<C> {
+        implements AValue<A>, BValue<B>, CValue<C>, DValue<D> {
 
     private static final long serialVersionUID = 0L;
 
-    private Triplet(A a, B b, C c) {
-        super(a, b, c);
+    private Quartet(A a, B b, C c, D d) {
+        super(a, b, c, d);
     }
 
-    /**
-     * Creates new triplet with the passed values.
-     */
-    public static <A extends Message, B extends Message, C extends Message>
-    Triplet<A, B, C> of(A a, B b, C c) {
-        checkAllAreNotNullOrEmpty(Triplet.class, a, b, c);
-        final Triplet<A, B, C> result = new Triplet<>(a, b, c);
+    public static <A extends Message, B extends Message, C extends Message, D extends Message>
+    Quartet<A, B, C, D> of(A a, B b, C c, D d) {
+        checkAllAreNotNullOrEmpty(Quartet.class, a, b, c, d);
+        final Quartet<A, B, C, D> result = new Quartet<>(a, b, c, d);
         return result;
     }
 
-    /**
-     * Creates a new triplet with optional second and third elements.
-     */
-    public static <A extends Message, B extends Message, C extends Message>
-    Triplet<A, Optional<B>, Optional<C>> withNullable(A a, @Nullable B b, @Nullable C c) {
+    public static <A extends Message, B extends Message, C extends Message, D extends Message>
+    Quartet<A, Optional<B>, Optional<C>, Optional<D>> withNullable(A a,
+                                                                   @Nullable B b,
+                                                                   @Nullable C c,
+                                                                   @Nullable D d) {
         checkNotNullOrEmpty(Triplet.class, a);
-        checkAllNotEmpty(Triplet.class, b, c);
-        final Triplet<A, Optional<B>, Optional<C>> result =
-                new Triplet<>(a, fromNullable(b), fromNullable(c));
+        checkAllNotEmpty(Quartet.class, b, c, d);
+        final Quartet<A, Optional<B>, Optional<C>, Optional<D>> result =
+                new Quartet<>(a, fromNullable(b), fromNullable(c), fromNullable(d));
         return result;
     }
 
@@ -87,5 +86,10 @@ public final class Triplet<A extends Message, B, C>
     @Override
     public C getC() {
         return value(this, 2);
+    }
+
+    @Override
+    public D getD() {
+        return value(this, 3);
     }
 }

--- a/server/src/main/java/io/spine/server/tuple/Quartet.java
+++ b/server/src/main/java/io/spine/server/tuple/Quartet.java
@@ -59,7 +59,7 @@ public final class Quartet<A extends Message, B, C, D>
      */
     public static <A extends Message, B extends Message, C extends Message, D extends Message>
     Quartet<A, B, C, D> of(A a, B b, C c, D d) {
-        checkAllAreNotNullOrEmpty(Quartet.class, a, b, c, d);
+        checkAllNotNullOrEmpty(Quartet.class, a, b, c, d);
         final Quartet<A, B, C, D> result = new Quartet<>(a, b, c, d);
         return result;
     }
@@ -69,7 +69,7 @@ public final class Quartet<A extends Message, B, C, D>
      */
     public static <A extends Message, B extends Message, C extends Message, D extends Message>
     Quartet<A, B, C, Optional<D>> withNullable(A a, B b, C c, @Nullable D d) {
-        checkAllAreNotNullOrEmpty(Quartet.class, a, b, c);
+        checkAllNotNullOrEmpty(Quartet.class, a, b, c);
         checkNotEmpty(Quartet.class, d);
         final Quartet<A, B, C, Optional<D>> result = new Quartet<>(a, b, c, fromNullable(d));
         return result;
@@ -80,7 +80,7 @@ public final class Quartet<A extends Message, B, C, D>
      */
     public static <A extends Message, B extends Message, C extends Message, D extends Message>
     Quartet<A, B, Optional<C>, Optional<D>> withNullable2(A a, B b, @Nullable C c, @Nullable D d) {
-        checkAllAreNotNullOrEmpty(Quartet.class, a, b);
+        checkAllNotNullOrEmpty(Quartet.class, a, b);
         checkAllNotEmpty(Quartet.class, c, d);
         final Quartet<A, B, Optional<C>, Optional<D>> result =
                 new Quartet<>(a, b, fromNullable(c), fromNullable(d));

--- a/server/src/main/java/io/spine/server/tuple/Quartet.java
+++ b/server/src/main/java/io/spine/server/tuple/Quartet.java
@@ -54,6 +54,9 @@ public final class Quartet<A extends Message, B, C, D>
         super(a, b, c, d);
     }
 
+    /**
+     * Creates a quartet with all values present.
+     */
     public static <A extends Message, B extends Message, C extends Message, D extends Message>
     Quartet<A, B, C, D> of(A a, B b, C c, D d) {
         checkAllAreNotNullOrEmpty(Quartet.class, a, b, c, d);
@@ -61,12 +64,38 @@ public final class Quartet<A extends Message, B, C, D>
         return result;
     }
 
+    /**
+     * Creates a quartet with one optional value.
+     */
     public static <A extends Message, B extends Message, C extends Message, D extends Message>
-    Quartet<A, Optional<B>, Optional<C>, Optional<D>> withNullable(A a,
-                                                                   @Nullable B b,
-                                                                   @Nullable C c,
-                                                                   @Nullable D d) {
-        checkNotNullOrEmpty(Triplet.class, a);
+    Quartet<A, B, C, Optional<D>> withNullable(A a, B b, C c, @Nullable D d) {
+        checkAllAreNotNullOrEmpty(Quartet.class, a, b, c);
+        checkNotEmpty(Quartet.class, d);
+        final Quartet<A, B, C, Optional<D>> result = new Quartet<>(a, b, c, fromNullable(d));
+        return result;
+    }
+
+    /**
+     * Creates a quartet with two optional values.
+     */
+    public static <A extends Message, B extends Message, C extends Message, D extends Message>
+    Quartet<A, B, Optional<C>, Optional<D>> withNullable2(A a, B b, @Nullable C c, @Nullable D d) {
+        checkAllAreNotNullOrEmpty(Quartet.class, a, b);
+        checkAllNotEmpty(Quartet.class, c, d);
+        final Quartet<A, B, Optional<C>, Optional<D>> result =
+                new Quartet<>(a, b, fromNullable(c), fromNullable(d));
+        return result;
+    }
+
+    /**
+     * Creates a quartet with three optional values.
+     */
+    public static <A extends Message, B extends Message, C extends Message, D extends Message>
+    Quartet<A, Optional<B>, Optional<C>, Optional<D>> withNullable3(A a,
+                                                                    @Nullable B b,
+                                                                    @Nullable C c,
+                                                                    @Nullable D d) {
+        checkNotNullOrEmpty(Quartet.class, a);
         checkAllNotEmpty(Quartet.class, b, c, d);
         final Quartet<A, Optional<B>, Optional<C>, Optional<D>> result =
                 new Quartet<>(a, fromNullable(b), fromNullable(c), fromNullable(d));

--- a/server/src/main/java/io/spine/server/tuple/Triplet.java
+++ b/server/src/main/java/io/spine/server/tuple/Triplet.java
@@ -63,7 +63,7 @@ public final class Triplet<A extends Message, B, C>
     }
 
     /**
-     * Creates a triplet with last element optional.
+     * Creates a triplet with the last element optional.
      */
     public static <A extends Message, B extends Message, C extends Message>
     Triplet<A, B, Optional<C>> withNullable(A a, B b, @Nullable C c) {

--- a/server/src/main/java/io/spine/server/tuple/Triplet.java
+++ b/server/src/main/java/io/spine/server/tuple/Triplet.java
@@ -57,8 +57,19 @@ public final class Triplet<A extends Message, B, C>
      */
     public static <A extends Message, B extends Message, C extends Message>
     Triplet<A, B, C> of(A a, B b, C c) {
-        checkAllAreNotNullOrEmpty(Triplet.class, a, b, c);
+        checkAllNotNullOrEmpty(Triplet.class, a, b, c);
         final Triplet<A, B, C> result = new Triplet<>(a, b, c);
+        return result;
+    }
+
+    /**
+     * Creates a triplet with last element optional.
+     */
+    public static <A extends Message, B extends Message, C extends Message>
+    Triplet<A, B, Optional<C>> withNullable(A a, B b, @Nullable C c) {
+        checkAllNotNullOrEmpty(Triplet.class, a, b);
+        checkNotEmpty(Triplet.class, c);
+        final Triplet<A, B, Optional<C>> result = new Triplet<>(a, b, fromNullable(c));
         return result;
     }
 
@@ -66,7 +77,7 @@ public final class Triplet<A extends Message, B, C>
      * Creates a new triplet with optional second and third elements.
      */
     public static <A extends Message, B extends Message, C extends Message>
-    Triplet<A, Optional<B>, Optional<C>> withNullable(A a, @Nullable B b, @Nullable C c) {
+    Triplet<A, Optional<B>, Optional<C>> withNullable2(A a, @Nullable B b, @Nullable C c) {
         checkNotNullOrEmpty(Triplet.class, a);
         checkAllNotEmpty(Triplet.class, b, c);
         final Triplet<A, Optional<B>, Optional<C>> result =

--- a/server/src/main/java/io/spine/server/tuple/Tuple.java
+++ b/server/src/main/java/io/spine/server/tuple/Tuple.java
@@ -103,6 +103,20 @@ public abstract class Tuple implements Iterable<Message>, Serializable {
         return checkNotEmpty(checkingClass, value);
     }
 
+    static <T extends Tuple>
+    void checkAllAreNotNullOrEmpty(Class<T> checkingClass, Message... values) {
+        for (Message value : values) {
+            checkNotNullOrEmpty(checkingClass, value);
+        }
+    }
+
+    static <T extends Tuple>
+    void checkAllNotEmpty(Class<T> checkingClass, Message... values) {
+        for (Message value : values) {
+            checkNotEmpty(checkingClass, value);
+        }
+    }
+
     @Nonnull
     @Override
     public final Iterator<Message> iterator() {

--- a/server/src/main/java/io/spine/server/tuple/Tuple.java
+++ b/server/src/main/java/io/spine/server/tuple/Tuple.java
@@ -104,7 +104,7 @@ public abstract class Tuple implements Iterable<Message>, Serializable {
     }
 
     static <T extends Tuple>
-    void checkAllAreNotNullOrEmpty(Class<T> checkingClass, Message... values) {
+    void checkAllNotNullOrEmpty(Class<T> checkingClass, Message... values) {
         for (Message value : values) {
             checkNotNullOrEmpty(checkingClass, value);
         }

--- a/server/src/test/java/io/spine/server/tuple/PairShould.java
+++ b/server/src/test/java/io/spine/server/tuple/PairShould.java
@@ -46,6 +46,7 @@ public class PairShould {
     @Test
     public void pass_null_tolerance_check() {
         new NullPointerTester().setDefault(Message.class, TestValues.newUuidValue())
+                               .setDefault(Either.class, EitherOfTwo.withB(Time.getCurrentTime()))
                                .testAllPublicStaticMethods(Pair.class);
     }
 

--- a/server/src/test/java/io/spine/server/tuple/PairShould.java
+++ b/server/src/test/java/io/spine/server/tuple/PairShould.java
@@ -28,6 +28,7 @@ import com.google.protobuf.Empty;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
 import io.spine.test.TestValues;
+import io.spine.time.Time;
 import org.junit.Test;
 
 import java.util.Iterator;
@@ -135,5 +136,8 @@ public class PairShould {
         reserializeAndAssert(Pair.of(a, b));
         reserializeAndAssert(Pair.withNullable(a, b));
         reserializeAndAssert(Pair.withNullable(a, null));
+
+        reserializeAndAssert(Pair.withEither(a, EitherOfTwo.withA(Time.getCurrentTime())));
+        reserializeAndAssert(Pair.withEither(a, EitherOfTwo.withB(TestValues.newUuidValue())));
     }
 }

--- a/server/src/test/java/io/spine/server/tuple/QuartetShould.java
+++ b/server/src/test/java/io/spine/server/tuple/QuartetShould.java
@@ -97,7 +97,9 @@ public class QuartetShould {
     public void support_equality() {
         new EqualsTester().addEqualityGroup(Quartet.of(monkey, donkey, goat, bear),
                                             Quartet.of(monkey, donkey, goat, bear))
-                          
+
+                          .addEqualityGroup(Quartet.of(bear, donkey, monkey, goat))
+
                           .addEqualityGroup(Quartet.withNullable(monkey, donkey, goat, bear))
                           .addEqualityGroup(Quartet.withNullable(monkey, donkey, goat, null))
 

--- a/server/src/test/java/io/spine/server/tuple/QuartetShould.java
+++ b/server/src/test/java/io/spine/server/tuple/QuartetShould.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.tuple;
+
+import com.google.common.base.Optional;
+import com.google.common.testing.NullPointerTester;
+import com.google.protobuf.Message;
+import io.spine.test.tuple.Bear;
+import io.spine.test.tuple.Donkey;
+import io.spine.test.tuple.Goat;
+import io.spine.test.tuple.Instrument;
+import io.spine.test.tuple.Monkey;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.google.common.testing.SerializableTester.reserializeAndAssert;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Alexander Yevsyukov
+ */
+public class QuartetShould {
+
+    private final Monkey monkey = Monkey.newBuilder()
+                                        .setMessage("Show must go on!")
+                                        .setInstrument(Instrument.VIOLIN)
+                                        .build();
+
+    private final Donkey donkey = Donkey.newBuilder()
+                                        .setMessage("Let's play!")
+                                        .setInstrument(Instrument.ALTO_VIOLIN)
+                                        .build();
+
+    private final Goat goat = Goat.newBuilder()
+                                  .setMessage("We will rock you!")
+                                  .setInstrument(Instrument.VIOLIN)
+                                  .build();
+
+    private final Bear bear = Bear.newBuilder()
+                                  .setMessage("Why not?")
+                                  .setInstrument(Instrument.BASS)
+                                  .build();
+
+    private Quartet<Monkey, Donkey, Goat, Bear> quartet;
+
+    @Before
+    public void setUp() {
+        quartet = Quartet.of(monkey, donkey, goat, bear);
+    }
+
+    @Test
+    public void pass_null_tolerance_check() {
+        new NullPointerTester().setDefault(Message.class, goat)
+                               .setDefault(Optional.class, Optional.of(goat))
+                               .testAllPublicStaticMethods(Quartet.class);
+    }
+
+    @Test
+    public void serialize() {
+        reserializeAndAssert(Quartet.of(monkey, donkey, goat, bear));
+        reserializeAndAssert(Quartet.withNullable(monkey, null, goat, bear));
+        reserializeAndAssert(Quartet.withNullable(monkey, donkey, null, bear));
+        reserializeAndAssert(Quartet.withNullable(monkey, donkey, goat, null));
+        reserializeAndAssert(Quartet.withNullable(monkey, null, null, null));
+    }
+
+    @Test
+    public void return_elements() {
+        assertEquals(monkey, quartet.getA());
+        assertEquals(donkey, quartet.getB());
+        assertEquals(goat, quartet.getC());
+        assertEquals(bear, quartet.getD());
+    }
+}

--- a/server/src/test/java/io/spine/server/tuple/QuartetShould.java
+++ b/server/src/test/java/io/spine/server/tuple/QuartetShould.java
@@ -21,6 +21,7 @@
 package io.spine.server.tuple;
 
 import com.google.common.base.Optional;
+import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Message;
 import io.spine.test.tuple.Bear;
@@ -76,10 +77,36 @@ public class QuartetShould {
     @Test
     public void serialize() {
         reserializeAndAssert(Quartet.of(monkey, donkey, goat, bear));
-        reserializeAndAssert(Quartet.withNullable(monkey, null, goat, bear));
-        reserializeAndAssert(Quartet.withNullable(monkey, donkey, null, bear));
+
+        reserializeAndAssert(Quartet.withNullable(monkey, donkey, goat, bear));
         reserializeAndAssert(Quartet.withNullable(monkey, donkey, goat, null));
-        reserializeAndAssert(Quartet.withNullable(monkey, null, null, null));
+
+        reserializeAndAssert(Quartet.withNullable2(monkey, donkey, goat, bear));
+        reserializeAndAssert(Quartet.withNullable2(monkey, donkey, null, bear));
+        reserializeAndAssert(Quartet.withNullable2(monkey, donkey, goat, null));
+        reserializeAndAssert(Quartet.withNullable2(monkey, donkey, null, null));
+
+        reserializeAndAssert(Quartet.withNullable3(monkey, donkey, goat, bear));
+        reserializeAndAssert(Quartet.withNullable3(monkey, null, goat, bear));
+        reserializeAndAssert(Quartet.withNullable3(monkey, donkey, null, bear));
+        reserializeAndAssert(Quartet.withNullable3(monkey, donkey, goat, null));
+        reserializeAndAssert(Quartet.withNullable3(monkey, null, null, null));
+    }
+
+    @Test
+    public void support_equality() {
+        new EqualsTester().addEqualityGroup(Quartet.of(monkey, donkey, goat, bear),
+                                            Quartet.of(monkey, donkey, goat, bear))
+                          
+                          .addEqualityGroup(Quartet.withNullable(monkey, donkey, goat, bear))
+                          .addEqualityGroup(Quartet.withNullable(monkey, donkey, goat, null))
+
+                          .addEqualityGroup(Quartet.withNullable2(monkey, donkey, goat, bear))
+                          .addEqualityGroup(Quartet.withNullable2(monkey, donkey, null, null))
+
+                          .addEqualityGroup(Quartet.withNullable3(monkey, donkey, goat, bear))
+                          .addEqualityGroup(Quartet.withNullable3(monkey, null, null, null))
+                          .testEquals();
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/tuple/TripletShould.java
+++ b/server/src/test/java/io/spine/server/tuple/TripletShould.java
@@ -67,12 +67,15 @@ public class TripletShould {
 
     @Test
     public void support_equality() {
-        final Triplet<StringValue, BoolValue, UInt32Value> t1 = Triplet.of(a, b, c);
-        final Triplet<StringValue, BoolValue, UInt32Value> t2 = Triplet.of(a, b, c);
-        final Triplet<BoolValue, StringValue, UInt32Value> t3 = Triplet.of(b, a, c);
+        new EqualsTester().addEqualityGroup(Triplet.of(a, b, c), Triplet.of(a, b, c))
 
-        new EqualsTester().addEqualityGroup(t1, t2)
-                          .addEqualityGroup(t3)
+                          .addEqualityGroup(Triplet.withNullable(a, b, c))
+                          .addEqualityGroup(Triplet.withNullable(a, b, null))
+
+                          .addEqualityGroup(Triplet.withNullable2(a, b, c))
+                          .addEqualityGroup(Triplet.withNullable2(a, b, null))
+                          .addEqualityGroup(Triplet.withNullable2(a, null, c))
+                          .addEqualityGroup(Triplet.withNullable2(a, null, null))
                           .testEquals();
     }
 
@@ -101,7 +104,7 @@ public class TripletShould {
     @Test
     public void allow_optional_elements_present() {
         Triplet<StringValue, Optional<BoolValue>, Optional<UInt32Value>> optTriplet =
-                Triplet.withNullable(a, b, c);
+                Triplet.withNullable2(a, b, c);
 
         assertEquals(a, optTriplet.getA());
         assertEquals(Optional.of(b), optTriplet.getB());
@@ -111,7 +114,7 @@ public class TripletShould {
     @Test
     public void allow_optional_elements_absent() {
         Triplet<StringValue, Optional<BoolValue>, Optional<UInt32Value>> optTriplet =
-                Triplet.withNullable(a, null, null);
+                Triplet.withNullable2(a, null, null);
 
         assertEquals(a, optTriplet.getA());
         assertEquals(Optional.absent(), optTriplet.getB());
@@ -121,7 +124,7 @@ public class TripletShould {
     @Test
     public void return_Empty_for_absent_Optional_in_iterator() {
         Triplet<StringValue, Optional<BoolValue>, Optional<UInt32Value>> optTriplet =
-                Triplet.withNullable(a, null, null);
+                Triplet.withNullable2(a, null, null);
 
         final Iterator<Message> iterator = optTriplet.iterator();
 
@@ -144,7 +147,7 @@ public class TripletShould {
     @Test
     public void return_values_from_optional_in_iteration() {
         Triplet<StringValue, Optional<BoolValue>, Optional<UInt32Value>> optTriplet =
-                Triplet.withNullable(a, b, c);
+                Triplet.withNullable2(a, b, c);
 
         final Iterator<Message> iterator = optTriplet.iterator();
 
@@ -157,8 +160,12 @@ public class TripletShould {
     @Test
     public void serialize() {
         reserializeAndAssert(Triplet.of(a, b, c));
-        reserializeAndAssert(Triplet.withNullable(a, null, null));
+
+        reserializeAndAssert(Triplet.withNullable(a, b, c));
         reserializeAndAssert(Triplet.withNullable(a, b, null));
-        reserializeAndAssert(Triplet.withNullable(a, null, c));
+
+        reserializeAndAssert(Triplet.withNullable2(a, null, null));
+        reserializeAndAssert(Triplet.withNullable2(a, b, null));
+        reserializeAndAssert(Triplet.withNullable2(a, null, c));
     }
 }

--- a/server/src/test/proto/spine/test/tuple/quartet.proto
+++ b/server/src/test/proto/spine/test/tuple/quartet.proto
@@ -1,0 +1,55 @@
+//
+// Copyright 2018, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.test.tuple;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package="io.spine.test.tuple";
+option java_outer_classname = "QuartetProto";
+option java_multiple_files = true;
+
+message Monkey {
+    string message = 1;
+    Instrument instrument = 2;
+}
+
+message Donkey {
+    string message = 1;
+    Instrument instrument = 2;
+}
+
+message Goat {
+    string message = 1;
+    Instrument instrument = 2;
+}
+
+message Bear {
+    string message = 1;
+    Instrument instrument = 2;
+}
+
+enum Instrument {
+    VIOLIN = 0;
+    ALTO_VIOLIN = 1;
+    BASS = 2;
+}


### PR DESCRIPTION
This PR:
* introduces `Quartet` tuple
* adds `Either` parameter for a `Pair`
* adds factory methods for optional `Triplet` parameters

Spine version advanced to `0.10.21-SNAPSHOT`.