### PR TITLE
Make applier methods package-private

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.23-SNAPSHOT'
+def final SPINE_VERSION = '0.10.24-SNAPSHOT'
 
 //noinspection GroovyAssignabilityCheck
 ext {

--- a/server/src/main/java/io/spine/server/aggregate/Apply.java
+++ b/server/src/main/java/io/spine/server/aggregate/Apply.java
@@ -28,13 +28,13 @@ import java.lang.annotation.Target;
 /**
  * Marks a method of an aggregate as one that modifies the state of the aggregate with data
  * from the passed event.
-
+ *
  * <p>As we apply the event to the aggregate state, we call such method <i>Event Applier</i>.
  *
  * <p>An event applier method:
  * <ul>
  *     <li>is annotated with {@link Apply};
- *     <li>is {@code private};
+ *     <li>has package-private visibility;
  *     <li>is {@code void};
  *     <li>accepts an event derived from {@link com.google.protobuf.Message Message}
  *         as the only parameter.

--- a/server/src/test/java/io/spine/server/Given.java
+++ b/server/src/test/java/io/spine/server/Given.java
@@ -223,7 +223,7 @@ public class Given {
         }
 
         @Apply
-        private void event(AggProjectCreated event) {
+        void event(AggProjectCreated event) {
             getBuilder()
                     .setId(event.getProjectId())
                     .setStatus(Status.CREATED)
@@ -231,11 +231,11 @@ public class Given {
         }
 
         @Apply
-        private void event(AggTaskAdded event) {
+        void event(AggTaskAdded event) {
         }
 
         @Apply
-        private void event(AggProjectStarted event) {
+        void event(AggProjectStarted event) {
             getBuilder()
                     .setId(event.getProjectId())
                     .setStatus(Status.STARTED)
@@ -269,7 +269,7 @@ public class Given {
         }
 
         @Apply
-        private void event(CustomerCreated event) {
+        void event(CustomerCreated event) {
             getBuilder().mergeFrom(event.getCustomer());
         }
     }

--- a/server/src/test/java/io/spine/server/aggregate/AggregatePartRepositoryLookupShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregatePartRepositoryLookupShould.java
@@ -129,7 +129,7 @@ public class AggregatePartRepositoryLookupShould {
         }
 
         @Apply
-        private void apply(AggProjectCreated event) {
+        void apply(AggProjectCreated event) {
             getBuilder().setId(event.getProjectId())
                         .setName(event.getName());
         }

--- a/server/src/test/java/io/spine/server/aggregate/AggregateShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateShould.java
@@ -675,7 +675,7 @@ public class AggregateShould {
         }
 
         @Apply
-        private void event(AggProjectCreated event) {
+        void event(AggProjectCreated event) {
             getBuilder()
                     .setId(event.getProjectId())
                     .setStatus(Status.CREATED);
@@ -684,13 +684,13 @@ public class AggregateShould {
         }
 
         @Apply
-        private void event(AggTaskAdded event) {
+        void event(AggTaskAdded event) {
             isTaskAddedEventApplied = true;
             getBuilder().addTask(event.getTask());
         }
 
         @Apply
-        private void event(AggProjectStarted event) {
+        void event(AggProjectStarted event) {
             getBuilder()
                     .setId(event.getProjectId())
                     .setStatus(Status.STARTED);
@@ -741,12 +741,12 @@ public class AggregateShould {
         }
 
         @Apply
-        private void on(AggProjectPaused event) {
+        void on(AggProjectPaused event) {
             // do nothing.
         }
 
         @Apply
-        private void on(AggProjectCancelled event) {
+        void on(AggProjectCancelled event) {
             // do nothing.
         }
     }

--- a/server/src/test/java/io/spine/server/aggregate/AggregateTransactionShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateTransactionShould.java
@@ -168,7 +168,7 @@ public class AggregateTransactionShould
         }
 
         @Apply
-        private void event(AggProjectCreated event) {
+        void event(AggProjectCreated event) {
             receivedEvents.add(event);
             final Project newState = Project.newBuilder(getState())
                                             .setId(event.getProjectId())
@@ -178,7 +178,7 @@ public class AggregateTransactionShould
         }
 
         @Apply
-        private void event(AggTaskAdded event) {
+        void event(AggTaskAdded event) {
             throw new RuntimeException("that tests the tx behaviour");
         }
 

--- a/server/src/test/java/io/spine/server/aggregate/EventApplierMethodShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/EventApplierMethodShould.java
@@ -87,7 +87,7 @@ public class EventApplierMethodShould {
 
     @Test
     public void check_method_access_modifier() {
-        final Method method = new ValidApplierButNotPrivate().getMethod();
+        final Method method = new ValidApplierButNotPackagePrivate().getMethod();
 
         factory.checkAccessModifier(method);
     }
@@ -101,7 +101,7 @@ public class EventApplierMethodShould {
 
     @Test
     public void consider_not_private_applier_valid() {
-        final Method method = new ValidApplierButNotPrivate().getMethod();
+        final Method method = new ValidApplierButNotPackagePrivate().getMethod();
 
         assertIsEventApplier(method);
     }
@@ -158,12 +158,12 @@ public class EventApplierMethodShould {
         private RefProjectCreated eventApplied;
 
         @Apply
-        private void apply(RefProjectCreated event) {
+        void apply(RefProjectCreated event) {
             this.eventApplied = event;
         }
     }
 
-    private static class ValidApplierButNotPrivate extends TestEventApplier {
+    private static class ValidApplierButNotPackagePrivate extends TestEventApplier {
         @Apply
         public void apply(RefProjectCreated event) {
         }

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregateCommandEndpointTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregateCommandEndpointTestEnv.java
@@ -74,7 +74,7 @@ public class AggregateCommandEndpointTestEnv {
         }
 
         @Apply
-        private void apply(AggProjectCreated event) {
+        void apply(AggProjectCreated event) {
             getBuilder().setId(event.getProjectId())
                         .setName(event.getName());
         }
@@ -88,7 +88,7 @@ public class AggregateCommandEndpointTestEnv {
         }
 
         @Apply
-        private void apply(AggTaskAdded event) {
+        void apply(AggTaskAdded event) {
             getBuilder().setId(event.getProjectId());
         }
 
@@ -101,7 +101,7 @@ public class AggregateCommandEndpointTestEnv {
         }
 
         @Apply
-        private void apply(AggProjectStarted event) {
+        void apply(AggProjectStarted event) {
         }
     }
 

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregateMessageDeliveryTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregateMessageDeliveryTestEnv.java
@@ -144,7 +144,7 @@ public class AggregateMessageDeliveryTestEnv {
 
         @SuppressWarnings("unused")     // an applier is required by the framework.
         @Apply
-        private void the(AggProjectCreated event) {
+        void the(AggProjectCreated event) {
             // do nothing.
         }
 

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregatePartTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregatePartTestEnv.java
@@ -86,7 +86,7 @@ public class AggregatePartTestEnv {
         }
 
         @Apply
-        private void apply(AggTaskAdded event) {
+        void apply(AggTaskAdded event) {
             getBuilder().setDescription(TASK_DESCRIPTION);
         }
     }
@@ -110,7 +110,7 @@ public class AggregatePartTestEnv {
         }
 
         @Apply
-        private void apply(AggTaskAdded event) {
+        void apply(AggTaskAdded event) {
             getBuilder().setValue("Description value");
         }
     }

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregateRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregateRepositoryTestEnv.java
@@ -162,7 +162,7 @@ public class AggregateRepositoryTestEnv {
         }
 
         @Apply
-        private void apply(AggProjectCreated event) {
+        void apply(AggProjectCreated event) {
             getBuilder().setId(event.getProjectId())
                         .setName(event.getName());
         }
@@ -176,7 +176,7 @@ public class AggregateRepositoryTestEnv {
         }
 
         @Apply
-        private void apply(AggTaskAdded event) {
+        void apply(AggTaskAdded event) {
             getBuilder().setId(event.getProjectId())
                         .addTask(event.getTask());
         }
@@ -189,7 +189,7 @@ public class AggregateRepositoryTestEnv {
         }
 
         @Apply
-        private void apply(AggProjectStarted event) {
+        void apply(AggProjectStarted event) {
             getBuilder().setStatus(Status.STARTED);
         }
 
@@ -209,7 +209,7 @@ public class AggregateRepositoryTestEnv {
         }
 
         @Apply
-        private void apply(AggProjectArchived event) {
+        void apply(AggProjectArchived event) {
             setArchived(true);
         }
 
@@ -499,12 +499,12 @@ public class AggregateRepositoryTestEnv {
         }
 
         @Apply
-        private void apply(AggProjectArchived event) {
+        void apply(AggProjectArchived event) {
             getBuilder().setValue(PROJECT_ARCHIVED);
         }
 
         @Apply
-        private void apply(AggProjectDeleted event) {
+        void apply(AggProjectDeleted event) {
             getBuilder().setValue(PROJECT_DELETED);
         }
     }

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregateRepositoryViewTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregateRepositoryViewTestEnv.java
@@ -68,7 +68,7 @@ public class AggregateRepositoryViewTestEnv {
         }
 
         @Apply
-        private void on(StringValue eventMessage) {
+        void on(StringValue eventMessage) {
             final String msg = RepoOfAggregateWithLifecycle.getMessage(eventMessage);
             if (archived.name()
                         .equalsIgnoreCase(msg)) {

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregateRootTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregateRootTestEnv.java
@@ -67,7 +67,7 @@ public class AggregateRootTestEnv {
         }
 
         @Apply
-        private void apply(AggProjectCreated event) {
+        void apply(AggProjectCreated event) {
             getBuilder().setId(event.getProjectId())
                         .setName(event.getName());
         }
@@ -95,7 +95,7 @@ public class AggregateRootTestEnv {
         }
 
         @Apply
-        private void apply(AggProjectStarted event) {
+        void apply(AggProjectStarted event) {
             getBuilder().setStatus(Status.STARTED);
         }
     }

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregateTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregateTestEnv.java
@@ -104,7 +104,7 @@ public class AggregateTestEnv {
         }
 
         @Apply
-        private void event(AggProjectCreated event) {
+        void event(AggProjectCreated event) {
             if (brokenApplier) {
                 throw new IllegalStateException(BROKEN_APPLIER);
             }

--- a/server/src/test/java/io/spine/server/bc/given/BoundedContextTestEnv.java
+++ b/server/src/test/java/io/spine/server/bc/given/BoundedContextTestEnv.java
@@ -81,19 +81,19 @@ public class BoundedContextTestEnv {
         }
 
         @Apply
-        private void event(BcProjectCreated event) {
+        void event(BcProjectCreated event) {
             getBuilder()
                     .setId(event.getProjectId())
                     .setStatus(Project.Status.CREATED);
         }
 
         @Apply
-        private void event(BcTaskAdded event) {
+        void event(BcTaskAdded event) {
             // NOP
         }
 
         @Apply
-        private void event(BcProjectStarted event) {
+        void event(BcProjectStarted event) {
             getBuilder()
                     .setId(event.getProjectId())
                     .setStatus(Project.Status.STARTED)

--- a/server/src/test/java/io/spine/server/model/given/ModelTestEnv.java
+++ b/server/src/test/java/io/spine/server/model/given/ModelTestEnv.java
@@ -58,7 +58,7 @@ public class ModelTestEnv {
         }
 
         @Apply
-        private void event(RefProjectCreated evt) {
+        void event(RefProjectCreated evt) {
             getBuilder().setId(evt.getProjectId());
         }
 
@@ -68,7 +68,7 @@ public class ModelTestEnv {
         }
 
         @Apply
-        private void event(RefProjectStarted evt) {
+        void event(RefProjectStarted evt) {
             getBuilder().setId(evt.getProjectId());
         }
     }

--- a/testutil-server/src/test/java/io/spine/server/aggregate/AggregateCommandTestShould.java
+++ b/testutil-server/src/test/java/io/spine/server/aggregate/AggregateCommandTestShould.java
@@ -98,7 +98,7 @@ public class AggregateCommandTestShould {
         }
 
         @Apply
-        private void on(Timestamp timestamp) {
+        void on(Timestamp timestamp) {
             getBuilder().setValue(Timestamps.toString(timestamp));
         }
     }

--- a/testutil-server/src/test/java/io/spine/server/aggregate/AggregatePartCommandTestShould.java
+++ b/testutil-server/src/test/java/io/spine/server/aggregate/AggregatePartCommandTestShould.java
@@ -101,7 +101,7 @@ public class AggregatePartCommandTestShould {
         }
 
         @Apply
-        private void on(Timestamp timestamp) {
+        void on(Timestamp timestamp) {
             getBuilder().setValue(getState().getValue() + 1);
         }
     }


### PR DESCRIPTION
Before, we recommended the applier methods to be `private`.
The issue with that is that the static code analyzers complain of that methods as "unused".

Now, we recommend the event applier methods to be package-private. This should resolve the problem with the static code analysis.
