### PR TITLE
Add forceful shutdown of GrpcContainer

### DIFF
--- a/server/src/main/java/io/spine/server/transport/GrpcContainer.java
+++ b/server/src/main/java/io/spine/server/transport/GrpcContainer.java
@@ -41,8 +41,6 @@ import static com.google.common.base.Preconditions.checkState;
  * <p>Maintains and deploys several of gRPC services within a single server.
  *
  * <p>Uses {@link ServerServiceDefinition}s of each service.
- *
- * @author Alex Tymchenko
  */
 public class GrpcContainer {
 
@@ -91,6 +89,21 @@ public class GrpcContainer {
     public void shutdown() {
         checkState(grpcServer != null, SERVER_NOT_STARTED_MSG);
         grpcServer.shutdown();
+        grpcServer = null;
+    }
+
+    /**
+     * Initiates a forceful shutdown in which preexisting and new calls are rejected.
+     *
+     * <p>The method returns when the service becomes terminated.
+     * The most common usage scenario for this method is clean-up in unit tests
+     * (e.g. {@literal @}{@code AfterEach} in JUnit5) that involve gRPC communications.
+     */
+    @VisibleForTesting
+    public void shutdownNowAndWait() {
+        checkState(grpcServer != null, SERVER_NOT_STARTED_MSG);
+        grpcServer.shutdownNow();
+        awaitTermination();
         grpcServer = null;
     }
 

--- a/server/src/main/java/io/spine/server/transport/GrpcContainer.java
+++ b/server/src/main/java/io/spine/server/transport/GrpcContainer.java
@@ -89,7 +89,7 @@ public class GrpcContainer {
     public void shutdown() {
         checkState(grpcServer != null, SERVER_NOT_STARTED_MSG);
         grpcServer.shutdown();
-        grpcServer = null;
+        this.grpcServer = null;
     }
 
     /**
@@ -104,7 +104,7 @@ public class GrpcContainer {
         checkState(grpcServer != null, SERVER_NOT_STARTED_MSG);
         grpcServer.shutdownNow();
         awaitTermination();
-        grpcServer = null;
+        this.grpcServer = null;
     }
 
     /** Waits for the service to become terminated. */

--- a/server/src/test/java/io/spine/server/transport/GrpcContainerTest.java
+++ b/server/src/test/java/io/spine/server/transport/GrpcContainerTest.java
@@ -75,10 +75,13 @@ class GrpcContainerTest {
     @Test
     @DisplayName("add and remove parameters from builder")
     void setParamsInBuilder() {
-        GrpcContainer.Builder builder = GrpcContainer.newBuilder()
-                                                     .setPort(8080)
-                                                     .setPort(60);
-        assertEquals(60, builder.getPort());
+        int port = 60;
+        GrpcContainer.Builder builder = GrpcContainer
+                .newBuilder()
+                .setPort(8080)
+                .setPort(port);
+
+        assertEquals(port, builder.getPort());
 
         int count = 3;
         List<ServerServiceDefinition> definitions = new ArrayList<>(count);
@@ -120,6 +123,15 @@ class GrpcContainerTest {
         grpcContainer.shutdown();
 
         verify(server).shutdown();
+    }
+
+    @Test
+    @DisplayName("forcefully shutdown server")
+    void shutdownAndWait() throws IOException {
+        grpcContainer.start();
+        grpcContainer.shutdownNowAndWait();
+
+        assertTrue(grpcContainer.isShutdown());
     }
 
     @Test


### PR DESCRIPTION
This PR adds `shutdownAndWait()` method for `GrpcContainer` so that unit tests for gRPC-based communications do not depend on timing of the gRPC server shutdown.

We are now having such an issue in the `examples-java`, and this PR is meant to fix the problem.
