### PR TITLE
Inherited annotations

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -7,6 +7,7 @@
       <option name="JD_P_AT_EMPTY_LINES" value="false" />
       <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
       <REPEAT_ANNOTATIONS>
+        <ANNO name="javax.annotation.OverridingMethodsMustInvokeSuper" />
         <ANNO name="org.junit.After" />
         <ANNO name="org.junit.Before" />
         <ANNO name="org.junit.Test" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -6,6 +6,14 @@
       <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1000" />
       <option name="JD_P_AT_EMPTY_LINES" value="false" />
       <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
+      <REPEAT_ANNOTATIONS>
+        <ANNO name="org.junit.After" />
+        <ANNO name="org.junit.Before" />
+        <ANNO name="org.junit.Test" />
+        <ANNO name="org.junit.jupiter.api.AfterEach" />
+        <ANNO name="org.junit.jupiter.api.BeforeEach" />
+        <ANNO name="org.junit.jupiter.api.Test" />
+      </REPEAT_ANNOTATIONS>
     </JavaCodeStyleSettings>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />

--- a/server/src/test/java/io/spine/server/stand/MultiTenantStandShould.java
+++ b/server/src/test/java/io/spine/server/stand/MultiTenantStandShould.java
@@ -54,6 +54,7 @@ public class MultiTenantStandShould extends StandShould {
     @Override
     @Before
     public void setUp() {
+        super.setUp();
         final TenantId tenantId = newUuid();
 
         setCurrentTenant(tenantId);


### PR DESCRIPTION
In this PR we change the Java code style configs in order to make the IDE automatically add some annotations to overridden method.

For example, let test class `BaseTest` define following method:
```java
@Before
public void setUp() {
    // Perform some test case setup.
}
```
If a class `DerivedTest extends BaseTest` overrides that method, it should look as follows:
```java
@Before
@Override
public void setUp() {
    super.setUp();
    // Perform some extra test case setup.
}
```

This behavior is enforced for following annotation types:
- `javax.annotation.OverridingMethodsMustInvokeSuper`
- `org.junit.After`
- `org.junit.Before`
- `org.junit.Test`
- `org.junit.jupiter.api.AfterEach`
- `org.junit.jupiter.api.BeforeEach`
- `org.junit.jupiter.api.Test`