### PR TITLE
Widen storage tests

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.30-SNAPSHOT'
+def final SPINE_VERSION = '0.10.31-SNAPSHOT'
 
 //noinspection GroovyAssignabilityCheck
 ext {

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
@@ -447,6 +447,20 @@ public abstract class AggregateStorageShould
         assertTrue(isDefault(loadedOrigin.getEnrichment()));
     }
 
+    @Test
+    public void read_archived_records() {
+        readRecordsWithLifecycle(LifecycleFlags.newBuilder()
+                                               .setArchived(true)
+                                               .build());
+    }
+
+    @Test
+    public void read_deleted_records() {
+        readRecordsWithLifecycle(LifecycleFlags.newBuilder()
+                                               .setDeleted(true)
+                                               .build());
+    }
+
     @Test(expected = IllegalStateException.class)
     public void throw_exception_if_try_to_write_event_count_to_closed_storage() {
         close(storage);
@@ -506,6 +520,16 @@ public abstract class AggregateStorageShould
     private Iterator<AggregateEventRecord> historyBackward() {
         final AggregateReadRequest<ProjectId> readRequest = newReadRequest(id);
         return storage.historyBackward(readRequest);
+    }
+
+    private void readRecordsWithLifecycle(LifecycleFlags flags) {
+        final AggregateStateRecord record = newStorageRecord();
+        storage.write(id, record);
+        storage.writeLifecycleFlags(id, flags);
+        final Optional<AggregateStateRecord> read = storage.read(newReadRequest(id));
+        assertTrue(read.isPresent());
+        final AggregateStateRecord readRecord = read.get();
+        assertEquals(record, readRecord);
     }
 
     protected static final Function<AggregateEventRecord, Event> TO_EVENT =

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageShould.java
@@ -461,6 +461,14 @@ public abstract class AggregateStorageShould
                                                .build());
     }
 
+    @Test
+    public void read_archived_and_deleted_records() {
+        readRecordsWithLifecycle(LifecycleFlags.newBuilder()
+                                               .setArchived(true)
+                                               .setDeleted(true)
+                                               .build());
+    }
+
     @Test(expected = IllegalStateException.class)
     public void throw_exception_if_try_to_write_event_count_to_closed_storage() {
         close(storage);


### PR DESCRIPTION
In this PR we add tests for reading aggregates which are `archived` or `deleted`.