### PR TITLE
Disallow a handler method declare a `RuntimeException` thrown

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.58-SNAPSHOT'
+def final SPINE_VERSION = '0.10.59-SNAPSHOT'
 
 ext {
 

--- a/server/src/main/java/io/spine/server/command/model/CommandHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandHandlerMethod.java
@@ -107,7 +107,7 @@ public final class CommandHandlerMethod extends CommandAcceptingMethod {
         @Override
         protected void checkThrownExceptions(Method method) {
             MethodExceptionChecker checker = MethodExceptionChecker.forMethod(method);
-            checker.checkThrowsNoExceptionsBut(RuntimeException.class, ThrowableMessage.class);
+            checker.checkThrowsNoExceptionsBut(ThrowableMessage.class);
         }
 
         @Override

--- a/server/src/main/java/io/spine/server/model/AbstractHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/model/AbstractHandlerMethod.java
@@ -318,7 +318,7 @@ public abstract class AbstractHandlerMethod<M extends MessageClass, C extends Me
          */
         protected void checkThrownExceptions(Method method) {
             MethodExceptionChecker checker = forMethod(method);
-            checker.checkThrowsNoCheckedExceptions();
+            checker.checkDeclaresNoExceptionsThrown();
         }
     }
 }

--- a/server/src/main/java/io/spine/server/model/MethodExceptionChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodExceptionChecker.java
@@ -63,15 +63,12 @@ public class MethodExceptionChecker {
     }
 
     /**
-     * Ensures that contained {@link Method} does not declare any thrown checked exceptions.
-     *
-     * <p>{@link RuntimeException} and its descendants can still be declared and thrown from
-     * the method.
+     * Ensures that contained {@link Method} does not declare any thrown exceptions.
      *
      * @throws IllegalStateException if the check fails
      */
-    public void checkThrowsNoCheckedExceptions() {
-        checkThrowsNoExceptionsBut(RuntimeException.class);
+    public void checkDeclaresNoExceptionsThrown() {
+        checkThrowsNoExceptionsBut();
     }
 
     /**

--- a/server/src/test/java/io/spine/server/model/AbstractHandlerMethodTest.java
+++ b/server/src/test/java/io/spine/server/model/AbstractHandlerMethodTest.java
@@ -180,8 +180,8 @@ class AbstractHandlerMethodTest {
         @Test
         @DisplayName("runtime exception")
         void runtimeException() {
-            OneParamMethod method = factory.create(StubHandler.getMethodWithRuntimeException());
-            assertEquals(StubHandler.getMethodWithRuntimeException(), method.getRawMethod());
+            assertThrows(IllegalStateException.class,
+                         () -> factory.create(StubHandler.getMethodWithRuntimeException()));
         }
     }
 }

--- a/server/src/test/java/io/spine/server/model/AbstractHandlerMethodTest.java
+++ b/server/src/test/java/io/spine/server/model/AbstractHandlerMethodTest.java
@@ -166,17 +166,22 @@ class AbstractHandlerMethodTest {
         assertNotEquals(System.identityHashCode(twoParamMethod), twoParamMethod.hashCode());
     }
 
-    @Test
-    @DisplayName("not be created from method throwing checked exception")
-    void rejectMethodThrowingChecked() {
-        assertThrows(IllegalStateException.class,
-                     () -> factory.create(StubHandler.getMethodWithCheckedException()));
-    }
+    @Nested
+    @DisplayName("not be created from method throwing")
+    class RejectMethodThrowing {
 
-    @Test
-    @DisplayName("be normally created from method throwing runtime exception")
-    void acceptMethodThrowingRuntime() {
-        OneParamMethod method = factory.create(StubHandler.getMethodWithRuntimeException());
-        assertEquals(StubHandler.getMethodWithRuntimeException(), method.getRawMethod());
+        @Test
+        @DisplayName("checked exception")
+        void checkedException() {
+            assertThrows(IllegalStateException.class,
+                         () -> factory.create(StubHandler.getMethodWithCheckedException()));
+        }
+
+        @Test
+        @DisplayName("runtime exception")
+        void runtimeException() {
+            OneParamMethod method = factory.create(StubHandler.getMethodWithRuntimeException());
+            assertEquals(StubHandler.getMethodWithRuntimeException(), method.getRawMethod());
+        }
     }
 }

--- a/server/src/test/java/io/spine/server/model/MethodExceptionCheckerTest.java
+++ b/server/src/test/java/io/spine/server/model/MethodExceptionCheckerTest.java
@@ -21,6 +21,7 @@
 package io.spine.server.model;
 
 import com.google.common.testing.NullPointerTester;
+import io.spine.base.ThrowableMessage;
 import io.spine.server.model.given.MethodExceptionCheckerTestEnv.StubMethodContainer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -57,15 +58,11 @@ class MethodExceptionCheckerTest {
     class PassCheck {
 
         @Test
-        @DisplayName("no checked exceptions are thrown by method")
+        @DisplayName("no exceptions are thrown by method")
         void forNoCheckedThrown() {
             Method methodNoExceptions = getMethod("methodNoExceptions");
             MethodExceptionChecker noExceptionsChecker = forMethod(methodNoExceptions);
-            noExceptionsChecker.checkThrowsNoCheckedExceptions();
-
-            Method methodRuntimeExceptions = getMethod("methodRuntimeException");
-            MethodExceptionChecker runtimeExceptionsChecker = forMethod(methodRuntimeExceptions);
-            runtimeExceptionsChecker.checkThrowsNoCheckedExceptions();
+            noExceptionsChecker.checkDeclaresNoExceptionsThrown();
         }
 
         @Test
@@ -81,7 +78,7 @@ class MethodExceptionCheckerTest {
         void forAllowedDescendantsThrown() {
             Method methodDescendantException = getMethod("methodDescendantException");
             MethodExceptionChecker checker = forMethod(methodDescendantException);
-            checker.checkThrowsNoExceptionsBut(RuntimeException.class);
+            checker.checkThrowsNoExceptionsBut(ThrowableMessage.class);
         }
     }
 
@@ -94,7 +91,15 @@ class MethodExceptionCheckerTest {
         void forCheckedThrown() {
             Method methodCheckedException = getMethod("methodCheckedException");
             MethodExceptionChecker checker = forMethod(methodCheckedException);
-            assertThrows(IllegalStateException.class, checker::checkThrowsNoCheckedExceptions);
+            assertThrows(IllegalStateException.class, checker::checkDeclaresNoExceptionsThrown);
+        }
+
+        @Test
+        @DisplayName("runtime exceptions are thrown by method")
+        void forRuntimeThrown() {
+            Method methodRuntimeException = getMethod("methodRuntimeException");
+            MethodExceptionChecker checker = forMethod(methodRuntimeException);
+            assertThrows(IllegalStateException.class, checker::checkDeclaresNoExceptionsThrown);
         }
 
         @Test

--- a/server/src/test/java/io/spine/server/model/given/MethodExceptionCheckerTestEnv.java
+++ b/server/src/test/java/io/spine/server/model/given/MethodExceptionCheckerTestEnv.java
@@ -20,6 +20,10 @@
 
 package io.spine.server.model.given;
 
+import com.google.protobuf.Any;
+import com.google.protobuf.GeneratedMessageV3;
+import io.spine.base.ThrowableMessage;
+
 import java.io.IOException;
 
 /**
@@ -49,8 +53,17 @@ public class MethodExceptionCheckerTestEnv {
             throw new IOException("Test custom exception");
         }
 
-        private static void methodDescendantException() throws IllegalStateException {
-            throw new IllegalStateException("Test descendant exception");
+        private static void methodDescendantException() throws DescendantThrowableMessage {
+            throw new DescendantThrowableMessage(Any.getDefaultInstance());
+        }
+    }
+
+    private static class DescendantThrowableMessage extends ThrowableMessage {
+
+        private static final long serialVersionUID = 0L;
+
+        DescendantThrowableMessage(GeneratedMessageV3 message) {
+            super(message);
         }
     }
 }


### PR DESCRIPTION
This PR fixes issue https://github.com/SpineEventEngine/core-java/issues/774.

Previously, it was possible for handler methods to declare a `RuntimeException` thrown.

Now, no thrown exception types are allowed for such methods except for `ThrowableMessage` (rejection) for command handlers.

Spine version advances to `0.10.59-SNAPSHOT`.