### PR TITLE
Create `BlackBoxBoundedContext` by `BoundedContextBuilder`

### DIFF
--- a/core/src/main/java/io/spine/core/MessageEnvelope.java
+++ b/core/src/main/java/io/spine/core/MessageEnvelope.java
@@ -42,7 +42,7 @@ public interface MessageEnvelope<I extends Message, T, C extends Message> {
      * Obtains string representation of the message identifier.
      *
      * @apiNote The primary purpose of this method is to display the identifier in human-readable
-     * form in debug and error messages.
+     *          form in debug and error messages.
      */
     default String idAsString() {
         return Stringifiers.toString(getId());

--- a/server/src/main/java/io/spine/server/BoundedContext.java
+++ b/server/src/main/java/io/spine/server/BoundedContext.java
@@ -79,9 +79,9 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  * the model elements which belong to it.
  *
  * @see <a href="https://martinfowler.com/bliki/BoundedContext.html">
- *     Martin Fowler on bounded contexts</a>
+ *     Martin Fowler on Bounded Contexts</a>
  */
-@SuppressWarnings({"ClassWithTooManyMethods", "OverlyCoupledClass"})
+@SuppressWarnings("OverlyCoupledClass")
 public abstract class BoundedContext implements AutoCloseable, Logging {
 
     /**
@@ -112,8 +112,8 @@ public abstract class BoundedContext implements AutoCloseable, Logging {
      *
      * @throws IllegalStateException
      *         if called from a derived class, which is not a part of the framework
-     * @apiNote This constructor is for internal use of the framework.
-     *          Application developers should not create classes derived from {@code BoundedContext}
+     * @apiNote This constructor is for internal use of the framework. Application developers
+     *          should not create classes derived from {@code BoundedContext}.
      */
     @Internal
     protected BoundedContext(BoundedContextBuilder builder) {

--- a/server/src/main/java/io/spine/server/BoundedContext.java
+++ b/server/src/main/java/io/spine/server/BoundedContext.java
@@ -271,14 +271,7 @@ public abstract class BoundedContext implements AutoCloseable, Logging {
     public void registerEventDispatcher(EventDispatcherDelegate<?> dispatcher) {
         checkNotNull(dispatcher);
         DelegatingEventDispatcher<?> delegate = DelegatingEventDispatcher.of(dispatcher);
-        if (dispatcher.dispatchesEvents()) {
-            getEventBus().register(delegate);
-            SystemReadSide systemReadSide = getSystemClient().readSide();
-            systemReadSide.register(delegate);
-        }
-        if (dispatcher.dispatchesExternalEvents()) {
-            registerWithIntegrationBus(delegate);
-        }
+        registerEventDispatcher(delegate);
     }
 
     /**
@@ -302,8 +295,8 @@ public abstract class BoundedContext implements AutoCloseable, Logging {
     /**
      * Obtains a set of entity type names by their visibility.
      */
-    public Set<TypeName> getEntityTypes(Visibility visibility) {
-        Set<TypeName> result = guard.getEntityTypes(visibility);
+    public Set<TypeName> getEntityStateTypes(Visibility visibility) {
+        Set<TypeName> result = guard.getEntityStateTypes(visibility);
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/BoundedContextBuilder.java
+++ b/server/src/main/java/io/spine/server/BoundedContextBuilder.java
@@ -21,6 +21,7 @@
 package io.spine.server;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.spine.core.BoundedContextName;
 import io.spine.core.BoundedContextNames;
@@ -58,8 +59,6 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  *
  * <p>An application can have more than one bounded context. To distinguish
  * them use {@link #setName(String)}. If no ID is given the default ID will be assigned.
- *
- * @author Dmytro Dashenkov
  */
 @SuppressWarnings("ClassWithTooManyMethods") // OK for this central piece.
 public final class BoundedContextBuilder implements Logging {
@@ -263,6 +262,16 @@ public final class BoundedContextBuilder implements Logging {
         checkNotNull(repository);
         boolean result = repositories.contains(repository);
         return result;
+    }
+
+    /**
+     * Obtains the list of repositories added to the builder by the time of the call.
+     *
+     * <p>Adding repositories to the builder after this method returns will not update the
+     * returned list.
+     */
+    public ImmutableList<Repository<?, ?>> repositories() {
+        return ImmutableList.copyOf(repositories);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -133,20 +133,20 @@ public abstract class Aggregate<I,
     /**
      * Creates a new instance.
      *
-     * @apiNote Constructors of derived classes are likely to have package-private access level
-     * because of the following reasons:
-     * <ol>
-     *     <li>These constructors are not public API of an application.
-     *     Commands and aggregate IDs are.
-     *     <li>These constructors need to be accessible from tests in the same package.
-     * </ol>
+     * @param id
+     *         the ID for the new aggregate
+     * @apiNote Constructors of derived classes are likely to have package-private access
+     *         level because of the following reasons:
+     *         <ol>
+     *         <li>These constructors are not public API of an application.
+     *         Commands and aggregate IDs are.
+     *         <li>These constructors need to be accessible from tests in the same package.
+     *         </ol>
      *
-     * <p>If you do have tests that create aggregates via constructors, consider annotating them
-     * with {@code @VisibleForTesting}. Otherwise, aggregate constructors (that are invoked by
-     * {@link io.spine.server.aggregate.AggregateRepository AggregateRepository}
-     * via Reflection) may be left {@code private}.
-     *
-     * @param id the ID for the new aggregate
+     *         <p>If you do have tests that create aggregates via constructors, consider annotating
+     *         them with {@code @VisibleForTesting}. Otherwise, aggregate constructors (that are
+     *         invoked by {@link io.spine.server.aggregate.AggregateRepository AggregateRepository}
+     *         via Reflection) may be left {@code private}.
      */
     protected Aggregate(I id) {
         super(id);
@@ -211,7 +211,7 @@ public abstract class Aggregate<I,
      *
      * @param  event the envelope with the event to dispatch
      * @return a list of event messages that the aggregate produces in reaction to the event or
-     *         an empty list if the aggregate state does not change in reaction to the event
+     *         an empty list if the aggregate state does not change because of the event
      */
     List<Event> reactOn(EventEnvelope event) {
         idempotencyGuard.check(event);

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -72,11 +72,8 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  *
  * @param <I> the type of the aggregate IDs
  * @param <A> the type of the aggregates managed by this repository
- * @author Mikhail Melnik
- * @author Alexander Yevsyukov
- * @apiNote
- * This class is made {@code abstract} for preserving type information of aggregate ID and
- * aggregate classes used by implementations.
+ * @apiNote This class is made {@code abstract} for preserving type information of aggregate ID and
+ *          aggregate classes used by implementations.
  */
 @SuppressWarnings({"ClassWithTooManyMethods", "OverlyCoupledClass"})
 public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>

--- a/server/src/main/java/io/spine/server/entity/Entity.java
+++ b/server/src/main/java/io/spine/server/entity/Entity.java
@@ -48,7 +48,7 @@ public interface Entity<I, S extends Message> {
      * Obtains string representation of the entity identifier.
      *
      * @apiNote The primary purpose of this method is to display the identifier in human-readable
-     * form in debug and error messages.
+     *          form in debug and error messages.
      */
     default String idAsString() {
         return Stringifiers.toString(getId());

--- a/server/src/main/java/io/spine/server/entity/EventFilter.java
+++ b/server/src/main/java/io/spine/server/entity/EventFilter.java
@@ -38,7 +38,6 @@ import static io.spine.protobuf.AnyPacker.pack;
  * <p>A filter may {@linkplain #allowAll() allow any event}, reject certain types of events, or
  * change the event content.
  *
- * @author Dmytro Dashenkov
  * @apiNote This type is a {@link FunctionalInterface}, so that an event filter may be defined
  *          with a lambda expression.
  */
@@ -81,8 +80,8 @@ public interface EventFilter {
      * @param events
      *         the events to apply the filter to
      * @return non-empty filtering results for the given events
-     * @apiNote This method should have the same behaviour in any descendant. Override this method
-     *          <b>only</b> for performance improvement.
+     * @apiNote This method should have the same behaviour in any descendant.
+     *          Override this method <b>only</b> for performance improvement.
      */
     default ImmutableCollection<Event> filter(Collection<Event> events) {
         ImmutableCollection<Event> filteredEvents = events

--- a/server/src/main/java/io/spine/server/entity/VisibilityGuard.java
+++ b/server/src/main/java/io/spine/server/entity/VisibilityGuard.java
@@ -118,7 +118,7 @@ public final class VisibilityGuard {
     /**
      * Obtains a set of entity type names by their visibility.
      */
-    public Set<TypeName> getEntityTypes(Visibility visibility) {
+    public Set<TypeName> getEntityStateTypes(Visibility visibility) {
         checkNotNull(visibility);
 
         // Filter repositories of entities with this visibility.

--- a/server/src/main/java/io/spine/server/event/Enricher.java
+++ b/server/src/main/java/io/spine/server/event/Enricher.java
@@ -57,9 +57,6 @@ import static io.spine.util.Exceptions.newIllegalArgumentException;
  *         .build();
  *     }
  * </pre>
- *
- * @author Alexander Yevsyukov
- * @author Dmytro Dashenkov
  */
 @SPI
 public class Enricher {
@@ -160,10 +157,6 @@ public class Enricher {
                       "Enrichment is disabled for the message %s", envelope.getOuterObject());
     }
 
-    private ImmutableMultimap<Class<?>, EnrichmentFunction<?, ?, ?>> functions() {
-        return functions;
-    }
-
     /**
      * Finds a function that converts an source message field into an enrichment field.
      *
@@ -235,7 +228,7 @@ public class Enricher {
         /** Creates a new {@code Enricher}. */
         public Enricher build() {
             Enricher result = new Enricher(this);
-            validate(result.functions());
+            validate(result.functions);
             return result;
         }
 

--- a/server/src/main/java/io/spine/server/event/EventBus.java
+++ b/server/src/main/java/io/spine/server/event/EventBus.java
@@ -117,7 +117,7 @@ public class EventBus extends MulticastBus<Event, EventEnvelope, EventClass, Eve
     private @MonotonicNonNull EventValidator eventValidator;
 
     /** The enricher for posted events or {@code null} if the enrichment is not supported. */
-    private final @Nullable Enricher enricher;
+    private final @MonotonicNonNull Enricher enricher;
 
     /** Creates new instance by the passed builder. */
     private EventBus(Builder builder) {
@@ -183,8 +183,8 @@ public class EventBus extends MulticastBus<Event, EventEnvelope, EventClass, Eve
      * Posts the event for handling.
      *
      * <p>Performs the same action as the
-     * {@linkplain io.spine.server.bus.Bus#post(Message, StreamObserver)} parent method}, but does not
-     * require any response observer.
+     * {@linkplain io.spine.server.bus.Bus#post(Message, StreamObserver)} parent method},
+     * but does not require any response observer.
      *
      * @param event the event to be handled
      * @see io.spine.server.bus.Bus#post(Message, StreamObserver)
@@ -197,8 +197,8 @@ public class EventBus extends MulticastBus<Event, EventEnvelope, EventClass, Eve
      * Posts the events for handling.
      *
      * <p>Performs the same action as the
-     * {@linkplain io.spine.server.bus.Bus#post(Iterable, StreamObserver)} parent method}, but
-     * does not require any response observer.
+     * {@linkplain io.spine.server.bus.Bus#post(Iterable, StreamObserver)} parent method},
+     * but does not require any response observer.
      *
      * <p>This method should be used if the callee does not care about the events acknowledgement.
      *
@@ -207,6 +207,14 @@ public class EventBus extends MulticastBus<Event, EventEnvelope, EventClass, Eve
      */
     public final void post(Iterable<Event> events) {
         post(events, streamObserver);
+    }
+
+    /**
+     * Obtains {@code Enricher} used by this Event Bus.
+     */
+    @VisibleForTesting
+    public final Optional<Enricher> enricher() {
+        return Optional.ofNullable(enricher);
     }
 
     protected EventEnvelope enrich(EventEnvelope event) {
@@ -395,8 +403,8 @@ public class EventBus extends MulticastBus<Event, EventEnvelope, EventClass, Eve
          * <p>If the {@code Enricher} is not set, the enrichments
          * will <strong>NOT</strong> be supported for the {@code EventBus} instance built.
          *
-         * @param enricher the {@code Enricher} for events or {@code null} if enrichment is
-         *                 not supported
+         * @param enricher
+         *         the {@code Enricher} for events or {@code null} if enrichment is not supported
          */
         public Builder setEnricher(Enricher enricher) {
             this.enricher = enricher;

--- a/server/src/main/java/io/spine/server/model/MethodResult.java
+++ b/server/src/main/java/io/spine/server/model/MethodResult.java
@@ -66,10 +66,10 @@ public abstract class MethodResult<V extends Message> {
     /**
      * Assigns messages to a method result object.
      *
-     * @apiNote This method is meant to be called from withing a constructor of derived classes,
-     *          and called only once.
-     *
-     * @throws IllegalStateException if messages are already assigned
+     * @throws IllegalStateException
+     *         if messages are already assigned
+     * @apiNote This method is meant to be called from withing a constructor of derived
+     *          classes, and called only once.
      */
     protected final void setMessages(List<V> messages) {
         checkState(this.messages == null, "Method result messages are already assigned");

--- a/server/src/main/java/io/spine/server/model/Model.java
+++ b/server/src/main/java/io/spine/server/model/Model.java
@@ -135,9 +135,10 @@ public class Model {
      *
      * <p>This method must <em>not</em> be called from the production code.
      *
+     * @throws SecurityException
+     *         if called directly by non-authorized class
      * @apiNote This method <em>may</em> be called indirectly from authorized tool classes
-     *          or test utility classes.
-     * @throws SecurityException if called directly by non-authorized class
+     *         or test utility classes.
      */
     @VisibleForTesting
     public static synchronized void dropAllModels() {

--- a/server/src/main/java/io/spine/server/route/Route.java
+++ b/server/src/main/java/io/spine/server/route/Route.java
@@ -40,13 +40,14 @@ public interface Route<M extends Message, C extends Message, R>
     /**
      * Obtains entity ID(s) from the passed message and its context.
      *
-     * @param message an event or a command message
-     * @param context a context of the message
+     * @param message
+     *         an event or a command message
+     * @param context
+     *         a context of the message
      * @return a set of entity identifiers
-     * @apiNote
-     * This method overrides the one from {@code BiFunction} for more clarity in Javadoc
-     * references. Without overriding, it would be {@code #apply(Object, Object)},
-     * which may be confusing in the context of event routing.
+     * @apiNote This method overrides the one from {@code BiFunction} for more clarity in
+     *         Javadoc references. Without overriding, it would be {@code #apply(Object, Object)},
+     *         which may be confusing in the context of event routing.
      */
     @SuppressWarnings("AbstractMethodOverridesAbstractMethod") // see @apiNote
     @Override

--- a/server/src/test/java/io/spine/server/BoundedContextTest.java
+++ b/server/src/test/java/io/spine/server/BoundedContextTest.java
@@ -308,12 +308,12 @@ class BoundedContextTest {
     @Test
     @DisplayName("obtain entity types by visibility")
     void getEntityTypesByVisibility() {
-        assertTrue(boundedContext.getEntityTypes(EntityOption.Visibility.FULL)
+        assertTrue(boundedContext.getEntityStateTypes(EntityOption.Visibility.FULL)
                                  .isEmpty());
 
         registerAll();
 
-        assertFalse(boundedContext.getEntityTypes(EntityOption.Visibility.FULL)
+        assertFalse(boundedContext.getEntityStateTypes(EntityOption.Visibility.FULL)
                                   .isEmpty());
     }
 

--- a/server/src/test/java/io/spine/server/aggregate/given/importado/package-info.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/importado/package-info.java
@@ -23,7 +23,7 @@
  * into aggregates.
  *
  * @apiNote This package is named this way since “{@code import}” is a reserved word in Java.
- * So, we resorted to Spanish for the package name.
+ *          So, we resorted to Spanish for the package name.
  */
 
 @CheckReturnValue

--- a/server/src/test/java/io/spine/server/entity/VisibilityGuardTest.java
+++ b/server/src/test/java/io/spine/server/entity/VisibilityGuardTest.java
@@ -111,15 +111,15 @@ class VisibilityGuardTest {
     @Test
     @DisplayName("obtain repos by visibility")
     void obtainByVisibility() {
-        Set<TypeName> full = guard.getEntityTypes(Visibility.FULL);
+        Set<TypeName> full = guard.getEntityStateTypes(Visibility.FULL);
         assertEquals(1, full.size());
         assertTrue(full.contains(TypeName.of(FullAccessAggregate.class)));
 
-        Set<TypeName> subscribable = guard.getEntityTypes(Visibility.SUBSCRIBE);
+        Set<TypeName> subscribable = guard.getEntityStateTypes(Visibility.SUBSCRIBE);
         assertEquals(1, subscribable.size());
         assertTrue(subscribable.contains(TypeName.of(SubscribableAggregate.class)));
 
-        Set<TypeName> hidden = guard.getEntityTypes(Visibility.NONE);
+        Set<TypeName> hidden = guard.getEntityStateTypes(Visibility.NONE);
         assertEquals(1, hidden.size());
         assertTrue(hidden.contains(TypeName.of(HiddenAggregate.class)));
     }

--- a/server/src/test/java/io/spine/server/projection/ProjectionShould.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionShould.java
@@ -82,9 +82,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests {@link io.spine.server.projection.Projection}.
  *
- * @apiNote This class is named using the old-fashoned {@code Should} suffix to avoid the name clash
- * with {@link io.spine.testing.server.projection.ProjectionTest ProjectionTest} class, which is
- * a part of Testutil Server library.
+ * @apiNote This class is named using the old-fashoned {@code Should} suffix to avoid the
+ *         name clash with {@link io.spine.testing.server.projection.ProjectionTest ProjectionTest}
+ *         class, which is a part of Testutil Server library.
  */
 @DisplayName("Projection should")
 class ProjectionShould {

--- a/server/src/test/java/io/spine/testdata/Sample.java
+++ b/server/src/test/java/io/spine/testdata/Sample.java
@@ -63,14 +63,16 @@ public class Sample {
      * Number and {@code boolean} fields may or may not have their default values ({@code 0} and
      * {@code false}).
      *
-     * @apiNote This method casts the builder to the generic parameter {@code <B>} for brevity of
-     *          test code. It is the caller responsibility to ensure that the message
-     *          type {@code <M>} corresponds to the builder type {@code <B>}.
-     *
-     * @param clazz Java class of the stub message
-     * @param <M>   type of the required message
-     * @param <B>   type of the {@link Message.Builder} for the message
+     * @param clazz
+     *         Java class of the stub message
+     * @param <M>
+     *         type of the required message
+     * @param <B>
+     *         type of the {@link Message.Builder} for the message
      * @return new instance of the {@link Message.Builder} for given type
+     * @apiNote This method casts the builder to the generic parameter {@code <B>} for
+     *         brevity of test code. It is the caller responsibility to ensure that the message
+     *         type {@code <M>} corresponds to the builder type {@code <B>}.
      * @see #valueFor(FieldDescriptor)
      */
     @SuppressWarnings("TypeParameterUnusedInFormals") // See apiNote.

--- a/testutil-server/src/main/java/io/spine/testing/server/aggregate/AggregateBuilder.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/aggregate/AggregateBuilder.java
@@ -35,16 +35,12 @@ import io.spine.validate.ValidatingBuilder;
  * @param <A> the type of the aggregate to build
  * @param <I> the type of aggregate IDs
  * @param <S> the type of the aggregate state
- * @author Alexander Yevsyukov
  */
 @VisibleForTesting
 public class AggregateBuilder<A extends Aggregate<I, S, ?>,
                               I,
                               S extends Message> extends EntityBuilder<A, I, S> {
 
-    /**
-     * {@inheritDoc}
-     */
     public AggregateBuilder() {
         super();
         // Have the constructor for easier location of usages.
@@ -68,7 +64,7 @@ public class AggregateBuilder<A extends Aggregate<I, S, ?>,
      * A test-only implementation of an {@link AggregateTransaction} that sets the given
      * {@code state} and {@code version} as a starting point for the transaction.
      *
-     * @param <B> <B> the type of a {@code ValidatingBuilder} for the aggregate state
+     * @param <B> the type of a {@code ValidatingBuilder} for the aggregate state
      */
     private final class
     TestAggregateTransaction<B extends ValidatingBuilder<S, ? extends Message.Builder>>

--- a/testutil-server/src/main/java/io/spine/testing/server/aggregate/AggregatePartBuilder.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/aggregate/AggregatePartBuilder.java
@@ -34,10 +34,7 @@ import static io.spine.server.aggregate.model.AggregatePartClass.asAggregatePart
 
 /**
  * Utility class for building {@code AggregatePart}s for tests.
- *
- * @author Alexander Yevsyukov
  */
-@SuppressWarnings("MethodDoesntCallSuperMethod") // The call of the super method is not needed.
 public class AggregatePartBuilder<A extends AggregatePart<I, S, ?, R>,
                                   I,
                                   S extends Message,
@@ -46,9 +43,6 @@ public class AggregatePartBuilder<A extends AggregatePart<I, S, ?, R>,
 
     private R aggregateRoot;
 
-    /**
-     * {@inheritDoc}
-     */
     public AggregatePartBuilder() {
         super();
         // Have the constructor for easier location of usages.

--- a/testutil-server/src/main/java/io/spine/testing/server/aggregate/package-info.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/aggregate/package-info.java
@@ -25,7 +25,6 @@
 
  * @see io.spine.testing.server.aggregate.AggregateCommandTest
  * @see io.spine.testing.server.aggregate.AggregateEventReactionTest
- * @see io.spine.testing.server.aggregate.AggregatePartCommandTest
  */
 @CheckReturnValue
 @ParametersAreNonnullByDefault

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/AbstractVerify.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/AbstractVerify.java
@@ -36,11 +36,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Abstract base for classes verifying emitted messages.
- *
- * @author Mykhailo Drachuk
- * @author Alexander Yevsyukov
  */
-@SuppressWarnings("ClassReferencesSubclass")
 @VisibleForTesting
 abstract class AbstractVerify<E extends EmittedMessages> implements Verify<E> {
 
@@ -137,7 +133,9 @@ abstract class AbstractVerify<E extends EmittedMessages> implements Verify<E> {
         public void verify(E emittedMessages) {
             for (Class<? extends Message> messageClass : messageClasses) {
                 String className = messageClass.getName();
-                if (!emittedMessages.contain(messageClass)) {
+                @SuppressWarnings("unchecked") // this operation is type-safe.
+                boolean contains = emittedMessages.contain(messageClass);
+                if (!contains) {
                     fail(format("Bounded Context did not emit %s %s",
                                 className,
                                 emittedMessages.singular())
@@ -159,6 +157,7 @@ abstract class AbstractVerify<E extends EmittedMessages> implements Verify<E> {
         @Override
         public void verify(E emittedMessages) {
             String className = messageClass.getName();
+            @SuppressWarnings("unchecked") // this operation is type-safe.
             int actualCount = emittedMessages.count(messageClass);
             int expectedCount = expected();
             String moreOrLess = AbstractVerify.compare(actualCount, expectedCount);

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
@@ -21,6 +21,7 @@
 package io.spine.testing.server.blackbox;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Message;
 import io.spine.base.EventMessage;
@@ -29,6 +30,7 @@ import io.spine.client.QueryFactory;
 import io.spine.core.Ack;
 import io.spine.core.Event;
 import io.spine.grpc.MemoizingObserver;
+import io.spine.option.EntityOption.Visibility;
 import io.spine.server.BoundedContext;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.commandbus.CommandBus;
@@ -40,10 +42,12 @@ import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.testing.client.blackbox.Acknowledgements;
 import io.spine.testing.client.blackbox.VerifyAcknowledgements;
 import io.spine.testing.server.blackbox.verify.state.VerifyState;
+import io.spine.type.TypeName;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Lists.asList;
@@ -159,6 +163,21 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext> {
                .forEach(result::with);
 
         return result;
+    }
+
+    /**
+     * Obtains set of type names of entities known to this Bounded Context.
+     */
+    @VisibleForTesting
+    Set<TypeName> getAllEntityStateTypes() {
+        ImmutableSet.Builder<TypeName> result = ImmutableSet.builder();
+        for (Visibility visibility : Visibility.values()) {
+            if (visibility == Visibility.VISIBILITY_UNKNOWN) {
+                continue;
+            }
+            result.addAll(boundedContext.getEntityStateTypes(visibility));
+        }
+        return result.build();
     }
 
     /**

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
@@ -180,6 +180,11 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext> {
         return result.build();
     }
 
+    @VisibleForTesting
+    EventBus getEventBus() {
+        return boundedContext.getEventBus();
+    }
+
     /**
      * Registers passed repositories with the Bounded Context under the test.
      *

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
@@ -76,13 +76,17 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext> {
 
     protected BlackBoxBoundedContext(boolean multitenant, Enricher enricher) {
         this.commandTap = new CommandMemoizingTap();
+        EventBus.Builder eventBus = EventBus
+                .newBuilder()
+                .setEnricher(enricher);
+        CommandBus.Builder commandBus = CommandBus
+                .newBuilder()
+                .appendFilter(commandTap);
         this.boundedContext = BoundedContext
                 .newBuilder()
                 .setMultitenant(multitenant)
-                .setCommandBus(CommandBus.newBuilder()
-                                         .appendFilter(commandTap))
-                .setEventBus(EventBus.newBuilder()
-                                     .setEnricher(enricher))
+                .setCommandBus(commandBus)
+                .setEventBus(eventBus)
                 .build();
         this.observer = memoizingObserver();
     }

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
@@ -208,7 +208,7 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext> {
      * @param domainCommand
      *         a domain command to be dispatched to the Bounded Context
      * @return current instance
-     * @apiNote Returned value can be ignored when this method invoked for test setup
+     * @apiNote Returned value can be ignored when this method invoked for test setup.
      */
     @CanIgnoreReturnValue
     public T receivesCommand(Message domainCommand) {
@@ -225,7 +225,7 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext> {
      * @param otherCommands
      *         optional domain commands to be dispatched to the Bounded Context in supplied order
      * @return current instance
-     * @apiNote Returned value can be ignored when this method invoked for test setup
+     * @apiNote Returned value can be ignored when this method invoked for test setup.
      */
     @CanIgnoreReturnValue
     public
@@ -254,7 +254,7 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext> {
      *         Otherwise, an instance of {@code Event} will be generated basing on the passed
      *         event message and posted to the bus.
      * @return current instance
-     * @apiNote Returned value can be ignored when this method invoked for test setup
+     * @apiNote Returned value can be ignored when this method invoked for test setup.
      */
     @CanIgnoreReturnValue
     public T receivesEvent(Message messageOrEvent) {
@@ -276,7 +276,7 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext> {
      * @param otherEvents
      *         optional domain events to be dispatched to the Bounded Context in supplied order
      * @return current instance
-     * @apiNote Returned value can be ignored when this method invoked for test setup
+     * @apiNote Returned value can be ignored when this method invoked for test setup.
      */
     @CanIgnoreReturnValue
     public T receivesEvents(Message firstEvent, Message secondEvent, Message... otherEvents) {

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/EmittedMessages.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/EmittedMessages.java
@@ -39,7 +39,6 @@ import static com.google.common.collect.ImmutableList.copyOf;
  *         the type of the wrapper object containing messages
  * @param <M>
  *         the type of the emitted message
- * @author Alexander Yevsyukov
  */
 public abstract class EmittedMessages<C extends MessageClass<M>,
                                       W extends Message,

--- a/testutil-server/src/main/java/io/spine/testing/server/expected/CommanderExpected.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/expected/CommanderExpected.java
@@ -65,6 +65,7 @@ public class CommanderExpected<S extends Message>
 
     /**
      * {@inheritDoc}
+     *
      * @apiNote Overrides to expose the method.
      */
     @CanIgnoreReturnValue

--- a/testutil-server/src/main/java/io/spine/testing/server/package-info.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/package-info.java
@@ -24,7 +24,6 @@
 
  * @see io.spine.testing.server.aggregate.AggregateCommandTest
  * @see io.spine.testing.server.aggregate.AggregateEventReactionTest
- * @see io.spine.testing.server.aggregate.AggregatePartCommandTest
  * @see io.spine.testing.server.procman.PmCommandTest
  * @see io.spine.testing.server.procman.PmEventReactionTest
  * @see io.spine.testing.server.projection.ProjectionTest

--- a/testutil-server/src/test/java/io/spine/testing/server/procman/given/SamplePmCommandOnEventTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/procman/given/SamplePmCommandOnEventTest.java
@@ -60,6 +60,7 @@ public class SamplePmCommandOnEventTest
 
     /**
      * Exposes {@link #message() to the test.
+     *
      * @apiNote we cannot override, since {@codd message()} is {@code final}.
      */
     public Message storedMessage() {


### PR DESCRIPTION
This PR adds an ability to create `BlackBoxBoundedContext` by `BoundedContextBuilder`. 
It would eliminate the need to duplicate Bounded Context configuration for testing purposes.
Examples are:  multiple repositories or complex `Enricher` configurations.

Other notable changes:
  * Improved method names for obtaining entity state types.

