### PR TITLE
Fix `ProcessManagerRepository` Javadoc to mention commanding method

### DIFF
--- a/server/src/main/java/io/spine/server/entity/DefaultEntityStorageConverter.java
+++ b/server/src/main/java/io/spine/server/entity/DefaultEntityStorageConverter.java
@@ -30,40 +30,39 @@ import io.spine.type.TypeUrl;
  * @param <I> the type of entity IDs
  * @param <E> the type of entities
  * @param <S> the type of entity states
- * @author Alexander Yevsyukov
  */
 class DefaultEntityStorageConverter<I, E extends AbstractEntity<I, S>, S extends Message>
         extends EntityStorageConverter<I, E, S> {
 
     private static final long serialVersionUID = 0L;
 
-    private DefaultEntityStorageConverter(TypeUrl entityStateType,
+    private DefaultEntityStorageConverter(TypeUrl stateType,
                                           EntityFactory<I, E> factory,
                                           FieldMask fieldMask) {
-        super(entityStateType, factory, fieldMask);
+        super(stateType, factory, fieldMask);
     }
 
     static <I, E extends AbstractEntity<I, S>, S extends Message>
-    EntityStorageConverter<I, E, S> forAllFields(TypeUrl entityStateType,
-                                                 EntityFactory<I, E> factory) {
-        return new DefaultEntityStorageConverter<>(entityStateType,
-                                                   factory,
-                                                   FieldMask.getDefaultInstance());
+    EntityStorageConverter<I, E, S> forAllFields(TypeUrl stateType, EntityFactory<I, E> factory) {
+        FieldMask allFields = FieldMask.getDefaultInstance();
+        return new DefaultEntityStorageConverter<>(stateType, factory, allFields);
     }
 
     @Override
     public EntityStorageConverter<I, E, S> withFieldMask(FieldMask fieldMask) {
-        return new DefaultEntityStorageConverter<>(getEntityStateType(),
-                                                   getEntityFactory(),
-                                                   fieldMask);
+        TypeUrl stateType = getEntityStateType();
+        EntityFactory<I, E> factory = getEntityFactory();
+        return new DefaultEntityStorageConverter<>(stateType, factory, fieldMask);
     }
 
     /**
      * Sets lifecycle flags in the builder from the entity, if the entity is
      * {@linkplain AbstractVersionableEntity versionable}.
      *
-     * @param builder the entity builder to update
-     * @param entity  the entity which data is passed to the {@link EntityRecord} we are building
+     * @param builder
+     *         the entity builder to update
+     * @param entity
+     *         the entity which data is passed to the {@link EntityRecord} we are building
      */
     @SuppressWarnings("CheckReturnValue") // calling builder
     @Override
@@ -83,17 +82,14 @@ class DefaultEntityStorageConverter<I, E extends AbstractEntity<I, S>, S extends
      * <p>If not, {@code IllegalStateException} is thrown suggesting to provide a custom
      * {@link EntityStorageConverter} in the repository which manages entities of this class.
      *
-     * @param entity       the entity to inject the state
-     * @param state        the state message to inject
-     * @param entityRecord the {@link EntityRecord} which contains additional attributes that may be
-     *                     injected
+     * @param entity
+     *         the entity to inject the state
+     * @param state
+     *         the state message to inject
+     * @param entityRecord
+     *         the {@link EntityRecord} which contains additional attributes that may be injected
      */
-    @SuppressWarnings({
-            "ChainOfInstanceofChecks" /* `DefaultEntityStorageConverter` supports conversion of
-                entities derived from standard abstract classes. A custom `Entity` class needs a
-                custom state injection. We do not want to expose state injection in the `Entity`
-                interface.*/,
-            "unchecked" /* The state type is the same as the parameter of this class. */})
+    @SuppressWarnings("unchecked" /* The state type is the same as the parameter of this class. */)
     @Override
     protected void injectState(E entity, S state, EntityRecord entityRecord) {
         if (entity instanceof AbstractVersionableEntity) {

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
@@ -78,8 +78,6 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  * @param <P> the type of process managers
  * @param <S> the type of process manager state messages
  * @see ProcessManager
- * @author Alexander Litus
- * @author Alexander Yevsyukov
  */
 @SuppressWarnings("OverlyCoupledClass")
 public abstract class ProcessManagerRepository<I,
@@ -145,9 +143,9 @@ public abstract class ProcessManagerRepository<I,
      * process manager:
      *
      * <ul>
-     *     <li>command handler methods;</li>
-     *     <li>domestic or external event reactor methods;</li>
-     *     <li>domestic or external rejection reactor methods.</li>
+     *     <li>command handler methods;
+     *     <li>domestic or external event reactor methods;
+     *     <li>domestic or external rejection reactor methods.
      * </ul>
      *
      * <p>Throws an {@code IllegalStateException} otherwise.


### PR DESCRIPTION
This PR:
 1. Fixes `ProcessManagerRepository` Javadoc to mention a commanding method as an option to have a valid `ProcessManager`.
 2.  Removes redundant warning suppression and improves code layout and naming in `DefaultEntityStorageConverter`.

