### PR TITLE
Filter commanding method output for `Empty` and `Nothing` instances

### DIFF
--- a/server/src/main/java/io/spine/server/command/model/CommandingMethod.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandingMethod.java
@@ -80,8 +80,9 @@ public interface CommandingMethod<T,
             super(rawMethodOutput);
             this.optional = optional;
             List<CommandMessage> messages = toMessages(rawMethodOutput);
-            checkMessages(messages);
-            setMessages(messages);
+            List<CommandMessage> filtered = filterIgnored(messages);
+            checkMessages(filtered);
+            setMessages(filtered);
         }
 
         private void checkMessages(List<CommandMessage> messages) {

--- a/server/src/main/java/io/spine/server/model/MethodResult.java
+++ b/server/src/main/java/io/spine/server/model/MethodResult.java
@@ -33,7 +33,6 @@ import java.util.Optional;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.copyOf;
-import static com.google.common.collect.Streams.stream;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;

--- a/server/src/main/java/io/spine/server/model/MethodResult.java
+++ b/server/src/main/java/io/spine/server/model/MethodResult.java
@@ -142,26 +142,22 @@ public abstract class MethodResult<V extends Message> {
             }
         }
 
-        // An `Iterable` is the one of the return types we expect from methods we call.
+        if (output instanceof List) {
+            // Cast to the list of messages as it is the one of the return types
+            // we expect by methods we call.
+            List<V> result = (List<V>) output;
+            return result;
+        }
+
+        // If it's not a list it could be another `Iterable`.
         if (output instanceof Iterable) {
-            Iterable<V> result = (Iterable<V>) output;
-            return filterOutEmpties(result);
+            Iterable<V> iterable = (Iterable<V>) output;
+            return copyOf(iterable);
         }
 
         // Another type of result is single event message (as Message).
         V singleMessage = (V) output;
         List<V> result = singletonList(singleMessage);
-        return result;
-    }
-
-    /**
-     * Removes all {@link Empty} messages from the given {@code Iterable} and collects everything
-     * else to {@code List}.
-     */
-    private static <V extends Message> List<V> filterOutEmpties(Iterable<V> output) {
-        List<V> result = stream(output)
-                .filter(v -> !(v instanceof Empty))
-                .collect(toList());
         return result;
     }
 

--- a/server/src/test/java/io/spine/server/commandbus/CommandHandlerTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandHandlerTest.java
@@ -53,9 +53,6 @@ import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-/**
- * @author Alexander Litus
- */
 @SuppressWarnings("DuplicateStringLiteralInspection") // Common test display names.
 @DisplayName("CommandHandler should")
 class CommandHandlerTest {
@@ -131,6 +128,39 @@ class CommandHandlerTest {
             Message expected = expectedMessages.get(i);
             Message actual = Events.getMessage(actualEvents.get(i).getOuterObject());
             assertEquals(expected, actual);
+        }
+    }
+
+    @Nested
+    @DisplayName("post Pair of events")
+    class PostPair {
+
+        @Test
+        @DisplayName("with two non-null values")
+        void withBothValues() {
+            Command cmd = Given.ACommand.createTask(true);
+
+            EventCatcher eventCatcher = new EventCatcher();
+            eventBus.register(eventCatcher);
+
+            handler.handle(cmd);
+
+            List<EventEnvelope> dispatchedEvents = eventCatcher.getDispatched();
+            assertEquals(2, dispatchedEvents.size());
+        }
+
+        @Test
+        @DisplayName("with null second value")
+        void withNullSecondValue() {
+            Command cmd = Given.ACommand.createTask(false);
+
+            EventCatcher eventCatcher = new EventCatcher();
+            eventBus.register(eventCatcher);
+
+            handler.handle(cmd);
+
+            List<EventEnvelope> dispatchedEvents = eventCatcher.getDispatched();
+            assertEquals(1, dispatchedEvents.size());
         }
     }
 

--- a/server/src/test/java/io/spine/server/commandbus/Given.java
+++ b/server/src/test/java/io/spine/server/commandbus/Given.java
@@ -29,17 +29,21 @@ import io.spine.core.TenantId;
 import io.spine.core.UserId;
 import io.spine.test.command.CmdAddTask;
 import io.spine.test.command.CmdCreateProject;
+import io.spine.test.command.CmdCreateTask;
 import io.spine.test.command.CmdRemoveTask;
 import io.spine.test.command.CmdStartProject;
 import io.spine.test.command.FirstCmdCreateProject;
 import io.spine.test.command.ProjectId;
 import io.spine.test.command.SecondCmdStartProject;
+import io.spine.test.command.Task;
+import io.spine.test.command.TaskId;
 import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.testing.core.given.GivenCommandContext;
 import io.spine.testing.core.given.GivenUserId;
 
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.base.Time.getCurrentTime;
+import static io.spine.testing.TestValues.random;
 
 public class Given {
 
@@ -49,15 +53,25 @@ public class Given {
 
     private static ProjectId newProjectId() {
         String uuid = newUuid();
-        return ProjectId.newBuilder()
-                        .setId(uuid)
-                        .build();
+        return ProjectId
+                .newBuilder()
+                .setId(uuid)
+                .build();
+    }
+
+    private static TaskId newTaskId() {
+        int id = random(1, 100);
+        return TaskId
+                .newBuilder()
+                .setId(id)
+                .build();
     }
 
     public static class ACommand {
 
         private static final UserId USER_ID = GivenUserId.newUuid();
         private static final ProjectId PROJECT_ID = newProjectId();
+        private static final TaskId TASK_ID = newTaskId();
 
         private ACommand() {
             // Prevent construction from outside.
@@ -82,6 +96,10 @@ public class Given {
             return create(message, USER_ID, getCurrentTime());
         }
 
+        public static Command createTask(boolean startTask) {
+            return createTask(TASK_ID, USER_ID, startTask);
+        }
+
         public static Command addTask() {
             return addTask(USER_ID, PROJECT_ID, getCurrentTime());
         }
@@ -94,6 +112,11 @@ public class Given {
         static Command firstCreateProject() {
             FirstCmdCreateProject command = CommandMessage.firstCreateProject(newProjectId());
             return create(command, USER_ID, getCurrentTime());
+        }
+
+        static Command createTask(TaskId taskId, UserId userId, boolean startTask) {
+            CmdCreateTask command = CommandMessage.createTask(taskId, userId, startTask);
+            return create(command, userId, getCurrentTime());
         }
 
         static Command addTask(UserId userId, ProjectId projectId, Timestamp when) {
@@ -148,6 +171,20 @@ public class Given {
 
         private CommandMessage() {
             // Prevent construction from outside.
+        }
+
+        static CmdCreateTask createTask(TaskId taskId, UserId userId, boolean startTask) {
+            Task task = Task
+                    .newBuilder()
+                    .setTaskId(taskId)
+                    .setAssignee(userId)
+                    .build();
+            return CmdCreateTask
+                    .newBuilder()
+                    .setTaskId(taskId)
+                    .setTask(task)
+                    .setStart(startTask)
+                    .build();
         }
 
         static CmdAddTask addTask(String projectId) {

--- a/server/src/test/java/io/spine/server/event/given/CommandHandlerTestEnv.java
+++ b/server/src/test/java/io/spine/server/event/given/CommandHandlerTestEnv.java
@@ -207,8 +207,7 @@ public class CommandHandlerTestEnv {
                                                     .setTaskId(taskId)
                                                     .build()
                                             : null;
-            return Pair.withNullable(
-                    cmdTaskAssigned, cmdTaskStarted);
+            return Pair.withNullable(cmdTaskAssigned, cmdTaskStarted);
         }
     }
 }

--- a/server/src/test/java/io/spine/server/event/given/CommandHandlerTestEnv.java
+++ b/server/src/test/java/io/spine/server/event/given/CommandHandlerTestEnv.java
@@ -35,13 +35,18 @@ import io.spine.server.command.CommandHistory;
 import io.spine.server.event.EventBus;
 import io.spine.server.event.EventDispatcher;
 import io.spine.server.integration.ExternalMessageDispatcher;
+import io.spine.server.tuple.Pair;
 import io.spine.test.command.CmdAddTask;
 import io.spine.test.command.CmdCreateProject;
+import io.spine.test.command.CmdCreateTask;
 import io.spine.test.command.CmdStartProject;
 import io.spine.test.command.ProjectId;
+import io.spine.test.command.TaskId;
 import io.spine.test.command.event.CmdProjectCreated;
 import io.spine.test.command.event.CmdProjectStarted;
 import io.spine.test.command.event.CmdTaskAdded;
+import io.spine.test.command.event.CmdTaskAssigned;
+import io.spine.test.command.event.CmdTaskStarted;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 
@@ -50,11 +55,9 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.Lists.newLinkedList;
+import static io.spine.core.EventClass.from;
 import static io.spine.util.Exceptions.unsupported;
 
-/**
- * @author Alexander Yevsyukov
- */
 public class CommandHandlerTestEnv {
 
     /** Prevents instantiation of this utility class. */
@@ -67,7 +70,11 @@ public class CommandHandlerTestEnv {
 
         @Override
         public Set<EventClass> getMessageClasses() {
-            return ImmutableSet.of(EventClass.from(CmdProjectStarted.class));
+            return ImmutableSet.of(
+                    from(CmdProjectStarted.class),
+                    from(CmdTaskAssigned.class),
+                    from(CmdTaskStarted.class)
+            );
         }
 
         @Override
@@ -152,6 +159,13 @@ public class CommandHandlerTestEnv {
             return eventsOnStartProjectCmd;
         }
 
+        @Assign
+        Pair<CmdTaskAssigned, Optional<CmdTaskStarted>>
+        handle(CmdCreateTask msg, CommandContext context) {
+            commandsHandled.add(msg, context);
+            return createEventsOnCreateTaskCmd(msg);
+        }
+
         @Override
         public void onError(CommandEnvelope envelope, RuntimeException exception) {
             super.onError(envelope, exception);
@@ -178,6 +192,23 @@ public class CommandHandlerTestEnv {
                     .build();
             CmdProjectStarted defaultEvent = CmdProjectStarted.getDefaultInstance();
             return ImmutableList.of(startedEvent, defaultEvent);
+        }
+
+        private static Pair<CmdTaskAssigned, Optional<CmdTaskStarted>>
+        createEventsOnCreateTaskCmd(CmdCreateTask msg) {
+            TaskId taskId = msg.getTaskId();
+            CmdTaskAssigned cmdTaskAssigned = CmdTaskAssigned
+                    .newBuilder()
+                    .setTaskId(taskId)
+                    .build();
+            CmdTaskStarted cmdTaskStarted = msg.getStart()
+                                            ? CmdTaskStarted
+                                                    .newBuilder()
+                                                    .setTaskId(taskId)
+                                                    .build()
+                                            : null;
+            return Pair.withNullable(
+                    cmdTaskAssigned, cmdTaskStarted);
         }
     }
 }

--- a/server/src/test/java/io/spine/server/event/model/given/reactor/RcReturnPair.java
+++ b/server/src/test/java/io/spine/server/event/model/given/reactor/RcReturnPair.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.event.model.given.reactor;
+
+import io.spine.server.event.React;
+import io.spine.server.tuple.Pair;
+import io.spine.test.reflect.event.RefProjectAssigned;
+import io.spine.test.reflect.event.RefProjectCreated;
+import io.spine.test.reflect.event.RefProjectStarted;
+
+import java.util.Optional;
+
+public class RcReturnPair extends TestEventReactor {
+
+    @React
+    Pair<RefProjectStarted, Optional<RefProjectAssigned>> react(RefProjectCreated event) {
+        RefProjectStarted refProjectStarted = RefProjectStarted
+                .newBuilder()
+                .setProjectId(event.getProjectId())
+                .build();
+        RefProjectAssigned refProjectAssigned = event.hasAssignee()
+                                                ? RefProjectAssigned
+                                                        .newBuilder()
+                                                        .setProjectId(event.getProjectId())
+                                                        .setAssignee(event.getAssignee())
+                                                        .build()
+                                                : null;
+
+        return Pair.withNullable(refProjectStarted, refProjectAssigned);
+    }
+}

--- a/server/src/test/proto/spine/test/command/commands.proto
+++ b/server/src/test/proto/spine/test/command/commands.proto
@@ -78,11 +78,16 @@ message SecondCmdStartProject {
 message CmdCreateTask {
     TaskId task_id = 1;
     Task task = 2;
+    bool start = 3;
 }
 
 message CmdAssignTask {
     TaskId task_id = 1;
     core.UserId assignee = 2;
+}
+
+message CmdStartTask {
+    TaskId task_id = 1;
 }
 
 message CmdSetTaskDescription {

--- a/server/src/test/proto/spine/test/command/events.proto
+++ b/server/src/test/proto/spine/test/command/events.proto
@@ -28,6 +28,7 @@ option java_package="io.spine.test.command.event";
 option java_outer_classname = "CommandEventsProto";
 option java_multiple_files = true;
 
+import "spine/core/user_id.proto";
 import "spine/test/command/project.proto";
 
 message CmdProjectCreated {
@@ -46,6 +47,15 @@ message CmdTaskAdded {
 message CmdTaskRemoved {
     ProjectId project_id = 1;
     Task task = 2;
+}
+
+message CmdTaskAssigned {
+    TaskId task_id = 1;
+    core.UserId assignee = 2;
+}
+
+message CmdTaskStarted {
+    TaskId task_id = 1;
 }
 
 message CmdProjectStarted {

--- a/server/src/test/proto/spine/test/reflect/events.proto
+++ b/server/src/test/proto/spine/test/reflect/events.proto
@@ -28,10 +28,12 @@ option java_package="io.spine.test.reflect.event";
 option java_outer_classname = "ReflectEventsProto";
 option java_multiple_files = true;
 
+import "spine/core/user_id.proto";
 import "spine/test/reflect/project.proto";
 
 message RefProjectCreated {
     ProjectId project_id = 1;
+    core.UserId assignee = 2;
 }
 
 message RefTaskAdded {
@@ -41,4 +43,9 @@ message RefTaskAdded {
 
 message RefProjectStarted {
     ProjectId project_id = 1;
+}
+
+message RefProjectAssigned {
+    ProjectId project_id = 1;
+    core.UserId assignee = 2;
 }


### PR DESCRIPTION
This PR fixes issue #894.

Previously, the `filterIgnored` method was not called for commanding method result to remove `Empty` and `Nothing` instances from the command list.

Now, the commanding method result is filtered in the same way as the `CommandHandler` and `EventReactor` results.