### PR TITLE
More alternatives

### DIFF
--- a/.idea/dictionaries/common.xml
+++ b/.idea/dictionaries/common.xml
@@ -48,6 +48,7 @@
       <w>switchman</w>
       <w>testutil</w>
       <w>threeten</w>
+      <w>tuples</w>
       <w>unregister</w>
       <w>unregistering</w>
       <w>unregisters</w>

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.22-SNAPSHOT'
+def final SPINE_VERSION = '0.10.23-SNAPSHOT'
 
 //noinspection GroovyAssignabilityCheck
 ext {

--- a/server/src/main/java/io/spine/server/tuple/EitherOfFive.java
+++ b/server/src/main/java/io/spine/server/tuple/EitherOfFive.java
@@ -25,69 +25,87 @@ import io.spine.server.tuple.Element.AValue;
 import io.spine.server.tuple.Element.BValue;
 import io.spine.server.tuple.Element.CValue;
 import io.spine.server.tuple.Element.DValue;
+import io.spine.server.tuple.Element.EValue;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * A value which can be of one of four possible types.
+ * A value which can be of one of five possible types.
  *
  * @param <A> the type for the first alternative
  * @param <B> the type of the second alternative
  * @param <C> the type of the third alternative
  * @param <D> the type of the fourth alternative
+ * @param <E> the type of the fifth alternative
  *
  * @author Alexander Yevsyukov
  */
-public final class EitherOfFour<A extends Message,
-                                B extends Message,
-                                C extends Message,
-                                D extends Message>
+public class EitherOfFive <A extends Message,
+                           B extends Message,
+                           C extends Message,
+                           D extends Message,
+                           E extends Message>
         extends Either
-        implements AValue<A>, BValue<B>, CValue<C>, DValue<D> {
+        implements AValue<A>, BValue<B>, CValue<C>, DValue<D>, EValue<E> {
 
     private static final long serialVersionUID = 0L;
 
-    private EitherOfFour(Message value, int index) {
+    private EitherOfFive(Message value, int index) {
         super(value, index);
     }
 
     /**
      * Creates a new instance with {@code <A>} value.
      */
-    public static <A extends Message, B extends Message, C extends Message, D extends Message>
-    EitherOfFour<A, B, C, D> withA(A a) {
+    public static
+    <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
+    EitherOfFive<A, B, C, D, E> withA(A a) {
         checkNotNull(a);
-        final EitherOfFour<A, B, C, D> result = new EitherOfFour<>(a, 0);
+        final EitherOfFive<A, B, C, D, E> result = new EitherOfFive<>(a, 0);
         return result;
     }
 
     /**
      * Creates a new instance with {@code <B>} value.
      */
-    public static <A extends Message, B extends Message, C extends Message, D extends Message>
-    EitherOfFour<A, B, C, D> withB(B b) {
+    public static
+    <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
+    EitherOfFive<A, B, C, D, E> withB(B b) {
         checkNotNull(b);
-        final EitherOfFour<A, B, C, D> result = new EitherOfFour<>(b, 1);
+        final EitherOfFive<A, B, C, D, E> result = new EitherOfFive<>(b, 1);
         return result;
     }
 
     /**
      * Creates a new instance with {@code <C>} value.
      */
-    public static <A extends Message, B extends Message, C extends Message, D extends Message>
-    EitherOfFour<A, B, C, D> withC(C c) {
+    public static
+    <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
+    EitherOfFive<A, B, C, D, E> withC(C c) {
         checkNotNull(c);
-        final EitherOfFour<A, B, C, D> result = new EitherOfFour<>(c, 2);
+        final EitherOfFive<A, B, C, D, E> result = new EitherOfFive<>(c, 2);
         return result;
     }
 
     /**
-     * Creates a new instance with {@code <C>} value.
+     * Creates a new instance with {@code <D>} value.
      */
-    public static <A extends Message, B extends Message, C extends Message, D extends Message>
-    EitherOfFour<A, B, C, D> withD(D d) {
+    public static
+    <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
+    EitherOfFive<A, B, C, D, E> withD(D d) {
         checkNotNull(d);
-        final EitherOfFour<A, B, C, D> result = new EitherOfFour<>(d, 3);
+        final EitherOfFive<A, B, C, D, E> result = new EitherOfFive<>(d, 3);
+        return result;
+    }
+
+    /**
+     * Creates a new instance with {@code <E>} value.
+     */
+    public static
+    <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
+    EitherOfFive<A, B, C, D, E> withE(E e) {
+        checkNotNull(e);
+        final EitherOfFive<A, B, C, D, E> result = new EitherOfFive<>(e, 4);
         return result;
     }
 
@@ -133,5 +151,10 @@ public final class EitherOfFour<A extends Message,
     @Override
     public D getD() {
         return get(this, 3);
+    }
+
+    @Override
+    public E getE() {
+        return get(this, 4);
     }
 }

--- a/server/src/main/java/io/spine/server/tuple/EitherOfFour.java
+++ b/server/src/main/java/io/spine/server/tuple/EitherOfFour.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.tuple;
+
+import com.google.protobuf.Message;
+import io.spine.server.tuple.Element.AValue;
+import io.spine.server.tuple.Element.BValue;
+import io.spine.server.tuple.Element.CValue;
+import io.spine.server.tuple.Element.DValue;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * @author Alexander Yevsyukov
+ */
+public final class EitherOfFour<A extends Message,
+                                B extends Message,
+                                C extends Message,
+                                D extends Message>
+        extends Either
+        implements AValue<A>, BValue<B>, CValue<C>, DValue<D> {
+
+    private static final long serialVersionUID = 0L;
+
+    private EitherOfFour(Message value, int index) {
+        super(value, index);
+    }
+
+    /**
+     * Creates a new instance with {@code <A>} value.
+     */
+    public static <A extends Message, B extends Message, C extends Message, D extends Message>
+    EitherOfFour<A, B, C, D> withA(A a) {
+        checkNotNull(a);
+        final EitherOfFour<A, B, C, D> result = new EitherOfFour<>(a, 0);
+        return result;
+    }
+
+    /**
+     * Creates a new instance with {@code <B>} value.
+     */
+    public static <A extends Message, B extends Message, C extends Message, D extends Message>
+    EitherOfFour<A, B, C, D> withB(B b) {
+        checkNotNull(b);
+        final EitherOfFour<A, B, C, D> result = new EitherOfFour<>(b, 1);
+        return result;
+    }
+
+    /**
+     * Creates a new instance with {@code <C>} value.
+     */
+    public static <A extends Message, B extends Message, C extends Message, D extends Message>
+    EitherOfFour<A, B, C, D> withC(C c) {
+        checkNotNull(c);
+        final EitherOfFour<A, B, C, D> result = new EitherOfFour<>(c, 2);
+        return result;
+    }
+
+    /**
+     * Creates a new instance with {@code <C>} value.
+     */
+    public static <A extends Message, B extends Message, C extends Message, D extends Message>
+    EitherOfFour<A, B, C, D> withD(D d) {
+        checkNotNull(d);
+        final EitherOfFour<A, B, C, D> result = new EitherOfFour<>(d, 3);
+        return result;
+    }
+
+    /**
+     * Obtains the value of the first alternative.
+     *
+     * @throws IllegalStateException if a value of another type is stored instead.
+     * @return the stored value.
+     */
+    @Override
+    public A getA() {
+        return get(this, 0);
+    }
+
+    /**
+     * Obtains the value of the second alternative.
+     *
+     * @throws IllegalStateException if a value of another type is stored instead.
+     * @return the stored value.
+     */
+    @Override
+    public B getB() {
+        return get(this, 1);
+    }
+
+    /**
+     * Obtains the value of the third alternative.
+     *
+     * @throws IllegalStateException if a value of another type is stored instead.
+     * @return the stored value.
+     */
+    @Override
+    public C getC() {
+        return get(this, 2);
+    }
+
+    /**
+     * Obtains the value of the third alternative.
+     *
+     * @throws IllegalStateException if a value of another type is stored instead.
+     * @return the stored value.
+     */
+    @Override
+    public D getD() {
+        return get(this, 3);
+    }
+}

--- a/server/src/main/java/io/spine/server/tuple/package-info.java
+++ b/server/src/main/java/io/spine/server/tuple/package-info.java
@@ -78,6 +78,13 @@
  * <p>We believe that a list of alternatives longer than five is hard to understand.
  * If you face a such a need, consider splitting a command into two or more independent commands
  * so that their outcome is more obvious.
+ *
+ * <h2>Using Tuples with Alternatives</h2>
+ *
+ * <p>A {@link io.spine.server.tuple.Pair Pair} can be defined with the second parameter being on
+ * of the {@link io.spine.server.tuple.Either Either} subclasses, and created using
+ * {@link io.spine.server.tuple.Pair#withEither(com.google.protobuf.Message,
+ * io.spine.server.tuple.Either) Pair.withEither()}.
  */
 
 @ParametersAreNonnullByDefault

--- a/server/src/main/java/io/spine/server/tuple/package-info.java
+++ b/server/src/main/java/io/spine/server/tuple/package-info.java
@@ -69,8 +69,8 @@
  * <ul>
  *     <li>{@link io.spine.server.tuple.EitherOfTwo EitherOfTwo&lt;A, B&gt;}
  *     <li>{@link io.spine.server.tuple.EitherOfThree EitherOfThree&lt;A, B, C&gt;}
- *     <li>{@code EitherOfFour&lt;A, B, C, D&gt;}
- *     <li>{@code EitherOfFive&lt;A, B, C, D, E&gt;}
+ *     <li>{@link io.spine.server.tuple.EitherOfFour EitherOfFour&lt;A, B, C, D&gt;}
+ *     <li>{@link io.spine.server.tuple.EitherOfFive EitherOfFive&lt;A, B, C, D, E&gt;}
  * </ul>
  *
  * <p>Generic parameters for alternatives can be only {@link com.google.protobuf.Message Message}.

--- a/server/src/test/java/io/spine/server/tuple/EitherOfFiveShould.java
+++ b/server/src/test/java/io/spine/server/tuple/EitherOfFiveShould.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.tuple;
+
+import com.google.common.testing.EqualsTester;
+import com.google.common.testing.NullPointerTester;
+import com.google.protobuf.BoolValue;
+import com.google.protobuf.FloatValue;
+import com.google.protobuf.Message;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.UInt32Value;
+import io.spine.test.TestValues;
+import io.spine.time.Time;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static com.google.common.testing.SerializableTester.reserializeAndAssert;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author Alexander Yevsyukov
+ */
+@SuppressWarnings("FieldNamingConvention") // short vars are OK for tuple tests.
+public class EitherOfFiveShould {
+
+    private final StringValue a = TestValues.newUuidValue();
+    private final BoolValue b = BoolValue.of(true);
+    private final Timestamp c = Time.getCurrentTime();
+    private final UInt32Value d = UInt32Value.newBuilder()
+                                             .setValue(512)
+                                             .build();
+    private final FloatValue e = FloatValue.newBuilder()
+                                           .setValue(3.14159f)
+                                           .build();
+
+    private EitherOfFive<StringValue, BoolValue, Timestamp, UInt32Value, FloatValue> eitherWithA;
+    private EitherOfFive<StringValue, BoolValue, Timestamp, UInt32Value, FloatValue> eitherWithB;
+    private EitherOfFive<StringValue, BoolValue, Timestamp, UInt32Value, FloatValue> eitherWithC;
+    private EitherOfFive<StringValue, BoolValue, Timestamp, UInt32Value, FloatValue> eitherWithD;
+    private EitherOfFive<StringValue, BoolValue, Timestamp, UInt32Value, FloatValue> eitherWithE;
+
+    @Before
+    public void setUp() {
+        eitherWithA = EitherOfFive.withA(a);
+        eitherWithB = EitherOfFive.withB(b);
+        eitherWithC = EitherOfFive.withC(c);
+        eitherWithD = EitherOfFive.withD(d);
+        eitherWithE = EitherOfFive.withE(e);
+    }
+
+    @Test
+    public void support_equality() {
+        new EqualsTester().addEqualityGroup(eitherWithA, EitherOfFive.withA(a))
+                          .addEqualityGroup(eitherWithB)
+                          .addEqualityGroup(eitherWithC)
+                          .addEqualityGroup(eitherWithD)
+                          .addEqualityGroup(eitherWithE)
+                          .testEquals();
+    }
+
+    @Test
+    public void pass_null_tolerance_check() {
+        new NullPointerTester().testAllPublicStaticMethods(EitherOfFive.class);
+    }
+
+    @Test
+    public void return_values() {
+        assertEquals(a, eitherWithA.getA());
+        assertEquals(b, eitherWithB.getB());
+        assertEquals(c, eitherWithC.getC());
+        assertEquals(d, eitherWithD.getD());
+        assertEquals(e, eitherWithE.getE());
+    }
+
+    @Test
+    public void return_value_index() {
+        assertEquals(0, eitherWithA.getIndex());
+        assertEquals(1, eitherWithB.getIndex());
+        assertEquals(2, eitherWithC.getIndex());
+        assertEquals(3, eitherWithD.getIndex());
+        assertEquals(4, eitherWithE.getIndex());
+    }
+
+    @Test
+    public void return_only_one_value_in_iteration() {
+        final Iterator<Message> iteratorA = eitherWithA.iterator();
+
+        assertEquals(a, iteratorA.next());
+        assertFalse(iteratorA.hasNext());
+
+        final Iterator<Message> iteratorB = eitherWithB.iterator();
+
+        assertEquals(b, iteratorB.next());
+        assertFalse(iteratorB.hasNext());
+
+        final Iterator<Message> iteratorC = eitherWithC.iterator();
+
+        assertEquals(c, iteratorC.next());
+        assertFalse(iteratorC.hasNext());
+
+        final Iterator<Message> iteratorD = eitherWithD.iterator();
+
+        assertEquals(d, iteratorD.next());
+        assertFalse(iteratorD.hasNext());
+
+        final Iterator<Message> iteratorE = eitherWithE.iterator();
+
+        assertEquals(e, iteratorE.next());
+        assertFalse(iteratorE.hasNext());
+    }
+
+    @Test
+    public void serialize() {
+        reserializeAndAssert(eitherWithA);
+        reserializeAndAssert(eitherWithB);
+        reserializeAndAssert(eitherWithC);
+        reserializeAndAssert(eitherWithD);
+        reserializeAndAssert(eitherWithE);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_A_B() {
+        eitherWithA.getB();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_A_C() {
+        eitherWithA.getC();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_A_D() {
+        eitherWithA.getD();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_A_E() {
+        eitherWithA.getE();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_B_A() {
+        eitherWithB.getA();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_B_C() {
+        eitherWithB.getC();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_B_D() {
+        eitherWithB.getD();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_B_E() {
+        eitherWithB.getE();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_C_A() {
+        eitherWithC.getA();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_C_B() {
+        eitherWithC.getB();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_C_D() {
+        eitherWithC.getD();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_C_E() {
+        eitherWithC.getE();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_D_A() {
+        eitherWithD.getA();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_D_B() {
+        eitherWithD.getB();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_D_C() {
+        eitherWithD.getC();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_D_E() {
+        eitherWithD.getE();
+    }
+}

--- a/server/src/test/java/io/spine/server/tuple/EitherOfFourShould.java
+++ b/server/src/test/java/io/spine/server/tuple/EitherOfFourShould.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.tuple;
+
+import com.google.common.testing.EqualsTester;
+import com.google.common.testing.NullPointerTester;
+import com.google.protobuf.BoolValue;
+import com.google.protobuf.Message;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.UInt32Value;
+import io.spine.test.TestValues;
+import io.spine.time.Time;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static com.google.common.testing.SerializableTester.reserializeAndAssert;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author Alexander Yevsyukov
+ */
+@SuppressWarnings("FieldNamingConvention") // short vars are OK for tuple tests.
+public class EitherOfFourShould {
+
+    private final StringValue a = TestValues.newUuidValue();
+    private final BoolValue b = BoolValue.of(true);
+    private final Timestamp c = Time.getCurrentTime();
+    private final UInt32Value d = UInt32Value.newBuilder()
+                                             .setValue(1024)
+                                             .build();
+
+    private EitherOfFour<StringValue, BoolValue, Timestamp, UInt32Value> eitherWithA;
+    private EitherOfFour<StringValue, BoolValue, Timestamp, UInt32Value> eitherWithB;
+    private EitherOfFour<StringValue, BoolValue, Timestamp, UInt32Value> eitherWithC;
+    private EitherOfFour<StringValue, BoolValue, Timestamp, UInt32Value> eitherWithD;
+
+    @Before
+    public void setUp() {
+        eitherWithA = EitherOfFour.withA(a);
+        eitherWithB = EitherOfFour.withB(b);
+        eitherWithC = EitherOfFour.withC(c);
+        eitherWithD = EitherOfFour.withD(d);
+    }
+
+    @Test
+    public void support_equality() {
+        new EqualsTester().addEqualityGroup(eitherWithA, EitherOfFour.withA(a))
+                          .addEqualityGroup(eitherWithB)
+                          .addEqualityGroup(eitherWithC)
+                          .addEqualityGroup(eitherWithD)
+                          .testEquals();
+    }
+
+    @Test
+    public void pass_null_tolerance_check() {
+        new NullPointerTester().testAllPublicStaticMethods(EitherOfFour.class);
+    }
+
+    @Test
+    public void return_values() {
+        assertEquals(a, eitherWithA.getA());
+        assertEquals(b, eitherWithB.getB());
+        assertEquals(c, eitherWithC.getC());
+        assertEquals(d, eitherWithD.getD());
+    }
+
+    @Test
+    public void return_value_index() {
+        assertEquals(0, eitherWithA.getIndex());
+        assertEquals(1, eitherWithB.getIndex());
+        assertEquals(2, eitherWithC.getIndex());
+        assertEquals(3, eitherWithD.getIndex());
+    }
+
+    @Test
+    public void return_only_one_value_in_iteration() {
+        final Iterator<Message> iteratorA = eitherWithA.iterator();
+
+        assertEquals(a, iteratorA.next());
+        assertFalse(iteratorA.hasNext());
+
+        final Iterator<Message> iteratorB = eitherWithB.iterator();
+
+        assertEquals(b, iteratorB.next());
+        assertFalse(iteratorB.hasNext());
+
+        final Iterator<Message> iteratorC = eitherWithC.iterator();
+
+        assertEquals(c, iteratorC.next());
+        assertFalse(iteratorC.hasNext());
+
+        final Iterator<Message> iteratorD = eitherWithD.iterator();
+
+        assertEquals(d, iteratorD.next());
+        assertFalse(iteratorD.hasNext());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_A_B() {
+        eitherWithA.getB();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_A_C() {
+        eitherWithA.getC();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_A_D() {
+        eitherWithA.getD();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_B_A() {
+        eitherWithB.getA();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_B_C() {
+        eitherWithB.getC();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_B_D() {
+        eitherWithB.getD();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_C_A() {
+        eitherWithC.getA();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_C_B() {
+        eitherWithC.getB();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_C_D() {
+        eitherWithC.getD();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_D_A() {
+        eitherWithD.getA();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_D_B() {
+        eitherWithD.getB();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void prohibit_obtaining_the_other_value_D_C() {
+        eitherWithD.getC();
+    }
+
+    @Test
+    public void serialize() {
+        reserializeAndAssert(eitherWithA);
+        reserializeAndAssert(eitherWithB);
+        reserializeAndAssert(eitherWithC);
+        reserializeAndAssert(eitherWithD);
+    }
+}

--- a/server/src/test/java/io/spine/server/tuple/EitherOfThreeShould.java
+++ b/server/src/test/java/io/spine/server/tuple/EitherOfThreeShould.java
@@ -97,12 +97,12 @@ public class EitherOfThreeShould {
         final Iterator<Message> iteratorB = eitherWithB.iterator();
 
         assertEquals(b, iteratorB.next());
-        assertFalse(iteratorA.hasNext());
+        assertFalse(iteratorB.hasNext());
 
         final Iterator<Message> iteratorC = eitherWithC.iterator();
 
         assertEquals(c, iteratorC.next());
-        assertFalse(iteratorA.hasNext());
+        assertFalse(iteratorC.hasNext());
     }
 
     @Test(expected = IllegalStateException.class)

--- a/server/src/test/java/io/spine/server/tuple/EitherOfTwoShould.java
+++ b/server/src/test/java/io/spine/server/tuple/EitherOfTwoShould.java
@@ -88,7 +88,7 @@ public class EitherOfTwoShould {
         final Iterator<Message> iteratorB = eitherWithB.iterator();
 
         assertEquals(b, iteratorB.next());
-        assertFalse(iteratorA.hasNext());
+        assertFalse(iteratorB.hasNext());
     }
 
     @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
This PR adds `EitherOfFour` and `EitherOfFive` to the list of alternatives.

This PR also fixes test for `EitherOfThree` which previously checked wrong iterator instances for the end of iteration.

Spine version advanced to `0.10.23-SNAPSHOT`.