### PR TITLE
Fix unpacking the identifier in the test sources

### DIFF
--- a/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
+++ b/server/src/test/java/io/spine/server/storage/RecordStorageShould.java
@@ -656,7 +656,7 @@ public abstract class RecordStorageShould<I, S extends RecordStorage<I>>
         assertEquals(1, readRecords.size());
         final EntityRecord readRecord = readRecords.get(0);
         assertEquals(targetEntity.getState(), unpack(readRecord.getState()));
-        assertEquals(targetId, unpack(readRecord.getEntityId()));
+        assertEquals(targetId, Identifier.unpack(readRecord.getEntityId()));
     }
 
     @SuppressWarnings("MismatchedQueryAndUpdateOfCollection"/* Storing of generated objects and


### PR DESCRIPTION
This PR fixes a minor issue with the `RecordStorageShould` tests.

Entity identifier from the `EntityRecord` was unpacked not in the same way as it was packed for the query. This issue has no impact on the `ProjectId` identifiers, so all tests for `core-java` were working correctly. 

But in the `jdbc-storage` repository there is a `JdbcRecordStorageShould` test which relies on the `String` identifier type and extends `RecordStorageShould` test class. Incorrect unpack of the `String` identifier led to the `AssertionError` in tests, thus not enabling `jdbc-storage` to build with the `core-java` dependency `'0.10.26-SNAPSHOT'`.