### PR TITLE
Add library version to the name of the dependency-updating branch

### DIFF
--- a/scripts/dependent-repositories/gae-update-core-version.sh
+++ b/scripts/dependent-repositories/gae-update-core-version.sh
@@ -15,7 +15,7 @@ readonly OWN_FILE_WITH_VERSION='ext.gradle'
 readonly OWN_VERSION_VARIABLE='spineGaeVersion'
 readonly OWN_COMMIT_MESSAGE="Update the library version to *version*."
 
-readonly NEW_BRANCH_NAME='update-core-version'
+readonly NEW_BRANCH_NAME='update-to-core-java-*version*'
 readonly BRANCH_TO_MERGE_INTO='master'
 
 readonly PULL_REQUEST_TITLE="Update the dependency to \`core-java\` *version*."

--- a/scripts/dependent-repositories/jdbc-update-core-version.sh
+++ b/scripts/dependent-repositories/jdbc-update-core-version.sh
@@ -15,7 +15,7 @@ readonly OWN_FILE_WITH_VERSION='ext.gradle'
 readonly OWN_VERSION_VARIABLE='JDBC_VERSION'
 readonly OWN_COMMIT_MESSAGE="Update the library version to *version*."
 
-readonly NEW_BRANCH_NAME='update-core-version'
+readonly NEW_BRANCH_NAME='update-to-core-java-*version*'
 readonly BRANCH_TO_MERGE_INTO='master'
 
 readonly PULL_REQUEST_TITLE="Update the dependency to \`core-java\` *version*."

--- a/scripts/dependent-repositories/update-dependency-version.sh
+++ b/scripts/dependent-repositories/update-dependency-version.sh
@@ -636,6 +636,12 @@ function updateVersion() {
     local fullFilePath="$(obtainFullFilePath "${fileWithVersion}" \
         "${repositoryUrl}")"
 
+    local targetVersionNoQuotes="$(replace "\'" "" "${targetVersion}")"
+
+    newBranchName="$(replace "\*version\*" \
+        "${targetVersionNoQuotes}" \
+        "${newBranchName}")"
+
     local branchExists="$(checkBranchExists "${newBranchName}" \
         "${repositoryUrl}")"
 
@@ -681,8 +687,6 @@ function updateVersion() {
 
         local newFileContentEncoded="$(encode "${newFileContent}")"
         local fileSha="$(obtainFileSha "${fileData}")"
-
-        local targetVersionNoQuotes="$(replace "\'" "" "${targetVersion}")"
 
         local commitMessageWithVersion="$(replace "\*version\*" \
             "${targetVersionNoQuotes}" \
@@ -737,7 +741,7 @@ function updateVersion() {
 #   targetRepository - target repository URL via GitHub API
 #   targetFileWithVersion - relative path to the configuration file containing target version
 #   targetVersionVariable - name of the variable representing the target version of the library
-#   newBranchName - name of the branch for the updated file
+#   newBranchName - name of the branch for the updated file; use "*version*" placeholder to insert the new version into it
 #   branchToMergeInto - name of the branch to merge the updated version of the file into
 #   commitMessage - title of the commit with the updated file; use "*version*" placeholder to insert the new version into it
 #   pullRequestTitle - title of the new pull request; use "*version*" placeholder to insert the new version into it


### PR DESCRIPTION
This pull request is an addition to the https://github.com/SpineEventEngine/core-java/pull/670 and https://github.com/SpineEventEngine/core-java/pull/676.

Previously, the script updating `core-java` dependency in the `jdbc-storage` and `gae-java` repositories was always creating the branch with the same generic name, independent of the new version of the library. Now, the script will insert the new library version into the created branch name, for example: `update-to-core-java-0.10.26-SHAPSHOT`.