### PR TITLE
Clear global `Model` before applying `ModelVerifier`

### DIFF
--- a/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifier.java
+++ b/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifier.java
@@ -76,6 +76,7 @@ final class ModelVerifier {
      */
     void verify(CommandHandlers spineModel) {
         Logger log = log();
+        model.clear();
         for (String commandHandlingClass : spineModel.getCommandHandlingTypesList()) {
             final Class<?> cls;
             try {

--- a/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierPluginTest.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierPluginTest.java
@@ -67,9 +67,7 @@ class ModelVerifierPluginTest {
                 .executeTask(VERIFY_MODEL);
     }
 
-    // See https://github.com/SpineEventEngine/core-java/issues/737 as to why it's disabled.
     @Test
-    @Disabled("the test is failing other tests in the suite")
     @DisplayName("halt build on duplicate command handling methods")
     void rejectDuplicateHandlingMethods() {
         BuildResult result = newProjectWithJava(

--- a/server/src/main/java/io/spine/server/model/Model.java
+++ b/server/src/main/java/io/spine/server/model/Model.java
@@ -69,7 +69,7 @@ public class Model {
         return Singleton.INSTANCE.value;
     }
 
-    /** Prevent instantiation from outside. */
+    /** Prevents instantiation from outside. */
     private Model() {
     }
 

--- a/server/src/main/java/io/spine/server/model/Model.java
+++ b/server/src/main/java/io/spine/server/model/Model.java
@@ -73,8 +73,13 @@ public class Model {
     private Model() {
     }
 
-    @VisibleForTesting
-    void clear() {
+    /**
+     * Clears the classes already added to the {@code Model}.
+     *
+     * <p>This method can be useful when multiple Spine projects are processed under the same
+     * static context, e.g. in tests.
+     */
+    public void clear() {
         classes.clear();
     }
 


### PR DESCRIPTION
This PR fixes issue https://github.com/SpineEventEngine/core-java/issues/737.

Currently, we have `Model` as a system-wide singleton. Thus, if multiple Spine projects are built under the same JVM (for example via the [`GradleRunner`](https://docs.gradle.org/current/javadoc/org/gradle/testkit/runner/GradleRunner.html) in tests), the `Model` gets polluted by the classes from all the projects and searches for duplicates among them. This leads to unexpected `verifyModel` task failures.

With this PR, the `Model` will be cleared before every `ModelVerifier` application, so each project is  verified independently of others.

This PR should be counted as a temporary fix, because with the introduction of https://github.com/SpineEventEngine/core-java/issues/726 and one `Model` per `BoundedContext` the problem will go away automatically.