### PR TITLE
Filter empty messages from results of aggregate dispatch

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.25-SNAPSHOT'
+def final SPINE_VERSION = '0.10.26-SNAPSHOT'
 
 //noinspection GroovyAssignabilityCheck
 ext {

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.24-SNAPSHOT'
+def final SPINE_VERSION = '0.10.25-SNAPSHOT'
 
 //noinspection GroovyAssignabilityCheck
 ext {

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -198,7 +198,7 @@ public abstract class Aggregate<I,
         final CommandHandlerMethod method = thisClass().getHandler(command.getMessageClass());
         final List<? extends Message> messages =
                 method.invoke(this, command.getMessage(), command.getCommandContext());
-        return EmptyFilter.INSTANCE.apply(messages);
+        return emptyFilter().apply(messages);
     }
 
     /**
@@ -214,7 +214,7 @@ public abstract class Aggregate<I,
         final EventReactorMethod method = thisClass().getReactor(event.getMessageClass());
         final List<? extends Message> messages =
                 method.invoke(this, event.getMessage(), event.getEventContext());
-        return EmptyFilter.INSTANCE.apply(messages);
+        return emptyFilter().apply(messages);
     }
 
     /**
@@ -231,7 +231,7 @@ public abstract class Aggregate<I,
         final RejectionReactorMethod method = thisClass().getReactor(rejection.getMessageClass());
         final List<? extends Message> messages =
                 method.invoke(this, rejection.getMessage(), rejection.getRejectionContext());
-        return EmptyFilter.INSTANCE.apply(messages);
+        return emptyFilter().apply(messages);
     }
 
     /**
@@ -432,14 +432,26 @@ public abstract class Aggregate<I,
     protected int versionNumber() {
         return super.versionNumber();
     }
-    
-    private enum EmptyFilter implements Function<Collection<? extends Message>, List<? extends Message>> {
+
+    /**
+     * @return an instance of an {@linkplain EmptyFilter empty filter}
+     */
+    private static EmptyFilter emptyFilter() {
+        return EmptyFilter.INSTANCE;
+    }
+
+    /**
+     * Removes all {@linkplain Empty empty} messages from a collection.
+     */
+    private enum EmptyFilter implements Function<Collection<? extends Message>, 
+                                                 List<? extends Message>> {
         INSTANCE;
 
         private static final Empty EMPTY = Empty.getDefaultInstance();
 
         /**
-         * Creates a new collection without {@linkplain Empty empty} messages.
+         * Creates a new list copying all the elements of a collection except for
+         * {@linkplain Empty empty}.
          *
          * @param  messages a list of messages to be filtered
          * @return a new list with all the items of the passed {@code messages}

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -187,7 +187,7 @@ public abstract class Aggregate<I,
     /**
      * Obtains a method for the passed command and invokes it.
      *
-     * <p>All the {@link Empty} messages are filtered out from the result.
+     * <p>All the {@linkplain Empty empty} messages are filtered out from the result.
      * 
      * @param  command the envelope with the command to dispatch
      * @return a list with event messages that the aggregate produces in reaction to the event or
@@ -204,7 +204,7 @@ public abstract class Aggregate<I,
     /**
      * Dispatches the event on which the aggregate reacts.
      *
-     * <p>All the {@link Empty} messages are filtered out from the result.
+     * <p>All the {@linkplain Empty empty} messages are filtered out from the result.
      *
      * @param  event the envelope with the event to dispatch
      * @return a list with event messages that the aggregate produces in reaction to the event or
@@ -220,7 +220,7 @@ public abstract class Aggregate<I,
     /**
      * Dispatches the rejection to which the aggregate reacts.
      * 
-     * <p>All the {@link Empty} messages are filtered out from the result.
+     * <p>All the {@linkplain Empty empty} messages are filtered out from the result.
      *
      * @param  rejection the envelope with the rejection
      * @return a list with event messages that the aggregate produces in reaction to
@@ -439,7 +439,7 @@ public abstract class Aggregate<I,
         private static final Empty EMPTY = Empty.getDefaultInstance();
 
         /**
-         * Creates a new collection without {@link Empty} messages.
+         * Creates a new collection without {@linkplain Empty empty} messages.
          *
          * @param  messages a list of messages to be filtered
          * @return a new list with all the items of the passed {@code messages}

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -187,7 +187,8 @@ public abstract class Aggregate<I,
     /**
      * Obtains a method for the passed command and invokes it.
      *
-     * <p>All the {@linkplain Empty empty} messages are filtered out from the result.
+     * <p>Dispatching the commands results in emitting event messages. All the 
+     * {@linkplain Empty empty} messages are filtered out from the result.
      * 
      * @param  command the envelope with the command to dispatch
      * @return a list of event messages that the aggregate produces by handling the command
@@ -203,7 +204,8 @@ public abstract class Aggregate<I,
     /**
      * Dispatches the event on which the aggregate reacts.
      *
-     * <p>All the {@linkplain Empty empty} messages are filtered out from the result.
+     * <p>Reacting on a event may result in emitting event messages. All the {@linkplain Empty empty} 
+     * messages are filtered out from the result.
      *
      * @param  event the envelope with the event to dispatch
      * @return a list of event messages that the aggregate produces in reaction to the event or
@@ -219,7 +221,8 @@ public abstract class Aggregate<I,
     /**
      * Dispatches the rejection to which the aggregate reacts.
      * 
-     * <p>All the {@linkplain Empty empty} messages are filtered out from the result.
+     * <p>Reacting on a rejection may result in emitting event messages. All the 
+     * {@linkplain Empty empty} messages are filtered out from the result.
      *
      * @param  rejection the envelope with the rejection
      * @return a list of event messages that the aggregate produces in reaction to

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -190,8 +190,7 @@ public abstract class Aggregate<I,
      * <p>All the {@linkplain Empty empty} messages are filtered out from the result.
      * 
      * @param  command the envelope with the command to dispatch
-     * @return a list with event messages that the aggregate produces in reaction to the event or
-     *         an empty list if the aggregate state does not change in reaction to the event
+     * @return a list of event messages that the aggregate produces by handling the command
      */
     @Override
     protected List<? extends Message> dispatchCommand(CommandEnvelope command) {
@@ -207,7 +206,7 @@ public abstract class Aggregate<I,
      * <p>All the {@linkplain Empty empty} messages are filtered out from the result.
      *
      * @param  event the envelope with the event to dispatch
-     * @return a list with event messages that the aggregate produces in reaction to the event or
+     * @return a list of event messages that the aggregate produces in reaction to the event or
      *         an empty list if the aggregate state does not change in reaction to the event
      */
     List<? extends Message> reactOn(EventEnvelope event) {
@@ -223,7 +222,7 @@ public abstract class Aggregate<I,
      * <p>All the {@linkplain Empty empty} messages are filtered out from the result.
      *
      * @param  rejection the envelope with the rejection
-     * @return a list with event messages that the aggregate produces in reaction to
+     * @return a list of event messages that the aggregate produces in reaction to
      *         the rejection, or an empty list if the aggregate state does not change in
      *         response to this rejection
      */

--- a/server/src/test/java/io/spine/server/aggregate/AggregateShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateShould.java
@@ -634,7 +634,7 @@ public class AggregateShould {
     }
 
     /**
-     * Ensures that a {@link io.spine.server.tuple.Pair} with an empty second optional value
+     * Ensures that a {@linkplain io.spine.server.tuple.Pair pair} with an empty second optional value
      * returned from a command handler stores a single event.
      *
      * <p>The command handler that should return a pair is
@@ -669,7 +669,7 @@ public class AggregateShould {
     }
 
     /**
-     * Ensures that a {@link io.spine.server.tuple.Pair} with an empty second optional value
+     * Ensures that a {@linkplain io.spine.server.tuple.Pair pair} with an empty second optional value
      * returned from a reaction on an event stores a single event.
      *
      * <p>The first event is produced while handling a command by the
@@ -714,7 +714,7 @@ public class AggregateShould {
     }
 
     /**
-     * Ensures that a {@link io.spine.server.tuple.Pair} with an empty second optional value
+     * Ensures that a {@linkplain io.spine.server.tuple.Pair pair} with an empty second optional value
      * returned from a reaction on a rejection stores a single event.
      *
      * <p>The rejection is fired by the {@link io.spine.server.aggregate.given.AggregateTestEnv.TaskAggregate#handle(AggReassignTask, CommandContext)}

--- a/server/src/test/java/io/spine/server/aggregate/AggregateShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateShould.java
@@ -36,6 +36,7 @@ import io.spine.core.CommandEnvelope;
 import io.spine.core.Commands;
 import io.spine.core.Event;
 import io.spine.core.Rejection;
+import io.spine.core.TenantId;
 import io.spine.grpc.MemoizingObserver;
 import io.spine.server.BoundedContext;
 import io.spine.server.aggregate.given.AggregateTestEnv;
@@ -89,11 +90,11 @@ import static io.spine.server.TestEventClasses.assertContains;
 import static io.spine.server.TestEventClasses.getEventClasses;
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
 import static io.spine.server.aggregate.given.AggregateTestEnv.assignTask;
-import static io.spine.server.aggregate.given.AggregateTestEnv.newTaskBoundedContext;
 import static io.spine.server.aggregate.given.AggregateTestEnv.createTask;
-import static io.spine.server.aggregate.given.AggregateTestEnv.typeUrlOf;
+import static io.spine.server.aggregate.given.AggregateTestEnv.newTaskBoundedContext;
 import static io.spine.server.aggregate.given.AggregateTestEnv.readAllEvents;
 import static io.spine.server.aggregate.given.AggregateTestEnv.reassignTask;
+import static io.spine.server.aggregate.given.AggregateTestEnv.typeUrlOf;
 import static io.spine.server.aggregate.given.Given.EventMessage.projectCancelled;
 import static io.spine.server.aggregate.given.Given.EventMessage.projectCreated;
 import static io.spine.server.aggregate.given.Given.EventMessage.projectPaused;
@@ -152,6 +153,13 @@ public class AggregateShould {
     }
 
     private static Command command(Message commandMessage) {
+        return requestFactory.command()
+                             .create(commandMessage);
+    }
+
+    private static Command command(Message commandMessage, TenantId tenantId) {
+        final TestActorRequestFactory requestFactory =
+                TestActorRequestFactory.newInstance(AggregateShould.class, tenantId);
         return requestFactory.command()
                              .create(commandMessage);
     }
@@ -634,9 +642,11 @@ public class AggregateShould {
      */
     @Test
     public void create_single_event_for_a_pair_of_events_with_empty_for_a_command_dispatch() {
-        final Command command = command(createTask());
-        final MemoizingObserver<Ack> observer = memoizingObserver();
         final BoundedContext boundedContext = newTaskBoundedContext();
+
+        final TenantId tenantId = AggregateTestEnv.newTenantId();
+        final Command command = command(createTask(), tenantId);
+        final MemoizingObserver<Ack> observer = memoizingObserver();
 
         boundedContext.getCommandBus()
                       .post(command, observer);
@@ -654,7 +664,7 @@ public class AggregateShould {
         final Rejection emptyRejection = Rejection.getDefaultInstance();
         assertEquals(emptyRejection, status.getRejection());
 
-        final List<Event> events = readAllEvents(boundedContext);
+        final List<Event> events = readAllEvents(boundedContext, tenantId);
         assertSize(1, events);
     }
 
@@ -669,9 +679,11 @@ public class AggregateShould {
      */
     @Test
     public void create_single_event_for_a_pair_of_events_with_empty_for_an_event_react() {
-        final Command command = command(assignTask());
-        final MemoizingObserver<Ack> observer = memoizingObserver();
         final BoundedContext boundedContext = newTaskBoundedContext();
+
+        final TenantId tenantId = AggregateTestEnv.newTenantId();
+        final Command command = command(assignTask(), tenantId);
+        final MemoizingObserver<Ack> observer = memoizingObserver();
 
         boundedContext.getCommandBus()
                       .post(command, observer);
@@ -689,7 +701,7 @@ public class AggregateShould {
         final Rejection emptyRejection = Rejection.getDefaultInstance();
         assertEquals(emptyRejection, status.getRejection());
 
-        final List<Event> events = readAllEvents(boundedContext);
+        final List<Event> events = readAllEvents(boundedContext, tenantId);
         assertSize(2, events);
 
         final Event sourceEvent = events.get(0);
@@ -710,9 +722,11 @@ public class AggregateShould {
      */
     @Test
     public void create_single_event_for_a_pair_of_events_with_empty_for_a_rejection_react() {
-        final Command command = command(reassignTask());
-        final MemoizingObserver<Ack> observer = memoizingObserver();
         final BoundedContext boundedContext = newTaskBoundedContext();
+
+        final TenantId tenantId = AggregateTestEnv.newTenantId();
+        final Command command = command(reassignTask(), tenantId);
+        final MemoizingObserver<Ack> observer = memoizingObserver();
 
         boundedContext.getCommandBus()
                       .post(command, observer);
@@ -730,7 +744,7 @@ public class AggregateShould {
         final Rejection emptyRejection = Rejection.getDefaultInstance();
         assertEquals(emptyRejection, status.getRejection());
 
-        final List<Event> events = readAllEvents(boundedContext);
+        final List<Event> events = readAllEvents(boundedContext, tenantId);
         assertSize(1, events);
 
         final Event reactionEvent = events.get(0);

--- a/server/src/test/java/io/spine/server/aggregate/AggregateShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateShould.java
@@ -638,7 +638,7 @@ public class AggregateShould {
      * returned from a command handler stores a single event.
      *
      * <p>The command handler that should return a pair is
-     * {@link io.spine.server.aggregate.given.AggregateTestEnv.TaskAggregate#handle(AggAssignTask, CommandContext)}.
+     * {@link io.spine.server.aggregate.given.AggregateTestEnv.TaskAggregate#handle(AggAssignTask) TaskAggregate#handle(AggAssignTask)}.
      */
     @Test
     public void create_single_event_for_a_pair_of_events_with_empty_for_a_command_dispatch() {
@@ -673,9 +673,9 @@ public class AggregateShould {
      * returned from a reaction on an event stores a single event.
      *
      * <p>The first event is produced while handling a command by the
-     * {@link io.spine.server.aggregate.given.AggregateTestEnv.TaskAggregate#handle(AggAssignTask, CommandContext)}.
+     * {@link io.spine.server.aggregate.given.AggregateTestEnv.TaskAggregate#handle(AggAssignTask) TaskAggregate#handle(AggAssignTask)}.
      * Then as a reaction to this event a single event should be fired as part of the pair by
-     * {@link io.spine.server.aggregate.given.AggregateTestEnv.TaskAggregate#on(AggTaskAssigned)}.
+     * {@link io.spine.server.aggregate.given.AggregateTestEnv.TaskAggregate#on(AggTaskAssigned) TaskAggregate#on(AggTaskAssigned)}.
      */
     @Test
     public void create_single_event_for_a_pair_of_events_with_empty_for_an_event_react() {
@@ -717,8 +717,8 @@ public class AggregateShould {
      * Ensures that a {@linkplain io.spine.server.tuple.Pair pair} with an empty second optional value
      * returned from a reaction on a rejection stores a single event.
      *
-     * <p>The rejection is fired by the {@link io.spine.server.aggregate.given.AggregateTestEnv.TaskAggregate#handle(AggReassignTask, CommandContext)}
-     * and handled by the {@link io.spine.server.aggregate.given.AggregateTestEnv.TaskAggregate#on(Rejections.AggCannotReassignUnassignedTask)}.
+     * <p>The rejection is fired by the {@link io.spine.server.aggregate.given.AggregateTestEnv.TaskAggregate#handle(AggReassignTask) TaskAggregate#handle(AggReassignTask)}
+     * and handled by the {@link io.spine.server.aggregate.given.AggregateTestEnv.TaskAggregate#on(Rejections.AggCannotReassignUnassignedTask) TaskAggregate#on(AggCannotReassignUnassignedTask)}.
      */
     @Test
     public void create_single_event_for_a_pair_of_events_with_empty_for_a_rejection_react() {

--- a/server/src/test/java/io/spine/server/aggregate/AggregateShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateShould.java
@@ -92,6 +92,7 @@ import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchComma
 import static io.spine.server.aggregate.given.AggregateTestEnv.assignTask;
 import static io.spine.server.aggregate.given.AggregateTestEnv.createTask;
 import static io.spine.server.aggregate.given.AggregateTestEnv.newTaskBoundedContext;
+import static io.spine.server.aggregate.given.AggregateTestEnv.newTenantId;
 import static io.spine.server.aggregate.given.AggregateTestEnv.readAllEvents;
 import static io.spine.server.aggregate.given.AggregateTestEnv.reassignTask;
 import static io.spine.server.aggregate.given.AggregateTestEnv.typeUrlOf;
@@ -644,7 +645,7 @@ public class AggregateShould {
     public void create_single_event_for_a_pair_of_events_with_empty_for_a_command_dispatch() {
         final BoundedContext boundedContext = newTaskBoundedContext();
 
-        final TenantId tenantId = AggregateTestEnv.newTenantId();
+        final TenantId tenantId = newTenantId();
         final Command command = command(createTask(), tenantId);
         final MemoizingObserver<Ack> observer = memoizingObserver();
 
@@ -681,7 +682,7 @@ public class AggregateShould {
     public void create_single_event_for_a_pair_of_events_with_empty_for_an_event_react() {
         final BoundedContext boundedContext = newTaskBoundedContext();
 
-        final TenantId tenantId = AggregateTestEnv.newTenantId();
+        final TenantId tenantId = newTenantId();
         final Command command = command(assignTask(), tenantId);
         final MemoizingObserver<Ack> observer = memoizingObserver();
 
@@ -724,7 +725,7 @@ public class AggregateShould {
     public void create_single_event_for_a_pair_of_events_with_empty_for_a_rejection_react() {
         final BoundedContext boundedContext = newTaskBoundedContext();
 
-        final TenantId tenantId = AggregateTestEnv.newTenantId();
+        final TenantId tenantId = newTenantId();
         final Command command = command(reassignTask(), tenantId);
         final MemoizingObserver<Ack> observer = memoizingObserver();
 

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregateTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregateTestEnv.java
@@ -120,7 +120,8 @@ public class AggregateTestEnv {
     }
 
     /**
-     * Creates a new multitenant bounded context with a registered {@link TaskAggregateRepository}.
+     * Creates a new multitenant bounded context with a registered 
+     * {@linkplain TaskAggregateRepository task repository}.
      */
     public static BoundedContext newTaskBoundedContext() {
         final BoundedContext boundedContext = BoundedContext.newBuilder()
@@ -263,7 +264,7 @@ public class AggregateTestEnv {
          * A command handler that returns a pair with an optional second element.
          *
          * <p>{@link AggTaskAssigned} is present when the command contains an
-         * {@link AggCreateTask#getAssignee() assignee}.
+         * {@linkplain AggCreateTask#getAssignee() assignee}.
          */
         @Assign
         Pair<AggTaskCreated, Optional<AggTaskAssigned>> handle(AggCreateTask command) {
@@ -284,7 +285,7 @@ public class AggregateTestEnv {
 
         /**
          * Creates a new {@link AggTaskAssigned} event message with provided values. If the
-         * {@link UserId assignee} is a default empty instance returns {@code null}.
+         * {@linkplain UserId assignee} is a default empty instance returns {@code null}.
          */
         @Nullable
         private static AggTaskAssigned taskAssignedOrNull(AggTaskId id, UserId assignee) {

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregateTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregateTestEnv.java
@@ -64,6 +64,7 @@ import static io.spine.server.aggregate.given.Given.EventMessage.projectCreated;
 
 /**
  * @author Alexander Yevsyukov
+ * @author Mykhailo Drachuk
  */
 public class AggregateTestEnv {
 

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregateTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregateTestEnv.java
@@ -101,12 +101,6 @@ public class AggregateTestEnv {
                                .build();
     }
 
-    public static AggCreateTask createTask() {
-        return AggCreateTask.newBuilder()
-                            .setTaskId(newTaskId())
-                            .build();
-    }
-
     private static AggTaskId newTaskId() {
         return AggTaskId.newBuilder()
                         .setId(newUuid())
@@ -134,6 +128,12 @@ public class AggregateTestEnv {
                                                             .build();
         boundedContext.register(new TaskAggregateRepository());
         return boundedContext;
+    }
+
+    public static AggCreateTask createTask() {
+        return AggCreateTask.newBuilder()
+                            .setTaskId(newTaskId())
+                            .build();
     }
 
     public static AggAssignTask assignTask() {

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregateTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregateTestEnv.java
@@ -241,8 +241,8 @@ public class AggregateTestEnv {
             extends AggregateRepository<AggTaskId, TaskAggregate> { }
 
     /**
-     * An aggregate that fires a {@link Pair} with an optional upon handling a command, an event
-     * or a rejection.
+     * An aggregate that fires a {@linkplain Pair pair} with an optional upon handling a command, 
+     * an event or a rejection.
      *
      * @see io.spine.server.aggregate.AggregateShould#create_single_event_for_a_pair_of_events_with_empty_for_a_command_dispatch
      * @see io.spine.server.aggregate.AggregateShould#create_single_event_for_a_pair_of_events_with_empty_for_an_event_react
@@ -260,11 +260,10 @@ public class AggregateTestEnv {
          * A command handler that returns a pair with an optional second element.
          *
          * <p>{@link AggTaskAssigned} is present when the command contains an
-         * {@link AggCreateTask#getAssignee()}.
+         * {@link AggCreateTask#getAssignee() assignee}.
          */
         @Assign
-        Pair<AggTaskCreated, Optional<AggTaskAssigned>> handle(AggCreateTask command,
-                                                               CommandContext context) {
+        Pair<AggTaskCreated, Optional<AggTaskAssigned>> handle(AggCreateTask command) {
             final AggTaskId id = command.getTaskId();
             final AggTaskCreated createdEvent = taskCreated(id);
 
@@ -282,7 +281,7 @@ public class AggregateTestEnv {
 
         /**
          * Creates a new {@link AggTaskAssigned} event message with provided values. If the
-         * {@link UserId} is a default empty instance returns {@code null}ю
+         * {@link UserId assignee} is a default empty instance returns {@code null}.
          */
         @Nullable
         private static AggTaskAssigned taskAssignedOrNull(AggTaskId id, UserId assignee) {
@@ -299,7 +298,7 @@ public class AggregateTestEnv {
         }
 
         @Assign
-        AggTaskAssigned handle(AggAssignTask command, CommandContext context) {
+        AggTaskAssigned handle(AggAssignTask command) {
             final AggTaskId id = command.getTaskId();
             final UserId newAssignee = command.getAssignee();
             final UserId previousAssignee = getState().getAssignee();
@@ -309,7 +308,7 @@ public class AggregateTestEnv {
         }
 
         @Assign
-        AggTaskAssigned handle(AggReassignTask command, CommandContext context)
+        AggTaskAssigned handle(AggReassignTask command)
                 throws AggCannotReassignUnassignedTask {
             final AggTaskId id = command.getTaskId();
             final UserId newAssignee = command.getAssignee();

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregateTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregateTestEnv.java
@@ -20,19 +20,46 @@
 
 package io.spine.server.aggregate.given;
 
+import com.google.common.base.Optional;
+import com.google.protobuf.Any;
 import io.spine.core.CommandContext;
+import io.spine.core.Event;
+import io.spine.core.React;
+import io.spine.core.UserId;
+import io.spine.grpc.MemoizingObserver;
+import io.spine.server.BoundedContext;
 import io.spine.server.aggregate.Aggregate;
+import io.spine.server.aggregate.AggregateRepository;
 import io.spine.server.aggregate.Apply;
 import io.spine.server.command.Assign;
+import io.spine.server.event.EventStreamQuery;
+import io.spine.server.tuple.Pair;
 import io.spine.test.aggregate.Project;
 import io.spine.test.aggregate.ProjectId;
 import io.spine.test.aggregate.ProjectVBuilder;
 import io.spine.test.aggregate.Status;
+import io.spine.test.aggregate.command.AggAssignTask;
 import io.spine.test.aggregate.command.AggCreateProject;
+import io.spine.test.aggregate.command.AggCreateTask;
+import io.spine.test.aggregate.command.AggReassignTask;
 import io.spine.test.aggregate.event.AggProjectCreated;
+import io.spine.test.aggregate.event.AggTaskAssigned;
+import io.spine.test.aggregate.event.AggTaskCreated;
+import io.spine.test.aggregate.event.AggUserNotified;
+import io.spine.test.aggregate.rejection.AggCannotReassignUnassignedTask;
+import io.spine.test.aggregate.rejection.Rejections;
+import io.spine.test.aggregate.task.AggTask;
+import io.spine.test.aggregate.task.AggTaskId;
+import io.spine.test.aggregate.task.AggTaskVBuilder;
 import io.spine.test.aggregate.user.User;
 import io.spine.test.aggregate.user.UserVBuilder;
+import io.spine.type.TypeUrl;
 
+import javax.annotation.Nullable;
+import java.util.List;
+
+import static io.spine.Identifier.newUuid;
+import static io.spine.grpc.StreamObservers.memoizingObserver;
 import static io.spine.server.aggregate.given.Given.EventMessage.projectCreated;
 
 /**
@@ -42,6 +69,76 @@ public class AggregateTestEnv {
 
     private AggregateTestEnv() {
         // Prevent instantiation of this utility class.
+    }
+
+    /**
+     * Reads all events from the bounded context.
+     */
+    public static List<Event> readAllEvents(BoundedContext boundedContext) {
+        final MemoizingObserver<Event> queryObserver = memoizingObserver();
+        boundedContext.getEventBus()
+                      .getEventStore()
+                      .read(allEventsQuery(), queryObserver);
+        return queryObserver.responses();
+    }
+
+    /**
+     * Creates a new {@link EventStreamQuery} without any filters.
+     */
+    private static EventStreamQuery allEventsQuery() {
+        return EventStreamQuery.newBuilder()
+                               .build();
+    }
+
+    public static AggCreateTask createTask() {
+        return AggCreateTask.newBuilder()
+                            .setTaskId(newTaskId())
+                            .build();
+    }
+
+    private static AggTaskId newTaskId() {
+        return AggTaskId.newBuilder()
+                        .setId(newUuid())
+                        .build();
+    }
+
+    private static UserId newUserId() {
+        return UserId.newBuilder()
+                     .setValue(newUuid())
+                     .build();
+    }
+
+    /**
+     * Creates a new bounded context with a registered {@link TaskAggregateRepository}.
+     */
+    public static BoundedContext newTaskBoundedContext() {
+        final BoundedContext boundedContext = BoundedContext.newBuilder()
+                                                            .build();
+        boundedContext.register(new TaskAggregateRepository());
+        return boundedContext;
+    }
+
+    public static AggAssignTask assignTask() {
+        return AggAssignTask.newBuilder()
+                            .setTaskId(newTaskId())
+                            .setAssignee(newUserId())
+                            .build();
+    }
+
+    public static AggReassignTask reassignTask() {
+        return AggReassignTask.newBuilder()
+                            .setTaskId(newTaskId())
+                            .setAssignee(newUserId())
+                            .build();
+    }
+
+    /**
+     * Obtains the {@link TypeUrl} of the message from the provided event.
+     */
+    public static TypeUrl typeUrlOf(Event event) {
+        final Any message = event.getMessage();
+        final TypeUrl result = TypeUrl.parse(message.getTypeUrl());
+        return result;
     }
 
     /**
@@ -119,6 +216,156 @@ public class AggregateTestEnv {
     public static class UserAggregate extends Aggregate<String, User, UserVBuilder> {
         private UserAggregate(String id) {
             super(id);
+        }
+    }
+
+    public static class TaskAggregateRepository
+            extends AggregateRepository<AggTaskId, TaskAggregate> { }
+
+    /**
+     * An aggregate that fires a {@link Pair} with an optional upon handling a command, an event
+     * or a rejection.
+     *
+     * @see io.spine.server.aggregate.AggregateShould#create_single_event_for_a_pair_of_events_with_empty_for_a_command_dispatch
+     * @see io.spine.server.aggregate.AggregateShould#create_single_event_for_a_pair_of_events_with_empty_for_an_event_react
+     * @see io.spine.server.aggregate.AggregateShould#create_single_event_for_a_pair_of_events_with_empty_for_a_rejection_react
+     */
+    public static class TaskAggregate extends Aggregate<AggTaskId, AggTask, AggTaskVBuilder> {
+
+        private static final UserId EMPTY_USER_ID = UserId.getDefaultInstance();
+
+        protected TaskAggregate(AggTaskId id) {
+            super(id);
+        }
+
+        /**
+         * A command handler that returns a pair with an optional second element.
+         *
+         * <p>{@link AggTaskAssigned} is present when the command contains an
+         * {@link AggCreateTask#getAssignee()}.
+         */
+        @Assign
+        Pair<AggTaskCreated, Optional<AggTaskAssigned>> handle(AggCreateTask command,
+                                                               CommandContext context) {
+            final AggTaskId id = command.getTaskId();
+            final AggTaskCreated createdEvent = taskCreated(id);
+
+            final UserId assignee = command.getAssignee();
+            final AggTaskAssigned assignedEvent = taskAssignedOrNull(id, assignee);
+
+            return Pair.withNullable(createdEvent, assignedEvent);
+        }
+
+        private static AggTaskCreated taskCreated(AggTaskId id) {
+            return AggTaskCreated.newBuilder()
+                                 .setTaskId(id)
+                                 .build();
+        }
+
+        /**
+         * Creates a new {@link AggTaskAssigned} event message with provided values. If the
+         * {@link UserId} is a default empty instance returns {@code null}ю
+         */
+        @Nullable
+        private static AggTaskAssigned taskAssignedOrNull(AggTaskId id, UserId assignee) {
+            final UserId emptyUserId = UserId.getDefaultInstance();
+            if (assignee.equals(emptyUserId)) {
+                return null;
+            }
+            final AggTaskAssigned event =
+                    AggTaskAssigned.newBuilder()
+                                   .setTaskId(id)
+                                   .setNewAssignee(assignee)
+                                   .build();
+            return event;
+        }
+
+        @Assign
+        AggTaskAssigned handle(AggAssignTask command, CommandContext context) {
+            final AggTaskId id = command.getTaskId();
+            final UserId newAssignee = command.getAssignee();
+            final UserId previousAssignee = getState().getAssignee();
+            
+            final AggTaskAssigned event = taskAssigned(id, previousAssignee, newAssignee);
+            return event;
+        }
+
+        @Assign
+        AggTaskAssigned handle(AggReassignTask command, CommandContext context)
+                throws AggCannotReassignUnassignedTask {
+            final AggTaskId id = command.getTaskId();
+            final UserId newAssignee = command.getAssignee();
+            final UserId previousAssignee = getState().getAssignee();
+
+            if (previousAssignee.equals(EMPTY_USER_ID)) {
+                throw new AggCannotReassignUnassignedTask(id, previousAssignee);
+            }
+
+            final AggTaskAssigned event = taskAssigned(id, previousAssignee, newAssignee);
+            return event;
+        }
+
+        private static AggTaskAssigned taskAssigned(AggTaskId id,
+                                                    UserId previousAssignee,
+                                                    UserId newAssignee) {
+            return AggTaskAssigned.newBuilder()
+                                  .setTaskId(id)
+                                  .setPreviousAssignee(previousAssignee)
+                                  .setNewAssignee(newAssignee)
+                                  .build();
+        }
+
+        @Apply
+        void event(AggTaskCreated event) {
+            getBuilder().setId(event.getTaskId());
+        }
+
+        @Apply
+        void event(AggTaskAssigned event) {
+            getBuilder().setAssignee(event.getNewAssignee());
+        }
+
+        @React
+        Pair<AggUserNotified, Optional<AggUserNotified>>
+        on(AggTaskAssigned event) {
+            final AggTaskId taskId = event.getTaskId();
+            final UserId previousAssignee = event.getPreviousAssignee();
+            final AggUserNotified previousAssigneeNotified =
+                    userNotifiedOrNull(taskId, previousAssignee);
+            final UserId newAssignee = event.getNewAssignee();
+            final AggUserNotified newAssigneeNotified = userNotified(taskId, newAssignee);
+            return Pair.withNullable(newAssigneeNotified, previousAssigneeNotified);
+        }
+
+        @Nullable
+        private static AggUserNotified userNotifiedOrNull(AggTaskId taskId, UserId userId) {
+            if (userId.equals(EMPTY_USER_ID)) {
+                return null;
+            }
+            final AggUserNotified event = userNotified(taskId, userId);
+            return event;
+        }
+
+        private static AggUserNotified userNotified(AggTaskId taskId, UserId userId) {
+            final AggUserNotified event =
+                    AggUserNotified.newBuilder()
+                                   .setTaskId(taskId)
+                                   .setUserId(userId)
+                                   .build();
+            return event;
+        }
+
+        @React
+        Pair<AggUserNotified, Optional<AggUserNotified>>
+        on(Rejections.AggCannotReassignUnassignedTask rejection) {
+            final AggUserNotified event = userNotified(rejection.getTaskId(), 
+                                                       rejection.getUserId());
+            return Pair.withNullable(event, null);
+        }
+        
+        @Apply
+        void event(AggUserNotified event) {
+            // Do nothing.
         }
     }
 }

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregateTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregateTestEnv.java
@@ -237,7 +237,10 @@ public class AggregateTestEnv {
         }
     }
 
-    public static class TaskAggregateRepository
+    /**
+     * A repository that manages {@link TaskAggregate} instances.
+     */
+    private static class TaskAggregateRepository
             extends AggregateRepository<AggTaskId, TaskAggregate> { }
 
     /**

--- a/server/src/test/proto/spine/test/aggregate/events.proto
+++ b/server/src/test/proto/spine/test/aggregate/events.proto
@@ -29,7 +29,10 @@ option java_outer_classname = "AggregateEventsProto";
 option java_multiple_files = true;
 option java_generate_equals_and_hash = true;
 
+import "spine/core/user_id.proto";
+
 import "spine/test/aggregate/project.proto";
+import "spine/test/aggregate/task.proto";
 
 message AggProjectCreated {
     ProjectId project_id = 1;
@@ -62,4 +65,23 @@ message AggProjectPaused {
 
 message AggProjectCancelled {
     ProjectId project_id = 1;
+}
+
+message AggTaskCreated {
+    AggTaskId task_id = 1;
+}
+
+message AggTaskAssigned {
+    AggTaskId task_id = 1;
+    spine.core.UserId previousAssignee = 2;
+    spine.core.UserId newAssignee = 3;
+}
+
+message AggTaskStarted {
+    AggTaskId task_id = 1;
+}
+
+message AggUserNotified {
+    AggTaskId task_id = 1;
+    spine.core.UserId user_id = 2;
 }

--- a/server/src/test/proto/spine/test/aggregate/rejections.proto
+++ b/server/src/test/proto/spine/test/aggregate/rejections.proto
@@ -27,9 +27,17 @@ option (type_url_prefix) = "type.spine.io";
 option java_package="io.spine.test.aggregate.rejection";
 option java_generate_equals_and_hash = true;
 
+import "spine/core/user_id.proto";
+
 import "spine/test/aggregate/project.proto";
+import "spine/test/aggregate/task.proto";
 
 message AggCannotStartArchivedProject {
     ProjectId project_id = 1;
     repeated ProjectId child_project_id = 2;
+}
+
+message AggCannotReassignUnassignedTask {
+    AggTaskId task_id = 1;
+    spine.core.UserId user_id = 2;
 }

--- a/server/src/test/proto/spine/test/aggregate/task.proto
+++ b/server/src/test/proto/spine/test/aggregate/task.proto
@@ -19,71 +19,24 @@
 //
 syntax = "proto3";
 
-package spine.test.aggregate.command;
+package spine.test.aggregate;
 
 import "spine/options.proto";
 
 option (type_url_prefix) = "type.spine.io";
-option java_package="io.spine.test.aggregate.command";
-option java_outer_classname = "AggregateCommandsProto";
+option java_package="io.spine.test.aggregate.task";
 option java_multiple_files = true;
-option java_generate_equals_and_hash = true;
 
-import "spine/core/event.proto";
 import "spine/core/user_id.proto";
 
-import "spine/test/aggregate/project.proto";
-import "spine/test/aggregate/task.proto";
-
-message AggCreateProject {
-    ProjectId project_id = 1;
-    string name = 2;
+message AggTaskId {
+    string id = 1;
 }
 
-message AggCreateProjectWithChildren {
-    ProjectId project_id = 1;
-    string name = 2;
-    repeated ProjectId child_project_id = 3;
-}
+message AggTask {
 
-message AggStartProjectWithChildren {
-    ProjectId project_id = 1;
-}
-
-message AggAddTask {
-    ProjectId project_id = 1;
-    Task task = 2;
-}
-
-message AggStartProject {
-    ProjectId project_id = 1;
-    repeated ProjectId child_project_id = 3;
-}
-
-message ImportEvents {
-    ProjectId project_id = 1;
-    repeated core.Event event = 2;
-}
-
-message AggPauseProject {
-    ProjectId project_id = 1;
-}
-
-message AggCancelProject {
-    ProjectId project_id = 1;
-}
-
-message AggCreateTask {
-    AggTaskId task_id = 1;
+    AggTaskId id = 1;
+    
     spine.core.UserId assignee = 2;
 }
 
-message AggAssignTask {
-    AggTaskId task_id = 1;
-    spine.core.UserId assignee = 2;
-}
-
-message AggReassignTask {
-    AggTaskId task_id = 1;
-    spine.core.UserId assignee = 2;
-}

--- a/server/src/test/proto/spine/test/aggregate/task.proto
+++ b/server/src/test/proto/spine/test/aggregate/task.proto
@@ -39,4 +39,3 @@ message AggTask {
     
     spine.core.UserId assignee = 2;
 }
-


### PR DESCRIPTION
This PR implements empty filtering for the results of command handling, event reactions, and rejection reactions for aggregates. 

Empty messages cannot be returned directly but they can be created indirectly and should, therefore, be handled properly. A real-world case of empty messages falling into dispatching results are the returned tuples with empty `Optional` values.