### PR TITLE
Stop treating received events as emitted in BlackBoxBoundedContext

### DIFF
--- a/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryTest.java
@@ -86,8 +86,11 @@ import static io.spine.server.aggregate.given.AggregateRepositoryTestEnv.request
 import static io.spine.server.aggregate.given.AggregateRepositoryTestEnv.resetBoundedContext;
 import static io.spine.server.aggregate.given.AggregateRepositoryTestEnv.resetRepository;
 import static io.spine.server.aggregate.model.AggregateClass.asAggregateClass;
+import static io.spine.testing.client.blackbox.Count.none;
+import static io.spine.testing.client.blackbox.Count.thrice;
+import static io.spine.testing.client.blackbox.VerifyAcknowledgements.acked;
 import static io.spine.testing.core.given.GivenTenantId.newUuid;
-import static io.spine.testing.server.blackbox.VerifyEvents.emittedEvents;
+import static io.spine.testing.server.blackbox.VerifyEvents.emittedEvent;
 import static io.spine.testing.server.blackbox.VerifyEvents.emittedEventsHadVersions;
 import static io.spine.validate.Validate.isNotDefault;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -531,7 +534,6 @@ public class AggregateRepositoryTest {
                                   .receivesEvent(archived)
                                   .assertThat(emittedEventsHadVersions(
                                           1, 2, // Product creation
-                                          0,    // Manually assembled event (`archived`)
                                           3     // Event produced in response to `archived` event
                                   ))
                                   .close();
@@ -560,7 +562,8 @@ public class AggregateRepositoryTest {
                                   .with(new EventDiscardingAggregateRepository())
                                   .receivesCommands(create, start)
                                   .receivesEvent(archived)
-                                  .assertThat(emittedEvents(AggProjectArchived.class))
+                                  .assertThat(emittedEvent(none()))
+                                  .assertThat(acked(thrice()).withoutErrorsOrRejections())
                                   .close();
         }
     }

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
@@ -544,7 +544,7 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext> {
     }
 
     /**
-     * Obtains events emitted in the bounded context. 
+     * Obtains events emitted in the bounded context.
      *
      * <p>They do not include the events posted to the bounded context via {@code receivesEvent...}
      * calls.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
@@ -158,9 +158,9 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext> {
      *
      * <p>In particular:
      * <ul>
-     * <li>multi-tenancy status;
-     * <li>{@code Enricher};
-     * <li>added repositories.
+     *     <li>multi-tenancy status;
+     *     <li>{@code Enricher};
+     *     <li>added repositories.
      * </ul>
      */
     public static BlackBoxBoundedContext from(BoundedContextBuilder builder) {

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
@@ -544,8 +544,10 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext> {
     }
 
     /**
-     * Obtains events emitted in the bounded context. They do not include the events posted to the
-     * bounded context via {@code receivesEvent...} calls.
+     * Obtains events emitted in the bounded context. 
+     *
+     * <p>They do not include the events posted to the bounded context via {@code receivesEvent...}
+     * calls.
      */
     protected EmittedEvents emittedEvents() {
         MemoizingObserver<Event> queryObserver = memoizingObserver();

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
@@ -544,7 +544,8 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext> {
     }
 
     /**
-     * Obtains events emitted in the bounded context.
+     * Obtains events emitted in the bounded context. They do not include the events posted to the
+     * bounded context via {@code receivesEvent...} calls.
      */
     protected EmittedEvents emittedEvents() {
         MemoizingObserver<Event> queryObserver = memoizingObserver();

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxSetup.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxSetup.java
@@ -101,10 +101,12 @@ final class BlackBoxSetup {
      *
      * @param domainEvents
      *         a list of {@linkplain EventMessage event messages} or {@linkplain Event events}
+     * @return list of events posted to {@link EventBus}
      */
-    void postEvents(Collection<Message> domainEvents) {
+    List<Event> postEvents(Collection<Message> domainEvents) {
         List<Event> events = toEvents(domainEvents, eventFactory);
         eventBus.post(events, observer);
+        return events;
     }
 
     /**
@@ -116,12 +118,15 @@ final class BlackBoxSetup {
      *         the first event to be posted
      * @param otherEvents
      *         other events to be posted, if any
+     * @return list of events posted to {@link EventBus}
      */
-    void postEvents(Object producerId, EventMessage firstEvent, EventMessage... otherEvents) {
+    List<Event> postEvents(Object producerId, EventMessage firstEvent,
+                           EventMessage... otherEvents) {
         List<Message> eventMessages = asList(firstEvent, otherEvents);
         TestEventFactory customFactory = newEventFactory(producerId);
         List<Event> events = toEvents(eventMessages, customFactory);
         eventBus.post(events, observer);
+        return events;
     }
 
     /**

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/BlackBoxBoundedContextTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/BlackBoxBoundedContextTest.java
@@ -105,6 +105,16 @@ abstract class BlackBoxBoundedContextTest<T extends BlackBoxBoundedContext<T>> {
     T boundedContext() {
         return context;
     }
+    
+    @Test
+    @DisplayName("ignore events sent events in emitted")
+    void ignoreSentEvents() {
+        BbProjectId id = newProjectId();
+        context.receivesCommand(createProject(id))
+               .receivesEvent(taskAdded(id))
+               .assertThat(emittedEvent(once()))
+               .assertThat(emittedEvent(BbProjectCreated.class, once()));
+    }
 
     @Nested
     @DisplayName("verify state of")
@@ -205,7 +215,7 @@ abstract class BlackBoxBoundedContextTest<T extends BlackBoxBoundedContext<T>> {
                .receivesCommand(createReport(projectId))
                .receivesEvent(taskAdded(projectId))
                .assertThat(acked(twice()).withoutErrorsOrRejections())
-               .assertThat(emittedEvent(thrice()))
+               .assertThat(emittedEvent(twice()))
                .assertThat(emittedEvent(BbReportCreated.class, once()))
                .assertThat(emittedEvent(BbTaskAddedToReport.class, once()));
     }
@@ -218,7 +228,7 @@ abstract class BlackBoxBoundedContextTest<T extends BlackBoxBoundedContext<T>> {
                .receivesCommand(createReport(projectId))
                .receivesEvents(taskAdded(projectId), taskAdded(projectId), taskAdded(projectId))
                .assertThat(acked(count(4)).withoutErrorsOrRejections())
-               .assertThat(emittedEvent(count(7)))
+               .assertThat(emittedEvent(count(4)))
                .assertThat(emittedEvent(BbReportCreated.class, once()))
                .assertThat(emittedEvent(BbTaskAddedToReport.class, thrice()));
     }


### PR DESCRIPTION
This PR filters out the events sent by `BlackBoxBoundedContext` from emitted events verifiers.

Such a change is required to match the expected behaviour when calling methods treating `emitted` events.