### PR TITLE
Update dependent repositories own version along with the `core-java` dependency

### DIFF
--- a/scripts/dependent-repositories/gae-update-core-version.sh
+++ b/scripts/dependent-repositories/gae-update-core-version.sh
@@ -9,11 +9,15 @@ readonly SOURCE_VERSION_VARIABLE='SPINE_VERSION'
 readonly TARGET_REPOSITORY=https://api.github.com/repos/SpineEventEngine/gae-java
 readonly TARGET_FILE_WITH_VERSION='ext.gradle'
 readonly TARGET_VERSION_VARIABLE='spineVersion'
+readonly TARGET_COMMIT_MESSAGE="Update the dependency to \`core-java\` *version*."
+
+readonly OWN_FILE_WITH_VERSION='ext.gradle'
+readonly OWN_VERSION_VARIABLE='spineGaeVersion'
+readonly OWN_COMMIT_MESSAGE="Update own version to *version*."
 
 readonly NEW_BRANCH_NAME='update-core-version'
 readonly BRANCH_TO_MERGE_INTO='master'
 
-readonly COMMIT_MESSAGE="Update the dependency to \`core-java\` *version*."
 readonly PULL_REQUEST_TITLE="Update the dependency to \`core-java\` *version*."
 readonly PULL_REQUEST_BODY='Auto-generated PR to update core library dependency to the latest version.'
 readonly PULL_REQUEST_ASSIGNEE='armiol'
@@ -32,7 +36,23 @@ function main() {
         "${TARGET_VERSION_VARIABLE}" \
         "${NEW_BRANCH_NAME}" \
         "${BRANCH_TO_MERGE_INTO}" \
-        "${COMMIT_MESSAGE}" \
+        "${TARGET_COMMIT_MESSAGE}" \
+        "${PULL_REQUEST_TITLE}" \
+        "${PULL_REQUEST_BODY}" \
+        "${PULL_REQUEST_ASSIGNEE}"
+
+    # As the branch already exists, the second script call will push files directly there.
+    ./scripts/dependent-repositories/update-dependency-version.sh \
+        "${gitAuthorizationToken}" \
+        "${SOURCE_REPOSITORY}" \
+        "${SOURCE_FILE_WITH_VERSION}" \
+        "${SOURCE_VERSION_VARIABLE}" \
+        "${TARGET_REPOSITORY}" \
+        "${OWN_FILE_WITH_VERSION}" \
+        "${OWN_VERSION_VARIABLE}" \
+        "${NEW_BRANCH_NAME}" \
+        "${BRANCH_TO_MERGE_INTO}" \
+        "${OWN_COMMIT_MESSAGE}" \
         "${PULL_REQUEST_TITLE}" \
         "${PULL_REQUEST_BODY}" \
         "${PULL_REQUEST_ASSIGNEE}"

--- a/scripts/dependent-repositories/gae-update-core-version.sh
+++ b/scripts/dependent-repositories/gae-update-core-version.sh
@@ -13,7 +13,7 @@ readonly TARGET_COMMIT_MESSAGE="Update the dependency to \`core-java\` *version*
 
 readonly OWN_FILE_WITH_VERSION='ext.gradle'
 readonly OWN_VERSION_VARIABLE='spineGaeVersion'
-readonly OWN_COMMIT_MESSAGE="Update own version to *version*."
+readonly OWN_COMMIT_MESSAGE="Update the library version to *version*."
 
 readonly NEW_BRANCH_NAME='update-core-version'
 readonly BRANCH_TO_MERGE_INTO='master'

--- a/scripts/dependent-repositories/jdbc-update-core-version.sh
+++ b/scripts/dependent-repositories/jdbc-update-core-version.sh
@@ -9,11 +9,15 @@ readonly SOURCE_VERSION_VARIABLE='SPINE_VERSION'
 readonly TARGET_REPOSITORY=https://api.github.com/repos/SpineEventEngine/jdbc-storage
 readonly TARGET_FILE_WITH_VERSION='ext.gradle'
 readonly TARGET_VERSION_VARIABLE='coreVersion'
+readonly TARGET_COMMIT_MESSAGE="Update the dependency to \`core-java\` *version*."
+
+readonly OWN_FILE_WITH_VERSION='ext.gradle'
+readonly OWN_VERSION_VARIABLE='JDBC_VERSION'
+readonly OWN_COMMIT_MESSAGE="Update own version to *version*."
 
 readonly NEW_BRANCH_NAME='update-core-version'
 readonly BRANCH_TO_MERGE_INTO='master'
 
-readonly COMMIT_MESSAGE="Update the dependency to \`core-java\` *version*."
 readonly PULL_REQUEST_TITLE="Update the dependency to \`core-java\` *version*."
 readonly PULL_REQUEST_BODY='Auto-generated PR to update core library dependency to the latest version.'
 readonly PULL_REQUEST_ASSIGNEE='armiol'
@@ -32,7 +36,23 @@ function main() {
         "${TARGET_VERSION_VARIABLE}" \
         "${NEW_BRANCH_NAME}" \
         "${BRANCH_TO_MERGE_INTO}" \
-        "${COMMIT_MESSAGE}" \
+        "${TARGET_COMMIT_MESSAGE}" \
+        "${PULL_REQUEST_TITLE}" \
+        "${PULL_REQUEST_BODY}" \
+        "${PULL_REQUEST_ASSIGNEE}"
+
+    # As the branch already exists, the second script call will push files directly there.
+    ./scripts/dependent-repositories/update-dependency-version.sh \
+        "${gitAuthorizationToken}" \
+        "${SOURCE_REPOSITORY}" \
+        "${SOURCE_FILE_WITH_VERSION}" \
+        "${SOURCE_VERSION_VARIABLE}" \
+        "${TARGET_REPOSITORY}" \
+        "${OWN_FILE_WITH_VERSION}" \
+        "${OWN_VERSION_VARIABLE}" \
+        "${NEW_BRANCH_NAME}" \
+        "${BRANCH_TO_MERGE_INTO}" \
+        "${OWN_COMMIT_MESSAGE}" \
         "${PULL_REQUEST_TITLE}" \
         "${PULL_REQUEST_BODY}" \
         "${PULL_REQUEST_ASSIGNEE}"

--- a/scripts/dependent-repositories/jdbc-update-core-version.sh
+++ b/scripts/dependent-repositories/jdbc-update-core-version.sh
@@ -13,7 +13,7 @@ readonly TARGET_COMMIT_MESSAGE="Update the dependency to \`core-java\` *version*
 
 readonly OWN_FILE_WITH_VERSION='ext.gradle'
 readonly OWN_VERSION_VARIABLE='JDBC_VERSION'
-readonly OWN_COMMIT_MESSAGE="Update own version to *version*."
+readonly OWN_COMMIT_MESSAGE="Update the library version to *version*."
 
 readonly NEW_BRANCH_NAME='update-core-version'
 readonly BRANCH_TO_MERGE_INTO='master'


### PR DESCRIPTION
This PR is an addition to the https://github.com/SpineEventEngine/core-java/pull/670.

It introduces changes which will allow dependent repositories to auto-update their own version along with the `core-java` dependency.

On the successful build in the `master` branch of `core-java`, pull requests are opened in the `jdbc-storage` and `gae-java` repositories. These pull requests contain version update for the `core-java` dependency in the corresponding repository, and now, with the changes in this PR, the own version of the repository will be updated to the same value too.