### PR TITLE
Use `TempDirectory` from `spine-testlib` instead of JUnit Pioneer

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.45-SNAPSHOT'
+def final SPINE_VERSION = '0.10.46-SNAPSHOT'
 
 ext {
 
@@ -33,7 +33,7 @@ ext {
     spineVersion = SPINE_VERSION
 
     // Depend on `base` for the general definitions and a model compiler.
-    spineBaseVersion = '0.10.45-SNAPSHOT'
+    spineBaseVersion = '0.10.46-SNAPSHOT'
 
     spineTimeVersion = '0.10.29-SNAPSHOT'
 

--- a/model/model-verifier/build.gradle
+++ b/model/model-verifier/build.gradle
@@ -22,10 +22,6 @@ buildscript {
     apply from: "$rootDir/ext.gradle"
 }
 
-ext {
-    jUnitPioneerVersion = '0.1-SNAPSHOT'
-}
-
 group 'io.spine.tools'
 
 repositories {
@@ -49,8 +45,8 @@ dependencies {
     implementation project(':model-assembler')
 
     testImplementation gradleTestKit()
+    testImplementation "io.spine:spine-testlib:$spineBaseVersion"
     testImplementation "io.spine.tools:spine-plugin-testlib:$spineBaseVersion"
-    testImplementation "org.junit-pioneer:junit-pioneer:$jUnitPioneerVersion"
 }
 
 test {

--- a/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierPluginTest.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierPluginTest.java
@@ -20,6 +20,8 @@
 
 package io.spine.model.verify;
 
+import io.spine.test.TempDirectory;
+import io.spine.test.TempDirectory.TempDir;
 import io.spine.tools.gradle.GradleProject;
 import io.spine.tools.gradle.TaskName;
 import org.gradle.testkit.runner.BuildResult;
@@ -30,8 +32,6 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
-import org.junitpioneer.jupiter.TempDirectory.TempDir;
 
 import java.nio.file.Path;
 


### PR DESCRIPTION
This PR takes advantage of https://github.com/SpineEventEngine/base/pull/132 to remove the [JUnit Pioneer](https://github.com/junit-pioneer/junit-pioneer) dependency from the project and use the functionality from `base` instead.

See https://github.com/SpineEventEngine/core-java/issues/743 for details.

The `base` dependency version and the Spine version advance to `0.10.46-SNAPSHOT`.