### PR TITLE
Fix model verifier

### DIFF
--- a/model/model-verifier/build.gradle
+++ b/model/model-verifier/build.gradle
@@ -40,6 +40,7 @@ sourceSets {
 dependencies {
     implementation gradleApi()
     implementation "io.spine.tools:spine-plugin-base:$spineBaseVersion"
+    implementation "io.spine.tools:spine-model-compiler:$spineBaseVersion"
     implementation project(':server')
     implementation project(':model-assembler')
 

--- a/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifierPlugin.java
+++ b/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifierPlugin.java
@@ -128,15 +128,19 @@ public final class ModelVerifierPlugin extends SpinePlugin {
             if (project.getExtensions().findByName(pluginExtensionName) != null) {
                 String path = Extension.getMainDescriptorSetPath(project);
                 File descriptorFile = new File(path);
-                if (descriptorFile.exists()) {
-                    _debug("Extending known types with types from {}.", descriptorFile);
-                    MoreKnownTypes.extendWith(descriptorFile);
-                } else {
-                    _warn("Descriptor file {} does not exist.", descriptorFile);
-                }
+                tryExtend(descriptorFile);
             } else {
                 _warn("{} plugin extension is not found. Apply the Spine model compiler plugin.",
                       pluginExtensionName);
+            }
+        }
+
+        private void tryExtend(File descriptorFile) {
+            if (descriptorFile.exists()) {
+                _debug("Extending known types with types from {}.", descriptorFile);
+                MoreKnownTypes.extendWith(descriptorFile);
+            } else {
+                _warn("Descriptor file {} does not exist.", descriptorFile);
             }
         }
 

--- a/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifierPlugin.java
+++ b/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifierPlugin.java
@@ -27,7 +27,7 @@ import io.spine.model.assemble.AssignLookup;
 import io.spine.tools.gradle.SpinePlugin;
 import io.spine.tools.gradle.compiler.Extension;
 import io.spine.tools.gradle.compiler.ModelCompilerPlugin;
-import io.spine.typehack.MoreKnownTypes;
+import io.spine.tools.type.MoreKnownTypes;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;

--- a/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierPluginTest.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierPluginTest.java
@@ -42,9 +42,6 @@ import static org.gradle.testkit.runner.TaskOutcome.FAILED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-/**
- * @author Dmytro Dashenkov
- */
 @ExtendWith(TempDirectory.class)
 @DisplayName("ModelVerifierPlugin should")
 class ModelVerifierPluginTest {

--- a/server/src/main/java/io/spine/server/model/Handlers.java
+++ b/server/src/main/java/io/spine/server/model/Handlers.java
@@ -21,6 +21,7 @@
 package io.spine.server.model;
 
 import io.spine.type.MessageClass;
+import io.spine.type.TypeName;
 import io.spine.type.TypeUrl;
 
 /**
@@ -71,7 +72,8 @@ public final class Handlers {
     }
 
     private static String typeUrl(MessageClass<?> messageClass) {
-        TypeUrl typeUrl = TypeUrl.of(messageClass.value());
+        TypeName typeName = messageClass.getTypeName();
+        TypeUrl typeUrl = typeName.toUrl();
         return typeUrl.value();
     }
 }

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.11.2-SNAPSHOT'
+def final SPINE_VERSION = '0.11.4-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.

--- a/version.gradle
+++ b/version.gradle
@@ -32,7 +32,7 @@ ext {
     versionToPublish = SPINE_VERSION
 
     // Depend on `base` for the general definitions and a model compiler.
-    spineBaseVersion = '0.11.3-SNAPSHOT'
+    spineBaseVersion = '0.11.4-SNAPSHOT'
 
     // Depend on `time` for `ZoneOffset` and other date/time types and utilities.
     spineTimeVersion = '0.11.00-SNAPSHOT'

--- a/version.gradle
+++ b/version.gradle
@@ -8,7 +8,7 @@
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE gitCOPYRIGHT
  * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
  * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
@@ -25,14 +25,14 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.11.4-SNAPSHOT'
+def final SPINE_VERSION = '0.11.5-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.
     versionToPublish = SPINE_VERSION
 
     // Depend on `base` for the general definitions and a model compiler.
-    spineBaseVersion = '0.11.4-SNAPSHOT'
+    spineBaseVersion = '0.11.5-SNAPSHOT'
 
     // Depend on `time` for `ZoneOffset` and other date/time types and utilities.
     spineTimeVersion = '0.11.00-SNAPSHOT'

--- a/version.gradle
+++ b/version.gradle
@@ -32,7 +32,7 @@ ext {
     versionToPublish = SPINE_VERSION
 
     // Depend on `base` for the general definitions and a model compiler.
-    spineBaseVersion = '0.11.1-SNAPSHOT'
+    spineBaseVersion = '0.11.3-SNAPSHOT'
 
     // Depend on `time` for `ZoneOffset` and other date/time types and utilities.
     spineTimeVersion = '0.11.00-SNAPSHOT'


### PR DESCRIPTION
In this PR we fix the model-verifier plugin issue.

Previously, the model verifier had only the Spine types in its `KnownTypes`. Now, the user types are added to the `KnownTypes` of the verifier at runtime.

Fixes #842.