### PR TITLE
Move tests of `EntityBuilder` to proper test suite

### DIFF
--- a/server/src/test/java/io/spine/server/aggregate/AggregatePartTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregatePartTest.java
@@ -24,35 +24,27 @@ import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Message;
 import io.spine.core.CommandEnvelope;
 import io.spine.server.BoundedContext;
-import io.spine.server.aggregate.given.AggregatePartTestEnv.AnAggregatePart;
 import io.spine.server.aggregate.given.AggregatePartTestEnv.AnAggregateRoot;
 import io.spine.server.aggregate.given.AggregatePartTestEnv.TaskDescriptionPart;
 import io.spine.server.aggregate.given.AggregatePartTestEnv.TaskDescriptionRepository;
 import io.spine.server.aggregate.given.AggregatePartTestEnv.TaskPart;
 import io.spine.server.aggregate.given.AggregatePartTestEnv.TaskRepository;
-import io.spine.server.entity.InvalidEntityStateException;
 import io.spine.test.aggregate.ProjectId;
 import io.spine.test.aggregate.Task;
 import io.spine.test.aggregate.command.AggAddTask;
-import io.spine.test.aggregate.user.User;
 import io.spine.testdata.Sample;
 import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.testing.server.aggregate.AggregateMessageDispatcher;
 import io.spine.testing.server.model.ModelTests;
-import io.spine.validate.ConstraintViolation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
-import java.util.List;
 
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
-import static io.spine.testing.Verify.assertSize;
-import static io.spine.testing.server.entity.given.Given.aggregatePartOfClass;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Illia Shepilov
@@ -106,49 +98,6 @@ class AggregatePartTest {
         taskRepository.store(taskPart);
         final Task task = taskDescriptionPart.getPartState(Task.class);
         assertEquals(TASK_DESCRIPTION, task.getDescription());
-    }
-
-    @SuppressWarnings("CheckReturnValue") // Method called to throw exception.
-    @Test
-    @DisplayName("throw InvalidEntityStateException if entity state is invalid")
-    void throwOnInvalidState() {
-        final User user = User.newBuilder()
-                              .setFirstName("|")
-                              .setLastName("|")
-                              .build();
-        try {
-            aggregatePartOfClass(AnAggregatePart.class)
-                    .withRoot(root)
-                    .withId(getClass().getName())
-                    .withVersion(1)
-                    .withState(user)
-                    .build();
-            fail("Should have thrown InvalidEntityStateException.");
-        } catch (InvalidEntityStateException e) {
-            List<ConstraintViolation> violations =
-                    e.getError()
-                     .getValidationError()
-                     .getConstraintViolationList();
-            assertSize(user.getAllFields()
-                           .size(), violations);
-        }
-    }
-
-    @Test
-    @DisplayName("update valid entity state")
-    void updateEntityState() {
-        User user = User.newBuilder()
-                        .setFirstName("Firstname")
-                        .setLastName("Lastname")
-                        .build();
-        AnAggregatePart part = aggregatePartOfClass(AnAggregatePart.class)
-                .withRoot(root)
-                .withId(getClass().getName())
-                .withVersion(1)
-                .withState(user)
-                .build();
-
-        assertEquals(user, part.getState());
     }
 
     private NullPointerTester createNullPointerTester() throws NoSuchMethodException {

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregatePartTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregatePartTestEnv.java
@@ -33,8 +33,6 @@ import io.spine.test.aggregate.command.AggAddTask;
 import io.spine.test.aggregate.command.AggCreateProject;
 import io.spine.test.aggregate.event.AggProjectCreated;
 import io.spine.test.aggregate.event.AggTaskAdded;
-import io.spine.test.aggregate.user.User;
-import io.spine.test.aggregate.user.UserVBuilder;
 import io.spine.validate.StringValueVBuilder;
 
 public class AggregatePartTestEnv {
@@ -62,8 +60,8 @@ public class AggregatePartTestEnv {
     }
 
     public static class AnAggregatePart extends AggregatePart<String,
-            User,
-            UserVBuilder,
+            StringValue,
+            StringValueVBuilder,
             AnAggregateRoot> {
 
         public AnAggregatePart(AnAggregateRoot root) {

--- a/testutil-server/src/test/java/io/spine/testing/server/entity/EntityBuilderTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/entity/EntityBuilderTest.java
@@ -24,10 +24,10 @@ import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.StringValue;
 import com.google.protobuf.Timestamp;
 import io.spine.base.Time;
-import io.spine.server.entity.AbstractVersionableEntity;
 import io.spine.server.entity.InvalidEntityStateException;
 import io.spine.server.entity.VersionableEntity;
 import io.spine.testing.server.User;
+import io.spine.testing.server.entity.EntityBuilderTestEnv.TestEntity;
 import io.spine.testing.server.entity.EntityBuilderTestEnv.UserAggregate;
 import io.spine.validate.ConstraintViolation;
 import org.junit.jupiter.api.DisplayName;
@@ -162,11 +162,5 @@ class EntityBuilderTest {
                 .build();
 
         assertEquals(user, aggregate.getState());
-    }
-
-    private static class TestEntity extends AbstractVersionableEntity<Long, StringValue> {
-        protected TestEntity(Long id) {
-            super(id);
-        }
     }
 }

--- a/testutil-server/src/test/java/io/spine/testing/server/entity/EntityBuilderTestEnv.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/entity/EntityBuilderTestEnv.java
@@ -20,7 +20,9 @@
 
 package io.spine.testing.server.entity;
 
+import com.google.protobuf.StringValue;
 import io.spine.server.aggregate.Aggregate;
+import io.spine.server.entity.AbstractVersionableEntity;
 import io.spine.testing.server.User;
 import io.spine.testing.server.UserVBuilder;
 
@@ -35,6 +37,12 @@ public class EntityBuilderTestEnv {
      */
     static class UserAggregate extends Aggregate<String, User, UserVBuilder> {
         private UserAggregate(String id) {
+            super(id);
+        }
+    }
+
+    static class TestEntity extends AbstractVersionableEntity<Long, StringValue> {
+        protected TestEntity(Long id) {
             super(id);
         }
     }

--- a/testutil-server/src/test/java/io/spine/testing/server/entity/EntityBuilderTestEnv.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/entity/EntityBuilderTestEnv.java
@@ -18,19 +18,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.server.aggregate.given.aggregate;
+package io.spine.testing.server.entity;
 
 import io.spine.server.aggregate.Aggregate;
-import io.spine.test.aggregate.user.User;
-import io.spine.test.aggregate.user.UserVBuilder;
+import io.spine.testing.server.User;
+import io.spine.testing.server.UserVBuilder;
 
 /**
- * The test environment aggregate for testing validation during aggregate state transition.
- *
  * @author Alexander Yevsyukov
+ * @author Dmytro Kuzmin
  */
-public class UserAggregate extends Aggregate<String, User, UserVBuilder> {
-    private UserAggregate(String id) {
-        super(id);
+public class EntityBuilderTestEnv {
+
+    /**
+     * The test environment aggregate for testing validation during aggregate state transition.
+     */
+    static class UserAggregate extends Aggregate<String, User, UserVBuilder> {
+        private UserAggregate(String id) {
+            super(id);
+        }
     }
 }

--- a/testutil-server/src/test/proto/spine/testing/server/user.proto
+++ b/testutil-server/src/test/proto/spine/testing/server/user.proto
@@ -19,12 +19,12 @@
 //
 syntax = "proto3";
 
-package spine.test.aggregate.user;
+package spine.testing.server;
 
 import "spine/options.proto";
 
 option (type_url_prefix) = "type.spine.io";
-option java_package = "io.spine.test.aggregate.user";
+option java_package = "io.spine.testing.server";
 option java_multiple_files = true;
 
 message User {


### PR DESCRIPTION
This PR fixes issue https://github.com/SpineEventEngine/core-java/issues/711.

The `AggregateTest` and `AggregatePartTest` classes had methods that in fact checked `EntityBuilder` functionality.

Now these tests are moved to the `EntityBuilderTest` and merged (because there is no substantial difference whether to use `Aggregate` or `AggregatePart` for test).