### PR TITLE
Unpack rejection message before assertion in CommandHandlerExpected

### DIFF
--- a/testutil-server/src/main/java/io/spine/testing/server/CommandHandlerTest.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/CommandHandlerTest.java
@@ -25,6 +25,7 @@ import com.google.protobuf.Message;
 import io.spine.base.ThrowableMessage;
 import io.spine.client.ActorRequestFactory;
 import io.spine.core.Command;
+import io.spine.core.Rejection;
 import io.spine.server.command.CommandHandlingEntity;
 import io.spine.server.model.HandlerMethodFailedException;
 import io.spine.testing.client.TestActorRequestFactory;
@@ -85,7 +86,7 @@ public abstract class CommandHandlerTest<I,
     @Override
     protected CommandHandlerExpected<S> expectThat(E entity) {
         S initialState = entity.getState();
-        Message rejection = null;
+        Rejection rejection = null;
 
         List<? extends Message> events = emptyList();
         try {

--- a/testutil-server/src/main/java/io/spine/testing/server/expected/CommandHandlerExpected.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/expected/CommandHandlerExpected.java
@@ -22,12 +22,14 @@ package io.spine.testing.server.expected;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Message;
+import io.spine.core.Rejection;
 
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import static io.spine.protobuf.AnyPacker.unpack;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -44,10 +46,10 @@ public class CommandHandlerExpected<S extends Message>
         extends MessageProducingExpected<S, CommandHandlerExpected<S>> {
 
     @Nullable
-    private final Message rejection;
+    private final Rejection rejection;
 
     public CommandHandlerExpected(List<? extends Message> events,
-                                  @Nullable Message rejection,
+                                  @Nullable Rejection rejection,
                                   S initialState,
                                   S state,
                                   List<Message> interceptedCommands) {
@@ -121,7 +123,7 @@ public class CommandHandlerExpected<S extends Message>
     public CommandHandlerExpected<S> throwsRejection(Class<? extends Message> rejectionClass) {
         assertNotNull(rejection, format("No rejection encountered. Expected %s",
                                         rejectionClass.getSimpleName()));
-        assertTrue(rejectionClass.isInstance(rejection),
+        assertTrue(rejectionClass.isInstance(unpack(rejection.getMessage())),
                    format("%s is not an instance of %s.",
                           rejection.getClass()
                                    .getSimpleName(),

--- a/testutil-server/src/test/java/io/spine/testing/server/TestBoundedContextTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/TestBoundedContextTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * @author Vladyslav Lubenskyi
  */
 @DisplayName("TestBoundedContext should")
-class TestBoundedContextShould {
+class TestBoundedContextTest {
 
     @Test
     @DisplayName("create instance")

--- a/testutil-server/src/test/java/io/spine/testing/server/aggregate/AggregateCommandTestShould.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/aggregate/AggregateCommandTestShould.java
@@ -21,7 +21,7 @@
 package io.spine.testing.server.aggregate;
 
 import com.google.protobuf.Timestamp;
-import io.spine.core.Rejection;
+import io.spine.testing.server.Rejections.TUFailedToAssignProject;
 import io.spine.testing.server.TUProjectAggregate;
 import io.spine.testing.server.aggregate.given.AggregateCommandTestShouldEnv.CommandHandlingAggregate;
 import io.spine.testing.server.expected.CommandHandlerExpected;
@@ -72,13 +72,13 @@ class AggregateCommandTestShould {
     }
 
     @Test
-    @DisplayName("not fail when rejected")
-    void shouldHandleRejection() {
+    @DisplayName("track rejection")
+    void trackGeneratedRejection() {
         aggregateRejectionCommandTest.setUp();
         CommandHandlingAggregate testAggregate = aggregate();
         CommandHandlerExpected<TUProjectAggregate> expected =
                 aggregateRejectionCommandTest.expectThat(testAggregate);
-        expected.throwsRejection(Rejection.class);
+        expected.throwsRejection(TUFailedToAssignProject.class);
     }
 }
 

--- a/testutil-server/src/test/java/io/spine/testing/server/expected/CommandHandlerExpectedShould.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/expected/CommandHandlerExpectedShould.java
@@ -22,7 +22,7 @@ package io.spine.testing.server.expected;
 
 import com.google.protobuf.StringValue;
 import com.google.protobuf.UInt64Value;
-import io.spine.core.Rejection;
+import io.spine.testing.server.Rejections.TUFailedToAssignProject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
@@ -49,7 +49,7 @@ class CommandHandlerExpectedShould {
     void trackRejection() {
         CommandHandlerExpected<UInt64Value> expected =
                 commandExpectedWithRejection(rejection());
-        expected.throwsRejection(Rejection.class);
+        expected.throwsRejection(TUFailedToAssignProject.class);
     }
 
     @Test

--- a/testutil-server/src/test/java/io/spine/testing/server/expected/CommandHandlerExpectedTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/expected/CommandHandlerExpectedTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 @SuppressWarnings("DuplicateStringLiteralInspection")
 @DisplayName("CommandHandlerExpected should")
-class CommandHandlerExpectedShould {
+class CommandHandlerExpectedTest {
 
     @Test
     @DisplayName("validate the rejection")

--- a/testutil-server/src/test/java/io/spine/testing/server/expected/CommandHandlerExpectedTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/expected/CommandHandlerExpectedTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class CommandHandlerExpectedTest {
 
     @Test
-    @DisplayName("validate the rejectionMessage")
+    @DisplayName("validate the rejection")
     void trackRejection() {
         CommandHandlerExpected<UInt64Value> expected =
                 commandExpectedWithRejection(rejectionMessage());

--- a/testutil-server/src/test/java/io/spine/testing/server/expected/CommandHandlerExpectedTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/expected/CommandHandlerExpectedTest.java
@@ -33,7 +33,7 @@ import static io.spine.testing.server.expected.given.CommandExpectedTestEnv.comm
 import static io.spine.testing.server.expected.given.CommandExpectedTestEnv.commandExpectedWithEvent;
 import static io.spine.testing.server.expected.given.CommandExpectedTestEnv.commandExpectedWithRejection;
 import static io.spine.testing.server.expected.given.CommandExpectedTestEnv.emptyExpected;
-import static io.spine.testing.server.expected.given.CommandExpectedTestEnv.rejection;
+import static io.spine.testing.server.expected.given.CommandExpectedTestEnv.rejectionMessage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -45,10 +45,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class CommandHandlerExpectedTest {
 
     @Test
-    @DisplayName("validate the rejection")
+    @DisplayName("validate the rejectionMessage")
     void trackRejection() {
         CommandHandlerExpected<UInt64Value> expected =
-                commandExpectedWithRejection(rejection());
+                commandExpectedWithRejection(rejectionMessage());
         expected.throwsRejection(TUFailedToAssignProject.class);
     }
 
@@ -70,7 +70,7 @@ class CommandHandlerExpectedTest {
     @DisplayName("not ignore message if it was rejected")
     void notIgnoreRejectedCommand() {
         CommandHandlerExpected<UInt64Value> expected =
-                commandExpectedWithRejection(rejection());
+                commandExpectedWithRejection(rejectionMessage());
         assertThrows(AssertionFailedError.class, expected::ignoresMessage);
     }
 
@@ -78,7 +78,7 @@ class CommandHandlerExpectedTest {
     @DisplayName("not track events if rejected")
     void notTrackEventsIfRejected() {
         CommandHandlerExpected<UInt64Value> expected =
-                commandExpectedWithRejection(rejection());
+                commandExpectedWithRejection(rejectionMessage());
         assertThrows(AssertionFailedError.class, () -> expected.producesEvents(StringValue.class));
     }
 

--- a/testutil-server/src/test/java/io/spine/testing/server/expected/EventHandlerExpectedTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/expected/EventHandlerExpectedTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 @SuppressWarnings("DuplicateStringLiteralInspection")
 @DisplayName("EventHandlerExpected should")
-class EventHandlerExpectedShould {
+class EventHandlerExpectedTest {
 
     @Test
     @DisplayName("validate state")

--- a/testutil-server/src/test/java/io/spine/testing/server/expected/given/CommandExpectedTestEnv.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/expected/given/CommandExpectedTestEnv.java
@@ -84,8 +84,8 @@ public class CommandExpectedTestEnv {
 
     private static Rejection rejection(Message rejectionMessage) {
         RejectionId id = RejectionId.newBuilder()
-                                         .setValue("test rejectionMessage")
-                                         .build();
+                                    .setValue("test rejection")
+                                    .build();
         return Rejection.newBuilder()
                         .setId(id)
                         .setMessage(pack(rejectionMessage))

--- a/testutil-server/src/test/java/io/spine/testing/server/expected/given/CommandExpectedTestEnv.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/expected/given/CommandExpectedTestEnv.java
@@ -51,23 +51,17 @@ public class CommandExpectedTestEnv {
     private CommandExpectedTestEnv() {
     }
 
-    public static Rejection rejection() {
-        RejectionId id = RejectionId.newBuilder()
-                                    .setValue("test rejection")
-                                    .build();
+    public static Message rejectionMessage() {
         TUProjectId entityId = TUProjectId.newBuilder()
                                           .setValue("entity ID")
                                           .build();
         TUFailedToAssignProject rejectionMessage = TUFailedToAssignProject.newBuilder()
                                                                           .setId(entityId)
                                                                           .build();
-        return Rejection.newBuilder()
-                        .setId(id)
-                        .setMessage(pack(rejectionMessage))
-                        .build();
+        return rejectionMessage;
     }
 
-    public static List<Message> interceptedCommands() {
+    private static List<Message> interceptedCommands() {
         StringValue firstCommand = StringValue.newBuilder()
                                               .setValue("command 1")
                                               .build();
@@ -78,14 +72,24 @@ public class CommandExpectedTestEnv {
     }
 
     public static CommandHandlerExpected<UInt64Value>
-    commandExpectedWithRejection(Rejection rejection) {
+    commandExpectedWithRejection(Message rejectionMessage) {
         CommandHandlerExpected<UInt64Value> expected =
                 new CommandHandlerExpected<>(events(),
-                                             rejection,
+                                             rejection(rejectionMessage),
                                              oldState(),
                                              newState(),
                                              interceptedCommands());
         return expected;
+    }
+
+    private static Rejection rejection(Message rejectionMessage) {
+        RejectionId id = RejectionId.newBuilder()
+                                         .setValue("test rejectionMessage")
+                                         .build();
+        return Rejection.newBuilder()
+                        .setId(id)
+                        .setMessage(pack(rejectionMessage))
+                        .build();
     }
 
     public static CommandHandlerExpected<UInt64Value> commandExpectedWithEvent(Message event) {

--- a/testutil-server/src/test/java/io/spine/testing/server/expected/given/CommandExpectedTestEnv.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/expected/given/CommandExpectedTestEnv.java
@@ -26,10 +26,13 @@ import com.google.protobuf.StringValue;
 import com.google.protobuf.UInt64Value;
 import io.spine.core.Rejection;
 import io.spine.core.RejectionId;
+import io.spine.testing.server.Rejections.TUFailedToAssignProject;
+import io.spine.testing.server.TUProjectId;
 import io.spine.testing.server.expected.CommandHandlerExpected;
 
 import java.util.List;
 
+import static com.google.protobuf.Any.pack;
 import static io.spine.testing.server.expected.given.EventHandlerExpectedTestEnv.events;
 import static io.spine.testing.server.expected.given.EventHandlerExpectedTestEnv.newState;
 import static io.spine.testing.server.expected.given.EventHandlerExpectedTestEnv.oldState;
@@ -48,12 +51,19 @@ public class CommandExpectedTestEnv {
     private CommandExpectedTestEnv() {
     }
 
-    public static Message rejection() {
+    public static Rejection rejection() {
         RejectionId id = RejectionId.newBuilder()
                                     .setValue("test rejection")
                                     .build();
+        TUProjectId entityId = TUProjectId.newBuilder()
+                                          .setValue("entity ID")
+                                          .build();
+        TUFailedToAssignProject rejectionMessage = TUFailedToAssignProject.newBuilder()
+                                                                          .setId(entityId)
+                                                                          .build();
         return Rejection.newBuilder()
                         .setId(id)
+                        .setMessage(pack(rejectionMessage))
                         .build();
     }
 
@@ -67,7 +77,8 @@ public class CommandExpectedTestEnv {
         return asList(firstCommand, secondCommand);
     }
 
-    public static CommandHandlerExpected<UInt64Value> commandExpectedWithRejection(Message rejection) {
+    public static CommandHandlerExpected<UInt64Value> commandExpectedWithRejection(
+            Rejection rejection) {
         CommandHandlerExpected<UInt64Value> expected =
                 new CommandHandlerExpected<>(events(),
                                              rejection,

--- a/testutil-server/src/test/java/io/spine/testing/server/expected/given/CommandExpectedTestEnv.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/expected/given/CommandExpectedTestEnv.java
@@ -77,8 +77,8 @@ public class CommandExpectedTestEnv {
         return asList(firstCommand, secondCommand);
     }
 
-    public static CommandHandlerExpected<UInt64Value> commandExpectedWithRejection(
-            Rejection rejection) {
+    public static CommandHandlerExpected<UInt64Value>
+    commandExpectedWithRejection(Rejection rejection) {
         CommandHandlerExpected<UInt64Value> expected =
                 new CommandHandlerExpected<>(events(),
                                              rejection,


### PR DESCRIPTION
This PR fixes an issue in `CommandHandlerExpected`. 

Previously, when calling `CommandHandlerExpected.throwsRejection()` the assertion was always made against `Rejection` instance. 

Now, the assertion is made against Rejection's `message`.