### PR TITLE
Use Gradle project's class loader in model verifier

### DIFF
--- a/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifier.java
+++ b/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifier.java
@@ -28,12 +28,12 @@ import io.spine.server.command.CommandHandler;
 import io.spine.server.model.Model;
 import io.spine.server.procman.ProcessManager;
 import io.spine.tools.gradle.ProjectHierarchy;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -127,9 +127,11 @@ final class ModelVerifier {
         final URL[] compiledCodePath = extractDestinationDirs(tasks);
         log().debug("Initializing ClassLoader for URLs: {}", deepToString(compiledCodePath));
         try {
+            ClassLoader projectClassloader = project.getBuildscript()
+                                                    .getClassLoader();
             @SuppressWarnings("ClassLoaderInstantiation") // Caught exception.
             final URLClassLoader result =
-                    new URLClassLoader(compiledCodePath, ModelVerifier.class.getClassLoader());
+                    new URLClassLoader(compiledCodePath, projectClassloader);
             return result;
         } catch (SecurityException e) {
             throw new IllegalStateException("Cannot analyze project source code.", e);

--- a/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierTest.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierTest.java
@@ -30,6 +30,7 @@ import io.spine.model.verify.given.ModelVerifierTestEnv.Int32HandlerAggregate;
 import io.spine.model.verify.given.ModelVerifierTestEnv.Int64HandlerProcMan;
 import io.spine.server.model.DuplicateCommandHandlerError;
 import org.gradle.api.Project;
+import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.compile.JavaCompile;
@@ -67,8 +68,12 @@ class ModelVerifierTest {
     @BeforeEach
     void setUp() {
         project = mock(Project.class);
+        ScriptHandler buildScript = mock(ScriptHandler.class);
+        when(buildScript.getClassLoader()).thenReturn(ModelVerifierTest.class.getClassLoader());
         when(project.getSubprojects()).thenReturn(emptySet());
         when(project.getRootProject()).thenReturn(project);
+        when(project.getBuildscript()).thenReturn(buildScript);
+
         TaskContainer tasks = mock(TaskContainer.class);
         TaskCollection emptyTaskCollection = mock(TaskCollection.class);
         when(emptyTaskCollection.iterator()).thenReturn(Iterators.emptyIterator());


### PR DESCRIPTION
Addresses https://github.com/SpineEventEngine/core-java/issues/739.

### Before

Right now, the `ModelVerifier` uses it's own class loader appended with projects' output directories.


### After
In this PR, I make it use the class loader of the current project's `buildscript`.