### PR TITLE
Disallow returning empty event list from command handlers

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.57-SNAPSHOT'
+def final SPINE_VERSION = '0.10.58-SNAPSHOT'
 
 ext {
 

--- a/server/src/main/java/io/spine/server/command/model/CommandHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandHandlerMethod.java
@@ -34,6 +34,8 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.function.Predicate;
 
+import static com.google.common.base.Preconditions.checkState;
+
 /**
  * The wrapper for a command handler method.
  *
@@ -62,14 +64,13 @@ public final class CommandHandlerMethod extends CommandAcceptingMethod {
      * {@inheritDoc}
      *
      * @return the list of event messages
+     * @throws IllegalStateException if the invoked method does not produce any events
      */
     @Override
     public List<? extends Message> invoke(Object target, Message message, CommandContext context) {
         Object handlingResult = super.invoke(target, message, context);
         List<? extends Message> events = toList(handlingResult);
-        //TODO:2018-07-22:alexander.yevsyukov: Have the below check once ProcessManagers stop violating the contract of `@Assign`.
-        // see: https://github.com/SpineEventEngine/core-java/issues/773
-        // checkState(!events.isEmpty(), "Command handling method did not produce events");
+        checkState(!events.isEmpty(), "Command handling method did not produce events");
         return events;
     }
 

--- a/server/src/test/java/io/spine/server/command/given/CommandHandlerMethodTestEnv.java
+++ b/server/src/test/java/io/spine/server/command/given/CommandHandlerMethodTestEnv.java
@@ -42,6 +42,7 @@ import java.util.List;
 import static com.google.common.collect.Lists.newLinkedList;
 import static io.spine.server.model.given.Given.EventMessage.projectCreated;
 import static io.spine.util.Exceptions.newIllegalStateException;
+import static java.util.Collections.emptyList;
 
 public class CommandHandlerMethodTestEnv {
 
@@ -171,6 +172,20 @@ public class CommandHandlerMethodTestEnv {
         @Apply
         void event(RefProjectCreated evt) {
             // Do nothing.
+        }
+    }
+
+    public static class HandlerReturnsEmptyList extends TestCommandHandler {
+        @Assign
+        List<Message> handleTest(RefCreateProject cmd) {
+            return emptyList();
+        }
+    }
+
+    public static class HandlerReturnsEmpty extends TestCommandHandler {
+        @Assign
+        Empty handleTest(RefCreateProject cmd) {
+            return Empty.getDefaultInstance();
         }
     }
 

--- a/server/src/test/java/io/spine/server/command/model/CommandHandlerMethodTest.java
+++ b/server/src/test/java/io/spine/server/command/model/CommandHandlerMethodTest.java
@@ -29,6 +29,8 @@ import io.spine.core.CommandContext;
 import io.spine.core.CommandEnvelope;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.command.CommandHandler;
+import io.spine.server.command.given.CommandHandlerMethodTestEnv.HandlerReturnsEmpty;
+import io.spine.server.command.given.CommandHandlerMethodTestEnv.HandlerReturnsEmptyList;
 import io.spine.server.command.given.CommandHandlerMethodTestEnv.InvalidHandlerNoAnnotation;
 import io.spine.server.command.given.CommandHandlerMethodTestEnv.InvalidHandlerNoParams;
 import io.spine.server.command.given.CommandHandlerMethodTestEnv.InvalidHandlerOneNotMsgParam;
@@ -135,6 +137,33 @@ class CommandHandlerMethodTest {
             assertEquals(1, events.size());
             RefProjectCreated event = (RefProjectCreated) events.get(0);
             assertEquals(cmd.getProjectId(), event.getProjectId());
+        }
+    }
+
+    @Nested
+    @DisplayName("throw ISE when invoked method produces")
+    class ThrowWhenProduces {
+
+        @Test
+        @DisplayName("no events")
+        void noEvents() {
+            HandlerReturnsEmptyList handlerObject = new HandlerReturnsEmptyList();
+            CommandHandlerMethod handler = from(handlerObject.getHandler());
+            RefCreateProject cmd = createProject();
+
+            assertThrows(IllegalStateException.class,
+                         () -> handler.invoke(handlerObject, cmd, emptyContext));
+        }
+
+        @Test
+        @DisplayName("`Empty` event")
+        void emptyEvent() {
+            HandlerReturnsEmpty handlerObject = new HandlerReturnsEmpty();
+            CommandHandlerMethod handler = from(handlerObject.getHandler());
+            RefCreateProject cmd = createProject();
+
+            assertThrows(IllegalStateException.class,
+                         () -> handler.invoke(handlerObject, cmd, emptyContext));
         }
     }
 

--- a/server/src/test/java/io/spine/server/procman/given/ProcessManagerRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/procman/given/ProcessManagerRepositoryTestEnv.java
@@ -47,6 +47,9 @@ import io.spine.test.procman.command.PmDeleteProcess;
 import io.spine.test.procman.command.PmDoNothing;
 import io.spine.test.procman.command.PmStartProject;
 import io.spine.test.procman.command.PmThrowEntityAlreadyArchived;
+import io.spine.test.procman.event.PmDidNothing;
+import io.spine.test.procman.event.PmProcessArchived;
+import io.spine.test.procman.event.PmProcessDeleted;
 import io.spine.test.procman.event.PmProjectCreated;
 import io.spine.test.procman.event.PmProjectStarted;
 import io.spine.test.procman.event.PmTaskAdded;
@@ -56,7 +59,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.List;
 
 import static io.spine.protobuf.AnyPacker.pack;
-import static java.util.Collections.emptyList;
 
 /**
  * @author Alexander Yevsyukov
@@ -175,23 +177,38 @@ public class ProcessManagerRepositoryTestEnv {
         }
 
         @Assign
-        Empty handle(PmArchiveProcess command) {
+        PmProcessArchived handle(PmArchiveProcess command) {
             keep(command);
             setArchived(true);
-            return withNothing();
+
+            PmProcessArchived event = ((PmProcessArchived.Builder)
+                    Sample.builderForType(PmProcessArchived.class))
+                    .setProjectId(command.getProjectId())
+                    .build();
+            return event;
         }
 
         @Assign
-        Empty handle(PmDeleteProcess command) {
+        PmProcessDeleted handle(PmDeleteProcess command) {
             keep(command);
             setDeleted(true);
-            return withNothing();
+
+            PmProcessDeleted event = ((PmProcessDeleted.Builder)
+                    Sample.builderForType(PmProcessDeleted.class))
+                    .setProjectId(command.getProjectId())
+                    .build();
+            return event;
         }
 
         @Assign
-        List<Message> handle(PmDoNothing command, CommandContext ignored) {
+        PmDidNothing handle(PmDoNothing command, CommandContext ignored) {
             keep(command);
-            return emptyList();
+
+            PmDidNothing event = ((PmDidNothing.Builder)
+                    Sample.builderForType(PmDidNothing.class))
+                    .setProjectId(command.getProjectId())
+                    .build();
+            return event;
         }
 
         @Assign

--- a/server/src/test/java/io/spine/system/server/given/EntityHistoryTestEnv.java
+++ b/server/src/test/java/io/spine/system/server/given/EntityHistoryTestEnv.java
@@ -56,6 +56,8 @@ import io.spine.system.server.HidePerson;
 import io.spine.system.server.Person;
 import io.spine.system.server.PersonCreated;
 import io.spine.system.server.PersonCreation;
+import io.spine.system.server.PersonCreationCompleted;
+import io.spine.system.server.PersonCreationStarted;
 import io.spine.system.server.PersonCreationVBuilder;
 import io.spine.system.server.PersonDetails;
 import io.spine.system.server.PersonDetailsVBuilder;
@@ -276,16 +278,26 @@ public final class EntityHistoryTestEnv {
         }
 
         @Assign
-        Empty handle(StartPersonCreation command) {
+        PersonCreationStarted handle(StartPersonCreation command) {
             getBuilder().setId(command.getId());
-            return Empty.getDefaultInstance();
+
+            PersonCreationStarted event = PersonCreationStarted
+                    .newBuilder()
+                    .setId(command.getId())
+                    .build();
+            return event;
         }
 
         @Assign
-        Empty handle(CompletePersonCreation command) {
+        PersonCreationCompleted handle(CompletePersonCreation command) {
             getBuilder().setId(command.getId())
                         .setCreated(true);
-            return Empty.getDefaultInstance();
+
+            PersonCreationCompleted event = PersonCreationCompleted
+                    .newBuilder()
+                    .setId(command.getId())
+                    .build();
+            return event;
         }
 
         @React

--- a/server/src/test/proto/spine/test/procman/events.proto
+++ b/server/src/test/proto/spine/test/procman/events.proto
@@ -47,3 +47,16 @@ message PmNotificationSent {
 message PmProjectStarted {
     ProjectId project_id = 1;
 }
+
+// A response for a `PmDoNothing` command, which does not modify a process manager state.
+message PmDidNothing {
+    ProjectId project_id = 1;
+}
+
+message PmProcessArchived {
+    ProjectId project_id = 1;
+}
+
+message PmProcessDeleted {
+    ProjectId project_id = 1;
+}

--- a/server/src/test/proto/spine/test/system/server/c/events.proto
+++ b/server/src/test/proto/spine/test/system/server/c/events.proto
@@ -39,6 +39,16 @@ message PersonCreated {
     spine.people.PersonName name = 2;
 }
 
+message PersonCreationStarted {
+
+    PersonId id = 1;
+}
+
+message PersonCreationCompleted {
+
+    PersonId id = 1;
+}
+
 message PersonNameCreated {
 
     PersonId id = 1;


### PR DESCRIPTION
This PR fixes issue https://github.com/SpineEventEngine/core-java/issues/773.

Previously, it was possible to violate the `@Assign` contract by returning empty event list from the command handler method. Thus, the command was basically ignored.

This PR adds the check which prevents contract violation and fixes all `...TestEnv` classes which did that and thus became invalid.

Spine version advances to `0.10.58-SNAPSHOT`.