### PR TITLE
Fix posting of multiple commands in response to an event

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.77-SNAPSHOT'
+def final SPINE_VERSION = '0.10.78-SNAPSHOT'
 
 ext {
 

--- a/server/src/main/java/io/spine/server/command/model/CommandingMethod.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandingMethod.java
@@ -138,6 +138,7 @@ interface CommandingMethod<T, M extends MessageClass, C extends Message, R exten
             } else {
                 SeveralCommands seq = respondMany(event);
                 seq.addAll(messages);
+                seq.postAll(bus);
             }
         }
     }

--- a/server/src/main/java/io/spine/server/commandbus/SeveralCommands.java
+++ b/server/src/main/java/io/spine/server/commandbus/SeveralCommands.java
@@ -71,4 +71,15 @@ public class SeveralCommands
         builder.addProduced(commandId);
         markReacted(gateway, commandId);
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @apiNote Overrides to open the method for outside use.
+     */
+    @Override
+    @CanIgnoreReturnValue
+    public MarkCausedCommands postAll(CommandBus bus) {
+        return super.postAll(bus);
+    }
 }

--- a/server/src/test/java/io/spine/server/procman/given/pm/GivenMessages.java
+++ b/server/src/test/java/io/spine/server/procman/given/pm/GivenMessages.java
@@ -30,12 +30,12 @@ import io.spine.core.Rejections;
 import io.spine.server.commandbus.Given;
 import io.spine.server.entity.rejection.StandardRejections.EntityAlreadyArchived;
 import io.spine.test.procman.command.PmAddTask;
+import io.spine.test.procman.command.PmCencelIteration;
 import io.spine.test.procman.command.PmCreateProject;
 import io.spine.test.procman.command.PmStartProject;
 import io.spine.test.procman.event.PmOwnerChanged;
 
 import static io.spine.server.procman.given.pm.TestProcessManager.ID;
-import static io.spine.testdata.Sample.builderForType;
 import static io.spine.testdata.Sample.messageOfType;
 
 /**
@@ -47,19 +47,29 @@ public class GivenMessages {
     }
 
     public static PmCreateProject createProject() {
-        return ((PmCreateProject.Builder) builderForType(PmCreateProject.class))
+        return PmCreateProject
+                .newBuilder()
                 .setProjectId(ID)
                 .build();
     }
 
     public static PmStartProject startProject() {
-        return ((PmStartProject.Builder) builderForType(PmStartProject.class))
+        return PmStartProject
+                .newBuilder()
                 .setProjectId(ID)
                 .build();
     }
 
     public static PmAddTask addTask() {
-        return ((PmAddTask.Builder) builderForType(PmAddTask.class))
+        return PmAddTask
+                .newBuilder()
+                .setProjectId(ID)
+                .build();
+    }
+
+    public static PmCencelIteration cancelIteration() {
+        return PmCencelIteration
+                .newBuilder()
                 .setProjectId(ID)
                 .build();
     }
@@ -76,7 +86,8 @@ public class GivenMessages {
     }
 
     public static PmOwnerChanged ownerChanged() {
-        return ((PmOwnerChanged.Builder) builderForType(PmOwnerChanged.class))
+        return PmOwnerChanged
+                .newBuilder()
                 .setProjectId(ID)
                 .build();
     }

--- a/server/src/test/proto/spine/test/procman/commands.proto
+++ b/server/src/test/proto/spine/test/procman/commands.proto
@@ -65,3 +65,15 @@ message PmArchiveProcess {
 message PmDeleteProcess {
     ProjectId project_id = 1;
 }
+
+message PmCencelIteration {
+    ProjectId project_id = 1;
+}
+
+message PmScheduleRetrospective {
+    ProjectId project_id = 1;
+}
+
+message PmPlanIteration {
+    ProjectId project_id = 1;
+}

--- a/server/src/test/proto/spine/test/procman/events.proto
+++ b/server/src/test/proto/spine/test/procman/events.proto
@@ -51,3 +51,15 @@ message PmProjectStarted {
 message PmOwnerChanged {
     ProjectId project_id = 1;
 }
+
+message PmIterationCompleted {
+    ProjectId project_id = 1;
+}
+
+message PmRetrospectiveScheduled {
+    ProjectId project_id = 1;
+}
+
+message PmIterationPlanned {
+    ProjectId project_id = 1;
+}


### PR DESCRIPTION
This PR fixes the bug which did not allow to post more than one command in response to incoming event.
