### PR TITLE
Rename tuples

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -75,7 +75,6 @@
     <inspection_tool class="BreakStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="BreakStatementWithLabel" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="BusyWait" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="CStyleArrayDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CallToNativeMethodWhileLocked" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CallToStringConcatCanBeReplacedByOperator" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CastConflictsWithInstanceof" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -285,8 +284,8 @@
     <inspection_tool class="InconsistentLanguageLevel" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="IncrementDecrementUsedAsExpression" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="InnerClassMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true">
-      <scope name="Production" level="WARNING" enabled="true"/>
-      <scope name="Tests" enabled="false"/>
+      <scope name="Production" level="WARNING" enabled="true" />
+      <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
     <inspection_tool class="InstanceMethodNamingConvention" enabled="true" level="INFO" enabled_by_default="true">
       <scope name="Tests" level="INFO" enabled="false">
@@ -380,6 +379,9 @@
     <inspection_tool class="JavaLangImport" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="JavaLangReflect" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="JavadocHtmlLint" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="JavadocReference" enabled="true" level="ERROR" enabled_by_default="true">
+      <scope name="Tests" level="ERROR" enabled="false" />
+    </inspection_tool>
     <inspection_tool class="LabeledStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="LengthOneStringInIndexOf" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="LengthOneStringsInConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -787,7 +789,6 @@
       <option name="m_ignoreStaticMethodCalls" value="false" />
       <option name="m_ignoreStaticAccessFromStaticContext" value="false" />
     </inspection_tool>
-    <inspection_tool class="UnnecessaryCallToStringValueOf" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnnecessaryConstantArrayCreationExpression" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnnecessaryConstructor" enabled="false" level="TYPO" enabled_by_default="false">
       <option name="ignoreAnnotations" value="true" />

--- a/core/src/main/java/io/spine/change/ChangePreconditions.java
+++ b/core/src/main/java/io/spine/change/ChangePreconditions.java
@@ -27,11 +27,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Checking of parameters for working with changes.
- *
- * @author Alexander Yevsyukov
  */
 @SuppressWarnings("OverloadedMethodsWithSameNumberOfParameters")
-final class Preconditions2 {
+final class ChangePreconditions {
 
     private static final String NEW_VALUE_CANNOT_BE_EMPTY =
             "newValue cannot be empty";
@@ -43,7 +41,7 @@ final class Preconditions2 {
             "`expected` and `actual` cannot be equal in ValueMismatch";
 
     /** Prevent instantiation of this utility class. */
-    private Preconditions2() {
+    private ChangePreconditions() {
     }
 
     /**

--- a/core/src/main/java/io/spine/change/Changes.java
+++ b/core/src/main/java/io/spine/change/Changes.java
@@ -24,8 +24,8 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.change.Preconditions2.checkNewValueNotEmpty;
-import static io.spine.change.Preconditions2.checkNotEqual;
+import static io.spine.change.ChangePreconditions.checkNewValueNotEmpty;
+import static io.spine.change.ChangePreconditions.checkNotEqual;
 
 /**
  * Utility class for working with field changes.

--- a/core/src/main/java/io/spine/change/DoubleMismatch.java
+++ b/core/src/main/java/io/spine/change/DoubleMismatch.java
@@ -24,7 +24,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.DoubleValue;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.change.Preconditions2.checkNotNullOrEqual;
+import static io.spine.change.ChangePreconditions.checkNotNullOrEqual;
 import static io.spine.protobuf.AnyPacker.unpack;
 import static io.spine.protobuf.TypeConverter.toAny;
 

--- a/core/src/main/java/io/spine/change/FloatMismatch.java
+++ b/core/src/main/java/io/spine/change/FloatMismatch.java
@@ -24,7 +24,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.FloatValue;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.change.Preconditions2.checkNotNullOrEqual;
+import static io.spine.change.ChangePreconditions.checkNotNullOrEqual;
 import static io.spine.protobuf.AnyPacker.unpack;
 import static io.spine.protobuf.TypeConverter.toAny;
 

--- a/core/src/main/java/io/spine/change/IntMismatch.java
+++ b/core/src/main/java/io/spine/change/IntMismatch.java
@@ -24,7 +24,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.Int32Value;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.change.Preconditions2.checkNotNullOrEqual;
+import static io.spine.change.ChangePreconditions.checkNotNullOrEqual;
 import static io.spine.protobuf.AnyPacker.unpack;
 import static io.spine.protobuf.TypeConverter.toAny;
 

--- a/core/src/main/java/io/spine/change/LongMismatch.java
+++ b/core/src/main/java/io/spine/change/LongMismatch.java
@@ -24,7 +24,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.Int64Value;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.change.Preconditions2.checkNotNullOrEqual;
+import static io.spine.change.ChangePreconditions.checkNotNullOrEqual;
 import static io.spine.protobuf.AnyPacker.unpack;
 import static io.spine.protobuf.TypeConverter.toAny;
 

--- a/core/src/main/java/io/spine/change/MessageMismatch.java
+++ b/core/src/main/java/io/spine/change/MessageMismatch.java
@@ -24,7 +24,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.change.Preconditions2.checkNotEqual;
+import static io.spine.change.ChangePreconditions.checkNotEqual;
 import static io.spine.protobuf.AnyPacker.pack;
 import static io.spine.protobuf.AnyPacker.unpack;
 

--- a/core/src/main/java/io/spine/change/StringMismatch.java
+++ b/core/src/main/java/io/spine/change/StringMismatch.java
@@ -24,7 +24,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.StringValue;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.change.Preconditions2.checkNotEqual;
+import static io.spine.change.ChangePreconditions.checkNotEqual;
 import static io.spine.protobuf.AnyPacker.unpack;
 import static io.spine.protobuf.TypeConverter.toAny;
 

--- a/core/src/test/java/io/spine/change/BooleanMismatchTest.java
+++ b/core/src/test/java/io/spine/change/BooleanMismatchTest.java
@@ -20,7 +20,7 @@
 
 package io.spine.change;
 
-import com.google.common.testing.NullPointerTester;
+import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,30 +30,18 @@ import static io.spine.change.BooleanMismatch.expectedTrue;
 import static io.spine.change.BooleanMismatch.unpackActual;
 import static io.spine.change.BooleanMismatch.unpackExpected;
 import static io.spine.change.BooleanMismatch.unpackNewValue;
-import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
-import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
-import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings({"InnerClassMayBeStatic" /* JUnit nested classes cannot be static */,
                    "DuplicateStringLiteralInspection" /* A lot of similar test display names */})
 @DisplayName("BooleanMismatch should")
-class BooleanMismatchTest {
+class BooleanMismatchTest extends UtilityClassTest<BooleanMismatch> {
 
     private static final int VERSION = 2;
 
-    @Test
-    @DisplayName(HAVE_PARAMETERLESS_CTOR)
-    void haveUtilityConstructor() {
-        assertHasPrivateParameterlessCtor(BooleanMismatch.class);
-    }
-
-    @Test
-    @DisplayName(NOT_ACCEPT_NULLS)
-    void passNullToleranceCheck() {
-        new NullPointerTester()
-                .testAllPublicStaticMethods(BooleanMismatch.class);
+    BooleanMismatchTest() {
+        super(BooleanMismatch.class);
     }
 
     @Nested

--- a/core/src/test/java/io/spine/change/ChangePreconditionsTest.java
+++ b/core/src/test/java/io/spine/change/ChangePreconditionsTest.java
@@ -20,32 +20,19 @@
 
 package io.spine.change;
 
-import com.google.common.testing.NullPointerTester;
-import com.google.common.testing.NullPointerTester.Visibility;
 import com.google.protobuf.ByteString;
+import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.change.Preconditions2.checkNewValueNotEmpty;
-import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
-import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
-import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
+import static io.spine.change.ChangePreconditions.checkNewValueNotEmpty;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("Preconditions2 utility should")
-class Preconditions2Test {
+class ChangePreconditionsTest extends UtilityClassTest<ChangePreconditions> {
 
-    @Test
-    @DisplayName(HAVE_PARAMETERLESS_CTOR)
-    void haveUtilityConstructor() {
-        assertHasPrivateParameterlessCtor(Preconditions2.class);
-    }
-
-    @Test
-    @DisplayName(NOT_ACCEPT_NULLS)
-    void passNullToleranceCheck() {
-        new NullPointerTester()
-                .testStaticMethods(Preconditions2.class, Visibility.PACKAGE);
+    protected ChangePreconditionsTest() {
+        super(ChangePreconditions.class);
     }
 
     @Test

--- a/core/src/test/java/io/spine/change/ChangesTest.java
+++ b/core/src/test/java/io/spine/change/ChangesTest.java
@@ -24,6 +24,7 @@ import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
 import io.spine.base.Time;
+import io.spine.testing.UtilityClassTest;
 import io.spine.time.testing.TimeTests;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -33,21 +34,17 @@ import java.util.UUID;
 
 import static com.google.protobuf.ByteString.copyFromUtf8;
 import static io.spine.base.Time.getCurrentTime;
-import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
-import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
-import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings({"ConstantConditions" /* We pass `null` to some of the methods to check handling
                                         of preconditions */,
                    "ResultOfMethodCallIgnored" /* ...when methods throw exceptions */,
-                   "ClassWithTooManyMethods",
                    "OverlyCoupledClass" /* we test many data types and utility methods */,
                    "InnerClassMayBeStatic" /* JUnit nested classes cannot be static */,
                    "DuplicateStringLiteralInspection" /* A lot of similar test display names */})
 @DisplayName("Changes utility should")
-class ChangesTest {
+class ChangesTest extends UtilityClassTest<Changes> {
 
     private static final String ERR_PREVIOUS_VALUE_CANNOT_BE_NULL =
             "do_not_accept_null_previousValue";
@@ -56,19 +53,15 @@ class ChangesTest {
     private static final String ERR_VALUES_CANNOT_BE_EQUAL =
             "do_not_accept_equal_values";
 
-    @Test
-    @DisplayName(HAVE_PARAMETERLESS_CTOR)
-    void haveUtilityConstructor() {
-        assertHasPrivateParameterlessCtor(Changes.class);
+    ChangesTest() {
+        super(Changes.class);
     }
 
-    @Test
-    @DisplayName(NOT_ACCEPT_NULLS)
-    void passNullToleranceCheck() {
-        new NullPointerTester()
-                .setDefault(ByteString.class, ByteString.EMPTY)
-                .setDefault(Timestamp.class, Time.getCurrentTime())
-                .testAllPublicStaticMethods(Changes.class);
+    @Override
+    protected void configure(NullPointerTester tester) {
+        super.configure(tester);
+        tester.setDefault(ByteString.class, ByteString.EMPTY)
+               .setDefault(Timestamp.class, Time.getCurrentTime());
     }
 
     @Nested

--- a/core/src/test/java/io/spine/change/ChangesTest.java
+++ b/core/src/test/java/io/spine/change/ChangesTest.java
@@ -40,9 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @SuppressWarnings({"ConstantConditions" /* We pass `null` to some of the methods to check handling
                                         of preconditions */,
                    "ResultOfMethodCallIgnored" /* ...when methods throw exceptions */,
-                   "OverlyCoupledClass" /* we test many data types and utility methods */,
-                   "InnerClassMayBeStatic" /* JUnit nested classes cannot be static */,
-                   "DuplicateStringLiteralInspection" /* A lot of similar test display names */})
+                   "OverlyCoupledClass" /* we test many data types and utility methods */})
 @DisplayName("Changes utility should")
 class ChangesTest extends UtilityClassTest<Changes> {
 

--- a/core/src/test/java/io/spine/change/DoubleMismatchTest.java
+++ b/core/src/test/java/io/spine/change/DoubleMismatchTest.java
@@ -20,7 +20,7 @@
 
 package io.spine.change;
 
-import com.google.common.testing.NullPointerTester;
+import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -32,16 +32,11 @@ import static io.spine.change.DoubleMismatch.unexpectedValue;
 import static io.spine.change.DoubleMismatch.unpackActual;
 import static io.spine.change.DoubleMismatch.unpackExpected;
 import static io.spine.change.DoubleMismatch.unpackNewValue;
-import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
-import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
-import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SuppressWarnings({"InnerClassMayBeStatic" /* JUnit nested classes cannot be static */,
-                   "DuplicateStringLiteralInspection" /* A lot of similar test display names */})
 @DisplayName("DoubleMismatch should")
-class DoubleMismatchTest {
+class DoubleMismatchTest extends UtilityClassTest<DoubleMismatch> {
 
     private static final int VERSION = 100;
     private static final double EXPECTED = 18.39;
@@ -49,17 +44,8 @@ class DoubleMismatchTest {
     private static final double NEW_VALUE = 14.52;
     private static final double DELTA = 0.01;
 
-    @Test
-    @DisplayName(HAVE_PARAMETERLESS_CTOR)
-    void haveUtilityConstructor() {
-        assertHasPrivateParameterlessCtor(DoubleMismatch.class);
-    }
-
-    @Test
-    @DisplayName(NOT_ACCEPT_NULLS)
-    void passNullToleranceCheck() {
-        new NullPointerTester()
-                .testAllPublicStaticMethods(DoubleMismatch.class);
+    DoubleMismatchTest() {
+        super(DoubleMismatch.class);
     }
 
     @Nested

--- a/core/src/test/java/io/spine/change/FloatMismatchTest.java
+++ b/core/src/test/java/io/spine/change/FloatMismatchTest.java
@@ -20,7 +20,7 @@
 
 package io.spine.change;
 
-import com.google.common.testing.NullPointerTester;
+import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -32,16 +32,11 @@ import static io.spine.change.FloatMismatch.unexpectedValue;
 import static io.spine.change.FloatMismatch.unpackActual;
 import static io.spine.change.FloatMismatch.unpackExpected;
 import static io.spine.change.FloatMismatch.unpackNewValue;
-import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
-import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
-import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SuppressWarnings({"InnerClassMayBeStatic" /* JUnit nested classes cannot be static */,
-                   "DuplicateStringLiteralInspection" /* A lot of similar test display names */})
 @DisplayName("FloatMismatch should")
-class FloatMismatchTest {
+class FloatMismatchTest extends UtilityClassTest<FloatMismatch> {
 
     private static final int VERSION = 100;
     private static final float EXPECTED = 18.39f;
@@ -49,17 +44,8 @@ class FloatMismatchTest {
     private static final float NEW_VALUE = 14.52f;
     private static final float DELTA = 0.01f;
 
-    @Test
-    @DisplayName(HAVE_PARAMETERLESS_CTOR)
-    void haveUtilityConstructor() {
-        assertHasPrivateParameterlessCtor(FloatMismatch.class);
-    }
-
-    @Test
-    @DisplayName(NOT_ACCEPT_NULLS)
-    void passNullToleranceCheck() {
-        new NullPointerTester()
-                .testAllPublicStaticMethods(FloatMismatch.class);
+    FloatMismatchTest() {
+        super(FloatMismatch.class);
     }
 
     @Nested
@@ -101,7 +87,6 @@ class FloatMismatchTest {
             assertEquals(VERSION, mismatch.getVersion());
         }
 
-        @SuppressWarnings("Duplicates") // Common test case for different Mismatches.
         @Test
         @DisplayName("for unexpected float value")
         void forUnexpectedFloat() {

--- a/core/src/test/java/io/spine/change/IntMismatchTest.java
+++ b/core/src/test/java/io/spine/change/IntMismatchTest.java
@@ -21,6 +21,7 @@
 package io.spine.change;
 
 import com.google.common.testing.NullPointerTester;
+import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -38,15 +39,17 @@ import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SuppressWarnings({"InnerClassMayBeStatic" /* JUnit nested classes cannot be static */,
-                   "DuplicateStringLiteralInspection" /* A lot of similar test display names */})
 @DisplayName("IntMismatch should")
-class IntMismatchTest {
+class IntMismatchTest extends UtilityClassTest<IntMismatch> {
 
     private static final int EXPECTED = 1986;
     private static final int ACTUAL = 1567;
     private static final int NEW_VALUE = 1452;
     private static final int VERSION = 5;
+
+    IntMismatchTest() {
+        super(IntMismatch.class);
+    }
 
     @Test
     @DisplayName(HAVE_PARAMETERLESS_CTOR)
@@ -100,7 +103,6 @@ class IntMismatchTest {
             assertEquals(VERSION, mismatch.getVersion());
         }
 
-        @SuppressWarnings("Duplicates") // Common test case for different Mismatches.
         @Test
         @DisplayName("for unexpected int value")
         void forUnexpectedInt() {

--- a/core/src/test/java/io/spine/change/LongMismatchTest.java
+++ b/core/src/test/java/io/spine/change/LongMismatchTest.java
@@ -20,7 +20,7 @@
 
 package io.spine.change;
 
-import com.google.common.testing.NullPointerTester;
+import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -32,33 +32,19 @@ import static io.spine.change.LongMismatch.unexpectedValue;
 import static io.spine.change.LongMismatch.unpackActual;
 import static io.spine.change.LongMismatch.unpackExpected;
 import static io.spine.change.LongMismatch.unpackNewValue;
-import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
-import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
-import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SuppressWarnings({"InnerClassMayBeStatic" /* JUnit nested classes cannot be static */,
-                   "DuplicateStringLiteralInspection" /* A lot of similar test display names */})
 @DisplayName("LongMismatch should")
-class LongMismatchTest {
+class LongMismatchTest extends UtilityClassTest<LongMismatch> {
 
     private static final long EXPECTED = 1839L;
     private static final long ACTUAL = 1900L;
     private static final long NEW_VALUE = 1452L;
     private static final int VERSION = 7;
 
-    @Test
-    @DisplayName(HAVE_PARAMETERLESS_CTOR)
-    void haveUtilityConstructor() {
-        assertHasPrivateParameterlessCtor(LongMismatch.class);
-    }
-
-    @Test
-    @DisplayName(NOT_ACCEPT_NULLS)
-    void passNullToleranceCheck() {
-        new NullPointerTester()
-                .testAllPublicStaticMethods(LongMismatch.class);
+    LongMismatchTest() {
+        super(LongMismatch.class);
     }
 
     @Nested
@@ -100,7 +86,6 @@ class LongMismatchTest {
             assertEquals(VERSION, mismatch.getVersion());
         }
 
-        @SuppressWarnings("Duplicates") // Common test case for different Mismatches.
         @Test
         @DisplayName("for unexpected long value")
         void forUnexpectedLong() {

--- a/core/src/test/java/io/spine/change/MessageMismatchTest.java
+++ b/core/src/test/java/io/spine/change/MessageMismatchTest.java
@@ -20,8 +20,8 @@
 
 package io.spine.change;
 
-import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.StringValue;
+import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -33,13 +33,10 @@ import static io.spine.change.MessageMismatch.unpackActual;
 import static io.spine.change.MessageMismatch.unpackExpected;
 import static io.spine.change.MessageMismatch.unpackNewValue;
 import static io.spine.protobuf.TypeConverter.toMessage;
-import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
-import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
-import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DisplayName("MessageMismatch should")
-class MessageMismatchTest {
+class MessageMismatchTest extends UtilityClassTest<MessageMismatch> {
 
     private static final StringValue EXPECTED = toMessage("expected_value");
     private static final StringValue ACTUAL = toMessage("actual-value");
@@ -47,22 +44,10 @@ class MessageMismatchTest {
     private static final StringValue DEFAULT_VALUE = StringValue.getDefaultInstance();
     private static final int VERSION = 1;
 
-    @Test
-    @DisplayName(HAVE_PARAMETERLESS_CTOR)
-    void haveUtilityConstructor() {
-        assertHasPrivateParameterlessCtor(MessageMismatch.class);
+    MessageMismatchTest() {
+        super(MessageMismatch.class);
     }
 
-    @Test
-    @DisplayName(NOT_ACCEPT_NULLS)
-    void passNullToleranceCheck() {
-        new NullPointerTester()
-                .testAllPublicStaticMethods(MessageMismatch.class);
-    }
-
-    @SuppressWarnings({"InnerClassMayBeStatic" /* JUnit nested classes cannot be static */,
-                       "DuplicateStringLiteralInspection" /* Nested class display name similar to
-                                                          others */})
     @Nested
     @DisplayName("create ValueMismatch instance")
     class Create {
@@ -108,7 +93,6 @@ class MessageMismatchTest {
             assertEquals(VERSION, mismatch.getVersion());
         }
 
-        @SuppressWarnings("Duplicates") // Common test case for different Mismatches.
         @Test
         @DisplayName("for unexpected value")
         void forUnexpectedValue() {

--- a/core/src/test/java/io/spine/change/StringMismatchTest.java
+++ b/core/src/test/java/io/spine/change/StringMismatchTest.java
@@ -20,7 +20,7 @@
 
 package io.spine.change;
 
-import com.google.common.testing.NullPointerTester;
+import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -32,33 +32,19 @@ import static io.spine.change.StringMismatch.unexpectedValue;
 import static io.spine.change.StringMismatch.unpackActual;
 import static io.spine.change.StringMismatch.unpackExpected;
 import static io.spine.change.StringMismatch.unpackNewValue;
-import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
-import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
-import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SuppressWarnings({"InnerClassMayBeStatic" /* JUnit nested classes cannot be static */,
-                   "DuplicateStringLiteralInspection" /* A lot of similar test display names */})
 @DisplayName("StringMismatch should")
-class StringMismatchTest {
+class StringMismatchTest extends UtilityClassTest<StringMismatch> {
 
     private static final String EXPECTED = "expected string";
     private static final String ACTUAL = "actual string";
     private static final String NEW_VALUE = "new value to set";
     private static final int VERSION = 1;
 
-    @Test
-    @DisplayName(HAVE_PARAMETERLESS_CTOR)
-    void haveUtilityConstructor() {
-        assertHasPrivateParameterlessCtor(StringMismatch.class);
-    }
-
-    @Test
-    @DisplayName(NOT_ACCEPT_NULLS)
-    void passNullToleranceCheck() {
-        new NullPointerTester()
-                .testAllPublicStaticMethods(StringMismatch.class);
+    StringMismatchTest() {
+        super(StringMismatch.class);
     }
 
     @Nested
@@ -93,7 +79,6 @@ class StringMismatchTest {
             assertEquals(VERSION, mismatch.getVersion());
         }
 
-        @SuppressWarnings("Duplicates") // Common test case for different Mismatches.
         @Test
         @DisplayName("for unexpected value")
         void forUnexpectedValue() {

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
  
-def final SPINE_VERSION = '0.10.93-SNAPSHOT'
+def final SPINE_VERSION = '0.10.94-SNAPSHOT'
 
 ext {
 

--- a/server/src/main/java/io/spine/server/delivery/UniformAcrossTargets.java
+++ b/server/src/main/java/io/spine/server/delivery/UniformAcrossTargets.java
@@ -57,6 +57,8 @@ public class UniformAcrossTargets implements ShardingStrategy {
 
     private static final long serialVersionUID = 0L;
 
+    private static final ShardingStrategy singleShardStrategy = new UniformAcrossTargets(1);
+
     private final int numberOfShards;
 
     /**
@@ -119,7 +121,7 @@ public class UniformAcrossTargets implements ShardingStrategy {
      * @return a strategy that puts all entities in a single shard
      */
     public static ShardingStrategy singleShard() {
-        return SingleShard.INSTANCE.strategy;
+        return singleShardStrategy;
     }
 
     /**
@@ -138,10 +140,5 @@ public class UniformAcrossTargets implements ShardingStrategy {
                          .setIndex(indexValue)
                          .setOfTotal(totalShards)
                          .build();
-    }
-
-    private enum SingleShard {
-        INSTANCE;
-        private final UniformAcrossTargets strategy = new UniformAcrossTargets(1);
     }
 }

--- a/server/src/main/java/io/spine/server/delivery/UniformAcrossTargets.java
+++ b/server/src/main/java/io/spine/server/delivery/UniformAcrossTargets.java
@@ -20,8 +20,8 @@
 package io.spine.server.delivery;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.Immutable;
 
-import javax.annotation.concurrent.Immutable;
 import java.util.Objects;
 import java.util.Set;
 

--- a/server/src/main/java/io/spine/server/delivery/UniformAcrossTargets.java
+++ b/server/src/main/java/io/spine/server/delivery/UniformAcrossTargets.java
@@ -112,11 +112,6 @@ public class UniformAcrossTargets implements ShardingStrategy {
         return Objects.hash(numberOfShards);
     }
 
-    private enum SingleShard {
-        INSTANCE;
-        private final UniformAcrossTargets strategy = new UniformAcrossTargets(1);
-    }
-
     /**
      * Returns a pre-defined strategy instance, which defines a single shard and puts all
      * the targets into it.
@@ -134,7 +129,7 @@ public class UniformAcrossTargets implements ShardingStrategy {
      * @return a uniform distribution strategy instance for a given shard number
      */
     public static ShardingStrategy forNumber(int totalShards) {
-        UniformAcrossTargets result = new UniformAcrossTargets(totalShards);
+        ShardingStrategy result = new UniformAcrossTargets(totalShards);
         return result;
     }
 
@@ -143,5 +138,10 @@ public class UniformAcrossTargets implements ShardingStrategy {
                          .setIndex(indexValue)
                          .setOfTotal(totalShards)
                          .build();
+    }
+
+    private enum SingleShard {
+        INSTANCE;
+        private final UniformAcrossTargets strategy = new UniformAcrossTargets(1);
     }
 }

--- a/server/src/main/java/io/spine/server/delivery/UniformAcrossTargets.java
+++ b/server/src/main/java/io/spine/server/delivery/UniformAcrossTargets.java
@@ -21,6 +21,7 @@ package io.spine.server.delivery;
 
 import com.google.common.collect.ImmutableSet;
 
+import javax.annotation.concurrent.Immutable;
 import java.util.Objects;
 import java.util.Set;
 
@@ -36,21 +37,22 @@ import static java.lang.Math.abs;
  * <pre>
  *     {@code
  *
- *     final UserAggregate entity = ...
+ *     UserAggregate aggregate = ...
  *
- *     final int hashValue =  entity.getId().hashCode();
- *     final int numberOfShards = 4;
+ *     int hashValue =  aggregate.getId().hashCode();
+ *     int numberOfShards = 4;
  *
  *      // possible values are 0, 1, 2, and 3.
- *     final int shardIndexValue = Math.abs(hashValue % numberOfShards);
- *     final ShardIndex shardIndex = newIndex(shardIndexValue);
+ *     int shardIndexValue = Math.abs(hashValue % numberOfShards);
+ *     ShardIndex shardIndex = newIndex(shardIndexValue);
  *     }
  * </pre>
  *
  *  <p>Such an approach isn't truly uniform — as long as the ID nature may be very specific,
  *  making the {@code hashCode()} value distribution uneven. However, it's a good enough choice
- *  in a general case
+ *  in a general case.
  */
+@Immutable
 public class UniformAcrossTargets implements ShardingStrategy {
 
     private static final long serialVersionUID = 0L;

--- a/server/src/main/java/io/spine/server/entity/storage/ColumnValueConverter.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ColumnValueConverter.java
@@ -26,8 +26,6 @@ import java.io.Serializable;
 
 /**
  * An interface for converting the {@link EntityColumn} values to their persisted type.
- *
- * @author Dmytro Kuzmin
  */
 interface ColumnValueConverter {
 

--- a/server/src/main/java/io/spine/server/entity/storage/EnumConverter.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EnumConverter.java
@@ -29,7 +29,6 @@ import static io.spine.util.Exceptions.newIllegalArgumentException;
  * An abstract base for converting the {@link Enum} entity column value into the value for
  * persistence in the data storage.
  *
- * @author Dmytro Kuzmin
  * @see EnumConverters
  * @see EnumType
  */
@@ -42,7 +41,9 @@ abstract class EnumConverter implements ColumnValueConverter {
     }
 
     /**
-     * {@inheritDoc}
+     * Converts the passed enum value to its {@linkplain #convertEnumValue(Enum)} serializable}
+     * form.
+     *
      * @throws IllegalArgumentException in case the passed value is not of the {@link Enum} type
      */
     @Override
@@ -58,9 +59,6 @@ abstract class EnumConverter implements ColumnValueConverter {
         return convertedValue;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Class<? extends Enum> getSourceType() {
         return sourceType;

--- a/server/src/main/java/io/spine/server/event/model/EventHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/EventHandlerMethod.java
@@ -72,6 +72,20 @@ public abstract class EventHandlerMethod<T, R extends MethodResult>
         }
     }
 
+    /**
+     * Ensures that the passed event matches the {@code external} attribute
+     * of the method annotation.
+     *
+     * <p>If the method annotated to accept {@code external} events, the event passed to the handler
+     * method must be produced {@linkplain io.spine.core.EventContext#getExternal() outside} of
+     * the Bounded Context to which the handling entity belongs.
+     *
+     * <p>And vice versa, if the event handling method is designed for domestic events,
+     * it does not accept external events.
+     *
+     * @see io.spine.core.Subscribe#external()
+     * @see io.spine.server.event.React#external()
+     */
     @Override
     protected void checkAttributesMatch(EventEnvelope envelope) {
         boolean external = envelope.getEventContext()
@@ -82,8 +96,7 @@ public abstract class EventHandlerMethod<T, R extends MethodResult>
     /**
      * {@inheritDoc}
      *
-     * @apiNote
-     * Overridden to mark {@code rawMethodOutput} argument as nullable.
+     * @apiNote Overridden to mark the {@code rawMethodOutput} parameter as {@code Nullable}.
      */
     @SuppressWarnings("UnnecessaryInheritDoc") // IDEA bug: `@apiNote` isn't seen as modification
     @Override

--- a/server/src/main/java/io/spine/server/integration/ExternalMessageClass.java
+++ b/server/src/main/java/io/spine/server/integration/ExternalMessageClass.java
@@ -31,11 +31,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * A value object holding a class of {@linkplain ExternalMessage external message}.
- *
- * @author Alex Tymchenko
  */
 @Internal
-public final class ExternalMessageClass extends MessageClass {
+public final class ExternalMessageClass extends MessageClass<Message> {
 
     private static final long serialVersionUID = 0L;
 
@@ -47,9 +45,9 @@ public final class ExternalMessageClass extends MessageClass {
      * Creates an instance of {@code ExternalMessageClass} on top of existing message class.
      *
      * @param messageClass a message class to wrap
-     * @return a new instance of {@code ExternalMessageClass}.\
+     * @return a new instance of {@code ExternalMessageClass}
      */
-    public static ExternalMessageClass of(MessageClass messageClass) {
+    public static ExternalMessageClass of(MessageClass<?> messageClass) {
         checkNotNull(messageClass);
         return of(messageClass.value());
     }

--- a/server/src/main/java/io/spine/server/integration/IntegrationChannels.java
+++ b/server/src/main/java/io/spine/server/integration/IntegrationChannels.java
@@ -32,16 +32,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * A utility class for working with {@link MessageChannel message channels} and their
  * {@link ChannelId identifiers}, when they are used for {@link IntegrationBus} needs.
- *
- * @author Alex Tymchenko
  */
-class IntegrationChannels {
+final class IntegrationChannels {
 
     private static final TypeUrl EVENT_TYPE_URL = TypeUrl.of(Event.class);
 
-    /**
-     * Prevents the creation of the class instances.
-     */
+    /** Prevents instantiation of this utility class. */
     private IntegrationChannels() {
     }
 
@@ -72,13 +68,15 @@ class IntegrationChannels {
 
         TypeUrl typeUrl = TypeUrl.of(messageType);
 
-        StringValue asStringValue = StringValue.newBuilder()
-                                               .setValue(typeUrl.value())
-                                               .build();
+        StringValue asStringValue = StringValue
+                .newBuilder()
+                .setValue(typeUrl.value())
+                .build();
         Any packed = AnyPacker.pack(asStringValue);
-        ChannelId channelId = ChannelId.newBuilder()
-                                       .setIdentifier(packed)
-                                       .build();
+        ChannelId channelId = ChannelId
+                .newBuilder()
+                .setIdentifier(packed)
+                .build();
         return channelId;
     }
 
@@ -97,10 +95,11 @@ class IntegrationChannels {
         StringValue rawValue = AnyPacker.unpack(channelId.getIdentifier());
         TypeUrl typeUrl = TypeUrl.parse(rawValue.getValue());
 
-        ExternalMessageType result = ExternalMessageType.newBuilder()
-                                                        .setMessageTypeUrl(typeUrl.value())
-                                                        .setWrapperTypeUrl(EVENT_TYPE_URL.value())
-                                                        .build();
+        ExternalMessageType result = ExternalMessageType
+                .newBuilder()
+                .setMessageTypeUrl(typeUrl.value())
+                .setWrapperTypeUrl(EVENT_TYPE_URL.value())
+                .build();
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/model/AbstractHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/model/AbstractHandlerMethod.java
@@ -176,13 +176,19 @@ public abstract class AbstractHandlerMethod<T,
         return parameterSpec;
     }
 
-    /** Returns {@code true} if the method is declared {@code public}, {@code false} otherwise. */
+    /**
+     * Returns {@code true} if the method is declared {@code public},
+     * {@code false} otherwise.
+     */
     protected boolean isPublic() {
         boolean result = Modifier.isPublic(getModifiers());
         return result;
     }
 
-    /** Returns {@code true} if the method is declared {@code private}, {@code false} otherwise. */
+    /**
+     * Returns {@code true} if the method is declared {@code private},
+     * {@code false} otherwise.
+     */
     protected boolean isPrivate() {
         boolean result = Modifier.isPrivate(getModifiers());
         return result;
@@ -218,11 +224,10 @@ public abstract class AbstractHandlerMethod<T,
     }
 
     /**
-     * A callback for descending classes to make sure that the passed envelope matches
-     * the attributes of a method.
+     * Allows to make sure that the passed envelope matches the annotation attributes of a method.
      *
-     * <p>This method does nothing. Descending classes may override this method to ensure that
-     * the passed envelope matches arguments of the method annotation.
+     * <p>Default implementation does nothing. Descending classes may override for checking
+     * the match.
      *
      * @throws IllegalArgumentException
      *         the default implementation does not throw ever. Descending classes would throw

--- a/server/src/main/java/io/spine/server/model/AbstractHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/model/AbstractHandlerMethod.java
@@ -188,7 +188,6 @@ public abstract class AbstractHandlerMethod<T,
         return result;
     }
 
-    @SuppressWarnings("AssignmentOrReturnOfFieldWithMutableType")   // Returning immutable impl.
     @Override
     public Set<MethodAttribute<?>> getAttributes() {
         return attributes;
@@ -218,9 +217,20 @@ public abstract class AbstractHandlerMethod<T,
         }
     }
 
+    /**
+     * A callback for descending classes to make sure that the passed envelope matches
+     * the attributes of a method.
+     *
+     * <p>This method does nothing. Descending classes may override this method to ensure that
+     * the passed envelope matches arguments of the method annotation.
+     *
+     * @throws IllegalArgumentException
+     *         the default implementation does not throw ever. Descending classes would throw
+     *         if the annotation arguments do not match the message of the passed envelope.
+     * @param envelope the envelope with the massed to handle
+     */
     @SuppressWarnings("NoopMethodInAbstractClass") // Optional for descendants.
-    protected void checkAttributesMatch(@SuppressWarnings("unused") // See suppression above.
-                                        E envelope) {
+    protected void checkAttributesMatch(E envelope) throws IllegalArgumentException {
         // Do nothing by default.
     }
 

--- a/server/src/main/java/io/spine/server/model/HandlerMethod.java
+++ b/server/src/main/java/io/spine/server/model/HandlerMethod.java
@@ -38,8 +38,6 @@ import static com.google.common.base.Preconditions.checkArgument;
  * @param <C> the type of the incoming message class
  * @param <E> the type of the {@link MessageEnvelope} wrapping the method arguments
  * @param <R> the type of the method result object
- * @author Alexander Yevsyukov
- * @author Alex Tymchenko
  */
 @Immutable
 public interface HandlerMethod<T,
@@ -48,7 +46,7 @@ public interface HandlerMethod<T,
                                R extends MethodResult> {
 
     /**
-     * @return the type of the incoming message class
+     * Obtains the type of the incoming message class.
      */
     C getMessageClass();
 
@@ -63,12 +61,12 @@ public interface HandlerMethod<T,
     HandlerKey key();
 
     /**
-     * @return the set of method attributes configured for this method
+     * Obtains the set of method attributes configured for this method.
      */
     Set<MethodAttribute<?>> getAttributes();
 
     /**
-     * @return the handling method
+     * Returns the handling method reference.
      */
     Method getRawMethod();
 
@@ -109,7 +107,7 @@ public interface HandlerMethod<T,
      * @throws IllegalArgumentException is thrown if the value does not meet the expectation
      * @see ExternalAttribute
      */
-    default void ensureExternalMatch(boolean expectedValue) {
+    default void ensureExternalMatch(boolean expectedValue) throws IllegalArgumentException {
         checkArgument(isExternal() == expectedValue,
                       "Mismatch of `external` value for the handler method %s. " +
                               "Expected `external` = %s, but got the other way around.", this,

--- a/server/src/main/java/io/spine/server/tuple/EitherOf2.java
+++ b/server/src/main/java/io/spine/server/tuple/EitherOf2.java
@@ -23,63 +23,47 @@ package io.spine.server.tuple;
 import com.google.protobuf.Message;
 import io.spine.server.tuple.Element.AValue;
 import io.spine.server.tuple.Element.BValue;
-import io.spine.server.tuple.Element.CValue;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * A value which can be of one of three possible types.
+ * A value which can be one of two possible types.
  *
  * @param <A> the type for the first alternative
  * @param <B> the type of the second alternative
- * @param <C> the type of the third alternative
- *
- * @author Alexander Yevsyukov
  */
-public final class EitherOfThree<A extends Message, B extends Message, C extends Message>
-    extends Either
-    implements AValue<A>, BValue<B>, CValue<C> {
+public final class EitherOf2<A extends Message, B extends Message>
+        extends Either
+        implements AValue<A>, BValue<B> {
 
     private static final long serialVersionUID = 0L;
 
-    private EitherOfThree(Message value, int index) {
+    private EitherOf2(Message value, int index) {
         super(value, index);
     }
 
     /**
      * Creates a new instance with {@code <A>} value.
      */
-    public static <A extends Message, B extends Message, C extends Message>
-    EitherOfThree<A, B, C> withA(A a) {
+    public static <A extends Message, B extends Message> EitherOf2<A, B> withA(A a) {
         checkNotNull(a);
-        EitherOfThree<A, B, C> result = new EitherOfThree<>(a, 0);
+        EitherOf2<A, B> result = new EitherOf2<>(a, 0);
         return result;
     }
 
     /**
      * Creates a new instance with {@code <B>} value.
      */
-    public static <A extends Message, B extends Message, C extends Message>
-    EitherOfThree<A, B, C> withB(B b) {
+    public static <A extends Message, B extends Message> EitherOf2<A, B> withB(B b) {
         checkNotNull(b);
-        EitherOfThree<A, B, C> result = new EitherOfThree<>(b, 1);
-        return result;
-    }
-
-    /**
-     * Creates a new instance with {@code <C>} value.
-     */
-    public static <A extends Message, B extends Message, C extends Message>
-    EitherOfThree<A, B, C> withC(C c) {
-        checkNotNull(c);
-        EitherOfThree<A, B, C> result = new EitherOfThree<>(c, 2);
+        EitherOf2<A, B> result = new EitherOf2<>(b, 1);
         return result;
     }
 
     /**
      * Obtains the value of the first alternative.
      *
-     * @throws IllegalStateException if a value of another type is stored instead.
+     * @throws IllegalStateException if the {@code <B>} value is stored instead.
      * @return the stored value.
      */
     @Override
@@ -90,22 +74,11 @@ public final class EitherOfThree<A extends Message, B extends Message, C extends
     /**
      * Obtains the value of the second alternative.
      *
-     * @throws IllegalStateException if a value of another type is stored instead.
+     * @throws IllegalStateException if the {@code <A>} value is stored instead.
      * @return the stored value.
      */
     @Override
     public B getB() {
         return get(this, 1);
-    }
-
-    /**
-     * Obtains the value of the third alternative.
-     *
-     * @throws IllegalStateException if a value of another type is stored instead.
-     * @return the stored value.
-     */
-    @Override
-    public C getC() {
-        return get(this, 2);
     }
 }

--- a/server/src/main/java/io/spine/server/tuple/EitherOf2.java
+++ b/server/src/main/java/io/spine/server/tuple/EitherOf2.java
@@ -29,7 +29,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * A value which can be one of two possible types.
  *
- * @param <A> the type for the first alternative
+ * @param <A> the type of the first alternative
  * @param <B> the type of the second alternative
  */
 public final class EitherOf2<A extends Message, B extends Message>

--- a/server/src/main/java/io/spine/server/tuple/EitherOf3.java
+++ b/server/src/main/java/io/spine/server/tuple/EitherOf3.java
@@ -23,48 +23,61 @@ package io.spine.server.tuple;
 import com.google.protobuf.Message;
 import io.spine.server.tuple.Element.AValue;
 import io.spine.server.tuple.Element.BValue;
+import io.spine.server.tuple.Element.CValue;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * A value which can be one of two possible types.
+ * A value which can be of one of three possible types.
  *
  * @param <A> the type for the first alternative
  * @param <B> the type of the second alternative
- * @author Alexander Yevsyukov
+ * @param <C> the type of the third alternative
  */
-public final class EitherOfTwo<A extends Message, B extends Message>
-        extends Either
-        implements AValue<A>, BValue<B> {
+public final class EitherOf3<A extends Message, B extends Message, C extends Message>
+    extends Either
+    implements AValue<A>, BValue<B>, CValue<C> {
 
     private static final long serialVersionUID = 0L;
 
-    private EitherOfTwo(Message value, int index) {
+    private EitherOf3(Message value, int index) {
         super(value, index);
     }
 
     /**
      * Creates a new instance with {@code <A>} value.
      */
-    public static <A extends Message, B extends Message> EitherOfTwo<A, B> withA(A a) {
+    public static <A extends Message, B extends Message, C extends Message>
+    EitherOf3<A, B, C> withA(A a) {
         checkNotNull(a);
-        EitherOfTwo<A, B> result = new EitherOfTwo<>(a, 0);
+        EitherOf3<A, B, C> result = new EitherOf3<>(a, 0);
         return result;
     }
 
     /**
      * Creates a new instance with {@code <B>} value.
      */
-    public static <A extends Message, B extends Message> EitherOfTwo<A, B> withB(B b) {
+    public static <A extends Message, B extends Message, C extends Message>
+    EitherOf3<A, B, C> withB(B b) {
         checkNotNull(b);
-        EitherOfTwo<A, B> result = new EitherOfTwo<>(b, 1);
+        EitherOf3<A, B, C> result = new EitherOf3<>(b, 1);
+        return result;
+    }
+
+    /**
+     * Creates a new instance with {@code <C>} value.
+     */
+    public static <A extends Message, B extends Message, C extends Message>
+    EitherOf3<A, B, C> withC(C c) {
+        checkNotNull(c);
+        EitherOf3<A, B, C> result = new EitherOf3<>(c, 2);
         return result;
     }
 
     /**
      * Obtains the value of the first alternative.
      *
-     * @throws IllegalStateException if the {@code <B>} value is stored instead.
+     * @throws IllegalStateException if a value of another type is stored instead.
      * @return the stored value.
      */
     @Override
@@ -75,11 +88,22 @@ public final class EitherOfTwo<A extends Message, B extends Message>
     /**
      * Obtains the value of the second alternative.
      *
-     * @throws IllegalStateException if the {@code <A>} value is stored instead.
+     * @throws IllegalStateException if a value of another type is stored instead.
      * @return the stored value.
      */
     @Override
     public B getB() {
         return get(this, 1);
+    }
+
+    /**
+     * Obtains the value of the third alternative.
+     *
+     * @throws IllegalStateException if a value of another type is stored instead.
+     * @return the stored value.
+     */
+    @Override
+    public C getC() {
+        return get(this, 2);
     }
 }

--- a/server/src/main/java/io/spine/server/tuple/EitherOf3.java
+++ b/server/src/main/java/io/spine/server/tuple/EitherOf3.java
@@ -30,7 +30,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * A value which can be of one of three possible types.
  *
- * @param <A> the type for the first alternative
+ * @param <A> the type of the first alternative
  * @param <B> the type of the second alternative
  * @param <C> the type of the third alternative
  */

--- a/server/src/main/java/io/spine/server/tuple/EitherOf4.java
+++ b/server/src/main/java/io/spine/server/tuple/EitherOf4.java
@@ -31,15 +31,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * A value which can be of one of four possible types.
  *
- * @param <A> the type for the first alternative
+ * @param <A> the type of the first alternative
  * @param <B> the type of the second alternative
  * @param <C> the type of the third alternative
  * @param <D> the type of the fourth alternative
  */
 public final class EitherOf4<A extends Message,
-                                B extends Message,
-                                C extends Message,
-                                D extends Message>
+                             B extends Message,
+                             C extends Message,
+                             D extends Message>
         extends Either
         implements AValue<A>, BValue<B>, CValue<C>, DValue<D> {
 

--- a/server/src/main/java/io/spine/server/tuple/EitherOf4.java
+++ b/server/src/main/java/io/spine/server/tuple/EitherOf4.java
@@ -35,10 +35,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @param <B> the type of the second alternative
  * @param <C> the type of the third alternative
  * @param <D> the type of the fourth alternative
- *
- * @author Alexander Yevsyukov
  */
-public final class EitherOfFour<A extends Message,
+public final class EitherOf4<A extends Message,
                                 B extends Message,
                                 C extends Message,
                                 D extends Message>
@@ -47,7 +45,7 @@ public final class EitherOfFour<A extends Message,
 
     private static final long serialVersionUID = 0L;
 
-    private EitherOfFour(Message value, int index) {
+    private EitherOf4(Message value, int index) {
         super(value, index);
     }
 
@@ -55,9 +53,9 @@ public final class EitherOfFour<A extends Message,
      * Creates a new instance with {@code <A>} value.
      */
     public static <A extends Message, B extends Message, C extends Message, D extends Message>
-    EitherOfFour<A, B, C, D> withA(A a) {
+    EitherOf4<A, B, C, D> withA(A a) {
         checkNotNull(a);
-        EitherOfFour<A, B, C, D> result = new EitherOfFour<>(a, 0);
+        EitherOf4<A, B, C, D> result = new EitherOf4<>(a, 0);
         return result;
     }
 
@@ -65,9 +63,9 @@ public final class EitherOfFour<A extends Message,
      * Creates a new instance with {@code <B>} value.
      */
     public static <A extends Message, B extends Message, C extends Message, D extends Message>
-    EitherOfFour<A, B, C, D> withB(B b) {
+    EitherOf4<A, B, C, D> withB(B b) {
         checkNotNull(b);
-        EitherOfFour<A, B, C, D> result = new EitherOfFour<>(b, 1);
+        EitherOf4<A, B, C, D> result = new EitherOf4<>(b, 1);
         return result;
     }
 
@@ -75,9 +73,9 @@ public final class EitherOfFour<A extends Message,
      * Creates a new instance with {@code <C>} value.
      */
     public static <A extends Message, B extends Message, C extends Message, D extends Message>
-    EitherOfFour<A, B, C, D> withC(C c) {
+    EitherOf4<A, B, C, D> withC(C c) {
         checkNotNull(c);
-        EitherOfFour<A, B, C, D> result = new EitherOfFour<>(c, 2);
+        EitherOf4<A, B, C, D> result = new EitherOf4<>(c, 2);
         return result;
     }
 
@@ -85,9 +83,9 @@ public final class EitherOfFour<A extends Message,
      * Creates a new instance with {@code <C>} value.
      */
     public static <A extends Message, B extends Message, C extends Message, D extends Message>
-    EitherOfFour<A, B, C, D> withD(D d) {
+    EitherOf4<A, B, C, D> withD(D d) {
         checkNotNull(d);
-        EitherOfFour<A, B, C, D> result = new EitherOfFour<>(d, 3);
+        EitherOf4<A, B, C, D> result = new EitherOf4<>(d, 3);
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/tuple/EitherOf5.java
+++ b/server/src/main/java/io/spine/server/tuple/EitherOf5.java
@@ -37,10 +37,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @param <C> the type of the third alternative
  * @param <D> the type of the fourth alternative
  * @param <E> the type of the fifth alternative
- *
- * @author Alexander Yevsyukov
  */
-public class EitherOfFive <A extends Message,
+public class EitherOf5<A extends Message,
                            B extends Message,
                            C extends Message,
                            D extends Message,
@@ -50,7 +48,7 @@ public class EitherOfFive <A extends Message,
 
     private static final long serialVersionUID = 0L;
 
-    private EitherOfFive(Message value, int index) {
+    private EitherOf5(Message value, int index) {
         super(value, index);
     }
 
@@ -59,9 +57,9 @@ public class EitherOfFive <A extends Message,
      */
     public static
     <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
-    EitherOfFive<A, B, C, D, E> withA(A a) {
+    EitherOf5<A, B, C, D, E> withA(A a) {
         checkNotNull(a);
-        EitherOfFive<A, B, C, D, E> result = new EitherOfFive<>(a, 0);
+        EitherOf5<A, B, C, D, E> result = new EitherOf5<>(a, 0);
         return result;
     }
 
@@ -70,9 +68,9 @@ public class EitherOfFive <A extends Message,
      */
     public static
     <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
-    EitherOfFive<A, B, C, D, E> withB(B b) {
+    EitherOf5<A, B, C, D, E> withB(B b) {
         checkNotNull(b);
-        EitherOfFive<A, B, C, D, E> result = new EitherOfFive<>(b, 1);
+        EitherOf5<A, B, C, D, E> result = new EitherOf5<>(b, 1);
         return result;
     }
 
@@ -81,9 +79,9 @@ public class EitherOfFive <A extends Message,
      */
     public static
     <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
-    EitherOfFive<A, B, C, D, E> withC(C c) {
+    EitherOf5<A, B, C, D, E> withC(C c) {
         checkNotNull(c);
-        EitherOfFive<A, B, C, D, E> result = new EitherOfFive<>(c, 2);
+        EitherOf5<A, B, C, D, E> result = new EitherOf5<>(c, 2);
         return result;
     }
 
@@ -92,9 +90,9 @@ public class EitherOfFive <A extends Message,
      */
     public static
     <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
-    EitherOfFive<A, B, C, D, E> withD(D d) {
+    EitherOf5<A, B, C, D, E> withD(D d) {
         checkNotNull(d);
-        EitherOfFive<A, B, C, D, E> result = new EitherOfFive<>(d, 3);
+        EitherOf5<A, B, C, D, E> result = new EitherOf5<>(d, 3);
         return result;
     }
 
@@ -103,9 +101,9 @@ public class EitherOfFive <A extends Message,
      */
     public static
     <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
-    EitherOfFive<A, B, C, D, E> withE(E e) {
+    EitherOf5<A, B, C, D, E> withE(E e) {
         checkNotNull(e);
-        EitherOfFive<A, B, C, D, E> result = new EitherOfFive<>(e, 4);
+        EitherOf5<A, B, C, D, E> result = new EitherOf5<>(e, 4);
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/tuple/EitherOf5.java
+++ b/server/src/main/java/io/spine/server/tuple/EitherOf5.java
@@ -32,17 +32,17 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * A value which can be of one of five possible types.
  *
- * @param <A> the type for the first alternative
+ * @param <A> the type of the first alternative
  * @param <B> the type of the second alternative
  * @param <C> the type of the third alternative
  * @param <D> the type of the fourth alternative
  * @param <E> the type of the fifth alternative
  */
 public class EitherOf5<A extends Message,
-                           B extends Message,
-                           C extends Message,
-                           D extends Message,
-                           E extends Message>
+                       B extends Message,
+                       C extends Message,
+                       D extends Message,
+                       E extends Message>
         extends Either
         implements AValue<A>, BValue<B>, CValue<C>, DValue<D>, EValue<E> {
 

--- a/server/src/main/java/io/spine/server/tuple/package-info.java
+++ b/server/src/main/java/io/spine/server/tuple/package-info.java
@@ -71,10 +71,10 @@
  *
  * <p>In order to define alternatively returned values, please use the following classes:
  * <ul>
- *     <li>{@link io.spine.server.tuple.EitherOf2 EitherOfTwo&lt;A, B&gt;}
- *     <li>{@link io.spine.server.tuple.EitherOf3 EitherOfThree&lt;A, B, C&gt;}
- *     <li>{@link io.spine.server.tuple.EitherOf4 EitherOfFour&lt;A, B, C, D&gt;}
- *     <li>{@link io.spine.server.tuple.EitherOf5 EitherOfFive&lt;A, B, C, D, E&gt;}
+ *     <li>{@link io.spine.server.tuple.EitherOf2 EitherOf2&lt;A, B&gt;}
+ *     <li>{@link io.spine.server.tuple.EitherOf3 EitherOf3&lt;A, B, C&gt;}
+ *     <li>{@link io.spine.server.tuple.EitherOf4 EitherOf4&lt;A, B, C, D&gt;}
+ *     <li>{@link io.spine.server.tuple.EitherOf5 EitherOf5&lt;A, B, C, D, E&gt;}
  * </ul>
  *
  * <p>Generic parameters for alternatives can be only {@link com.google.protobuf.Message Message}.

--- a/server/src/main/java/io/spine/server/tuple/package-info.java
+++ b/server/src/main/java/io/spine/server/tuple/package-info.java
@@ -43,7 +43,7 @@
  * <p>It should re-iterated that the purpose of this package is limited to the scenarios
  * described above. Programmers are strongly discouraged from applying tuples for other purposes.
  *
- * <h2>Generic Types</h2>
+ * <h1>Generic Types</h1>
  *
  * <p>Classes provided by this package can support up to 5 generic parameters. They are named from
  * {@code <A>} through {@code <E>}.
@@ -54,7 +54,7 @@
  * <p>Types from {@code <B>} through {@code <E>} can be either {@code Message} or
  * {@link java.util.Optional Optional}. See sections below for details.
  *
- * <h2>Basic Tuples</h2>
+ * <h1>Basic Tuples</h1>
  *
  * <p>The following tuple classes are provided:
  * <ul>
@@ -67,14 +67,14 @@
  * <p>Basic tuple classes allow {@link java.util.Optional Optional} starting from
  * the second generic argument.
  *
- * <h2>Alternatives</h2>
+ * <h1>Alternatives</h1>
  *
  * <p>In order to define alternatively returned values, please use the following classes:
  * <ul>
- *     <li>{@link io.spine.server.tuple.EitherOfTwo EitherOfTwo&lt;A, B&gt;}
- *     <li>{@link io.spine.server.tuple.EitherOfThree EitherOfThree&lt;A, B, C&gt;}
- *     <li>{@link io.spine.server.tuple.EitherOfFour EitherOfFour&lt;A, B, C, D&gt;}
- *     <li>{@link io.spine.server.tuple.EitherOfFive EitherOfFive&lt;A, B, C, D, E&gt;}
+ *     <li>{@link io.spine.server.tuple.EitherOf2 EitherOfTwo&lt;A, B&gt;}
+ *     <li>{@link io.spine.server.tuple.EitherOf3 EitherOfThree&lt;A, B, C&gt;}
+ *     <li>{@link io.spine.server.tuple.EitherOf4 EitherOfFour&lt;A, B, C, D&gt;}
+ *     <li>{@link io.spine.server.tuple.EitherOf5 EitherOfFive&lt;A, B, C, D, E&gt;}
  * </ul>
  *
  * <p>Generic parameters for alternatives can be only {@link com.google.protobuf.Message Message}.
@@ -83,7 +83,7 @@
  * If you face a such a need, consider splitting a command into two or more independent commands
  * so that their outcome is more obvious.
  *
- * <h2>Using Tuples with Alternatives</h2>
+ * <h1>Using Tuples with Alternatives</h1>
  *
  * <p>A {@link io.spine.server.tuple.Pair Pair} can be defined with the second parameter being on
  * of the {@link io.spine.server.tuple.Either Either} subclasses, and created using

--- a/server/src/test/java/io/spine/server/aggregate/AggregatePartTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregatePartTest.java
@@ -32,7 +32,6 @@ import io.spine.server.aggregate.given.part.TaskRepository;
 import io.spine.test.aggregate.ProjectId;
 import io.spine.test.aggregate.Task;
 import io.spine.test.aggregate.command.AggAddTask;
-import io.spine.testdata.Sample;
 import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.testing.server.aggregate.AggregateMessageDispatcher;
 import io.spine.testing.server.model.ModelTests;
@@ -43,14 +42,10 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Constructor;
 
 import static io.spine.base.Identifier.newUuid;
+import static io.spine.testdata.Sample.builderForType;
 import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/**
- * @author Illia Shepilov
- */
-@SuppressWarnings({"OverlyCoupledClass",
-        "DuplicateStringLiteralInspection" /* Common test display names */})
 @DisplayName("AggregatePart should")
 class AggregatePartTest {
 
@@ -110,11 +105,10 @@ class AggregatePartTest {
     }
 
     private void prepareAggregatePart() {
-        AggAddTask addTask =
-                ((AggAddTask.Builder) Sample.builderForType(AggAddTask.class))
-                        .setProjectId(ProjectId.newBuilder()
-                                               .setId("agg-part-ID"))
-                        .build();
-        AggregateMessageDispatcher.dispatchCommand(taskPart, env(addTask));
+        AggAddTask.Builder addTask = builderForType(AggAddTask.class);
+        addTask.setProjectId(ProjectId.newBuilder()
+                                      .setId("agg-part-ID"))
+               .build();
+        AggregateMessageDispatcher.dispatchCommand(taskPart, env(addTask.build()));
     }
 }

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregateRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregateRepositoryTestEnv.java
@@ -82,6 +82,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.copyOf;
+import static io.spine.testdata.Sample.builderForType;
 import static io.spine.testing.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
 import static java.util.Collections.emptyList;
 import static java.util.Optional.empty;
@@ -181,22 +182,16 @@ public class AggregateRepositoryTestEnv {
                                               .withId(id)
                                               .build();
 
-            AggCreateProject createProject =
-                    ((AggCreateProject.Builder) Sample.builderForType(AggCreateProject.class))
-                            .setProjectId(id)
-                            .build();
-            AggAddTask addTask =
-                    ((AggAddTask.Builder) Sample.builderForType(AggAddTask.class))
-                            .setProjectId(id)
-                            .build();
-            AggStartProject startProject =
-                    ((AggStartProject.Builder) Sample.builderForType(AggStartProject.class))
-                            .setProjectId(id)
-                            .build();
+            AggCreateProject.Builder createProject = builderForType(AggCreateProject.class);
+            createProject.setProjectId(id);
+            AggAddTask.Builder addTask = builderForType(AggAddTask.class);
+            addTask.setProjectId(id);
+            AggStartProject.Builder startProject = builderForType(AggStartProject.class);
+            startProject.setProjectId(id);
 
-            dispatchCommand(aggregate, env(createProject));
-            dispatchCommand(aggregate, env(addTask));
-            dispatchCommand(aggregate, env(startProject));
+            dispatchCommand(aggregate, env(createProject.build()));
+            dispatchCommand(aggregate, env(addTask.build()));
+            dispatchCommand(aggregate, env(startProject.build()));
 
             return aggregate;
         }

--- a/server/src/test/java/io/spine/server/entity/storage/ColumnValueConverterTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ColumnValueConverterTest.java
@@ -59,7 +59,7 @@ class ColumnValueConverterTest {
     @DisplayName("convert enum to ordinal value")
     void convertEnumToOrdinal() {
         TaskStatus value = SUCCESS;
-        ColumnValueConverter converter = new OrdinalEnumConverter(value.getClass());
+        ColumnValueConverter converter = new OrdinalEnumConverter(value.getDeclaringClass());
         Serializable convertedValue = converter.convert(value);
         assertEquals(value.ordinal(), convertedValue);
     }
@@ -68,7 +68,7 @@ class ColumnValueConverterTest {
     @DisplayName("convert enum to string value")
     void convertEnumToString() {
         TaskStatus value = SUCCESS;
-        ColumnValueConverter converter = new StringEnumConverter(value.getClass());
+        ColumnValueConverter converter = new StringEnumConverter(value.getDeclaringClass());
         Serializable convertedValue = converter.convert(value);
         assertEquals(value.name(), convertedValue);
     }

--- a/server/src/test/java/io/spine/server/entity/storage/ColumnValueConverterTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ColumnValueConverterTest.java
@@ -32,9 +32,6 @@ import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-/**
- * @author Dmytro Kuzmin
- */
 @DisplayName("ColumnValueConverter should")
 class ColumnValueConverterTest {
 

--- a/server/src/test/java/io/spine/server/event/given/EventBusTestEnv.java
+++ b/server/src/test/java/io/spine/server/event/given/EventBusTestEnv.java
@@ -66,7 +66,6 @@ import io.spine.test.event.Task;
 import io.spine.test.event.command.EBAddTasks;
 import io.spine.test.event.command.EBArchiveProject;
 import io.spine.test.event.command.EBCreateProject;
-import io.spine.testdata.Sample;
 import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.testing.server.TestEventFactory;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -81,6 +80,7 @@ import static io.spine.core.Status.StatusCase.ERROR;
 import static io.spine.grpc.StreamObservers.memoizingObserver;
 import static io.spine.protobuf.AnyPacker.pack;
 import static io.spine.server.bus.Buses.reject;
+import static io.spine.testdata.Sample.builderForType;
 import static io.spine.util.Exceptions.unsupported;
 import static java.lang.String.format;
 import static java.util.Optional.empty;
@@ -118,18 +118,15 @@ public class EventBusTestEnv {
     }
 
     public static EBCreateProject createProject() {
-        EBCreateProject command =
-                ((EBCreateProject.Builder) Sample.builderForType(EBCreateProject.class))
-                        .setProjectId(PROJECT_ID)
-                        .build();
-        return command;
+        EBCreateProject.Builder command = builderForType(EBCreateProject.class);
+        return command.setProjectId(PROJECT_ID)
+                      .build();
     }
 
     public static EBAddTasks addTasks(Task... tasks) {
-        EBAddTasks.Builder builder =
-                ((EBAddTasks.Builder) Sample.builderForType(EBAddTasks.class))
-                        .setProjectId(PROJECT_ID)
-                        .clearTask();
+        EBAddTasks.Builder builder = builderForType(EBAddTasks.class);
+        builder.setProjectId(PROJECT_ID)
+               .clearTask();
         for (Task task : tasks) {
             builder.addTask(task);
         }
@@ -138,10 +135,9 @@ public class EventBusTestEnv {
     }
 
     public static Task newTask(boolean done) {
-        Task task = ((Task.Builder) Sample.builderForType(Task.class))
-                                          .setDone(done)
-                                          .build();
-        return task;
+        Task.Builder task = builderForType(Task.class);
+        return task.setDone(done)
+                   .build();
     }
 
     /**
@@ -149,11 +145,9 @@ public class EventBusTestEnv {
      * {@link EBArchiveProject#getReason()} field.
      */
     public static EBArchiveProject invalidArchiveProject() {
-        EBArchiveProject command =
-                ((EBArchiveProject.Builder) Sample.builderForType(EBArchiveProject.class))
-                        .setProjectId(PROJECT_ID)
-                        .build();
-        return command;
+        EBArchiveProject.Builder command = builderForType(EBArchiveProject.class);
+        return command.setProjectId(PROJECT_ID)
+                      .build();
     }
 
     public static Command command(CommandMessage message) {

--- a/server/src/test/java/io/spine/server/event/given/EventRootCommandIdTestEnv.java
+++ b/server/src/test/java/io/spine/server/event/given/EventRootCommandIdTestEnv.java
@@ -62,18 +62,15 @@ import io.spine.test.event.command.EvAcceptInvitation;
 import io.spine.test.event.command.EvAddTasks;
 import io.spine.test.event.command.EvAddTeamMember;
 import io.spine.test.event.command.EvInviteTeamMembers;
-import io.spine.testdata.Sample;
 import io.spine.testing.client.TestActorRequestFactory;
 
 import java.util.List;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.testdata.Sample.builderForType;
 import static java.util.Collections.singleton;
 
-/**
- * @author Mykhailo Drachuk
- */
 public class EventRootCommandIdTestEnv {
 
     public static final TenantId TENANT_ID = tenantId();
@@ -86,20 +83,21 @@ public class EventRootCommandIdTestEnv {
     }
 
     public static ProjectId projectId() {
-        return ((ProjectId.Builder) Sample.builderForType(ProjectId.class))
+        return ((ProjectId.Builder) builderForType(ProjectId.class))
                 .build();
     }
 
     public static EvTeamId teamId() {
-        return ((EvTeamId.Builder) Sample.builderForType(EvTeamId.class))
+        return ((EvTeamId.Builder) builderForType(EvTeamId.class))
                 .build();
     }
 
     private static TenantId tenantId() {
         String value = EventRootCommandIdTestEnv.class.getName();
-        TenantId id = TenantId.newBuilder()
-                              .setValue(value)
-                              .build();
+        TenantId id = TenantId
+                .newBuilder()
+                .setValue(value)
+                .build();
         return id;
     }
 
@@ -122,7 +120,7 @@ public class EventRootCommandIdTestEnv {
 
         EvAddTasks.Builder builder = EvAddTasks.newBuilder();
         for (int i = 0; i < count; i++) {
-            Task task = (Task) Sample.builderForType(Task.class)
+            Task task = (Task) builderForType(Task.class)
                                      .build();
             builder.addTask(task);
         }
@@ -134,7 +132,7 @@ public class EventRootCommandIdTestEnv {
     public static EvAddTeamMember addTeamMember(EvTeamId teamId) {
         checkNotNull(teamId);
 
-        return ((EvAddTeamMember.Builder) Sample.builderForType(EvAddTeamMember.class))
+        return ((EvAddTeamMember.Builder) builderForType(EvAddTeamMember.class))
                 .setTeamId(teamId)
                 .build();
     }
@@ -143,7 +141,7 @@ public class EventRootCommandIdTestEnv {
         checkNotNull(teamId);
 
         EvMemberInvitation invitation = memberInvitation(teamId);
-        return ((EvAcceptInvitation.Builder) Sample.builderForType(EvAcceptInvitation.class))
+        return ((EvAcceptInvitation.Builder) builderForType(EvAcceptInvitation.class))
                 .setInvitation(invitation)
                 .build();
     }
@@ -153,8 +151,9 @@ public class EventRootCommandIdTestEnv {
 
         EvInviteTeamMembers.Builder builder = EvInviteTeamMembers.newBuilder();
         for (int i = 0; i < count; i++) {
-            EmailAddress task = (EmailAddress) Sample.builderForType(EmailAddress.class)
-                                                     .build();
+            EmailAddress task = (EmailAddress)
+                    builderForType(EmailAddress.class)
+                            .build();
             builder.addEmail(task);
         }
 
@@ -163,7 +162,7 @@ public class EventRootCommandIdTestEnv {
     }
 
     private static EvMemberInvitation memberInvitation(EvTeamId teamId) {
-        return ((EvMemberInvitation.Builder) Sample.builderForType(EvMemberInvitation.class))
+        return ((EvMemberInvitation.Builder) builderForType(EvMemberInvitation.class))
                 .setTeamId(teamId)
                 .build();
     }
@@ -349,27 +348,31 @@ public class EventRootCommandIdTestEnv {
         }
 
         private EvTeamMemberAdded memberAdded(EvMember member) {
-            return EvTeamMemberAdded.newBuilder()
-                                    .setTeamId(getId())
-                                    .setMember(member)
-                                    .build();
+            return EvTeamMemberAdded
+                    .newBuilder()
+                    .setTeamId(getId())
+                    .setMember(member)
+                    .build();
         }
 
         private EvTeamMemberInvited teamMemberInvited(EmailAddress email) {
-            return EvTeamMemberInvited.newBuilder()
-                                      .setTeamId(getId())
-                                      .setEmail(email)
-                                      .build();
+            return EvTeamMemberInvited
+                    .newBuilder()
+                    .setTeamId(getId())
+                    .setEmail(email)
+                    .build();
         }
 
         private static EvMemberInvitation memberInvitation(EmailAddress email) {
-            return EvMemberInvitation.newBuilder()
-                                     .setEmail(email)
-                                     .build();
+            return EvMemberInvitation
+                    .newBuilder()
+                    .setEmail(email)
+                    .build();
         }
 
         private static EvMember member(UserId userId) {
-            return ((EvMember.Builder) Sample.builderForType(EvMember.class))
+            return EvMember
+                    .newBuilder()
                     .setUserId(userId)
                     .build();
         }
@@ -390,10 +393,11 @@ public class EventRootCommandIdTestEnv {
         }
 
         private EvInvitationAccepted invitationAccepted(EvMemberInvitation invitation) {
-            return EvInvitationAccepted.newBuilder()
-                                       .setInvitation(invitation)
-                                       .setUserId(getId())
-                                       .build();
+            return EvInvitationAccepted
+                    .newBuilder()
+                    .setInvitation(invitation)
+                    .setUserId(getId())
+                    .build();
         }
     }
 }

--- a/server/src/test/java/io/spine/server/event/model/given/reactor/RcIterableReturn.java
+++ b/server/src/test/java/io/spine/server/event/model/given/reactor/RcIterableReturn.java
@@ -21,29 +21,27 @@
 package io.spine.server.event.model.given.reactor;
 
 import io.spine.server.event.React;
-import io.spine.server.tuple.EitherOfTwo;
+import io.spine.server.tuple.EitherOf2;
 import io.spine.test.reflect.event.RefProjectCreated;
 import io.spine.test.reflect.event.RefProjectStarted;
 import io.spine.test.reflect.event.RefTaskAdded;
 
 /**
  * Provides a method that returns {@link Iterable}.
- *
- * @author Alexander Yevsyukov
  */
 public class RcIterableReturn extends TestEventReactor {
 
     @React
-    EitherOfTwo<RefProjectStarted, RefTaskAdded> react(RefProjectCreated event) {
+    EitherOf2<RefProjectStarted, RefTaskAdded> react(RefProjectCreated event) {
         if (event.hasProjectId()) {
-            return EitherOfTwo.withA(
+            return EitherOf2.withA(
                     RefProjectStarted.newBuilder()
                                      .setProjectId(event.getProjectId())
                                      .build()
             );
         }
 
-        return EitherOfTwo.withB(RefTaskAdded.newBuilder()
-                                             .build());
+        return EitherOf2.withB(RefTaskAdded.newBuilder()
+                                           .build());
     }
 }

--- a/server/src/test/java/io/spine/server/procman/ProcessManagerTest.java
+++ b/server/src/test/java/io/spine/server/procman/ProcessManagerTest.java
@@ -366,7 +366,7 @@ class ProcessManagerTest {
          * event.
          *
          * <p>As a reaction to {@link PmQuestionAnswered Quiestion Answered}
-         * the process manager emits an {@link io.spine.server.tuple.EitherOf3 Either Of Three}
+         * the process manager emits an {@link io.spine.server.tuple.EitherOf3 EitherOf3}
          * containing {@link Nothing}. This is done because the answered
          * question is not part of a quiz.
          *
@@ -406,7 +406,7 @@ class ProcessManagerTest {
          * <p>Because the quiz is started without any questions to solve,
          * an {@link PmAnswerQuestion answer question command} can not
          * match any questions. This results in emitting
-         * {@link io.spine.server.tuple.EitherOf3 Either Of Three}
+         * {@link io.spine.server.tuple.EitherOf3 EitherOf3}
          * containing {@link Nothing}.
          *
          * @see io.spine.server.procman.given.pm.DirectQuizProcman

--- a/server/src/test/java/io/spine/server/procman/ProcessManagerTest.java
+++ b/server/src/test/java/io/spine/server/procman/ProcessManagerTest.java
@@ -106,12 +106,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 
-/**
- * @author Alexander Litus
- * @author Dmytro Dashenkov
- * @author Alexander Yevsyukov
- */
-@SuppressWarnings({"OverlyCoupledClass",
+@SuppressWarnings({
         "InnerClassMayBeStatic", "ClassCanBeStatic" /* JUnit nested classes cannot be static. */,
         "DuplicateStringLiteralInspection" /* Common test display names. */})
 @DisplayName("ProcessManager should")
@@ -371,7 +366,7 @@ class ProcessManagerTest {
          * event.
          *
          * <p>As a reaction to {@link PmQuestionAnswered Quiestion Answered}
-         * the process manager emits an {@link io.spine.server.tuple.EitherOfThree Either Of Three}
+         * the process manager emits an {@link io.spine.server.tuple.EitherOf3 Either Of Three}
          * containing {@link Nothing}. This is done because the answered
          * question is not part of a quiz.
          *
@@ -411,7 +406,7 @@ class ProcessManagerTest {
          * <p>Because the quiz is started without any questions to solve,
          * an {@link PmAnswerQuestion answer question command} can not
          * match any questions. This results in emitting
-         * {@link io.spine.server.tuple.EitherOfThree Either Of Three}
+         * {@link io.spine.server.tuple.EitherOf3 Either Of Three}
          * containing {@link Nothing}.
          *
          * @see io.spine.server.procman.given.pm.DirectQuizProcman

--- a/server/src/test/java/io/spine/server/procman/given/pm/DirectQuizProcman.java
+++ b/server/src/test/java/io/spine/server/procman/given/pm/DirectQuizProcman.java
@@ -24,7 +24,7 @@ import io.spine.server.command.Assign;
 import io.spine.server.event.React;
 import io.spine.server.model.Nothing;
 import io.spine.server.procman.ProcessManager;
-import io.spine.server.tuple.EitherOfThree;
+import io.spine.server.tuple.EitherOf3;
 import io.spine.test.procman.quiz.PmAnswer;
 import io.spine.test.procman.quiz.PmQuestionId;
 import io.spine.test.procman.quiz.PmQuiz;
@@ -46,8 +46,6 @@ import java.util.List;
  * <p>Differs from the {@link QuizProcman} by scarcing the interjacent
  * {@link PmQuestionAnswered Question Answered event} and emits 
  * either of three when handling a command.
- * 
- * @author Mykhailo Drachuk
  */
 class DirectQuizProcman extends ProcessManager<PmQuizId, PmQuiz, PmQuizVBuilder> {
 
@@ -64,14 +62,13 @@ class DirectQuizProcman extends ProcessManager<PmQuizId, PmQuiz, PmQuizVBuilder>
     }
 
     @Assign
-    @SuppressWarnings("Duplicates")
-    EitherOfThree<PmQuestionSolved, PmQuestionFailed, Nothing> handle(PmAnswerQuestion command) {
+    EitherOf3<PmQuestionSolved, PmQuestionFailed, Nothing> handle(PmAnswerQuestion command) {
         PmAnswer answer = command.getAnswer();
         PmQuizId examId = command.getQuizId();
         PmQuestionId questionId = answer.getQuestionId();
 
         if (questionIsClosed(questionId)) {
-            return EitherOfThree.withC(nothing());
+            return EitherOf3.withC(nothing());
         }
 
         boolean answerIsCorrect = answer.getCorrect();
@@ -81,14 +78,14 @@ class DirectQuizProcman extends ProcessManager<PmQuizId, PmQuiz, PmQuizVBuilder>
                                     .setQuizId(examId)
                                     .setQuestionId(questionId)
                                     .build();
-            return EitherOfThree.withA(reaction);
+            return EitherOf3.withA(reaction);
         } else {
             PmQuestionFailed reaction =
                     PmQuestionFailed.newBuilder()
                                     .setQuizId(examId)
                                     .setQuestionId(questionId)
                                     .build();
-            return EitherOfThree.withB(reaction);
+            return EitherOf3.withB(reaction);
         }
     }
 

--- a/server/src/test/java/io/spine/server/procman/given/pm/QuizProcman.java
+++ b/server/src/test/java/io/spine/server/procman/given/pm/QuizProcman.java
@@ -24,7 +24,7 @@ import io.spine.server.command.Assign;
 import io.spine.server.event.React;
 import io.spine.server.model.Nothing;
 import io.spine.server.procman.ProcessManager;
-import io.spine.server.tuple.EitherOfThree;
+import io.spine.server.tuple.EitherOf3;
 import io.spine.test.procman.quiz.PmAnswer;
 import io.spine.test.procman.quiz.PmQuestionId;
 import io.spine.test.procman.quiz.PmQuiz;
@@ -76,13 +76,13 @@ class QuizProcman extends ProcessManager<PmQuizId, PmQuiz, PmQuizVBuilder> {
     }
 
     @React
-    EitherOfThree<PmQuestionSolved, PmQuestionFailed, Nothing> on(PmQuestionAnswered event) {
+    EitherOf3<PmQuestionSolved, PmQuestionFailed, Nothing> on(PmQuestionAnswered event) {
         PmAnswer answer = event.getAnswer();
         PmQuizId examId = event.getQuizId();
         PmQuestionId questionId = answer.getQuestionId();
 
         if (questionIsClosed(questionId)) {
-            return EitherOfThree.withC(nothing());
+            return EitherOf3.withC(nothing());
         }
 
         boolean answerIsCorrect = answer.getCorrect();
@@ -92,14 +92,14 @@ class QuizProcman extends ProcessManager<PmQuizId, PmQuiz, PmQuizVBuilder> {
                                     .setQuizId(examId)
                                     .setQuestionId(questionId)
                                     .build();
-            return EitherOfThree.withA(reaction);
+            return EitherOf3.withA(reaction);
         } else {
             PmQuestionFailed reaction =
                     PmQuestionFailed.newBuilder()
                                     .setQuizId(examId)
                                     .setQuestionId(questionId)
                                     .build();
-            return EitherOfThree.withB(reaction);
+            return EitherOf3.withB(reaction);
         }
     }
 

--- a/server/src/test/java/io/spine/server/procman/given/repo/GivenCommandMessage.java
+++ b/server/src/test/java/io/spine/server/procman/given/repo/GivenCommandMessage.java
@@ -32,6 +32,8 @@ import io.spine.test.procman.event.PmProjectStarted;
 import io.spine.test.procman.event.PmTaskAdded;
 import io.spine.testdata.Sample;
 
+import static io.spine.testdata.Sample.builderForType;
+
 /**
  * Factory methods for command messages.
  */
@@ -44,19 +46,19 @@ public class GivenCommandMessage {
     }
 
     public static PmCreateProject createProject() {
-        return ((PmCreateProject.Builder) Sample.builderForType(PmCreateProject.class))
+        return ((PmCreateProject.Builder) builderForType(PmCreateProject.class))
                 .setProjectId(ID)
                 .build();
     }
 
     public static PmStartProject startProject() {
-        return ((PmStartProject.Builder) Sample.builderForType(PmStartProject.class))
+        return ((PmStartProject.Builder) builderForType(PmStartProject.class))
                 .setProjectId(ID)
                 .build();
     }
 
     public static PmAddTask addTask() {
-        return ((PmAddTask.Builder) Sample.builderForType(PmAddTask.class))
+        return ((PmAddTask.Builder) builderForType(PmAddTask.class))
                 .setProjectId(ID)
                 .build();
     }
@@ -74,25 +76,25 @@ public class GivenCommandMessage {
     }
 
     public static PmDoNothing doNothing() {
-        return ((PmDoNothing.Builder) Sample.builderForType(PmDoNothing.class))
+        return ((PmDoNothing.Builder) builderForType(PmDoNothing.class))
                 .setProjectId(ID)
                 .build();
     }
 
     public static PmProjectStarted projectStarted() {
-        return ((PmProjectStarted.Builder) Sample.builderForType(PmProjectStarted.class))
+        return ((PmProjectStarted.Builder) builderForType(PmProjectStarted.class))
                 .setProjectId(ID)
                 .build();
     }
 
     public static PmProjectCreated projectCreated() {
-        return ((PmProjectCreated.Builder) Sample.builderForType(PmProjectCreated.class))
+        return ((PmProjectCreated.Builder) builderForType(PmProjectCreated.class))
                 .setProjectId(ID)
                 .build();
     }
 
     public static PmTaskAdded taskAdded() {
-        return ((PmTaskAdded.Builder) Sample.builderForType(PmTaskAdded.class))
+        return ((PmTaskAdded.Builder) builderForType(PmTaskAdded.class))
                 .setProjectId(ID)
                 .build();
     }

--- a/server/src/test/java/io/spine/server/procman/given/repo/TestProcessManager.java
+++ b/server/src/test/java/io/spine/server/procman/given/repo/TestProcessManager.java
@@ -48,16 +48,12 @@ import io.spine.test.procman.command.PmThrowEntityAlreadyArchived;
 import io.spine.test.procman.event.PmProjectCreated;
 import io.spine.test.procman.event.PmProjectStarted;
 import io.spine.test.procman.event.PmTaskAdded;
-import io.spine.testdata.Sample;
 
 import java.util.List;
 
 import static io.spine.protobuf.AnyPacker.pack;
+import static io.spine.testdata.Sample.builderForType;
 
-@SuppressWarnings({
-        "OverlyCoupledClass",
-        "UnusedParameters" /* The parameter left to show that a projection subscriber can have
-                            two parameters. */})
 public class TestProcessManager
         extends ProcessManager<ProjectId, Project, ProjectVBuilder>
         implements TestEntityWithStringColumn {
@@ -108,39 +104,28 @@ public class TestProcessManager
     @Assign
     PmProjectCreated handle(PmCreateProject command, CommandContext ignored) {
         keep(command);
-
-        PmProjectCreated event = ((PmProjectCreated.Builder)
-                Sample.builderForType(PmProjectCreated.class))
-                      .setProjectId(command.getProjectId())
-                      .build();
-        return event;
+        PmProjectCreated.Builder event = builderForType(PmProjectCreated.class);
+        return event.setProjectId(command.getProjectId())
+                    .build();
     }
 
     @Assign
     PmTaskAdded handle(PmAddTask command, CommandContext ignored) {
         keep(command);
-
-        PmTaskAdded event = ((PmTaskAdded.Builder)
-                Sample.builderForType(PmTaskAdded.class))
-                      .setProjectId(command.getProjectId())
-                      .build();
-        return event;
+        PmTaskAdded.Builder event = builderForType(PmTaskAdded.class);
+        return event.setProjectId(command.getProjectId())
+                    .build();
     }
 
     @Command
     Pair<PmAddTask, PmDoNothing> handle(PmStartProject command, CommandContext context) {
         keep(command);
-
         ProjectId projectId = command.getProjectId();
-        PmAddTask addTask = ((PmAddTask.Builder)
-                Sample.builderForType(PmAddTask.class))
-                .setProjectId(projectId)
-                .build();
-        PmDoNothing doNothing = ((PmDoNothing.Builder)
-                Sample.builderForType(PmDoNothing.class))
-                .setProjectId(projectId)
-                .build();
-        return Pair.of(addTask, doNothing);
+        PmAddTask.Builder addTask = builderForType(PmAddTask.class);
+        addTask.setProjectId(projectId);
+        PmDoNothing.Builder doNothing = builderForType(PmDoNothing.class);
+        doNothing.setProjectId(projectId);
+        return Pair.of(addTask.build(), doNothing.build());
     }
 
     @Assign

--- a/server/src/test/java/io/spine/server/storage/AbstractRecordStorateTest.java
+++ b/server/src/test/java/io/spine/server/storage/AbstractRecordStorateTest.java
@@ -69,7 +69,6 @@ import static org.mockito.Mockito.verify;
  * @param <S> the type of storage under the test
  * @author Alexander Yevsyukov
  */
-@SuppressWarnings("unused") // JUnit nested classes considered unused in abstract class.
 public abstract class AbstractRecordStorateTest<I, S extends RecordStorage<I>>
         extends AbstractStorageTest<I, EntityRecord, RecordReadRequest<I>, S> {
 
@@ -356,7 +355,6 @@ public abstract class AbstractRecordStorateTest<I, S extends RecordStorage<I>>
             assertFalse(optional.isPresent());
         }
 
-        @SuppressWarnings("ConstantConditions") // Converter nullability issues
         @Test
         @DisplayName("for new record")
         void forNewRecord() {
@@ -370,7 +368,6 @@ public abstract class AbstractRecordStorateTest<I, S extends RecordStorage<I>>
             assertEquals(LifecycleFlags.getDefaultInstance(), optional.get());
         }
 
-        @SuppressWarnings("OptionalGetWithoutIsPresent") // We verify in assertion.
         @Test
         @DisplayName("for record with updated visibility")
         void forUpdatedRecord() {

--- a/server/src/test/java/io/spine/server/tuple/EitherOf2Test.java
+++ b/server/src/test/java/io/spine/server/tuple/EitherOf2Test.java
@@ -25,12 +25,10 @@ import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
 import com.google.protobuf.Timestamp;
-import com.google.protobuf.UInt32Value;
 import io.spine.base.Time;
 import io.spine.testing.TestValues;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
@@ -41,45 +39,36 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-/**
- * @author Alexander Yevsyukov
- */
 @SuppressWarnings({"FieldNamingConvention", "InstanceVariableNamingConvention",
         /* Short vars are OK for tuple tests. */
         "DuplicateStringLiteralInspection" /* Common test display names. */,
         "ResultOfMethodCallIgnored" /* Methods are called to throw exception. */})
-@DisplayName("EitherOfThree should")
-class EitherOfThreeTest {
+@DisplayName("EitherOfTwo should")
+class EitherOf2Test {
 
     private final StringValue a = TestValues.newUuidValue();
-    private final UInt32Value b = UInt32Value.newBuilder()
-                                             .setValue(42)
-                                             .build();
-    private final Timestamp c = Time.getCurrentTime();
+    private final Timestamp b = Time.getCurrentTime();
 
-    private EitherOfThree<StringValue, UInt32Value, Timestamp> eitherWithA;
-    private EitherOfThree<StringValue, UInt32Value, Timestamp> eitherWithB;
-    private EitherOfThree<StringValue, UInt32Value, Timestamp> eitherWithC;
+    private EitherOf2<StringValue, Timestamp> eitherWithA;
+    private EitherOf2<StringValue, Timestamp> eitherWithB;
 
     @BeforeEach
     void setUp() {
-        eitherWithA = EitherOfThree.withA(a);
-        eitherWithB = EitherOfThree.withB(b);
-        eitherWithC = EitherOfThree.withC(c);
+        eitherWithA = EitherOf2.withA(a);
+        eitherWithB = EitherOf2.withB(b);
     }
 
     @Test
     @DisplayName(NOT_ACCEPT_NULLS)
     void passNullToleranceCheck() {
-        new NullPointerTester().testAllPublicStaticMethods(EitherOfThree.class);
+        new NullPointerTester().testAllPublicStaticMethods(EitherOf2.class);
     }
 
     @Test
     @DisplayName("support equality")
     void supportEquality() {
-        new EqualsTester().addEqualityGroup(eitherWithA, EitherOfThree.withA(a))
+        new EqualsTester().addEqualityGroup(eitherWithA, EitherOf2.withA(a))
                           .addEqualityGroup(eitherWithB)
-                          .addEqualityGroup(eitherWithC)
                           .testEquals();
     }
 
@@ -88,7 +77,6 @@ class EitherOfThreeTest {
     void returnValues() {
         assertEquals(a, eitherWithA.getA());
         assertEquals(b, eitherWithB.getB());
-        assertEquals(c, eitherWithC.getC());
     }
 
     @Test
@@ -96,7 +84,6 @@ class EitherOfThreeTest {
     void returnValueIndex() {
         assertEquals(0, eitherWithA.getIndex());
         assertEquals(1, eitherWithB.getIndex());
-        assertEquals(2, eitherWithC.getIndex());
     }
 
     @Test
@@ -111,11 +98,6 @@ class EitherOfThreeTest {
 
         assertEquals(b, iteratorB.next());
         assertFalse(iteratorB.hasNext());
-
-        Iterator<Message> iteratorC = eitherWithC.iterator();
-
-        assertEquals(c, iteratorC.next());
-        assertFalse(iteratorC.hasNext());
     }
 
     @Test
@@ -123,57 +105,17 @@ class EitherOfThreeTest {
     void serialize() {
         reserializeAndAssert(eitherWithA);
         reserializeAndAssert(eitherWithB);
-        reserializeAndAssert(eitherWithC);
     }
 
-    @Nested
-    @DisplayName("when A is set, prohibit obtaining")
-    class ProhibitObtainingForA {
-
-        @Test
-        @DisplayName("B")
-        void b() {
-            assertThrows(IllegalStateException.class, () -> eitherWithA.getB());
-        }
-
-        @Test
-        @DisplayName("C")
-        void c() {
-            assertThrows(IllegalStateException.class, () -> eitherWithA.getC());
-        }
+    @Test
+    @DisplayName("prohibit obtaining B when A is set")
+    void notGetBForA() {
+        assertThrows(IllegalStateException.class, () -> eitherWithA.getB());
     }
 
-    @Nested
-    @DisplayName("when B is set, prohibit obtaining")
-    class ProhibitObtainingForB {
-
-        @Test
-        @DisplayName("A")
-        void a() {
-            assertThrows(IllegalStateException.class, () -> eitherWithB.getA());
-        }
-
-        @Test
-        @DisplayName("C")
-        void c() {
-            assertThrows(IllegalStateException.class, () -> eitherWithB.getC());
-        }
-    }
-
-    @Nested
-    @DisplayName("when C is set, prohibit obtaining")
-    class ProhibitObtainingForC {
-
-        @Test
-        @DisplayName("A")
-        void a() {
-            assertThrows(IllegalStateException.class, () -> eitherWithC.getA());
-        }
-
-        @Test
-        @DisplayName("B")
-        void b() {
-            assertThrows(IllegalStateException.class, () -> eitherWithC.getB());
-        }
+    @Test
+    @DisplayName("prohibit obtaining A when B is set")
+    void notGetAForB() {
+        assertThrows(IllegalStateException.class, () -> eitherWithB.getA());
     }
 }

--- a/server/src/test/java/io/spine/server/tuple/EitherOf3Test.java
+++ b/server/src/test/java/io/spine/server/tuple/EitherOf3Test.java
@@ -25,10 +25,12 @@ import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
 import com.google.protobuf.Timestamp;
+import com.google.protobuf.UInt32Value;
 import io.spine.base.Time;
 import io.spine.testing.TestValues;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
@@ -39,39 +41,42 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-/**
- * @author Alexander Yevsyukov
- */
 @SuppressWarnings({"FieldNamingConvention", "InstanceVariableNamingConvention",
         /* Short vars are OK for tuple tests. */
         "DuplicateStringLiteralInspection" /* Common test display names. */,
         "ResultOfMethodCallIgnored" /* Methods are called to throw exception. */})
-@DisplayName("EitherOfTwo should")
-class EitherOfTwoTest {
+@DisplayName("EitherOfThree should")
+class EitherOf3Test {
 
     private final StringValue a = TestValues.newUuidValue();
-    private final Timestamp b = Time.getCurrentTime();
+    private final UInt32Value b = UInt32Value.newBuilder()
+                                             .setValue(42)
+                                             .build();
+    private final Timestamp c = Time.getCurrentTime();
 
-    private EitherOfTwo<StringValue, Timestamp> eitherWithA;
-    private EitherOfTwo<StringValue, Timestamp> eitherWithB;
+    private EitherOf3<StringValue, UInt32Value, Timestamp> eitherWithA;
+    private EitherOf3<StringValue, UInt32Value, Timestamp> eitherWithB;
+    private EitherOf3<StringValue, UInt32Value, Timestamp> eitherWithC;
 
     @BeforeEach
     void setUp() {
-        eitherWithA = EitherOfTwo.withA(a);
-        eitherWithB = EitherOfTwo.withB(b);
+        eitherWithA = EitherOf3.withA(a);
+        eitherWithB = EitherOf3.withB(b);
+        eitherWithC = EitherOf3.withC(c);
     }
 
     @Test
     @DisplayName(NOT_ACCEPT_NULLS)
     void passNullToleranceCheck() {
-        new NullPointerTester().testAllPublicStaticMethods(EitherOfTwo.class);
+        new NullPointerTester().testAllPublicStaticMethods(EitherOf3.class);
     }
 
     @Test
     @DisplayName("support equality")
     void supportEquality() {
-        new EqualsTester().addEqualityGroup(eitherWithA, EitherOfTwo.withA(a))
+        new EqualsTester().addEqualityGroup(eitherWithA, EitherOf3.withA(a))
                           .addEqualityGroup(eitherWithB)
+                          .addEqualityGroup(eitherWithC)
                           .testEquals();
     }
 
@@ -80,6 +85,7 @@ class EitherOfTwoTest {
     void returnValues() {
         assertEquals(a, eitherWithA.getA());
         assertEquals(b, eitherWithB.getB());
+        assertEquals(c, eitherWithC.getC());
     }
 
     @Test
@@ -87,6 +93,7 @@ class EitherOfTwoTest {
     void returnValueIndex() {
         assertEquals(0, eitherWithA.getIndex());
         assertEquals(1, eitherWithB.getIndex());
+        assertEquals(2, eitherWithC.getIndex());
     }
 
     @Test
@@ -101,6 +108,11 @@ class EitherOfTwoTest {
 
         assertEquals(b, iteratorB.next());
         assertFalse(iteratorB.hasNext());
+
+        Iterator<Message> iteratorC = eitherWithC.iterator();
+
+        assertEquals(c, iteratorC.next());
+        assertFalse(iteratorC.hasNext());
     }
 
     @Test
@@ -108,17 +120,57 @@ class EitherOfTwoTest {
     void serialize() {
         reserializeAndAssert(eitherWithA);
         reserializeAndAssert(eitherWithB);
+        reserializeAndAssert(eitherWithC);
     }
 
-    @Test
-    @DisplayName("prohibit obtaining B when A is set")
-    void notGetBForA() {
-        assertThrows(IllegalStateException.class, () -> eitherWithA.getB());
+    @Nested
+    @DisplayName("when A is set, prohibit obtaining")
+    class ProhibitObtainingForA {
+
+        @Test
+        @DisplayName("B")
+        void b() {
+            assertThrows(IllegalStateException.class, () -> eitherWithA.getB());
+        }
+
+        @Test
+        @DisplayName("C")
+        void c() {
+            assertThrows(IllegalStateException.class, () -> eitherWithA.getC());
+        }
     }
 
-    @Test
-    @DisplayName("prohibit obtaining A when B is set")
-    void notGetAForB() {
-        assertThrows(IllegalStateException.class, () -> eitherWithB.getA());
+    @Nested
+    @DisplayName("when B is set, prohibit obtaining")
+    class ProhibitObtainingForB {
+
+        @Test
+        @DisplayName("A")
+        void a() {
+            assertThrows(IllegalStateException.class, () -> eitherWithB.getA());
+        }
+
+        @Test
+        @DisplayName("C")
+        void c() {
+            assertThrows(IllegalStateException.class, () -> eitherWithB.getC());
+        }
+    }
+
+    @Nested
+    @DisplayName("when C is set, prohibit obtaining")
+    class ProhibitObtainingForC {
+
+        @Test
+        @DisplayName("A")
+        void a() {
+            assertThrows(IllegalStateException.class, () -> eitherWithC.getA());
+        }
+
+        @Test
+        @DisplayName("B")
+        void b() {
+            assertThrows(IllegalStateException.class, () -> eitherWithC.getB());
+        }
     }
 }

--- a/server/src/test/java/io/spine/server/tuple/EitherOf4Test.java
+++ b/server/src/test/java/io/spine/server/tuple/EitherOf4Test.java
@@ -23,7 +23,6 @@ package io.spine.server.tuple;
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.BoolValue;
-import com.google.protobuf.FloatValue;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
 import com.google.protobuf.Timestamp;
@@ -43,55 +42,46 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-/**
- * @author Alexander Yevsyukov
- */
 @SuppressWarnings({"FieldNamingConvention", "InstanceVariableNamingConvention",
         /* Short vars are OK for tuple tests. */
         "DuplicateStringLiteralInspection" /* Common test display names. */,
         "ResultOfMethodCallIgnored" /* Methods are called to throw exception. */})
-@DisplayName("EitherOfFive should")
-class EitherOfFiveTest {
+@DisplayName("EitherOfFour should")
+class EitherOf4Test {
 
     private final StringValue a = TestValues.newUuidValue();
     private final BoolValue b = BoolValue.of(true);
     private final Timestamp c = Time.getCurrentTime();
     private final UInt32Value d = UInt32Value.newBuilder()
-                                             .setValue(512)
+                                             .setValue(1024)
                                              .build();
-    private final FloatValue e = FloatValue.newBuilder()
-                                           .setValue(3.14159f)
-                                           .build();
 
-    private EitherOfFive<StringValue, BoolValue, Timestamp, UInt32Value, FloatValue> eitherWithA;
-    private EitherOfFive<StringValue, BoolValue, Timestamp, UInt32Value, FloatValue> eitherWithB;
-    private EitherOfFive<StringValue, BoolValue, Timestamp, UInt32Value, FloatValue> eitherWithC;
-    private EitherOfFive<StringValue, BoolValue, Timestamp, UInt32Value, FloatValue> eitherWithD;
-    private EitherOfFive<StringValue, BoolValue, Timestamp, UInt32Value, FloatValue> eitherWithE;
+    private EitherOf4<StringValue, BoolValue, Timestamp, UInt32Value> eitherWithA;
+    private EitherOf4<StringValue, BoolValue, Timestamp, UInt32Value> eitherWithB;
+    private EitherOf4<StringValue, BoolValue, Timestamp, UInt32Value> eitherWithC;
+    private EitherOf4<StringValue, BoolValue, Timestamp, UInt32Value> eitherWithD;
 
     @BeforeEach
     void setUp() {
-        eitherWithA = EitherOfFive.withA(a);
-        eitherWithB = EitherOfFive.withB(b);
-        eitherWithC = EitherOfFive.withC(c);
-        eitherWithD = EitherOfFive.withD(d);
-        eitherWithE = EitherOfFive.withE(e);
+        eitherWithA = EitherOf4.withA(a);
+        eitherWithB = EitherOf4.withB(b);
+        eitherWithC = EitherOf4.withC(c);
+        eitherWithD = EitherOf4.withD(d);
     }
 
     @Test
     @DisplayName(NOT_ACCEPT_NULLS)
     void passNullToleranceCheck() {
-        new NullPointerTester().testAllPublicStaticMethods(EitherOfFive.class);
+        new NullPointerTester().testAllPublicStaticMethods(EitherOf4.class);
     }
 
     @Test
     @DisplayName("support equality")
     void supportEquality() {
-        new EqualsTester().addEqualityGroup(eitherWithA, EitherOfFive.withA(a))
+        new EqualsTester().addEqualityGroup(eitherWithA, EitherOf4.withA(a))
                           .addEqualityGroup(eitherWithB)
                           .addEqualityGroup(eitherWithC)
                           .addEqualityGroup(eitherWithD)
-                          .addEqualityGroup(eitherWithE)
                           .testEquals();
     }
 
@@ -102,7 +92,6 @@ class EitherOfFiveTest {
         assertEquals(b, eitherWithB.getB());
         assertEquals(c, eitherWithC.getC());
         assertEquals(d, eitherWithD.getD());
-        assertEquals(e, eitherWithE.getE());
     }
 
     @Test
@@ -112,7 +101,6 @@ class EitherOfFiveTest {
         assertEquals(1, eitherWithB.getIndex());
         assertEquals(2, eitherWithC.getIndex());
         assertEquals(3, eitherWithD.getIndex());
-        assertEquals(4, eitherWithE.getIndex());
     }
 
     @Test
@@ -137,11 +125,6 @@ class EitherOfFiveTest {
 
         assertEquals(d, iteratorD.next());
         assertFalse(iteratorD.hasNext());
-
-        Iterator<Message> iteratorE = eitherWithE.iterator();
-
-        assertEquals(e, iteratorE.next());
-        assertFalse(iteratorE.hasNext());
     }
 
     @Test
@@ -151,7 +134,6 @@ class EitherOfFiveTest {
         reserializeAndAssert(eitherWithB);
         reserializeAndAssert(eitherWithC);
         reserializeAndAssert(eitherWithD);
-        reserializeAndAssert(eitherWithE);
     }
 
     @Nested
@@ -174,12 +156,6 @@ class EitherOfFiveTest {
         @DisplayName("D")
         void d() {
             assertThrows(IllegalStateException.class, () -> eitherWithA.getD());
-        }
-
-        @Test
-        @DisplayName("E")
-        void e() {
-            assertThrows(IllegalStateException.class, () -> eitherWithA.getE());
         }
     }
 
@@ -204,12 +180,6 @@ class EitherOfFiveTest {
         void d() {
             assertThrows(IllegalStateException.class, () -> eitherWithB.getD());
         }
-
-        @Test
-        @DisplayName("E")
-        void e() {
-            assertThrows(IllegalStateException.class, () -> eitherWithB.getE());
-        }
     }
 
     @Nested
@@ -233,12 +203,6 @@ class EitherOfFiveTest {
         void d() {
             assertThrows(IllegalStateException.class, () -> eitherWithC.getD());
         }
-
-        @Test
-        @DisplayName("E")
-        void e() {
-            assertThrows(IllegalStateException.class, () -> eitherWithC.getE());
-        }
     }
 
     @Nested
@@ -261,41 +225,6 @@ class EitherOfFiveTest {
         @DisplayName("C")
         void c() {
             assertThrows(IllegalStateException.class, () -> eitherWithD.getC());
-        }
-
-        @Test
-        @DisplayName("E")
-        void e() {
-            assertThrows(IllegalStateException.class, () -> eitherWithD.getE());
-        }
-    }
-
-    @Nested
-    @DisplayName("when E is set, prohibit obtaining")
-    class ProhibitObtainingForE {
-
-        @Test
-        @DisplayName("A")
-        void a() {
-            assertThrows(IllegalStateException.class, () -> eitherWithE.getA());
-        }
-
-        @Test
-        @DisplayName("B")
-        void b() {
-            assertThrows(IllegalStateException.class, () -> eitherWithE.getB());
-        }
-
-        @Test
-        @DisplayName("C")
-        void c() {
-            assertThrows(IllegalStateException.class, () -> eitherWithE.getC());
-        }
-
-        @Test
-        @DisplayName("D")
-        void d() {
-            assertThrows(IllegalStateException.class, () -> eitherWithE.getD());
         }
     }
 }

--- a/server/src/test/java/io/spine/server/tuple/EitherOf5Test.java
+++ b/server/src/test/java/io/spine/server/tuple/EitherOf5Test.java
@@ -23,6 +23,7 @@ package io.spine.server.tuple;
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.BoolValue;
+import com.google.protobuf.FloatValue;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
 import com.google.protobuf.Timestamp;
@@ -42,49 +43,52 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-/**
- * @author Alexander Yevsyukov
- */
 @SuppressWarnings({"FieldNamingConvention", "InstanceVariableNamingConvention",
         /* Short vars are OK for tuple tests. */
         "DuplicateStringLiteralInspection" /* Common test display names. */,
         "ResultOfMethodCallIgnored" /* Methods are called to throw exception. */})
-@DisplayName("EitherOfFour should")
-class EitherOfFourTest {
+@DisplayName("EitherOfFive should")
+class EitherOf5Test {
 
     private final StringValue a = TestValues.newUuidValue();
     private final BoolValue b = BoolValue.of(true);
     private final Timestamp c = Time.getCurrentTime();
     private final UInt32Value d = UInt32Value.newBuilder()
-                                             .setValue(1024)
+                                             .setValue(512)
                                              .build();
+    private final FloatValue e = FloatValue.newBuilder()
+                                           .setValue(3.14159f)
+                                           .build();
 
-    private EitherOfFour<StringValue, BoolValue, Timestamp, UInt32Value> eitherWithA;
-    private EitherOfFour<StringValue, BoolValue, Timestamp, UInt32Value> eitherWithB;
-    private EitherOfFour<StringValue, BoolValue, Timestamp, UInt32Value> eitherWithC;
-    private EitherOfFour<StringValue, BoolValue, Timestamp, UInt32Value> eitherWithD;
+    private EitherOf5<StringValue, BoolValue, Timestamp, UInt32Value, FloatValue> eitherWithA;
+    private EitherOf5<StringValue, BoolValue, Timestamp, UInt32Value, FloatValue> eitherWithB;
+    private EitherOf5<StringValue, BoolValue, Timestamp, UInt32Value, FloatValue> eitherWithC;
+    private EitherOf5<StringValue, BoolValue, Timestamp, UInt32Value, FloatValue> eitherWithD;
+    private EitherOf5<StringValue, BoolValue, Timestamp, UInt32Value, FloatValue> eitherWithE;
 
     @BeforeEach
     void setUp() {
-        eitherWithA = EitherOfFour.withA(a);
-        eitherWithB = EitherOfFour.withB(b);
-        eitherWithC = EitherOfFour.withC(c);
-        eitherWithD = EitherOfFour.withD(d);
+        eitherWithA = EitherOf5.withA(a);
+        eitherWithB = EitherOf5.withB(b);
+        eitherWithC = EitherOf5.withC(c);
+        eitherWithD = EitherOf5.withD(d);
+        eitherWithE = EitherOf5.withE(e);
     }
 
     @Test
     @DisplayName(NOT_ACCEPT_NULLS)
     void passNullToleranceCheck() {
-        new NullPointerTester().testAllPublicStaticMethods(EitherOfFour.class);
+        new NullPointerTester().testAllPublicStaticMethods(EitherOf5.class);
     }
 
     @Test
     @DisplayName("support equality")
     void supportEquality() {
-        new EqualsTester().addEqualityGroup(eitherWithA, EitherOfFour.withA(a))
+        new EqualsTester().addEqualityGroup(eitherWithA, EitherOf5.withA(a))
                           .addEqualityGroup(eitherWithB)
                           .addEqualityGroup(eitherWithC)
                           .addEqualityGroup(eitherWithD)
+                          .addEqualityGroup(eitherWithE)
                           .testEquals();
     }
 
@@ -95,6 +99,7 @@ class EitherOfFourTest {
         assertEquals(b, eitherWithB.getB());
         assertEquals(c, eitherWithC.getC());
         assertEquals(d, eitherWithD.getD());
+        assertEquals(e, eitherWithE.getE());
     }
 
     @Test
@@ -104,6 +109,7 @@ class EitherOfFourTest {
         assertEquals(1, eitherWithB.getIndex());
         assertEquals(2, eitherWithC.getIndex());
         assertEquals(3, eitherWithD.getIndex());
+        assertEquals(4, eitherWithE.getIndex());
     }
 
     @Test
@@ -128,6 +134,11 @@ class EitherOfFourTest {
 
         assertEquals(d, iteratorD.next());
         assertFalse(iteratorD.hasNext());
+
+        Iterator<Message> iteratorE = eitherWithE.iterator();
+
+        assertEquals(e, iteratorE.next());
+        assertFalse(iteratorE.hasNext());
     }
 
     @Test
@@ -137,6 +148,7 @@ class EitherOfFourTest {
         reserializeAndAssert(eitherWithB);
         reserializeAndAssert(eitherWithC);
         reserializeAndAssert(eitherWithD);
+        reserializeAndAssert(eitherWithE);
     }
 
     @Nested
@@ -159,6 +171,12 @@ class EitherOfFourTest {
         @DisplayName("D")
         void d() {
             assertThrows(IllegalStateException.class, () -> eitherWithA.getD());
+        }
+
+        @Test
+        @DisplayName("E")
+        void e() {
+            assertThrows(IllegalStateException.class, () -> eitherWithA.getE());
         }
     }
 
@@ -183,6 +201,12 @@ class EitherOfFourTest {
         void d() {
             assertThrows(IllegalStateException.class, () -> eitherWithB.getD());
         }
+
+        @Test
+        @DisplayName("E")
+        void e() {
+            assertThrows(IllegalStateException.class, () -> eitherWithB.getE());
+        }
     }
 
     @Nested
@@ -206,6 +230,12 @@ class EitherOfFourTest {
         void d() {
             assertThrows(IllegalStateException.class, () -> eitherWithC.getD());
         }
+
+        @Test
+        @DisplayName("E")
+        void e() {
+            assertThrows(IllegalStateException.class, () -> eitherWithC.getE());
+        }
     }
 
     @Nested
@@ -228,6 +258,41 @@ class EitherOfFourTest {
         @DisplayName("C")
         void c() {
             assertThrows(IllegalStateException.class, () -> eitherWithD.getC());
+        }
+
+        @Test
+        @DisplayName("E")
+        void e() {
+            assertThrows(IllegalStateException.class, () -> eitherWithD.getE());
+        }
+    }
+
+    @Nested
+    @DisplayName("when E is set, prohibit obtaining")
+    class ProhibitObtainingForE {
+
+        @Test
+        @DisplayName("A")
+        void a() {
+            assertThrows(IllegalStateException.class, () -> eitherWithE.getA());
+        }
+
+        @Test
+        @DisplayName("B")
+        void b() {
+            assertThrows(IllegalStateException.class, () -> eitherWithE.getB());
+        }
+
+        @Test
+        @DisplayName("C")
+        void c() {
+            assertThrows(IllegalStateException.class, () -> eitherWithE.getC());
+        }
+
+        @Test
+        @DisplayName("D")
+        void d() {
+            assertThrows(IllegalStateException.class, () -> eitherWithE.getD());
         }
     }
 }

--- a/server/src/test/java/io/spine/server/tuple/PairTest.java
+++ b/server/src/test/java/io/spine/server/tuple/PairTest.java
@@ -41,13 +41,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-/**
- * @author Alexander Yevsyukov
- */
 @SuppressWarnings({"LocalVariableNamingConvention" /* OK for tuple element values. */,
         "InnerClassMayBeStatic", "ClassCanBeStatic" /* JUnit nested classes cannot be static. */,
         "DuplicateStringLiteralInspection" /* Common test display names. */})
-
 @DisplayName("Pair should")
 class PairTest {
 
@@ -55,7 +51,7 @@ class PairTest {
     @DisplayName(NOT_ACCEPT_NULLS)
     void passNullToleranceCheck() {
         new NullPointerTester().setDefault(Message.class, TestValues.newUuidValue())
-                               .setDefault(Either.class, EitherOfTwo.withB(Time.getCurrentTime()))
+                               .setDefault(Either.class, EitherOf2.withB(Time.getCurrentTime()))
                                .testAllPublicStaticMethods(Pair.class);
     }
 
@@ -176,7 +172,7 @@ class PairTest {
         reserializeAndAssert(Pair.withNullable(a, b));
         reserializeAndAssert(Pair.withNullable(a, null));
 
-        reserializeAndAssert(Pair.withEither(a, EitherOfTwo.withA(Time.getCurrentTime())));
-        reserializeAndAssert(Pair.withEither(a, EitherOfTwo.withB(TestValues.newUuidValue())));
+        reserializeAndAssert(Pair.withEither(a, EitherOf2.withA(Time.getCurrentTime())));
+        reserializeAndAssert(Pair.withEither(a, EitherOf2.withB(TestValues.newUuidValue())));
     }
 }

--- a/server/src/test/java/io/spine/server/tuple/TupleTest.java
+++ b/server/src/test/java/io/spine/server/tuple/TupleTest.java
@@ -39,18 +39,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-/**
- * @author Alexander Yevsyukov
- */
-@SuppressWarnings({"LocalVariableNamingConvention", "FieldNamingConvention",
-        "InstanceVariableNamingConvention"}) // OK for tuple entry values.
+@SuppressWarnings({
+        "FieldNamingConvention",
+        "InstanceVariableNamingConvention" /* OK for tuple entry values. */
+})
 @DisplayName("Tuple should")
 class TupleTest {
 
     private final StringValue a = TestValues.newUuidValue();
-    private final EitherOfTwo<Timestamp, BoolValue> b = EitherOfTwo.withA(Time.getCurrentTime());
+    private final EitherOf2<Timestamp, BoolValue> b = EitherOf2.withA(Time.getCurrentTime());
 
-    private TTuple<StringValue, EitherOfTwo<Timestamp, BoolValue>> tuple;
+    private TTuple<StringValue, EitherOf2<Timestamp, BoolValue>> tuple;
 
     @BeforeEach
     void setUp() {

--- a/server/src/test/java/io/spine/testdata/Sample.java
+++ b/server/src/test/java/io/spine/testdata/Sample.java
@@ -48,11 +48,10 @@ import static java.lang.String.format;
 /**
  * Utility for creating simple stubs for generated messages, DTOs (like {@link Event} and
  * {@link Command}), storage objects and else.
- *
- * @author Dmytro Dashenkov
  */
 public class Sample {
 
+    /** Prevents instantiation of this utility class. */
     private Sample() {
     }
 
@@ -64,12 +63,17 @@ public class Sample {
      * Number and {@code boolean} fields may or may not have their default values ({@code 0} and
      * {@code false}).
      *
+     * @apiNote This method casts the builder to the generic parameter {@code <B>} for brevity of
+     *          test code. It is the caller responsibility to ensure that the message
+     *          type {@code <M>} corresponds to the builder type {@code <B>}.
+     *
      * @param clazz Java class of the stub message
      * @param <M>   type of the required message
      * @param <B>   type of the {@link Message.Builder} for the message
      * @return new instance of the {@link Message.Builder} for given type
      * @see #valueFor(FieldDescriptor)
      */
+    @SuppressWarnings("TypeParameterUnusedInFormals") // See apiNote.
     public static <M extends Message, B extends Message.Builder> B builderForType(Class<M> clazz) {
         checkClass(clazz);
 

--- a/server/src/test/java/io/spine/testdata/package-info.java
+++ b/server/src/test/java/io/spine/testdata/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, TeamDev Ltd. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -18,27 +18,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.server.entity.storage;
-
-import java.io.Serializable;
-
 /**
- * A converter which uses {@link Enum}'s {@linkplain Enum#ordinal() ordinal} to convert the
- * enumerated value into the {@link Integer} value.
+ * This package provides factories for creating test environments.
  */
-final class OrdinalEnumConverter extends EnumConverter {
 
-    OrdinalEnumConverter(Class<? extends Enum> sourceType) {
-        super(sourceType);
-    }
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.testdata;
 
-    @Override
-    public Class<? extends Serializable> getTargetType() {
-        return Integer.class;
-    }
+import com.google.errorprone.annotations.CheckReturnValue;
 
-    @Override
-    Integer convertEnumValue(Enum value) {
-        return value.ordinal();
-    }
-}
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
This PR renames `EitherOfXxx` classes to `EitherOfN` classes, where `N` is the number which used to be a word `Xxx`.

Also this PR:
  * Addresses `ErrorProne` warnings.
  * Makes tests of utility classes to inherit `UtilityClassTest` (to save on repeated general checks).
  * Makes `UniformAcrossTargets` `@Immutable`.
  * Makes test code which uses `Sampled.builderForType()` more compact.
