### PR TITLE
Prohibit checked exceptions in message handling methods

### DIFF
--- a/server/src/main/java/io/spine/server/aggregate/EventApplierMethod.java
+++ b/server/src/main/java/io/spine/server/aggregate/EventApplierMethod.java
@@ -115,7 +115,7 @@ final class EventApplierMethod extends HandlerMethod<EventClass, Empty> {
         @Override
         public void checkAccessModifier(Method method) {
             final MethodAccessChecker checker = forMethod(method);
-            checker.checkAccessIsPrivate("Event applier method {} must be declared 'private'.");
+            checker.checkPrivate("Event applier method {} must be declared 'private'.");
         }
 
         @Override

--- a/server/src/main/java/io/spine/server/aggregate/EventApplierMethod.java
+++ b/server/src/main/java/io/spine/server/aggregate/EventApplierMethod.java
@@ -29,10 +29,12 @@ import io.spine.core.EventClass;
 import io.spine.server.model.HandlerKey;
 import io.spine.server.model.HandlerMethod;
 import io.spine.server.model.HandlerMethodPredicate;
+import io.spine.server.model.MethodAccessChecker;
 import io.spine.server.model.MethodPredicate;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
+
+import static io.spine.server.model.MethodAccessChecker.forMethod;
 
 /**
  * A wrapper for event applier method.
@@ -92,7 +94,7 @@ final class EventApplierMethod extends HandlerMethod<EventClass, Empty> {
     }
 
     /** The factory for filtering methods that match {@code EventApplier} specification. */
-    private static class Factory implements HandlerMethod.Factory<EventApplierMethod> {
+    private static class Factory extends HandlerMethod.Factory<EventApplierMethod> {
 
         private static final Factory INSTANCE = new Factory();
 
@@ -106,20 +108,19 @@ final class EventApplierMethod extends HandlerMethod<EventClass, Empty> {
         }
 
         @Override
-        public EventApplierMethod create(Method method) {
-            return from(method);
-        }
-
-        @Override
         public Predicate<Method> getPredicate() {
             return predicate();
         }
 
         @Override
         public void checkAccessModifier(Method method) {
-            if (!Modifier.isPrivate(method.getModifiers())) {
-                warnOnWrongModifier("Event applier method {} must be declared 'private'.", method);
-            }
+            final MethodAccessChecker checker = forMethod(method);
+            checker.checkAccessIsPrivate("Event applier method {} must be declared 'private'.");
+        }
+
+        @Override
+        protected EventApplierMethod createForMethod(Method method) {
+            return from(method);
         }
     }
 

--- a/server/src/main/java/io/spine/server/aggregate/EventApplierMethod.java
+++ b/server/src/main/java/io/spine/server/aggregate/EventApplierMethod.java
@@ -119,7 +119,7 @@ final class EventApplierMethod extends HandlerMethod<EventClass, Empty> {
         }
 
         @Override
-        protected EventApplierMethod createForMethod(Method method) {
+        protected EventApplierMethod createFromMethod(Method method) {
             return from(method);
         }
     }

--- a/server/src/main/java/io/spine/server/command/CommandHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/command/CommandHandlerMethod.java
@@ -186,7 +186,7 @@ public final class CommandHandlerMethod extends HandlerMethod<CommandClass, Comm
         }
 
         @Override
-        protected CommandHandlerMethod createForMethod(Method method) {
+        protected CommandHandlerMethod createFromMethod(Method method) {
             return from(method);
         }
     }

--- a/server/src/main/java/io/spine/server/command/CommandHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/command/CommandHandlerMethod.java
@@ -168,8 +168,7 @@ public final class CommandHandlerMethod extends HandlerMethod<CommandClass, Comm
         @Override
         public void checkAccessModifier(Method method) {
             final MethodAccessChecker checker = MethodAccessChecker.forMethod(method);
-            checker.checkPackagePrivate(
-                    "Command handler method {} should be package-private.");
+            checker.checkPackagePrivate("Command handler method {} should be package-private.");
         }
 
         /**

--- a/server/src/main/java/io/spine/server/command/CommandHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/command/CommandHandlerMethod.java
@@ -182,7 +182,7 @@ public final class CommandHandlerMethod extends HandlerMethod<CommandClass, Comm
         @Override
         protected void checkThrownExceptions(Method method) {
             final MethodExceptionChecker checker = MethodExceptionChecker.forMethod(method);
-            checker.checkThrowsNoExceptionsExcept(RuntimeException.class, ThrowableMessage.class);
+            checker.checkThrowsNoExceptionsBut(RuntimeException.class, ThrowableMessage.class);
         }
 
         @Override

--- a/server/src/main/java/io/spine/server/command/CommandHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/command/CommandHandlerMethod.java
@@ -168,7 +168,7 @@ public final class CommandHandlerMethod extends HandlerMethod<CommandClass, Comm
         @Override
         public void checkAccessModifier(Method method) {
             final MethodAccessChecker checker = MethodAccessChecker.forMethod(method);
-            checker.checkAccessIsPackagePrivate(
+            checker.checkPackagePrivate(
                     "Command handler method {} should be package-private.");
         }
 

--- a/server/src/main/java/io/spine/server/event/EventReactorMethod.java
+++ b/server/src/main/java/io/spine/server/event/EventReactorMethod.java
@@ -111,7 +111,7 @@ public final class EventReactorMethod extends HandlerMethod<EventClass, EventCon
         @Override
         public void checkAccessModifier(Method method) {
             final MethodAccessChecker checker = forMethod(method);
-            checker.checkAccessIsPackagePrivate(
+            checker.checkPackagePrivate(
                     "Reactive handler method {} should be package-private.");
         }
 

--- a/server/src/main/java/io/spine/server/event/EventReactorMethod.java
+++ b/server/src/main/java/io/spine/server/event/EventReactorMethod.java
@@ -27,12 +27,14 @@ import io.spine.core.EventContext;
 import io.spine.core.React;
 import io.spine.server.model.HandlerKey;
 import io.spine.server.model.HandlerMethod;
+import io.spine.server.model.MethodAccessChecker;
 import io.spine.server.model.MethodPredicate;
 
 import java.lang.reflect.Method;
 import java.util.List;
 
 import static io.spine.server.model.HandlerMethods.ensureExternalMatch;
+import static io.spine.server.model.MethodAccessChecker.forMethod;
 import static io.spine.util.Exceptions.newIllegalStateException;
 
 /**
@@ -88,7 +90,7 @@ public final class EventReactorMethod extends HandlerMethod<EventClass, EventCon
     /**
      * The factory for creating {@link EventReactorMethod event reactor} methods.
      */
-    private static class Factory implements HandlerMethod.Factory<EventReactorMethod> {
+    private static class Factory extends HandlerMethod.Factory<EventReactorMethod> {
 
         private static final Factory INSTANCE = new Factory();
 
@@ -102,21 +104,20 @@ public final class EventReactorMethod extends HandlerMethod<EventClass, EventCon
         }
 
         @Override
-        public EventReactorMethod create(Method method) {
-            return from(method);
-        }
-
-        @Override
         public Predicate<Method> getPredicate() {
             return predicate();
         }
 
         @Override
         public void checkAccessModifier(Method method) {
-            if (!isPackagePrivate(method)) {
-                warnOnWrongModifier("Reactive handler method {} should be package-private.",
-                                    method);
-            }
+            final MethodAccessChecker checker = forMethod(method);
+            checker.checkAccessIsPackagePrivate(
+                    "Reactive handler method {} should be package-private.");
+        }
+
+        @Override
+        protected EventReactorMethod createForMethod(Method method) {
+            return from(method);
         }
     }
 

--- a/server/src/main/java/io/spine/server/event/EventReactorMethod.java
+++ b/server/src/main/java/io/spine/server/event/EventReactorMethod.java
@@ -111,8 +111,7 @@ public final class EventReactorMethod extends HandlerMethod<EventClass, EventCon
         @Override
         public void checkAccessModifier(Method method) {
             final MethodAccessChecker checker = forMethod(method);
-            checker.checkPackagePrivate(
-                    "Reactive handler method {} should be package-private.");
+            checker.checkPackagePrivate("Reactive handler method {} should be package-private.");
         }
 
         @Override

--- a/server/src/main/java/io/spine/server/event/EventReactorMethod.java
+++ b/server/src/main/java/io/spine/server/event/EventReactorMethod.java
@@ -116,7 +116,7 @@ public final class EventReactorMethod extends HandlerMethod<EventClass, EventCon
         }
 
         @Override
-        protected EventReactorMethod createForMethod(Method method) {
+        protected EventReactorMethod createFromMethod(Method method) {
             return from(method);
         }
     }

--- a/server/src/main/java/io/spine/server/event/EventSubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/event/EventSubscriberMethod.java
@@ -109,7 +109,7 @@ public final class EventSubscriberMethod extends HandlerMethod<EventClass, Event
         }
 
         @Override
-        protected EventSubscriberMethod createForMethod(Method method) {
+        protected EventSubscriberMethod createFromMethod(Method method) {
             return from(method);
         }
     }

--- a/server/src/main/java/io/spine/server/event/EventSubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/event/EventSubscriberMethod.java
@@ -105,7 +105,7 @@ public final class EventSubscriberMethod extends HandlerMethod<EventClass, Event
         @Override
         public void checkAccessModifier(Method method) {
             final MethodAccessChecker checker = forMethod(method);
-            checker.checkAccessIsPublic("Event subscriber {} must be declared 'public'");
+            checker.checkPublic("Event subscriber {} must be declared 'public'");
         }
 
         @Override

--- a/server/src/main/java/io/spine/server/event/EventSubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/event/EventSubscriberMethod.java
@@ -27,13 +27,14 @@ import io.spine.core.EventContext;
 import io.spine.core.Subscribe;
 import io.spine.server.model.HandlerKey;
 import io.spine.server.model.HandlerMethod;
+import io.spine.server.model.MethodAccessChecker;
 import io.spine.server.model.MethodPredicate;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 
 import static io.spine.core.Rejections.isRejection;
 import static io.spine.server.model.HandlerMethods.ensureExternalMatch;
+import static io.spine.server.model.MethodAccessChecker.forMethod;
 
 /**
  * A wrapper for an event subscriber method.
@@ -83,7 +84,7 @@ public final class EventSubscriberMethod extends HandlerMethod<EventClass, Event
     /**
      * The factory for creating {@linkplain EventSubscriberMethod event subscriber} methods.
      */
-    private static class Factory implements HandlerMethod.Factory<EventSubscriberMethod> {
+    private static class Factory extends HandlerMethod.Factory<EventSubscriberMethod> {
 
         private static final Factory INSTANCE = new Factory();
 
@@ -97,20 +98,19 @@ public final class EventSubscriberMethod extends HandlerMethod<EventClass, Event
         }
 
         @Override
-        public EventSubscriberMethod create(Method method) {
-            return from(method);
-        }
-
-        @Override
         public Predicate<Method> getPredicate() {
             return predicate();
         }
 
         @Override
         public void checkAccessModifier(Method method) {
-            if (!Modifier.isPublic(method.getModifiers())) {
-                warnOnWrongModifier("Event subscriber {} must be declared 'public'", method);
-            }
+            final MethodAccessChecker checker = forMethod(method);
+            checker.checkAccessIsPublic("Event subscriber {} must be declared 'public'");
+        }
+
+        @Override
+        protected EventSubscriberMethod createForMethod(Method method) {
+            return from(method);
         }
     }
 

--- a/server/src/main/java/io/spine/server/model/HandlerMethod.java
+++ b/server/src/main/java/io/spine/server/model/HandlerMethod.java
@@ -318,23 +318,23 @@ public abstract class HandlerMethod<M extends MessageClass, C extends Message> {
         public abstract void checkAccessModifier(Method method);
 
         /**
-         * Creates a {@linkplain HandlerMethod wrapper} for the method.
+         * Creates a {@linkplain HandlerMethod wrapper} from the method.
          *
          * <p>Performs various checks before wrapper creation, e.g. method access modifier or
          * whether method throws any prohibited exceptions.
          *
-         * @param method the method to create wrapper for
-         * @return a wrapper object for the method
+         * @param method the method to create wrapper from
+         * @return a wrapper object created from the method
          * @throws IllegalStateException in case some of the method checks fail
          */
         public H create(Method method) {
             checkAccessModifier(method);
             checkThrownExceptions(method);
-            return createForMethod(method);
+            return createFromMethod(method);
         }
 
-        /** Creates a wrapper object for a method. */
-        protected abstract H createForMethod(Method method);
+        /** Creates a wrapper object from a method. */
+        protected abstract H createFromMethod(Method method);
 
         /**
          * Ensures method does not throw any prohibited exception types.

--- a/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
@@ -36,10 +36,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * <p>If the access level check fails, the {@linkplain Logger#warn(String) warning} will be output
  * to the log. If the check passes, no action is performed.
  *
+ * <p>This class is effectively {@code final} since it has a single {@code private} constructor.
+ * Though the modifier "{@code final}" is absent to make it possible to create mocks for testing.
+ *
  * @author Dmytro Kuzmin
  */
 @Internal
-public final class MethodAccessChecker {
+public class MethodAccessChecker {
 
     private final Method method;
 

--- a/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
@@ -70,6 +70,7 @@ public final class MethodAccessChecker {
      * @see String#format(String, Object...)
      */
     public void checkPublic(String warningMessageFormat) {
+        checkNotNull(warningMessageFormat);
         if (!Modifier.isPublic(method.getModifiers())) {
             warnOnWrongModifier(warningMessageFormat);
         }
@@ -87,6 +88,7 @@ public final class MethodAccessChecker {
      * @see String#format(String, Object...)
      */
     public void checkPackagePrivate(String warningMessageFormat) {
+        checkNotNull(warningMessageFormat);
         if (!isPackagePrivate(method)) {
             warnOnWrongModifier(warningMessageFormat);
         }
@@ -104,6 +106,7 @@ public final class MethodAccessChecker {
      * @see String#format(String, Object...)
      */
     public void checkPrivate(String warningMessageFormat) {
+        checkNotNull(warningMessageFormat);
         if (!Modifier.isPrivate(method.getModifiers())) {
             warnOnWrongModifier(warningMessageFormat);
         }

--- a/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
@@ -33,8 +33,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * The checker of a {@link Method} access level.
  *
- * <p>If the access check fails, the {@linkplain Logger#warn(String) warning} will be output to
- * the log. If the check passes, no action is performed.
+ * <p>If the access level check fails, the {@linkplain Logger#warn(String) warning} will be output
+ * to the log. If the check passes, no action is performed.
  *
  * @author Dmytro Kuzmin
  */

--- a/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
@@ -69,7 +69,7 @@ public final class MethodAccessChecker {
      * @param warningMessageFormat a formatted {@code String} representing the warning message
      * @see String#format(String, Object...)
      */
-    public void checkAccessIsPublic(String warningMessageFormat) {
+    public void checkPublic(String warningMessageFormat) {
         if (!Modifier.isPublic(method.getModifiers())) {
             warnOnWrongModifier(warningMessageFormat);
         }
@@ -86,7 +86,7 @@ public final class MethodAccessChecker {
      * @param warningMessageFormat a formatted {@code String} representing the warning message
      * @see String#format(String, Object...)
      */
-    public void checkAccessIsPackagePrivate(String warningMessageFormat) {
+    public void checkPackagePrivate(String warningMessageFormat) {
         if (!isPackagePrivate(method)) {
             warnOnWrongModifier(warningMessageFormat);
         }
@@ -103,7 +103,7 @@ public final class MethodAccessChecker {
      * @param warningMessageFormat a formatted {@code String} representing the warning message
      * @see String#format(String, Object...)
      */
-    public void checkAccessIsPrivate(String warningMessageFormat) {
+    public void checkPrivate(String warningMessageFormat) {
         if (!Modifier.isPrivate(method.getModifiers())) {
             warnOnWrongModifier(warningMessageFormat);
         }

--- a/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
@@ -43,8 +43,7 @@ public class MethodAccessChecker {
 
     private final Method method;
 
-    @VisibleForTesting
-    MethodAccessChecker(Method method) {
+    private MethodAccessChecker(Method method) {
         this.method = method;
     }
 

--- a/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.model;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.spine.annotation.Internal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * The class designed to perform various checks on the specified {@link Method} access type.
+ *
+ * <p>If such check fails, the {@linkplain Logger#warn(String) warning} will be output to the log.
+ * If the check passes, no action is performed.
+ *
+ * @author Dmytro Kuzmin
+ */
+@Internal
+public class MethodAccessChecker {
+
+    private final Method method;
+
+    @VisibleForTesting
+    MethodAccessChecker(Method method) {
+        this.method = method;
+    }
+
+    /**
+     * Creates a new instance of the {@link MethodAccessChecker} for the specified {@link Method}.
+     *
+     * @param method the method to create new instance for
+     * @return a new instance of {@code MethodAccessChecker}
+     */
+    public static MethodAccessChecker forMethod(Method method) {
+        checkNotNull(method);
+
+        return new MethodAccessChecker(method);
+    }
+
+    /**
+     * Checks that method access is {@code public}.
+     *
+     * <p>If the access is not {@code public}, {@linkplain Logger#warn(String) prints} the warning
+     * to the log with the specified {@code warningMessageFormat}.
+     *
+     * <p>{@code warningMessageFormat} should contain a placeholder for the method name.
+     *
+     * @param warningMessageFormat a formatted {@code String} representing the warning message
+     * @see String#format(String, Object...)
+     */
+    public void checkAccessIsPublic(String warningMessageFormat) {
+        if (!Modifier.isPublic(method.getModifiers())) {
+            warnOnWrongModifier(warningMessageFormat);
+        }
+    }
+
+    /**
+     * Checks that method access is {@code package-private}.
+     *
+     * <p>If the access is not {@code package-private}, {@linkplain Logger#warn(String) prints}
+     * the warning to the log with the specified {@code warningMessageFormat}.
+     *
+     * <p>{@code warningMessageFormat} should contain a placeholder for the method name.
+     *
+     * @param warningMessageFormat a formatted {@code String} representing the warning message
+     * @see String#format(String, Object...)
+     */
+    public void checkAccessIsPackagePrivate(String warningMessageFormat) {
+        if (!isPackagePrivate(method)) {
+            warnOnWrongModifier(warningMessageFormat);
+        }
+    }
+
+    /**
+     * Checks that method access is {@code private}.
+     *
+     * <p>If the access is not {@code private}, {@linkplain Logger#warn(String) prints} the warning
+     * to the log with the specified {@code warningMessageFormat}.
+     *
+     * <p>{@code warningMessageFormat} should contain a placeholder for the method name.
+     *
+     * @param warningMessageFormat a formatted {@code String} representing the warning message
+     * @see String#format(String, Object...)
+     */
+    public void checkAccessIsPrivate(String warningMessageFormat) {
+        if (!Modifier.isPrivate(method.getModifiers())) {
+            warnOnWrongModifier(warningMessageFormat);
+        }
+    }
+
+    /**
+     * Logs a message at the WARN level according to the specified format.
+     *
+     * <p>{@code messageFormat} should contain a placeholder for the method name.
+     *
+     * @param messageFormat formatted {@code String} representing the warning message
+     * @see String#format(String, Object...)
+     */
+    @VisibleForTesting
+    void warnOnWrongModifier(String messageFormat) {
+        final String methodFullName = method.getDeclaringClass()
+                                            .getName() + '.' + method.getName() + "()";
+        log().warn(messageFormat, methodFullName);
+    }
+
+    /**
+     * Checks that the specified {@link Method} has the {@code package-private} access.
+     *
+     * @param method the method to check
+     * @return {@code true} if the method has the {@code package-private} access, {@code false}
+     *         otherwise
+     */
+    private static boolean isPackagePrivate(Method method) {
+        final int modifiers = method.getModifiers();
+        final boolean result =
+                !(Modifier.isPublic(modifiers)
+                        || Modifier.isProtected(modifiers)
+                        || Modifier.isPrivate(modifiers));
+        return result;
+    }
+
+
+    /** The common logger used by MethodAccessChecker classes. */
+    private static Logger log() {
+        return LogSingleton.INSTANCE.value;
+    }
+
+    private enum LogSingleton {
+        INSTANCE;
+        @SuppressWarnings("NonSerializableFieldInSerializableClass")
+        private final Logger value = LoggerFactory.getLogger(HandlerMethod.class);
+    }
+}

--- a/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
@@ -141,7 +141,7 @@ public final class MethodAccessChecker {
     }
 
 
-    /** The common logger used by MethodAccessChecker classes. */
+    /** The logger used by the MethodAccessChecker class. */
     private static Logger log() {
         return LogSingleton.INSTANCE.value;
     }

--- a/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
@@ -55,7 +55,6 @@ public class MethodAccessChecker {
      */
     public static MethodAccessChecker forMethod(Method method) {
         checkNotNull(method);
-
         return new MethodAccessChecker(method);
     }
 

--- a/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
@@ -39,7 +39,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @author Dmytro Kuzmin
  */
 @Internal
-public class MethodAccessChecker {
+public final class MethodAccessChecker {
 
     private final Method method;
 

--- a/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
@@ -146,7 +146,6 @@ public class MethodAccessChecker {
         return result;
     }
 
-
     /** The logger used by the MethodAccessChecker class. */
     private static Logger log() {
         return LogSingleton.INSTANCE.value;

--- a/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
@@ -31,10 +31,10 @@ import java.lang.reflect.Modifier;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * The class designed to perform various checks on the specified {@link Method} access type.
+ * The checker of a {@link Method} access level.
  *
- * <p>If such check fails, the {@linkplain Logger#warn(String) warning} will be output to the log.
- * If the check passes, no action is performed.
+ * <p>If the access check fails, the {@linkplain Logger#warn(String) warning} will be output to
+ * the log. If the check passes, no action is performed.
  *
  * @author Dmytro Kuzmin
  */

--- a/server/src/main/java/io/spine/server/model/MethodExceptionChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodExceptionChecker.java
@@ -37,7 +37,7 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  * <p>This class checks whether exception types thrown by the method match the provided list of
  * allowed exception types.
  *
- * <p>If such a check fails, the {@link IllegalStateException} will be thrown. If the check passes,
+ * <p>If such check fails, the {@link IllegalStateException} will be thrown. If the check passes,
  * no action is performed.
  *
  * @author Dmytro Kuzmin

--- a/server/src/main/java/io/spine/server/model/MethodExceptionChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodExceptionChecker.java
@@ -32,7 +32,7 @@ import static com.google.common.collect.Lists.newLinkedList;
 import static io.spine.util.Exceptions.newIllegalStateException;
 
 /**
- * The checker of a {@link Method} thrown exception types.
+ * The checker of the exception types thrown by a {@link Method}.
  *
  * <p>This class checks whether exception types thrown by the method match the provided list of
  * allowed exception types.

--- a/server/src/main/java/io/spine/server/model/MethodExceptionChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodExceptionChecker.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.model;
+
+import com.google.common.base.Joiner;
+import io.spine.annotation.Internal;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Lists.newLinkedList;
+import static io.spine.util.Exceptions.newIllegalStateException;
+
+/**
+ * The class designed to perform various checks on the specified {@link Method}'s thrown
+ * exception types.
+ *
+ * <p>If such check fails, the {@link IllegalStateException} will be thrown. If the check passes,
+ * no action is performed.
+ *
+ * @author Dmytro Kuzmin
+ */
+@Internal
+public class MethodExceptionChecker {
+
+    private final Method method;
+
+    private MethodExceptionChecker(Method method) {
+        this.method = method;
+    }
+
+    /**
+     * Creates new instance of the {@link MethodExceptionChecker} for the specified {@link Method}.
+     *
+     * @param method the method to create new instance for
+     * @return a new instance of {@code MethodExceptionChecker}
+     */
+    public static MethodExceptionChecker forMethod(Method method) {
+        checkNotNull(method);
+
+        return new MethodExceptionChecker(method);
+    }
+
+    /**
+     * Ensures that contained {@link Method} does not declare any thrown checked exceptions.
+     *
+     * <p>{@link RuntimeException} and its descendants can still be declared and thrown from
+     * the method.
+     *
+     * @throws IllegalStateException if the check fails
+     */
+    public void checkThrowsNoCheckedExceptions() {
+        checkThrowsNoExceptionsExcept(RuntimeException.class);
+    }
+
+    /**
+     * Checks that contained {@link Method} declares no thrown exception types except the ones
+     * specified and their descendants.
+     *
+     * @param exceptionTypes the allowed exception types
+     * @throws IllegalStateException if the method throws any exception types apart from the
+     *                               specified types and their descendants
+     */
+    public void checkThrowsNoExceptionsExcept(Class<?>... exceptionTypes) {
+        checkNotNull(exceptionTypes);
+
+        final Collection<Class<?>> allowedExceptions = Arrays.asList(exceptionTypes);
+        final Collection<Class<?>> exceptions =
+                obtainProhibitedExceptionsThrown(allowedExceptions);
+        if (!exceptions.isEmpty()) {
+            throwCheckFailedException(exceptions, allowedExceptions);
+        }
+    }
+
+    /**
+     * Obtain the {@link Collection} of prohibited exception types thrown by the {@link Method}.
+     *
+     * <p>Exception types are considered prohibited if they are not contained in the
+     * {@code allowedExceptions} and are not descendants of any types from the
+     * {@code allowedExceptions}.
+     *
+     * @param allowedExceptions the list of exceptions whose descendants won't be considered as
+     *                          prohibited exceptions
+     * @return a {@code Collection} of prohibited exceptions thrown
+     */
+    private Collection<Class<?>>
+    obtainProhibitedExceptionsThrown(Iterable<Class<?>> allowedExceptions) {
+        final Class<?>[] thrownExceptions = method.getExceptionTypes();
+        final Collection<Class<?>> result = newLinkedList();
+        for (Class<?> exceptionType : thrownExceptions) {
+            if (!isMemberOrDescendant(exceptionType, allowedExceptions)) {
+                result.add(exceptionType);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Throws {@link RuntimeException} with diagnostics information about the prohibited exception
+     * types thrown from the {@link Method}.
+     *
+     * <p>The message of the exception thrown will provide the user with the info about prohibited
+     * exception types thrown by the contained {@link Method}, as well as which exception types are
+     * allowed for this {@link Method}.
+     *
+     * @param exceptionsThrown  the list of prohibited exceptions thrown
+     * @param allowedExceptions the list of allowed exceptions for the contained {@link Method}
+     */
+    private void throwCheckFailedException(Iterable<Class<?>> exceptionsThrown,
+                                           Iterable<Class<?>> allowedExceptions) {
+        throw newIllegalStateException(
+                "Method %s#%s throws prohibited exception types: %s. " +
+                        "The allowed exception types for this method are: %s",
+                method.getDeclaringClass()
+                      .getCanonicalName(),
+                method.getName(),
+                iterableToString(exceptionsThrown),
+                iterableToString(allowedExceptions)
+        );
+    }
+
+    /**
+     * Checks if the specified exception type is among the specified list of types or is a
+     * descendant of any of them, or none.
+     *
+     * @param exceptionType  the exception type to check
+     * @param exceptionTypes the exception types among which the type is searched
+     * @return {@code true} if specified exception type is member or descendant of one of the
+     *         specified types, {@code false} otherwise.
+     */
+    private static boolean
+    isMemberOrDescendant(Class<?> exceptionType, Iterable<Class<?>> exceptionTypes) {
+        for (Class<?> type : exceptionTypes) {
+            if (isEqualOrSubclass(exceptionType, type)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the specified {@link Class} is the same class as the specified {@linkplain Class
+     * superclass} or its descendant.
+     *
+     * @param classCandidate the class to check
+     * @param superClass     the class to check against
+     * @return {@code true} if the {@code classCandidate} is the same class as {@code superClass}
+     *         or its descendant, {@code false} otherwise.
+     */
+    private static boolean isEqualOrSubclass(Class<?> classCandidate, Class<?> superClass) {
+        return superClass.isAssignableFrom(classCandidate);
+    }
+
+    /**
+     * Prints {@link Iterable} to {@link String}, separating all its elements by comma.
+     *
+     * @param iterable the {@code Iterable} to print
+     * @return the {@code String} containing all {@code Iterable}'s elements separated by comma
+     */
+    private static String iterableToString(Iterable<Class<?>> iterable) {
+        return Joiner.on(",").join(iterable);
+    }
+}

--- a/server/src/main/java/io/spine/server/model/MethodExceptionChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodExceptionChecker.java
@@ -32,10 +32,12 @@ import static com.google.common.collect.Lists.newLinkedList;
 import static io.spine.util.Exceptions.newIllegalStateException;
 
 /**
- * The class designed to perform various checks on the specified {@link Method}'s thrown
- * exception types.
+ * The checker of a {@link Method} thrown exception types.
  *
- * <p>If such check fails, the {@link IllegalStateException} will be thrown. If the check passes,
+ * <p>This class checks whether exception types thrown by the method match the provided list of
+ * allowed exception types.
+ *
+ * <p>If such a check fails, the {@link IllegalStateException} will be thrown. If the check passes,
  * no action is performed.
  *
  * @author Dmytro Kuzmin

--- a/server/src/main/java/io/spine/server/model/MethodExceptionChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodExceptionChecker.java
@@ -130,7 +130,7 @@ public class MethodExceptionChecker {
     private void throwCheckFailedException(Iterable<Class<?>> exceptionsThrown,
                                            Iterable<Class<?>> allowedExceptions) {
         throw newIllegalStateException(
-                "Method %s#%s throws prohibited exception types: %s. " +
+                "Method %s.%s throws prohibited exception types: %s. " +
                         "The allowed exception types for this method are: %s",
                 method.getDeclaringClass()
                       .getCanonicalName(),

--- a/server/src/main/java/io/spine/server/model/MethodExceptionChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodExceptionChecker.java
@@ -71,21 +71,21 @@ public class MethodExceptionChecker {
      * @throws IllegalStateException if the check fails
      */
     public void checkThrowsNoCheckedExceptions() {
-        checkThrowsNoExceptionsExcept(RuntimeException.class);
+        checkThrowsNoExceptionsBut(RuntimeException.class);
     }
 
     /**
      * Checks that contained {@link Method} declares no thrown exception types except the ones
-     * specified and their descendants.
+     * specified as the {@code whiteList} and their descendants.
      *
-     * @param exceptionTypes the allowed exception types
+     * @param whiteList the allowed exception types
      * @throws IllegalStateException if the method throws any exception types apart from the
-     *                               specified types and their descendants
+     *                               types specified in {@code whiteList} and their descendants
      */
-    public void checkThrowsNoExceptionsExcept(Class<?>... exceptionTypes) {
-        checkNotNull(exceptionTypes);
+    public void checkThrowsNoExceptionsBut(Class<?>... whiteList) {
+        checkNotNull(whiteList);
 
-        final Collection<Class<?>> allowedExceptions = Arrays.asList(exceptionTypes);
+        final Collection<Class<?>> allowedExceptions = Arrays.asList(whiteList);
         final Collection<Class<?>> exceptions =
                 obtainProhibitedExceptionsThrown(allowedExceptions);
         if (!exceptions.isEmpty()) {

--- a/server/src/main/java/io/spine/server/model/MethodExceptionChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodExceptionChecker.java
@@ -57,7 +57,6 @@ public class MethodExceptionChecker {
      */
     public static MethodExceptionChecker forMethod(Method method) {
         checkNotNull(method);
-
         return new MethodExceptionChecker(method);
     }
 

--- a/server/src/main/java/io/spine/server/rejection/RejectionReactorMethod.java
+++ b/server/src/main/java/io/spine/server/rejection/RejectionReactorMethod.java
@@ -26,13 +26,14 @@ import io.spine.annotation.Internal;
 import io.spine.core.React;
 import io.spine.core.RejectionContext;
 import io.spine.server.model.HandlerMethod;
+import io.spine.server.model.MethodAccessChecker;
 import io.spine.server.model.MethodPredicate;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.List;
 
 import static io.spine.server.model.HandlerMethods.ensureExternalMatch;
+import static io.spine.server.model.MethodAccessChecker.forMethod;
 
 /**
  * A wrapper for a rejection reactor method.
@@ -93,17 +94,11 @@ public class RejectionReactorMethod extends RejectionHandlerMethod {
     /**
      * The factory for filtering methods that match {@code RejectionReactorMethod} specification.
      */
-    private static class Factory implements HandlerMethod.Factory<RejectionReactorMethod> {
+    private static class Factory extends HandlerMethod.Factory<RejectionReactorMethod> {
 
         @Override
         public Class<RejectionReactorMethod> getMethodClass() {
             return RejectionReactorMethod.class;
-        }
-
-        @Override
-        public RejectionReactorMethod create(Method method) {
-            final RejectionReactorMethod result = new RejectionReactorMethod(method);
-            return result;
         }
 
         @Override
@@ -113,10 +108,14 @@ public class RejectionReactorMethod extends RejectionHandlerMethod {
 
         @Override
         public void checkAccessModifier(Method method) {
-            if (!Modifier.isPublic(method.getModifiers())) {
-                warnOnWrongModifier("Rejection reactor {} must be declared 'public'",
-                                    method);
-            }
+            final MethodAccessChecker checker = forMethod(method);
+            checker.checkAccessIsPublic("Rejection reactor {} must be declared 'public'");
+        }
+
+        @Override
+        protected RejectionReactorMethod createForMethod(Method method) {
+            final RejectionReactorMethod result = new RejectionReactorMethod(method);
+            return result;
         }
 
         private enum Singleton {

--- a/server/src/main/java/io/spine/server/rejection/RejectionReactorMethod.java
+++ b/server/src/main/java/io/spine/server/rejection/RejectionReactorMethod.java
@@ -113,7 +113,7 @@ public class RejectionReactorMethod extends RejectionHandlerMethod {
         }
 
         @Override
-        protected RejectionReactorMethod createForMethod(Method method) {
+        protected RejectionReactorMethod createFromMethod(Method method) {
             final RejectionReactorMethod result = new RejectionReactorMethod(method);
             return result;
         }

--- a/server/src/main/java/io/spine/server/rejection/RejectionReactorMethod.java
+++ b/server/src/main/java/io/spine/server/rejection/RejectionReactorMethod.java
@@ -109,7 +109,7 @@ public class RejectionReactorMethod extends RejectionHandlerMethod {
         @Override
         public void checkAccessModifier(Method method) {
             final MethodAccessChecker checker = forMethod(method);
-            checker.checkAccessIsPublic("Rejection reactor {} must be declared 'public'");
+            checker.checkPublic("Rejection reactor {} must be declared 'public'");
         }
 
         @Override

--- a/server/src/main/java/io/spine/server/rejection/RejectionSubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/rejection/RejectionSubscriberMethod.java
@@ -107,7 +107,7 @@ public class RejectionSubscriberMethod extends RejectionHandlerMethod {
         }
 
         @Override
-        protected RejectionSubscriberMethod createForMethod(Method method) {
+        protected RejectionSubscriberMethod createFromMethod(Method method) {
             final RejectionSubscriberMethod result = new RejectionSubscriberMethod(method);
             return result;
         }

--- a/server/src/main/java/io/spine/server/rejection/RejectionSubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/rejection/RejectionSubscriberMethod.java
@@ -103,7 +103,7 @@ public class RejectionSubscriberMethod extends RejectionHandlerMethod {
         @Override
         public void checkAccessModifier(Method method) {
             final MethodAccessChecker checker = forMethod(method);
-            checker.checkAccessIsPublic("Rejection subscriber {} must be declared 'public'");
+            checker.checkPublic("Rejection subscriber {} must be declared 'public'");
         }
 
         @Override

--- a/server/src/main/java/io/spine/server/rejection/RejectionSubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/rejection/RejectionSubscriberMethod.java
@@ -26,12 +26,13 @@ import io.spine.annotation.Internal;
 import io.spine.core.RejectionContext;
 import io.spine.core.Subscribe;
 import io.spine.server.model.HandlerMethod;
+import io.spine.server.model.MethodAccessChecker;
 import io.spine.server.model.MethodPredicate;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 
 import static io.spine.server.model.HandlerMethods.ensureExternalMatch;
+import static io.spine.server.model.MethodAccessChecker.forMethod;
 
 /**
  * A wrapper for a rejection subscriber method.
@@ -87,17 +88,11 @@ public class RejectionSubscriberMethod extends RejectionHandlerMethod {
     /**
      * The factory for filtering methods that match {@code RejectionSubscriberMethod} specification.
      */
-    private static class Factory implements HandlerMethod.Factory<RejectionSubscriberMethod> {
+    private static class Factory extends HandlerMethod.Factory<RejectionSubscriberMethod> {
 
         @Override
         public Class<RejectionSubscriberMethod> getMethodClass() {
             return RejectionSubscriberMethod.class;
-        }
-
-        @Override
-        public RejectionSubscriberMethod create(Method method) {
-            final RejectionSubscriberMethod result = new RejectionSubscriberMethod(method);
-            return result;
         }
 
         @Override
@@ -107,10 +102,14 @@ public class RejectionSubscriberMethod extends RejectionHandlerMethod {
 
         @Override
         public void checkAccessModifier(Method method) {
-            if (!Modifier.isPublic(method.getModifiers())) {
-                warnOnWrongModifier("Rejection subscriber {} must be declared 'public'",
-                                    method);
-            }
+            final MethodAccessChecker checker = forMethod(method);
+            checker.checkAccessIsPublic("Rejection subscriber {} must be declared 'public'");
+        }
+
+        @Override
+        protected RejectionSubscriberMethod createForMethod(Method method) {
+            final RejectionSubscriberMethod result = new RejectionSubscriberMethod(method);
+            return result;
         }
 
         private enum Singleton {

--- a/server/src/test/java/io/spine/server/commandbus/CommandStoreShould.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandStoreShould.java
@@ -255,8 +255,7 @@ public abstract class CommandStoreShould extends AbstractCommandBusTestSuite {
     }
 
     /**
-     * A stub handler that throws passed `RuntimeException` in the command handler method,
-     * rejecting the command.
+     * A stub handler that throws passed `RuntimeException` in the command handler method.
      *
      * @see #set_command_status_to_error_when_handler_throws_exception()
      */

--- a/server/src/test/java/io/spine/server/commandbus/CommandStoreShould.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandStoreShould.java
@@ -238,7 +238,7 @@ public abstract class CommandStoreShould extends AbstractCommandBusTestSuite {
 
         @Assign
         @SuppressWarnings({"unused"})
-            // Throwing is the purpose of this method.
+            // Reflective access.
         CmdProjectCreated handle(CmdCreateProject msg,
                                  CommandContext context) throws ThrowableMessage {
             throw throwable;
@@ -271,7 +271,7 @@ public abstract class CommandStoreShould extends AbstractCommandBusTestSuite {
 
         @Assign
         @SuppressWarnings({"unused"})
-            // Throwing is the purpose of this method.
+            // Reflective access.
         CmdProjectCreated handle(CmdCreateProject msg, CommandContext context) {
             throw exception;
         }

--- a/server/src/test/java/io/spine/server/model/HandlerMethodShould.java
+++ b/server/src/test/java/io/spine/server/model/HandlerMethodShould.java
@@ -269,9 +269,9 @@ public class HandlerMethodShould {
 
         private static class Factory extends HandlerMethod.Factory<OneParamMethod> {
 
-            private static final OneParamMethod.Factory INSTANCE = new OneParamMethod.Factory();
+            private static final Factory INSTANCE = new Factory();
 
-            private static OneParamMethod.Factory getInstance() {
+            private static Factory getInstance() {
                 return INSTANCE;
             }
 

--- a/server/src/test/java/io/spine/server/model/HandlerMethodShould.java
+++ b/server/src/test/java/io/spine/server/model/HandlerMethodShould.java
@@ -137,8 +137,7 @@ public class HandlerMethodShould {
         assertNotEquals(System.identityHashCode(twoParamMethod), twoParamMethod.hashCode());
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
-    // The purpose of the method is to throw exception.
+    @SuppressWarnings("ResultOfMethodCallIgnored") // Method is called only to throw exception.
     @Test(expected = IllegalStateException.class)
     public void do_not_be_created_from_method_with_checked_exception() {
         factory.create(StubHandler.getMethodWithCheckedException());

--- a/server/src/test/java/io/spine/server/model/HandlerMethodShould.java
+++ b/server/src/test/java/io/spine/server/model/HandlerMethodShould.java
@@ -145,8 +145,7 @@ public class HandlerMethodShould {
 
     @Test
     public void be_normally_created_from_method_with_runtime_exception() {
-        final OneParamMethod method =
-                factory.create(StubHandler.getMethodWithRuntimeException());
+        final OneParamMethod method = factory.create(StubHandler.getMethodWithRuntimeException());
         assertEquals(StubHandler.getMethodWithRuntimeException(), method.getMethod());
     }
 

--- a/server/src/test/java/io/spine/server/model/HandlerMethodShould.java
+++ b/server/src/test/java/io/spine/server/model/HandlerMethodShould.java
@@ -292,7 +292,7 @@ public class HandlerMethodShould {
             }
 
             @Override
-            protected OneParamMethod createForMethod(Method method) {
+            protected OneParamMethod createFromMethod(Method method) {
                 return new OneParamMethod(method);
             }
         }

--- a/server/src/test/java/io/spine/server/model/HandlerMethodShould.java
+++ b/server/src/test/java/io/spine/server/model/HandlerMethodShould.java
@@ -137,9 +137,10 @@ public class HandlerMethodShould {
         assertNotEquals(System.identityHashCode(twoParamMethod), twoParamMethod.hashCode());
     }
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    // The purpose of the method is to throw exception.
     @Test(expected = IllegalStateException.class)
     public void do_not_be_created_from_method_with_checked_exception() {
-        //noinspection ResultOfMethodCallIgnored
         factory.create(StubHandler.getMethodWithCheckedException());
     }
 
@@ -192,7 +193,6 @@ public class HandlerMethodShould {
             final Method method;
             final Class<?> clazz = StubHandler.class;
             try {
-                //noinspection DuplicateStringLiteralInspection
                 method = clazz.getDeclaredMethod("handle", BoolValue.class);
             } catch (NoSuchMethodException e) {
                 throw new IllegalStateException(e);

--- a/server/src/test/java/io/spine/server/model/MethodAccessCheckerShould.java
+++ b/server/src/test/java/io/spine/server/model/MethodAccessCheckerShould.java
@@ -20,7 +20,7 @@
 
 package io.spine.server.model;
 
-import io.spine.test.Tests;
+import com.google.common.testing.NullPointerTester;
 import org.junit.Test;
 
 import java.lang.reflect.Method;
@@ -38,10 +38,13 @@ public class MethodAccessCheckerShould {
 
     public static final String STUB_WARNING_MESSAGE = "Stub warning message";
 
-    @Test(expected = NullPointerException.class)
-    public void do_not_accept_null_method() {
-        //noinspection ResultOfMethodCallIgnored
-        forMethod(Tests.<Method>nullRef());
+    @Test
+    public void pass_null_check() {
+        new NullPointerTester().testAllPublicStaticMethods(MethodAccessChecker.class);
+
+        final Method method = getMethod("publicMethod");
+        final MethodAccessChecker checker = forMethod(method);
+        new NullPointerTester().testAllPublicInstanceMethods(checker);
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/model/MethodAccessCheckerShould.java
+++ b/server/src/test/java/io/spine/server/model/MethodAccessCheckerShould.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.model;
+
+import io.spine.test.Tests;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static io.spine.server.model.MethodAccessChecker.forMethod;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Dmytro Kuzmin
+ */
+public class MethodAccessCheckerShould {
+
+    public static final String STUB_WARNING_MESSAGE = "Stub warning message";
+
+    @Test(expected = NullPointerException.class)
+    public void do_not_accept_null_method() {
+        //noinspection ResultOfMethodCallIgnored
+        forMethod(Tests.<Method>nullRef());
+    }
+
+    @Test
+    public void do_not_log_warning_on_correct_access_modifier() {
+        final Method publicMethod = getMethod("publicMethod");
+        final TestMethodAccessChecker checkerPublic = testAccessCheckerFor(publicMethod);
+        checkerPublic.checkAccessIsPublic(STUB_WARNING_MESSAGE);
+        assertEquals(0, checkerPublic.getWarningCount());
+
+        final Method packagePrivateMethod = getMethod("packagePrivateMethod");
+        final TestMethodAccessChecker checkerPackagePrivate =
+                testAccessCheckerFor(packagePrivateMethod);
+        checkerPackagePrivate.checkAccessIsPackagePrivate(STUB_WARNING_MESSAGE);
+        assertEquals(0, checkerPackagePrivate.getWarningCount());
+
+        final Method privateMethod = getMethod("privateMethod");
+        final TestMethodAccessChecker checkerPrivate = testAccessCheckerFor(privateMethod);
+        checkerPrivate.checkAccessIsPrivate(STUB_WARNING_MESSAGE);
+        assertEquals(0, checkerPrivate.getWarningCount());
+    }
+
+    @Test
+    public void log_warning_on_incorrect_access_modifier() {
+        final Method method = getMethod("protectedMethod");
+        final TestMethodAccessChecker checker = testAccessCheckerFor(method);
+        checker.checkAccessIsPublic(STUB_WARNING_MESSAGE);
+        checker.checkAccessIsPackagePrivate(STUB_WARNING_MESSAGE);
+        checker.checkAccessIsPrivate(STUB_WARNING_MESSAGE);
+        assertEquals(3, checker.getWarningCount());
+    }
+
+    private static Method getMethod(String methodName) {
+        final Method method;
+        final Class<?> clazz = StubMethodContainer.class;
+        try {
+            method = clazz.getDeclaredMethod(methodName);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException(e);
+        }
+        return method;
+    }
+
+    private static TestMethodAccessChecker testAccessCheckerFor(Method method) {
+        return new TestMethodAccessChecker(method);
+    }
+
+    private static class StubMethodContainer {
+
+        @SuppressWarnings("unused") // Reflective access
+        public void publicMethod() {
+
+        }
+
+        @SuppressWarnings("unused") // Reflective access
+        protected void protectedMethod() {
+
+        }
+
+        @SuppressWarnings("unused")
+            // Reflective access
+        void packagePrivateMethod() {
+
+        }
+
+        @SuppressWarnings("unused") // Reflective access
+        private void privateMethod() {
+
+        }
+    }
+
+    /**
+     * Testing method access checker which allows to trace whether the warning function was called
+     * and how many times.
+     */
+    private static class TestMethodAccessChecker extends MethodAccessChecker {
+
+        private int warningCount;
+
+        private TestMethodAccessChecker(Method method) {
+            super(method);
+            warningCount = 0;
+        }
+
+        @Override
+        void warnOnWrongModifier(String messageFormat) {
+            super.warnOnWrongModifier(messageFormat);
+            warningCount++;
+        }
+
+        private int getWarningCount() {
+            return warningCount;
+        }
+    }
+}

--- a/server/src/test/java/io/spine/server/model/MethodAccessCheckerShould.java
+++ b/server/src/test/java/io/spine/server/model/MethodAccessCheckerShould.java
@@ -87,23 +87,23 @@ public class MethodAccessCheckerShould {
 
     private static class StubMethodContainer {
 
-        @SuppressWarnings("unused") // Reflective access
+        @SuppressWarnings("unused") // Reflective access.
         public void publicMethod() {
 
         }
 
-        @SuppressWarnings("unused") // Reflective access
+        @SuppressWarnings("unused") // Reflective access.
         protected void protectedMethod() {
 
         }
 
         @SuppressWarnings("unused")
-            // Reflective access
+            // Reflective access.
         void packagePrivateMethod() {
 
         }
 
-        @SuppressWarnings("unused") // Reflective access
+        @SuppressWarnings("unused") // Reflective access.
         private void privateMethod() {
 
         }

--- a/server/src/test/java/io/spine/server/model/MethodAccessCheckerShould.java
+++ b/server/src/test/java/io/spine/server/model/MethodAccessCheckerShould.java
@@ -87,23 +87,19 @@ public class MethodAccessCheckerShould {
 
         @SuppressWarnings("unused") // Reflective access.
         public void publicMethod() {
-
         }
 
         @SuppressWarnings("unused") // Reflective access.
         protected void protectedMethod() {
-
         }
 
         @SuppressWarnings("unused")
             // Reflective access.
         void packagePrivateMethod() {
-
         }
 
         @SuppressWarnings("unused") // Reflective access.
         private void privateMethod() {
-
         }
     }
 }

--- a/server/src/test/java/io/spine/server/model/MethodAccessCheckerShould.java
+++ b/server/src/test/java/io/spine/server/model/MethodAccessCheckerShould.java
@@ -48,17 +48,17 @@ public class MethodAccessCheckerShould {
     public void do_not_log_warning_on_correct_access_modifier() {
         final Method publicMethod = getMethod("publicMethod");
         final MethodAccessChecker checkerPublic = spy(forMethod(publicMethod));
-        checkerPublic.checkAccessIsPublic(STUB_WARNING_MESSAGE);
+        checkerPublic.checkPublic(STUB_WARNING_MESSAGE);
         verify(checkerPublic, never()).warnOnWrongModifier(STUB_WARNING_MESSAGE);
 
         final Method packagePrivateMethod = getMethod("packagePrivateMethod");
         final MethodAccessChecker checkerPackagePrivate = spy(forMethod(packagePrivateMethod));
-        checkerPackagePrivate.checkAccessIsPackagePrivate(STUB_WARNING_MESSAGE);
+        checkerPackagePrivate.checkPackagePrivate(STUB_WARNING_MESSAGE);
         verify(checkerPackagePrivate, never()).warnOnWrongModifier(STUB_WARNING_MESSAGE);
 
         final Method privateMethod = getMethod("privateMethod");
         final MethodAccessChecker checkerPrivate = spy(forMethod(privateMethod));
-        checkerPrivate.checkAccessIsPrivate(STUB_WARNING_MESSAGE);
+        checkerPrivate.checkPrivate(STUB_WARNING_MESSAGE);
         verify(checkerPrivate, never()).warnOnWrongModifier(STUB_WARNING_MESSAGE);
     }
 
@@ -66,9 +66,9 @@ public class MethodAccessCheckerShould {
     public void log_warning_on_incorrect_access_modifier() {
         final Method method = getMethod("protectedMethod");
         final MethodAccessChecker checker = spy(forMethod(method));
-        checker.checkAccessIsPublic(STUB_WARNING_MESSAGE);
-        checker.checkAccessIsPackagePrivate(STUB_WARNING_MESSAGE);
-        checker.checkAccessIsPrivate(STUB_WARNING_MESSAGE);
+        checker.checkPublic(STUB_WARNING_MESSAGE);
+        checker.checkPackagePrivate(STUB_WARNING_MESSAGE);
+        checker.checkPrivate(STUB_WARNING_MESSAGE);
         verify(checker, times(3)).warnOnWrongModifier(STUB_WARNING_MESSAGE);
     }
 

--- a/server/src/test/java/io/spine/server/model/MethodExceptionCheckerShould.java
+++ b/server/src/test/java/io/spine/server/model/MethodExceptionCheckerShould.java
@@ -62,14 +62,14 @@ public class MethodExceptionCheckerShould {
         //noinspection DuplicateStringLiteralInspection
         final Method methodCustomException = getMethod("methodCustomException");
         final MethodExceptionChecker checker = forMethod(methodCustomException);
-        checker.checkThrowsNoExceptionsExcept(IOException.class);
+        checker.checkThrowsNoExceptionsBut(IOException.class);
     }
 
     @Test
     public void pass_check_for_allowed_exception_types_descendants() {
         final Method methodDescendantException = getMethod("methodDescendantException");
         final MethodExceptionChecker checker = forMethod(methodDescendantException);
-        checker.checkThrowsNoExceptionsExcept(RuntimeException.class);
+        checker.checkThrowsNoExceptionsBut(RuntimeException.class);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -77,7 +77,7 @@ public class MethodExceptionCheckerShould {
         //noinspection DuplicateStringLiteralInspection
         final Method methodCustomException = getMethod("methodCustomException");
         final MethodExceptionChecker checker = forMethod(methodCustomException);
-        checker.checkThrowsNoExceptionsExcept(RuntimeException.class);
+        checker.checkThrowsNoExceptionsBut(RuntimeException.class);
     }
 
     private static Method getMethod(String methodName) {

--- a/server/src/test/java/io/spine/server/model/MethodExceptionCheckerShould.java
+++ b/server/src/test/java/io/spine/server/model/MethodExceptionCheckerShould.java
@@ -20,7 +20,7 @@
 
 package io.spine.server.model;
 
-import io.spine.test.Tests;
+import com.google.common.testing.NullPointerTester;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -33,10 +33,13 @@ import static io.spine.server.model.MethodExceptionChecker.forMethod;
  */
 public class MethodExceptionCheckerShould {
 
-    @Test(expected = NullPointerException.class)
-    public void do_not_accept_null_method() {
-        //noinspection ResultOfMethodCallIgnored
-        forMethod(Tests.<Method>nullRef());
+    @Test
+    public void pass_null_check() {
+        new NullPointerTester().testAllPublicStaticMethods(MethodExceptionChecker.class);
+
+        final Method method = getMethod("methodNoExceptions");
+        final MethodExceptionChecker checker = forMethod(method);
+        new NullPointerTester().testAllPublicInstanceMethods(checker);
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/model/MethodExceptionCheckerShould.java
+++ b/server/src/test/java/io/spine/server/model/MethodExceptionCheckerShould.java
@@ -95,7 +95,6 @@ public class MethodExceptionCheckerShould {
 
         @SuppressWarnings("unused") // Reflective access.
         private static void methodNoExceptions() {
-
         }
 
         @SuppressWarnings("unused") // Reflective access.

--- a/server/src/test/java/io/spine/server/model/MethodExceptionCheckerShould.java
+++ b/server/src/test/java/io/spine/server/model/MethodExceptionCheckerShould.java
@@ -31,7 +31,7 @@ import static io.spine.server.model.MethodExceptionChecker.forMethod;
 /**
  * @author Dmytro Kuzmin
  */
-public class MethodExceptionsCheckerShould {
+public class MethodExceptionCheckerShould {
 
     @Test(expected = NullPointerException.class)
     public void do_not_accept_null_method() {
@@ -92,6 +92,7 @@ public class MethodExceptionsCheckerShould {
     }
 
     private static class StubMethodContainer {
+
         @SuppressWarnings("unused") // Reflective access
         private static void methodNoExceptions() {
 

--- a/server/src/test/java/io/spine/server/model/MethodExceptionCheckerShould.java
+++ b/server/src/test/java/io/spine/server/model/MethodExceptionCheckerShould.java
@@ -93,27 +93,27 @@ public class MethodExceptionCheckerShould {
 
     private static class StubMethodContainer {
 
-        @SuppressWarnings("unused") // Reflective access
+        @SuppressWarnings("unused") // Reflective access.
         private static void methodNoExceptions() {
 
         }
 
-        @SuppressWarnings("unused") // Reflective access
+        @SuppressWarnings("unused") // Reflective access.
         private static void methodCheckedException() throws Exception {
             throw new IOException("Test checked exception");
         }
 
-        @SuppressWarnings("unused") // Reflective access
+        @SuppressWarnings("unused") // Reflective access.
         private static void methodRuntimeException() throws RuntimeException {
             throw new RuntimeException("Test runtime exception");
         }
 
-        @SuppressWarnings("unused") // Reflective access
+        @SuppressWarnings("unused") // Reflective access.
         private static void methodCustomException() throws IOException {
             throw new IOException("Test custom exception");
         }
 
-        @SuppressWarnings("unused") // Reflective access
+        @SuppressWarnings("unused") // Reflective access.
         private static void methodDescendantException() throws IllegalStateException {
             throw new IllegalStateException("Test descendant exception");
         }

--- a/server/src/test/java/io/spine/server/model/MethodExceptionCheckerShould.java
+++ b/server/src/test/java/io/spine/server/model/MethodExceptionCheckerShould.java
@@ -62,7 +62,6 @@ public class MethodExceptionCheckerShould {
 
     @Test
     public void pass_check_for_allowed_custom_exception_types() {
-        //noinspection DuplicateStringLiteralInspection
         final Method methodCustomException = getMethod("methodCustomException");
         final MethodExceptionChecker checker = forMethod(methodCustomException);
         checker.checkThrowsNoExceptionsBut(IOException.class);
@@ -77,7 +76,6 @@ public class MethodExceptionCheckerShould {
 
     @Test(expected = IllegalStateException.class)
     public void fail_check_for_prohibited_custom_exception_types() {
-        //noinspection DuplicateStringLiteralInspection
         final Method methodCustomException = getMethod("methodCustomException");
         final MethodExceptionChecker checker = forMethod(methodCustomException);
         checker.checkThrowsNoExceptionsBut(RuntimeException.class);

--- a/server/src/test/java/io/spine/server/model/MethodExceptionsCheckerShould.java
+++ b/server/src/test/java/io/spine/server/model/MethodExceptionsCheckerShould.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2018, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.model;
+
+import io.spine.test.Tests;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+import static io.spine.server.model.MethodExceptionChecker.forMethod;
+
+/**
+ * @author Dmytro Kuzmin
+ */
+public class MethodExceptionsCheckerShould {
+
+    @Test(expected = NullPointerException.class)
+    public void do_not_accept_null_method() {
+        //noinspection ResultOfMethodCallIgnored
+        forMethod(Tests.<Method>nullRef());
+    }
+
+    @Test
+    public void pass_check_when_no_checked_exceptions_thrown() {
+        final Method methodNoExceptions = getMethod("methodNoExceptions");
+        final MethodExceptionChecker noExceptionsChecker = forMethod(methodNoExceptions);
+        noExceptionsChecker.checkThrowsNoCheckedExceptions();
+
+        final Method methodRuntimeExceptions = getMethod("methodRuntimeException");
+        final MethodExceptionChecker runtimeExceptionsChecker = forMethod(methodRuntimeExceptions);
+        runtimeExceptionsChecker.checkThrowsNoCheckedExceptions();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void fail_check_when_checked_exceptions_thrown() {
+        final Method methodCheckedException = getMethod("methodCheckedException");
+        final MethodExceptionChecker checker = forMethod(methodCheckedException);
+        checker.checkThrowsNoCheckedExceptions();
+    }
+
+    @Test
+    public void pass_check_for_allowed_custom_exception_types() {
+        //noinspection DuplicateStringLiteralInspection
+        final Method methodCustomException = getMethod("methodCustomException");
+        final MethodExceptionChecker checker = forMethod(methodCustomException);
+        checker.checkThrowsNoExceptionsExcept(IOException.class);
+    }
+
+    @Test
+    public void pass_check_for_allowed_exception_types_descendants() {
+        final Method methodDescendantException = getMethod("methodDescendantException");
+        final MethodExceptionChecker checker = forMethod(methodDescendantException);
+        checker.checkThrowsNoExceptionsExcept(RuntimeException.class);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void fail_check_for_prohibited_custom_exception_types() {
+        //noinspection DuplicateStringLiteralInspection
+        final Method methodCustomException = getMethod("methodCustomException");
+        final MethodExceptionChecker checker = forMethod(methodCustomException);
+        checker.checkThrowsNoExceptionsExcept(RuntimeException.class);
+    }
+
+    private static Method getMethod(String methodName) {
+        final Method method;
+        final Class<?> clazz = StubMethodContainer.class;
+        try {
+            method = clazz.getDeclaredMethod(methodName);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException(e);
+        }
+        return method;
+    }
+
+    private static class StubMethodContainer {
+        @SuppressWarnings("unused") // Reflective access
+        private static void methodNoExceptions() {
+
+        }
+
+        @SuppressWarnings("unused") // Reflective access
+        private static void methodCheckedException() throws Exception {
+            throw new IOException("Test checked exception");
+        }
+
+        @SuppressWarnings("unused") // Reflective access
+        private static void methodRuntimeException() throws RuntimeException {
+            throw new RuntimeException("Test runtime exception");
+        }
+
+        @SuppressWarnings("unused") // Reflective access
+        private static void methodCustomException() throws IOException {
+            throw new IOException("Test custom exception");
+        }
+
+        @SuppressWarnings("unused") // Reflective access
+        private static void methodDescendantException() throws IllegalStateException {
+            throw new IllegalStateException("Test descendant exception");
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes issue https://github.com/SpineEventEngine/core-java/issues/548.

Previously, it was possible to declare a method annotated as message handler (e.g. `@Assign`, `@React` etc.) as one throwing checked exceptions. Then, after reflective invocation, such checked exceptions were not caught, leading to an undefined behavior.

Now, it is forbidden to declare message handling methods as ones throwing checked exceptions. If such declaration occurs, the handler creation mechanism will throw `IllegalStateException` during run-time. `RuntimeException` and its descendants can be still thrown and declared for such methods.

The exception to this rule is `ThrowableMessage` checked exception type allowed to be thrown from the command handler methods. This is done due to `ThrowableMessage` being part of the logic manipulating with `Rejection`s. It's propagation is handled correctly by the method invocation mechanism.