### PR TITLE
Remove duplicated javac config

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -484,7 +484,17 @@
     </inspection_tool>
     <inspection_tool class="NewExceptionWithoutArguments" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NewMethodNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
-      <scope name="Tests" level="INFO" enabled="false" />
+      <scope name="Tests" level="INFO" enabled="true">
+        <extension name="InstanceMethodNamingConvention" enabled="true">
+          <option name="m_regex" value="[a-z][A-Za-z\d]*" />
+          <option name="m_minLength" value="2" />
+          <option name="m_maxLength" value="32" />
+        </extension>
+        <extension name="JUnit4MethodNamingConvention" enabled="true">
+          <option name="m_regex" value="[a-z][A-Za-z\d]*" />
+          <option name="m_minLength" value="2" />
+        </extension>
+      </scope>
       <scope name="Production" level="WARNING" enabled="true">
         <extension name="InstanceMethodNamingConvention" enabled="true">
           <option name="m_regex" value="[a-z][A-Za-z\d]*" />

--- a/build.gradle
+++ b/build.gradle
@@ -216,7 +216,6 @@ subprojects {
 
     apply from: deps.scripts.testOutput
     apply from: deps.scripts.javadocOptions
-    apply from: deps.scripts.javacArgs
     
     task sourceJar(type: Jar) {
         from sourceSets.main.allJava


### PR DESCRIPTION
This PR removes duplicated ErrorProne javac configuration.

`config` dependency was also updated.