### PR TITLE
Replace Guava's `Predicate` with JDK8 `Predicate` [model]

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.64-SNAPSHOT'
+def final SPINE_VERSION = '0.10.67-SNAPSHOT'
 
 ext {
 

--- a/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifier.java
+++ b/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifier.java
@@ -21,7 +21,6 @@
 package io.spine.model.verify;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
 import io.spine.model.CommandHandlers;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.command.CommandHandler;
@@ -40,9 +39,10 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Collection;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.Collections2.transform;
 import static com.google.common.collect.Lists.newLinkedList;
 import static io.spine.util.Exceptions.newIllegalArgumentException;
 import static java.lang.String.format;
@@ -151,7 +151,9 @@ final class ModelVerifier {
     }
 
     private static URL[] extractDestinationDirs(Collection<JavaCompile> tasks) {
-        Collection<URL> urls = transform(tasks, GetDestinationDir.FUNCTION);
+        Collection<URL> urls = tasks.stream()
+                                    .map(GetDestinationDir.FUNCTION)
+                                    .collect(Collectors.toList());
         URL[] result = urls.toArray(EMPTY_URL_ARRAY);
         return result;
     }

--- a/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierTest.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierTest.java
@@ -20,7 +20,6 @@
 
 package io.spine.model.verify;
 
-import com.google.common.base.Function;
 import com.google.common.io.Files;
 import io.spine.model.CommandHandlers;
 import io.spine.model.verify.ModelVerifier.GetDestinationDir;
@@ -42,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.function.Function;
 
 import static io.spine.model.verify.given.ModelVerifierTestEnv.actualProject;
 import static io.spine.tools.gradle.TaskName.COMPILE_JAVA;


### PR DESCRIPTION
This PR replaces Giava's `Predicate` with JDK8 `Predicate`.
Also, it updates the version of the project to `0.10.67-SNAPSHOT`.