### PR TITLE
Quintet tuple

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.21-SNAPSHOT'
+def final SPINE_VERSION = '0.10.22-SNAPSHOT'
 
 //noinspection GroovyAssignabilityCheck
 ext {

--- a/server/src/main/java/io/spine/server/tuple/Element.java
+++ b/server/src/main/java/io/spine/server/tuple/Element.java
@@ -177,4 +177,11 @@ class Element implements Serializable {
          */
         T getD();
     }
+
+    interface EValue<T> extends OptionalValue {
+        /**
+         * Obtains the fifth element of the tuple.
+         */
+        T getE();
+    }
 }

--- a/server/src/main/java/io/spine/server/tuple/Pair.java
+++ b/server/src/main/java/io/spine/server/tuple/Pair.java
@@ -34,7 +34,11 @@ import static io.spine.server.tuple.Element.value;
 /**
  * A tuple with two elements.
  *
- * <p>The second element is optional.
+ * <p>The first element must be a non-default {@link Message}
+ * (and not {@link com.google.protobuf.Empty Empty}).
+ *
+ * <p>The second element can be {@code Message}, {@link com.google.common.base.Optional Optional} or
+ * {@link Either}.
  *
  * @param <A> the type of the first element
  * @param <B> the type of the second element

--- a/server/src/main/java/io/spine/server/tuple/Quartet.java
+++ b/server/src/main/java/io/spine/server/tuple/Quartet.java
@@ -35,7 +35,11 @@ import static io.spine.server.tuple.Element.value;
 /**
  * A tuple with four elements.
  *
- * <p>The second and third elements are optional.
+ * <p>The first element must be a non-default {@link Message}
+ * (and not {@link com.google.protobuf.Empty Empty}).
+ *
+ * <p>Other three can be {@code Message}, {@link com.google.common.base.Optional Optional} or
+ * {@link Either}.
  *
  * @param <A> the type of the first element
  * @param <B> the type of the second element

--- a/server/src/main/java/io/spine/server/tuple/Quintet.java
+++ b/server/src/main/java/io/spine/server/tuple/Quintet.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.tuple;
 
+import com.google.common.base.Optional;
 import com.google.protobuf.Message;
 import io.spine.server.tuple.Element.AValue;
 import io.spine.server.tuple.Element.BValue;
@@ -27,6 +28,9 @@ import io.spine.server.tuple.Element.CValue;
 import io.spine.server.tuple.Element.DValue;
 import io.spine.server.tuple.Element.EValue;
 
+import javax.annotation.Nullable;
+
+import static com.google.common.base.Optional.fromNullable;
 import static io.spine.server.tuple.Element.value;
 
 /**
@@ -64,6 +68,61 @@ public final class Quintet<A extends Message, B, C, D, E>
     Quintet<A, B, C, D, E> of(A a, B b, C c, D d, E e) {
         checkAllNotNullOrEmpty(Quintet.class, a, b, c, d, e);
         final Quintet<A, B, C, D, E> result = new Quintet<>(a, b, c, d, e);
+        return result;
+    }
+
+    /**
+     * Creates a quintet with one optional value.
+     */
+    public static
+    <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
+    Quintet<A, B, C, D, Optional<E>>
+    withNullable(A a, B b, C c, D d, @Nullable E e) {
+        checkAllNotNullOrEmpty(Quintet.class, a, b, c, d);
+        checkNotEmpty(Quintet.class, e);
+        final Quintet<A, B, C, D, Optional<E>> result = new Quintet<>(a, b, c, d, fromNullable(e));
+        return result;
+    }
+
+    /**
+     * Creates a quintet with two optional values.
+     */
+    public static
+    <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
+    Quintet<A, B, C, Optional<D>, Optional<E>>
+    withNullable2(A a, B b, C c, @Nullable D d, @Nullable E e) {
+        checkAllNotNullOrEmpty(Quintet.class, a, b, c);
+        checkAllNotEmpty(Quintet.class, e, d);
+        final Quintet<A, B, C, Optional<D>, Optional<E>> result =
+                new Quintet<>(a, b, c, fromNullable(d), fromNullable(e));
+        return result;
+    }
+
+    /**
+     * Creates a quintet with three optional values.
+     */
+    public static
+    <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
+    Quintet<A, B, Optional<C>, Optional<D>, Optional<E>>
+    withNullable3(A a, B b, @Nullable C c, @Nullable D d, @Nullable E e) {
+        checkAllNotNullOrEmpty(Quintet.class, a, b);
+        checkAllNotEmpty(Quintet.class, c, d, e);
+        final Quintet<A, B, Optional<C>, Optional<D>, Optional<E>> result =
+                new Quintet<>(a, b, fromNullable(c), fromNullable(d), fromNullable(e));
+        return result;
+    }
+
+    /**
+     * Creates a quintet with four optional values.
+     */
+    public static
+    <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
+    Quintet<A, Optional<B>, Optional<C>, Optional<D>, Optional<E>>
+    withNullable4(A a, @Nullable B b, @Nullable C c, @Nullable D d, @Nullable E e) {
+        checkNotNullOrEmpty(Quintet.class, a);
+        checkAllNotEmpty(Quintet.class, b, c, d, e);
+        final Quintet<A, Optional<B>, Optional<C>, Optional<D>, Optional<E>> result =
+                new Quintet<>(a, fromNullable(b), fromNullable(c), fromNullable(d), fromNullable(e));
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/tuple/Quintet.java
+++ b/server/src/main/java/io/spine/server/tuple/Quintet.java
@@ -21,6 +21,13 @@
 package io.spine.server.tuple;
 
 import com.google.protobuf.Message;
+import io.spine.server.tuple.Element.AValue;
+import io.spine.server.tuple.Element.BValue;
+import io.spine.server.tuple.Element.CValue;
+import io.spine.server.tuple.Element.DValue;
+import io.spine.server.tuple.Element.EValue;
+
+import static io.spine.server.tuple.Element.value;
 
 /**
  * A tuple of five elements.
@@ -39,6 +46,49 @@ import com.google.protobuf.Message;
  *
  * @author Alexander Yevsyukov
  */
-public class Quintet<A extends Message, B, C, D, E>
-    extends Tuple {
+public final class Quintet<A extends Message, B, C, D, E>
+    extends Tuple
+    implements AValue<A>, BValue<B>, CValue<C>, DValue<D>, EValue<E> {
+
+    private static final long serialVersionUID = 0L;
+
+    private Quintet(A a, B b, C c, D d, E e) {
+        super(a, b, c, d, e);
+    }
+
+    /**
+     * Creates a quintet with all values present.
+     */
+    public static
+    <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
+    Quintet<A, B, C, D, E> of(A a, B b, C c, D d, E e) {
+        checkAllNotNullOrEmpty(Quintet.class, a, b, c, d, e);
+        final Quintet<A, B, C, D, E> result = new Quintet<>(a, b, c, d, e);
+        return result;
+    }
+
+    @Override
+    public A getA() {
+        return value(this, 0);
+    }
+
+    @Override
+    public B getB() {
+        return value(this, 1);
+    }
+
+    @Override
+    public C getC() {
+        return value(this, 2);
+    }
+
+    @Override
+    public D getD() {
+        return value(this, 3);
+    }
+
+    @Override
+    public E getE() {
+        return value(this, 4);
+    }
 }

--- a/server/src/main/java/io/spine/server/tuple/Quintet.java
+++ b/server/src/main/java/io/spine/server/tuple/Quintet.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.tuple;
+
+import com.google.protobuf.Message;
+
+/**
+ * A tuple of five elements.
+ *
+ * <p>The first element must be a non-default {@link Message}
+ * (and not {@link com.google.protobuf.Empty Empty}).
+ *
+ * <p>Other four can be {@code Message}, {@link com.google.common.base.Optional Optional} or
+ * {@link Either}.
+ *
+ * @param <A> the type of the first element
+ * @param <B> the type of the second element
+ * @param <C> the type of the third element
+ * @param <D> the type of the fourth element
+ * @param <E> the type of the fifth element
+ *
+ * @author Alexander Yevsyukov
+ */
+public class Quintet<A extends Message, B, C, D, E>
+    extends Tuple {
+}

--- a/server/src/main/java/io/spine/server/tuple/Triplet.java
+++ b/server/src/main/java/io/spine/server/tuple/Triplet.java
@@ -34,7 +34,11 @@ import static io.spine.server.tuple.Element.value;
 /**
  * A tuple with three elements.
  *
- * <p>The second and third elements are optional.
+ * <p>The first element must be a non-default {@link Message}
+ * (and not {@link com.google.protobuf.Empty Empty}).
+ *
+ * <p>Other two can be {@code Message}, {@link com.google.common.base.Optional Optional} or
+ * {@link Either}.
  *
  * @param <A> the type of the first element
  * @param <B> the type of the second element

--- a/server/src/main/java/io/spine/server/tuple/package-info.java
+++ b/server/src/main/java/io/spine/server/tuple/package-info.java
@@ -54,22 +54,23 @@
  *
  * <p>The following tuple classes are provided:
  * <ul>
- *    <li>{@code Pair<A, B>}
- *    <li>{@code Triplet<A, B, C>}
- *    <li>{@code Quartet<A, B, C, D>}
- *    <li>{@code Quintet<A, B, C, D, E>}
+ *    <li>{@link io.spine.server.tuple.Pair Pair&lt;A, B&gt;}
+ *    <li>{@link io.spine.server.tuple.Triplet Triplet&lt;A, B, C&gt;}
+ *    <li>{@link io.spine.server.tuple.Quartet Quartet&lt;A, B, C, D&gt;}
+ *    <li>{@link io.spine.server.tuple.Quintet Quintet&lt;A, B, C, D, E&gt;}
  * </ul>
  *
- * <p>Basic tuple classes allow {@link com.google.common.base.Optional Optional} generic types.
+ * <p>Basic tuple classes allow {@link com.google.common.base.Optional Optional} and 
+ * {@link io.spine.server.tuple.Either} types, starting from the second generic argument.
  *
  * <h2>Alternatives</h2>
  *
  * <p>In order to define alternatively returned values, please use the following classes:
  * <ul>
- *     <li>{@code Either<A, B>}
- *     <li>{@code EitherOfThree<A, B, C>}
- *     <li>{@code EitherOfFour<A, B, C, D>}
- *     <li>{@code EitherOfFive<A, B, C, D, E>}
+ *     <li>{@link io.spine.server.tuple.EitherOfTwo EitherOfTwo&lt;A, B&gt;}
+ *     <li>{@link io.spine.server.tuple.EitherOfThree EitherOfThree&lt;A, B, C&gt;}
+ *     <li>{@code EitherOfFour&lt;A, B, C, D&gt;}
+ *     <li>{@code EitherOfFive&lt;A, B, C, D, E&gt;}
  * </ul>
  *
  * <p>Generic parameters for alternatives can be only {@link com.google.protobuf.Message Message}.

--- a/server/src/main/java/io/spine/server/tuple/package-info.java
+++ b/server/src/main/java/io/spine/server/tuple/package-info.java
@@ -60,8 +60,8 @@
  *    <li>{@link io.spine.server.tuple.Quintet Quintet&lt;A, B, C, D, E&gt;}
  * </ul>
  *
- * <p>Basic tuple classes allow {@link com.google.common.base.Optional Optional} and 
- * {@link io.spine.server.tuple.Either} types, starting from the second generic argument.
+ * <p>Basic tuple classes allow {@link com.google.common.base.Optional Optional} starting from
+ * the second generic argument.
  *
  * <h2>Alternatives</h2>
  *

--- a/server/src/test/java/io/spine/server/tuple/QuartetShould.java
+++ b/server/src/test/java/io/spine/server/tuple/QuartetShould.java
@@ -24,11 +24,11 @@ import com.google.common.base.Optional;
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Message;
-import io.spine.test.tuple.Bear;
-import io.spine.test.tuple.Donkey;
-import io.spine.test.tuple.Goat;
-import io.spine.test.tuple.Instrument;
-import io.spine.test.tuple.Monkey;
+import io.spine.test.tuple.quartet.Bear;
+import io.spine.test.tuple.quartet.Donkey;
+import io.spine.test.tuple.quartet.Goat;
+import io.spine.test.tuple.quartet.Instrument;
+import io.spine.test.tuple.quartet.Monkey;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/server/src/test/java/io/spine/server/tuple/QuintetShould.java
+++ b/server/src/test/java/io/spine/server/tuple/QuintetShould.java
@@ -67,6 +67,22 @@ public class QuintetShould {
     public void serialize() {
         reserializeAndAssert(celloQuintet);
         reserializeAndAssert(violaQuintet);
+
+        reserializeAndAssert(
+                Quintet.withNullable(newViola(), newViola(), newViola(), newViola(), null)
+        );
+
+        reserializeAndAssert(
+                Quintet.withNullable2(newViola(), newViola(), newViola(), null, null)
+        );
+
+        reserializeAndAssert(
+                Quintet.withNullable3(newViola(), newViola(), null, null, null)
+        );
+
+        reserializeAndAssert(
+                Quintet.withNullable4(newViola(), null, null, null, null)
+        );
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/tuple/QuintetShould.java
+++ b/server/src/test/java/io/spine/server/tuple/QuintetShould.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.tuple;
+
+import com.google.common.base.Optional;
+import com.google.common.testing.EqualsTester;
+import com.google.common.testing.NullPointerTester;
+import com.google.protobuf.Message;
+import io.spine.test.tuple.quintet.InstrumentNumber;
+import io.spine.test.tuple.quintet.Viola;
+import io.spine.test.tuple.quintet.Violin;
+import io.spine.test.tuple.quintet.ViolinCello;
+import io.spine.validate.Validate;
+import org.junit.Test;
+
+import static com.google.common.testing.SerializableTester.reserializeAndAssert;
+
+/**
+ * Tests {@link Quintet} tuple.
+ *
+ * <p>This test suite uses <a href="https://en.wikipedia.org/wiki/String_quintet">String quintets</a>
+ * types just to have test data other than default Protobuf types, and for some fun.
+ *
+ * <p>In a real app a {@link Quintet} should have only event messages, and not value objects.
+ *
+ * @author Alexander Yevsyukov
+ */
+public class QuintetShould {
+
+    private final Quintet celloQuintet = QuintetFactory.newCelloQuintet();
+    private final Quintet violaQuintet = QuintetFactory.newViolaQuintet();
+
+    @Test
+    public void pass_null_tolerance_check() {
+        new NullPointerTester().setDefault(Message.class,
+                                           InstrumentFactory.newViola())
+                               .setDefault(Optional.class,
+                                           Optional.of(InstrumentFactory.newViolinCello()))
+                               .testAllPublicStaticMethods(Quintet.class);
+    }
+
+    @Test
+    public void serialize() {
+        reserializeAndAssert(celloQuintet);
+        reserializeAndAssert(violaQuintet);
+    }
+
+    @Test
+    public void support_equality() {
+        new EqualsTester().addEqualityGroup(QuintetFactory.newCelloQuintet(),
+                                            QuintetFactory.newCelloQuintet())
+                          .addEqualityGroup(QuintetFactory.newViolaQuintet())
+                          .testEquals();
+    }
+
+    /*
+     * Test environment
+     *********************/
+
+    /**
+     * Creates typical <a href="https://en.wikipedia.org/wiki/String_quintet">String quintets</a>.
+     */
+    private static class QuintetFactory {
+
+        private static final InstrumentNumber NUM_1 = InstrumentNumber.newBuilder()
+                                                                      .setValue(1)
+                                                                      .build();
+
+        private static final InstrumentNumber NUM_2 = InstrumentNumber.newBuilder()
+                                                                      .setValue(2)
+                                                                      .build();
+
+        /** Prevents instantiation of this utility class. */
+        private QuintetFactory() {
+        }
+
+        static Quintet<Violin, Violin, Viola, ViolinCello, ViolinCello> newCelloQuintet() {
+            return Quintet.of(InstrumentFactory.newViolin(NUM_1),
+                              InstrumentFactory.newViolin(NUM_2),
+                              InstrumentFactory.newViola(),
+                              InstrumentFactory.newViolinCello(NUM_1),
+                              InstrumentFactory.newViolinCello(NUM_2));
+        }
+
+        static Quintet<Violin, Violin, Viola, Viola, ViolinCello> newViolaQuintet() {
+            return Quintet.of(InstrumentFactory.newViolin(NUM_1),
+                              InstrumentFactory.newViolin(NUM_2),
+                              InstrumentFactory.newViola(NUM_1),
+                              InstrumentFactory.newViola(NUM_2),
+                              InstrumentFactory.newViolinCello());
+        }
+    }
+
+    /**
+     * Creates instruments.
+     */
+    private static class InstrumentFactory {
+
+        /** Prevents instantiation of this utility class. */
+        private InstrumentFactory() {
+        }
+
+        private static Violin newViolin(InstrumentNumber number) {
+            final Violin result = Violin.newBuilder()
+                                        .setNumber(number)
+                                        .build();
+            Validate.checkValid(result);
+            return result;
+        }
+
+        private static Viola newViola() {
+            final Viola result = Viola.newBuilder()
+                                      .setSingle(true)
+                                      .build();
+            Validate.checkValid(result);
+            return result;
+        }
+
+        private static Viola newViola(InstrumentNumber number) {
+            final Viola result = Viola.newBuilder()
+                                      .setNumber(number)
+                                      .build();
+            Validate.checkValid(result);
+            return result;
+        }
+
+        private static ViolinCello newViolinCello(InstrumentNumber number) {
+            final ViolinCello result = ViolinCello.newBuilder()
+                                                  .setNumber(number)
+                                                  .build();
+            Validate.checkValid(result);
+            return result;
+        }
+
+        private static ViolinCello newViolinCello() {
+            final ViolinCello result = ViolinCello.newBuilder()
+                                                  .setSingle(true)
+                                                  .build();
+            Validate.checkValid(result);
+            return result;
+        }
+    }
+}

--- a/server/src/test/java/io/spine/server/tuple/QuintetShould.java
+++ b/server/src/test/java/io/spine/server/tuple/QuintetShould.java
@@ -32,6 +32,14 @@ import io.spine.validate.Validate;
 import org.junit.Test;
 
 import static com.google.common.testing.SerializableTester.reserializeAndAssert;
+import static io.spine.server.tuple.QuintetShould.InstrumentFactory.newViola;
+import static io.spine.server.tuple.QuintetShould.InstrumentFactory.newViolin;
+import static io.spine.server.tuple.QuintetShould.InstrumentFactory.newViolinCello;
+import static io.spine.server.tuple.QuintetShould.QuintetFactory.NUM_1;
+import static io.spine.server.tuple.QuintetShould.QuintetFactory.NUM_2;
+import static io.spine.server.tuple.QuintetShould.QuintetFactory.newCelloQuintet;
+import static io.spine.server.tuple.QuintetShould.QuintetFactory.newViolaQuintet;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests {@link Quintet} tuple.
@@ -45,15 +53,13 @@ import static com.google.common.testing.SerializableTester.reserializeAndAssert;
  */
 public class QuintetShould {
 
-    private final Quintet celloQuintet = QuintetFactory.newCelloQuintet();
-    private final Quintet violaQuintet = QuintetFactory.newViolaQuintet();
+    private final Quintet celloQuintet = newCelloQuintet();
+    private final Quintet violaQuintet = newViolaQuintet();
 
     @Test
     public void pass_null_tolerance_check() {
-        new NullPointerTester().setDefault(Message.class,
-                                           InstrumentFactory.newViola())
-                               .setDefault(Optional.class,
-                                           Optional.of(InstrumentFactory.newViolinCello()))
+        new NullPointerTester().setDefault(Message.class, newViola())
+                               .setDefault(Optional.class, Optional.of(newViolinCello()))
                                .testAllPublicStaticMethods(Quintet.class);
     }
 
@@ -65,10 +71,18 @@ public class QuintetShould {
 
     @Test
     public void support_equality() {
-        new EqualsTester().addEqualityGroup(QuintetFactory.newCelloQuintet(),
-                                            QuintetFactory.newCelloQuintet())
-                          .addEqualityGroup(QuintetFactory.newViolaQuintet())
+        new EqualsTester().addEqualityGroup(newCelloQuintet(), newCelloQuintet())
+                          .addEqualityGroup(newViolaQuintet())
                           .testEquals();
+    }
+
+    @Test
+    public void return_elements() {
+        assertEquals(newViolin(NUM_1), celloQuintet.getA());
+        assertEquals(newViolin(NUM_2), celloQuintet.getB());
+        assertEquals(newViola(), celloQuintet.getC());
+        assertEquals(newViolinCello(NUM_1), celloQuintet.getD());
+        assertEquals(newViolinCello(NUM_2), celloQuintet.getE());
     }
 
     /*
@@ -78,47 +92,47 @@ public class QuintetShould {
     /**
      * Creates typical <a href="https://en.wikipedia.org/wiki/String_quintet">String quintets</a>.
      */
-    private static class QuintetFactory {
+    static class QuintetFactory {
 
-        private static final InstrumentNumber NUM_1 = InstrumentNumber.newBuilder()
-                                                                      .setValue(1)
-                                                                      .build();
+        static final InstrumentNumber NUM_1 = InstrumentNumber.newBuilder()
+                                                              .setValue(1)
+                                                              .build();
 
-        private static final InstrumentNumber NUM_2 = InstrumentNumber.newBuilder()
-                                                                      .setValue(2)
-                                                                      .build();
+        static final InstrumentNumber NUM_2 = InstrumentNumber.newBuilder()
+                                                              .setValue(2)
+                                                              .build();
 
         /** Prevents instantiation of this utility class. */
         private QuintetFactory() {
         }
 
         static Quintet<Violin, Violin, Viola, ViolinCello, ViolinCello> newCelloQuintet() {
-            return Quintet.of(InstrumentFactory.newViolin(NUM_1),
-                              InstrumentFactory.newViolin(NUM_2),
-                              InstrumentFactory.newViola(),
-                              InstrumentFactory.newViolinCello(NUM_1),
-                              InstrumentFactory.newViolinCello(NUM_2));
+            return Quintet.of(newViolin(NUM_1),
+                              newViolin(NUM_2),
+                              newViola(),
+                              newViolinCello(NUM_1),
+                              newViolinCello(NUM_2));
         }
 
         static Quintet<Violin, Violin, Viola, Viola, ViolinCello> newViolaQuintet() {
-            return Quintet.of(InstrumentFactory.newViolin(NUM_1),
-                              InstrumentFactory.newViolin(NUM_2),
-                              InstrumentFactory.newViola(NUM_1),
-                              InstrumentFactory.newViola(NUM_2),
-                              InstrumentFactory.newViolinCello());
+            return Quintet.of(newViolin(NUM_1),
+                              newViolin(NUM_2),
+                              newViola(NUM_1),
+                              newViola(NUM_2),
+                              newViolinCello());
         }
     }
 
     /**
      * Creates instruments.
      */
-    private static class InstrumentFactory {
+    static class InstrumentFactory {
 
         /** Prevents instantiation of this utility class. */
         private InstrumentFactory() {
         }
 
-        private static Violin newViolin(InstrumentNumber number) {
+        static Violin newViolin(InstrumentNumber number) {
             final Violin result = Violin.newBuilder()
                                         .setNumber(number)
                                         .build();
@@ -126,7 +140,7 @@ public class QuintetShould {
             return result;
         }
 
-        private static Viola newViola() {
+        static Viola newViola() {
             final Viola result = Viola.newBuilder()
                                       .setSingle(true)
                                       .build();
@@ -134,7 +148,7 @@ public class QuintetShould {
             return result;
         }
 
-        private static Viola newViola(InstrumentNumber number) {
+        static Viola newViola(InstrumentNumber number) {
             final Viola result = Viola.newBuilder()
                                       .setNumber(number)
                                       .build();
@@ -142,7 +156,7 @@ public class QuintetShould {
             return result;
         }
 
-        private static ViolinCello newViolinCello(InstrumentNumber number) {
+        static ViolinCello newViolinCello(InstrumentNumber number) {
             final ViolinCello result = ViolinCello.newBuilder()
                                                   .setNumber(number)
                                                   .build();
@@ -150,7 +164,7 @@ public class QuintetShould {
             return result;
         }
 
-        private static ViolinCello newViolinCello() {
+        static ViolinCello newViolinCello() {
             final ViolinCello result = ViolinCello.newBuilder()
                                                   .setSingle(true)
                                                   .build();

--- a/server/src/test/java/io/spine/server/tuple/QuintetShould.java
+++ b/server/src/test/java/io/spine/server/tuple/QuintetShould.java
@@ -24,21 +24,16 @@ import com.google.common.base.Optional;
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Message;
-import io.spine.test.tuple.quintet.InstrumentNumber;
-import io.spine.test.tuple.quintet.Viola;
-import io.spine.test.tuple.quintet.Violin;
-import io.spine.test.tuple.quintet.ViolinCello;
-import io.spine.validate.Validate;
 import org.junit.Test;
 
 import static com.google.common.testing.SerializableTester.reserializeAndAssert;
-import static io.spine.server.tuple.QuintetShould.InstrumentFactory.newViola;
-import static io.spine.server.tuple.QuintetShould.InstrumentFactory.newViolin;
-import static io.spine.server.tuple.QuintetShould.InstrumentFactory.newViolinCello;
-import static io.spine.server.tuple.QuintetShould.QuintetFactory.NUM_1;
-import static io.spine.server.tuple.QuintetShould.QuintetFactory.NUM_2;
-import static io.spine.server.tuple.QuintetShould.QuintetFactory.newCelloQuintet;
-import static io.spine.server.tuple.QuintetShould.QuintetFactory.newViolaQuintet;
+import static io.spine.server.tuple.given.QuintetTestEnv.InstrumentFactory.newViola;
+import static io.spine.server.tuple.given.QuintetTestEnv.InstrumentFactory.newViolin;
+import static io.spine.server.tuple.given.QuintetTestEnv.InstrumentFactory.newViolinCello;
+import static io.spine.server.tuple.given.QuintetTestEnv.QuintetFactory.NUM_1;
+import static io.spine.server.tuple.given.QuintetTestEnv.QuintetFactory.NUM_2;
+import static io.spine.server.tuple.given.QuintetTestEnv.QuintetFactory.newCelloQuintet;
+import static io.spine.server.tuple.given.QuintetTestEnv.QuintetFactory.newViolaQuintet;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -71,18 +66,9 @@ public class QuintetShould {
         reserializeAndAssert(
                 Quintet.withNullable(newViola(), newViola(), newViola(), newViola(), null)
         );
-
-        reserializeAndAssert(
-                Quintet.withNullable2(newViola(), newViola(), newViola(), null, null)
-        );
-
-        reserializeAndAssert(
-                Quintet.withNullable3(newViola(), newViola(), null, null, null)
-        );
-
-        reserializeAndAssert(
-                Quintet.withNullable4(newViola(), null, null, null, null)
-        );
+        reserializeAndAssert(Quintet.withNullable2(newViola(), newViola(), newViola(), null, null));
+        reserializeAndAssert(Quintet.withNullable3(newViola(), newViola(), null, null, null));
+        reserializeAndAssert(Quintet.withNullable4(newViola(), null, null, null, null));
     }
 
     @Test
@@ -99,93 +85,5 @@ public class QuintetShould {
         assertEquals(newViola(), celloQuintet.getC());
         assertEquals(newViolinCello(NUM_1), celloQuintet.getD());
         assertEquals(newViolinCello(NUM_2), celloQuintet.getE());
-    }
-
-    /*
-     * Test environment
-     *********************/
-
-    /**
-     * Creates typical <a href="https://en.wikipedia.org/wiki/String_quintet">String quintets</a>.
-     */
-    static class QuintetFactory {
-
-        static final InstrumentNumber NUM_1 = InstrumentNumber.newBuilder()
-                                                              .setValue(1)
-                                                              .build();
-
-        static final InstrumentNumber NUM_2 = InstrumentNumber.newBuilder()
-                                                              .setValue(2)
-                                                              .build();
-
-        /** Prevents instantiation of this utility class. */
-        private QuintetFactory() {
-        }
-
-        static Quintet<Violin, Violin, Viola, ViolinCello, ViolinCello> newCelloQuintet() {
-            return Quintet.of(newViolin(NUM_1),
-                              newViolin(NUM_2),
-                              newViola(),
-                              newViolinCello(NUM_1),
-                              newViolinCello(NUM_2));
-        }
-
-        static Quintet<Violin, Violin, Viola, Viola, ViolinCello> newViolaQuintet() {
-            return Quintet.of(newViolin(NUM_1),
-                              newViolin(NUM_2),
-                              newViola(NUM_1),
-                              newViola(NUM_2),
-                              newViolinCello());
-        }
-    }
-
-    /**
-     * Creates instruments.
-     */
-    static class InstrumentFactory {
-
-        /** Prevents instantiation of this utility class. */
-        private InstrumentFactory() {
-        }
-
-        static Violin newViolin(InstrumentNumber number) {
-            final Violin result = Violin.newBuilder()
-                                        .setNumber(number)
-                                        .build();
-            Validate.checkValid(result);
-            return result;
-        }
-
-        static Viola newViola() {
-            final Viola result = Viola.newBuilder()
-                                      .setSingle(true)
-                                      .build();
-            Validate.checkValid(result);
-            return result;
-        }
-
-        static Viola newViola(InstrumentNumber number) {
-            final Viola result = Viola.newBuilder()
-                                      .setNumber(number)
-                                      .build();
-            Validate.checkValid(result);
-            return result;
-        }
-
-        static ViolinCello newViolinCello(InstrumentNumber number) {
-            final ViolinCello result = ViolinCello.newBuilder()
-                                                  .setNumber(number)
-                                                  .build();
-            Validate.checkValid(result);
-            return result;
-        }
-
-        static ViolinCello newViolinCello() {
-            final ViolinCello result = ViolinCello.newBuilder()
-                                                  .setSingle(true)
-                                                  .build();
-            Validate.checkValid(result);
-            return result;
-        }
     }
 }

--- a/server/src/test/java/io/spine/server/tuple/given/QuintetTestEnv.java
+++ b/server/src/test/java/io/spine/server/tuple/given/QuintetTestEnv.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.tuple.given;
+
+import io.spine.server.tuple.Quintet;
+import io.spine.test.tuple.quintet.InstrumentNumber;
+import io.spine.test.tuple.quintet.Viola;
+import io.spine.test.tuple.quintet.Violin;
+import io.spine.test.tuple.quintet.ViolinCello;
+import io.spine.validate.Validate;
+
+import static io.spine.server.tuple.given.QuintetTestEnv.InstrumentFactory.newViola;
+import static io.spine.server.tuple.given.QuintetTestEnv.InstrumentFactory.newViolin;
+import static io.spine.server.tuple.given.QuintetTestEnv.InstrumentFactory.newViolinCello;
+
+/**
+ * @author Alexander Yevsyukov
+ */
+public class QuintetTestEnv {
+
+    /** Prevents instantiation of this utility class. */
+    private QuintetTestEnv() {
+    }
+
+    /**
+     * Creates typical <a href="https://en.wikipedia.org/wiki/String_quintet">String quintets</a>.
+     */
+    public static class QuintetFactory {
+
+        public static final InstrumentNumber NUM_1 = InstrumentNumber.newBuilder()
+                                                              .setValue(1)
+                                                              .build();
+
+        public static final InstrumentNumber NUM_2 = InstrumentNumber.newBuilder()
+                                                              .setValue(2)
+                                                              .build();
+
+        /** Prevents instantiation of this utility class. */
+        private QuintetFactory() {
+        }
+
+        public static Quintet<Violin, Violin, Viola, ViolinCello, ViolinCello> newCelloQuintet() {
+            return Quintet.of(newViolin(NUM_1),
+                              newViolin(NUM_2),
+                              newViola(),
+                              newViolinCello(NUM_1),
+                              newViolinCello(NUM_2));
+        }
+
+        public static Quintet<Violin, Violin, Viola, Viola, ViolinCello> newViolaQuintet() {
+            return Quintet.of(newViolin(NUM_1),
+                              newViolin(NUM_2),
+                              newViola(NUM_1),
+                              newViola(NUM_2),
+                              newViolinCello());
+        }
+    }
+
+    /**
+     * Creates instruments.
+     */
+    public static class InstrumentFactory {
+
+        /** Prevents instantiation of this utility class. */
+        private InstrumentFactory() {
+        }
+
+        public static Violin newViolin(InstrumentNumber number) {
+            final Violin result = Violin.newBuilder()
+                                        .setNumber(number)
+                                        .build();
+            Validate.checkValid(result);
+            return result;
+        }
+
+        public static Viola newViola() {
+            final Viola result = Viola.newBuilder()
+                                      .setSingle(true)
+                                      .build();
+            Validate.checkValid(result);
+            return result;
+        }
+
+        public static Viola newViola(InstrumentNumber number) {
+            final Viola result = Viola.newBuilder()
+                                      .setNumber(number)
+                                      .build();
+            Validate.checkValid(result);
+            return result;
+        }
+
+        public static ViolinCello newViolinCello(InstrumentNumber number) {
+            final ViolinCello result = ViolinCello.newBuilder()
+                                                  .setNumber(number)
+                                                  .build();
+            Validate.checkValid(result);
+            return result;
+        }
+
+        public static ViolinCello newViolinCello() {
+            final ViolinCello result = ViolinCello.newBuilder()
+                                                  .setSingle(true)
+                                                  .build();
+            Validate.checkValid(result);
+            return result;
+        }
+    }
+}

--- a/server/src/test/java/io/spine/server/tuple/given/package-info.java
+++ b/server/src/test/java/io/spine/server/tuple/given/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test environments for the {@link io.spine.server.tuple}.
+ *
+ * @author Alexander Yevsyukov
+ */
+@ParametersAreNonnullByDefault
+package io.spine.server.tuple.given;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/test/proto/spine/test/tuple/quartet.proto
+++ b/server/src/test/proto/spine/test/tuple/quartet.proto
@@ -24,7 +24,7 @@ package spine.test.tuple;
 import "spine/options.proto";
 
 option (type_url_prefix) = "type.spine.io";
-option java_package="io.spine.test.tuple";
+option java_package="io.spine.test.tuple.quartet";
 option java_outer_classname = "QuartetProto";
 option java_multiple_files = true;
 

--- a/server/src/test/proto/spine/test/tuple/quartet.proto
+++ b/server/src/test/proto/spine/test/tuple/quartet.proto
@@ -19,7 +19,7 @@
 //
 syntax = "proto3";
 
-package spine.test.tuple;
+package spine.test.tuple.quartet;
 
 import "spine/options.proto";
 

--- a/server/src/test/proto/spine/test/tuple/quintet.proto
+++ b/server/src/test/proto/spine/test/tuple/quintet.proto
@@ -28,7 +28,13 @@ option java_package="io.spine.test.tuple.quintet";
 option java_outer_classname = "QuintentProto";
 option java_multiple_files = true;
 
-// See https://en.wikipedia.org/wiki/String_quintet for string quartet definitions.
+// Test environment data classes for testing `Quintet` tuple.
+//
+// These types are defined to have test data other than default Protobuf types, and for some fun.
+// In real life `Quintet` should contain event messages, and not value objects of some kind.
+//
+// See https://en.wikipedia.org/wiki/String_quintet for string quintet definitions.
+//
 
 //
 // A number of instrument in a quintet.

--- a/server/src/test/proto/spine/test/tuple/quintet.proto
+++ b/server/src/test/proto/spine/test/tuple/quintet.proto
@@ -47,6 +47,9 @@ message Viola {
     InstrumentNumber number = 1;
         // Since we do not put `valid` option here, the validation framework would accept
         // the default value when validating the instrument.
+
+    // Must be `true` if `number` is not set.
+    bool single = 2;
 }
 
 message Violin {
@@ -62,4 +65,7 @@ message ViolinCello {
     InstrumentNumber number = 1;
         // Since we do not put `valid` option here, the validation framework would accept
         // the default value when validating the instrument.
+
+    // Must be `true` if `number` is not set.
+    bool single = 2;
 }

--- a/server/src/test/proto/spine/test/tuple/quintet.proto
+++ b/server/src/test/proto/spine/test/tuple/quintet.proto
@@ -1,0 +1,65 @@
+//
+// Copyright 2018, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.test.tuple.quintet;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package="io.spine.test.tuple.quintet";
+option java_outer_classname = "QuintentProto";
+option java_multiple_files = true;
+
+// See https://en.wikipedia.org/wiki/String_quintet for string quartet definitions.
+
+//
+// A number of instrument in a quintet.
+//
+// The number is applicable if there are two instruments of such kind in a quintent.
+//
+message InstrumentNumber {
+
+    // Valid values are `1` and `2`.
+    uint32 value = 1 [(min).value = "1", (max).value = "2"];
+}
+
+message Viola {
+
+    // Has the default value in cello quintent and `1` and `2` in viola quintent.
+    InstrumentNumber number = 1;
+        // Since we do not put `valid` option here, the validation framework would accept
+        // the default value when validating the instrument.
+}
+
+message Violin {
+
+    // A violin has alwas a number in both cello and viola quintets.
+    // Cannot be zero.
+    InstrumentNumber number = 1 [(valid) = true];
+}
+
+message ViolinCello {
+
+    // Has the default value in a viola quintent and `1` and `2` in cello quintent.
+    InstrumentNumber number = 1;
+        // Since we do not put `valid` option here, the validation framework would accept
+        // the default value when validating the instrument.
+}


### PR DESCRIPTION
This PR introduces `Quintet` tuple.

Some other changes:
 * Test data for `Quartet` moved into a separate package.
 * Javadocs for tuples now better reflect types of parameters.
 * Spine version advanced to `0.10.22-SNAPSHOT`.