### PR TITLE
Migrate to `JUnit Pioneer`

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.70-SNAPSHOT'
+def final SPINE_VERSION = '0.10.71-SNAPSHOT'
 
 ext {
 

--- a/model/model-verifier/build.gradle
+++ b/model/model-verifier/build.gradle
@@ -22,6 +22,10 @@ buildscript {
     apply from: "$rootDir/ext.gradle"
 }
 
+ext {
+    jUnitPioneerVersion = '0.1.2'
+}
+
 group 'io.spine.tools'
 
 repositories {
@@ -47,6 +51,7 @@ dependencies {
     testImplementation gradleTestKit()
     testImplementation "io.spine:spine-testlib:$spineBaseVersion"
     testImplementation "io.spine.tools:spine-plugin-testlib:$spineBaseVersion"
+    testImplementation "org.junit-pioneer:junit-pioneer:$jUnitPioneerVersion"
 }
 
 test {

--- a/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierPluginTest.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierPluginTest.java
@@ -20,8 +20,6 @@
 
 package io.spine.model.verify;
 
-import io.spine.testing.TempDirectory;
-import io.spine.testing.TempDirectory.TempDir;
 import io.spine.tools.gradle.GradleProject;
 import io.spine.tools.gradle.TaskName;
 import org.gradle.testkit.runner.BuildResult;
@@ -32,6 +30,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junitpioneer.jupiter.TempDirectory;
 
 import java.nio.file.Path;
 
@@ -54,7 +53,7 @@ class ModelVerifierPluginTest {
     private Path tempDir;
 
     @BeforeEach
-    void setUp(@TempDir Path junitCreatedDir) {
+    void setUp(@TempDirectory.TempDir Path junitCreatedDir) {
         tempDir = junitCreatedDir;
     }
 

--- a/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierPluginTest.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierPluginTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junitpioneer.jupiter.TempDirectory;
+import org.junitpioneer.jupiter.TempDirectory.TempDir;
 
 import java.nio.file.Path;
 
@@ -53,7 +54,7 @@ class ModelVerifierPluginTest {
     private Path tempDir;
 
     @BeforeEach
-    void setUp(@TempDirectory.TempDir Path junitCreatedDir) {
+    void setUp(@TempDir Path junitCreatedDir) {
         tempDir = junitCreatedDir;
     }
 


### PR DESCRIPTION
This PR provides the following changes:
1. The `JUnit Pioneer` dependency is added to the `model-verifier` module;
2. The usage of the ` io.spine.testing.TempDirectory` class is replaced with `org.junitpioneer.jupiter.TempDirectory`;
3. The version is advanced to `0.10.71-SNAPSHOT`. 