### PR TITLE
Remove GCS Plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ before_install:
 script:
   - ./gradlew check --stacktrace
 
-  - ./gradlew cleanGCS --info
-
   # The publishing script should be executed in `script` section in order to
   # fail the Travis build if execution of this script is failed.
   - chmod +x ./scripts/publish.sh

--- a/build.gradle
+++ b/build.gradle
@@ -384,16 +384,3 @@ idea {
 apply from: spineJacocoScript
 
 apply from: publishPlugin
-
-apply plugin: spineGcsPlugin
-
-cleanGCS {
-    final Properties properties = new Properties()
-    final File gcsProperties = project.file("gcs.properties")
-    properties.load(gcsProperties.newDataInputStream())
-
-    authKeyPath = "gcs-auth-key.json"
-    bucketName = properties.getProperty("artifacts.bucket")
-    targetFolder = properties.getProperty("artifacts.folder")
-    threshold = TimeCategory.getDays(10)
-}


### PR DESCRIPTION
In this PR we remove usage of the Spine GCS plugin.

See [this `base` PR](https://github.com/SpineEventEngine/base/pull/122) for more details.