### PR TITLE
Clarify `is` prefix usage for entity columns

### DIFF
--- a/server/src/main/java/io/spine/server/entity/storage/Column.java
+++ b/server/src/main/java/io/spine/server/entity/storage/Column.java
@@ -31,8 +31,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * <p>The properties of the annotation affect how the column will be persisted.
  *
- * <p>The annotation will have affect only if it applied to a {@code public} instance getter,
- * i.e. a method without parameters with {@code get-} or {@code is-} prefix.
+ * <p>The annotation will have effect only if it's applied to a {@code public} instance getter,
+ * i.e. a method without parameters and with {@code get-} prefix. An {@code is-} prefix is
+ * supported only for properties of {@code boolean} type.
  *
  * <p>The class declaring an entity column <b>must</b> as well be {@code public}.
  *
@@ -42,8 +43,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * the exception will be raised on a repository
  * {@linkplain io.spine.server.BoundedContext#register(io.spine.server.entity.Repository)
  * registration} for the entity.
- *
- * @author Dmytro Grankin
  */
 @Target(METHOD)
 @Retention(RUNTIME)

--- a/server/src/main/java/io/spine/server/entity/storage/Column.java
+++ b/server/src/main/java/io/spine/server/entity/storage/Column.java
@@ -32,8 +32,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <p>The properties of the annotation affect how the column will be persisted.
  *
  * <p>The annotation will have effect only if it's applied to a {@code public} instance getter,
- * i.e. a method without parameters and with {@code get-} prefix. An {@code is-} prefix is
- * supported only for properties of {@code boolean} type.
+ * i.e. a method without parameters and with {@code get-} prefix. An {@code is-} prefix is also
+ * supported but only for properties of {@code boolean} type.
  *
  * <p>The class declaring an entity column <b>must</b> as well be {@code public}.
  *

--- a/server/src/main/java/io/spine/server/entity/storage/ColumnReader.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ColumnReader.java
@@ -44,8 +44,7 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  * checks verifying that {@link EntityColumn} definitions in the processed {@link Entity} class are
  * correct. If column definitions are incorrect, the exception is thrown upon
  * {@linkplain EntityColumn entity columns} reading.
- *
- * @author Dmytro Kuzmin
+ * 
  * @see Columns
  * @see EntityColumn
  */

--- a/server/src/main/java/io/spine/server/entity/storage/ColumnReader.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ColumnReader.java
@@ -44,7 +44,7 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  * checks verifying that {@link EntityColumn} definitions in the processed {@link Entity} class are
  * correct. If column definitions are incorrect, the exception is thrown upon
  * {@linkplain EntityColumn entity columns} reading.
- * 
+ *
  * @see Columns
  * @see EntityColumn
  */
@@ -57,7 +57,7 @@ class ColumnReader {
     }
 
     /**
-     * Creates an instance of {@link ColumnReader} for the given {@link Entity} class.
+     * Creates an instance of {@code ColumnReader} for the given {@link Entity} class.
      *
      * <p>The reader can be further used to {@linkplain ColumnReader#readColumns() obtain}
      * {@linkplain EntityColumn entity columns} for the given class.

--- a/server/src/main/java/io/spine/server/entity/storage/ColumnRecords.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ColumnRecords.java
@@ -36,7 +36,7 @@ import static java.lang.String.format;
  */
 public final class ColumnRecords {
 
-    /** Prevent initialization of the utility class */
+    /** Prevents initialization of the utility class. */
     private ColumnRecords() {
     }
 

--- a/server/src/main/java/io/spine/server/entity/storage/Columns.java
+++ b/server/src/main/java/io/spine/server/entity/storage/Columns.java
@@ -38,8 +38,8 @@ import static java.lang.String.format;
  *
  * <p>The methods of all {@link Entity entities} that fit
  * <a href="http://download.oracle.com/otndocs/jcp/7224-javabeans-1.01-fr-spec-oth-JSpec/">
- * the Java Bean</a> getter spec and annotated with {@link Column}
- * are considered {@linkplain EntityColumn columns}.
+ * the Java Bean</a> getter spec and annotated with {@link Column} are considered
+ * {@linkplain EntityColumn columns}.
  *
  * <p>Inherited columns are taken into account too, but building entity hierarchies is strongly
  * discouraged.
@@ -48,7 +48,6 @@ import static java.lang.String.format;
  * serializable, otherwise a runtime exception is thrown when trying to get an instance of
  * {@link EntityColumn}.
  *
- * @author Dmytro Dashenkov
  * @see EntityColumn
  */
 @Internal

--- a/server/src/main/java/io/spine/server/entity/storage/EntityColumn.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityColumn.java
@@ -74,6 +74,13 @@ import static java.lang.String.format;
  * <pre>
  *      {@code
  *
+ *         --OrderAggregate.java--
+ *
+ *         \@Column
+ *         public int isDuplicate() {
+ *             return getState().isDuplicate();
+ *         }
+ *
  *         --UserGroupAggregate.java--
  *
  *         \@Column
@@ -111,13 +118,17 @@ import static java.lang.String.format;
  *         \@Column
  *         public boolean hasChildren() { ... }
  *
+ *         // "is" prefix is allowed only for methods which return "boolean"
+ *         \@Column
+ *         public int isNew() { ... }
+ *
  *         // getter methods must not accept arguments
  *         \@Column
  *         public User getStateOf(UserAggregate other) { ... }
  *
  *         // only instance methods are considered Columns
  *         \@Column
- *         public static Integer isNew(UserAggregate aggregate) { ... }
+ *         public static boolean isDeleted(UserAggregate aggregate) { ... }
  *      }
  * </pre>
  *

--- a/server/src/main/java/io/spine/server/entity/storage/Methods.java
+++ b/server/src/main/java/io/spine/server/entity/storage/Methods.java
@@ -44,13 +44,12 @@ import static java.lang.reflect.Modifier.isStatic;
 
 /**
  * Utilities for working with methods.
- *
- * @author Dmytro Dashenkov
- * @author Alexander Yevsyukov
  */
 class Methods {
 
-    private static final String GETTER_PREFIX_REGEX = "(get)|(is)";
+    private static final String GET = "get";
+    private static final String IS = "is";
+    private static final String GETTER_PREFIX_REGEX = '(' + GET + ")|(" + IS + ')';
     private static final Pattern GETTER_PREFIX_PATTERN = Pattern.compile(GETTER_PREFIX_REGEX);
     private static final ImmutableSet<String> NULLABLE_ANNOTATION_SIMPLE_NAMES =
             ImmutableSet.of("CheckForNull", "Nullable", "NullableDecl", "NullableType");
@@ -107,6 +106,9 @@ class Methods {
                                            .find()
                               && getter.getParameterTypes().length == 0,
                       "Method `%s` is not a getter.", getter);
+        checkArgument(!getter.getName().startsWith(IS) ||
+                              boolean.class.isAssignableFrom(getter.getReturnType()),
+                      "Getter with an `is` prefix should have `boolean` return type.");
         checkArgument(getAnnotatedVersion(getter).isPresent(),
                       "Entity column getter should be annotated with `%s`.",
                       Column.class.getName());

--- a/server/src/test/java/io/spine/server/entity/storage/ColumnReaderTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ColumnReaderTest.java
@@ -73,7 +73,7 @@ class ColumnReaderTest {
             ColumnReader columnReader = forClass(EntityWithManyGetters.class);
             Collection<EntityColumn> entityColumns = columnReader.readColumns();
 
-            assertThat(entityColumns).hasSize(3);
+            assertThat(entityColumns).hasSize(4);
             assertTrue(containsColumn(entityColumns, "someMessage"));
             assertTrue(containsColumn(entityColumns, "integerFieldValue"));
             assertTrue(containsColumn(entityColumns, "floatNull"));
@@ -123,7 +123,7 @@ class ColumnReaderTest {
         void inheritedNonPublicColumns() {
             ColumnReader columnReader = forClass(EntityWithManyGettersDescendant.class);
             Collection<EntityColumn> entityColumns = columnReader.readColumns();
-            assertThat(entityColumns).hasSize(3);
+            assertThat(entityColumns).hasSize(4);
         }
 
         @Test

--- a/server/src/test/java/io/spine/server/entity/storage/ColumnTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ColumnTest.java
@@ -186,6 +186,13 @@ class ColumnTest {
             Method method = TestEntity.class.getDeclaredMethod("getParameter", String.class);
             assertThrows(IllegalArgumentException.class, () -> EntityColumn.from(method));
         }
+
+        @Test
+        @DisplayName("getter with `is` prefix and non-boolean return type")
+        void nonBooleanIsGetter() {
+            assertThrows(IllegalArgumentException.class,
+                         () -> forMethod("isNonBoolean", TestEntity.class));
+        }
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/entity/storage/ColumnValueExtractorTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ColumnValueExtractorTest.java
@@ -64,7 +64,7 @@ class ColumnValueExtractorTest {
             EntityWithManyGetters entity = new EntityWithManyGetters(TEST_ENTITY_ID);
             Map<String, EntityColumn.MemoizedValue> columnValues = extractColumnValues(entity);
 
-            assertThat(columnValues).hasSize(3);
+            assertThat(columnValues).hasSize(4);
             assertEquals(entity.getSomeMessage(), columnValues.get("someMessage")
                                                               .getValue());
         }

--- a/server/src/test/java/io/spine/server/entity/storage/ColumnsTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ColumnsTest.java
@@ -63,7 +63,7 @@ class ColumnsTest {
     private
     static void checkFields(EntityWithManyGetters entity, Map<String, MemoizedValue> fields) {
         assertNotNull(fields);
-        assertThat(fields).hasSize(3);
+        assertThat(fields).hasSize(4);
 
         String floatNullKey = "floatNull";
         MemoizedValue floatMemoizedNull = fields.get(floatNullKey);
@@ -95,10 +95,11 @@ class ColumnsTest {
     @Test
     @DisplayName("get all valid columns for entity class")
     void getAllColumns() {
-        Collection<EntityColumn> entityColumns = Columns.getAllColumns(EntityWithManyGetters.class);
+        Collection<EntityColumn> entityColumns =
+                Columns.getAllColumns(EntityWithManyGetters.class);
 
         assertNotNull(entityColumns);
-        assertThat(entityColumns).hasSize(3);
+        assertThat(entityColumns).hasSize(4);
     }
 
     @Test
@@ -126,6 +127,13 @@ class ColumnsTest {
 
         assertThrows(IllegalArgumentException.class,
                      () -> findColumn(entityClass, nonExistingColumnName));
+    }
+
+    @Test
+    @DisplayName("not count method with `is` prefix and non-boolean return type as column")
+    void requireBooleanTypeForIs() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> findColumn(EntityWithManyGetters.class, "isNonBoolean"));
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/entity/storage/given/ColumnTestEnv.java
+++ b/server/src/test/java/io/spine/server/entity/storage/given/ColumnTestEnv.java
@@ -40,9 +40,6 @@ import static io.spine.server.entity.storage.given.ColumnTestEnv.TaskStatus.SUCC
 import static io.spine.testing.Tests.nullRef;
 import static org.junit.jupiter.api.Assertions.fail;
 
-/**
- * @author Dmytro Grankin
- */
 public class ColumnTestEnv {
 
     public static final String CUSTOM_COLUMN_NAME = " customColumnName ";
@@ -81,6 +78,11 @@ public class ColumnTestEnv {
 
         public void setMutableState(@Nullable Integer mutableState) {
             this.mutableState = mutableState;
+        }
+
+        @Column
+        public int isNonBoolean() {
+            return 1;
         }
 
         @Column

--- a/server/src/test/java/io/spine/server/entity/storage/given/ColumnsTestEnv.java
+++ b/server/src/test/java/io/spine/server/entity/storage/given/ColumnsTestEnv.java
@@ -31,9 +31,6 @@ import io.spine.test.entity.ProjectId;
 import io.spine.testdata.Sample;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-/**
- * @author Dmytro Grankin
- */
 public class ColumnsTestEnv {
 
     public static final String CUSTOM_COLUMN_NAME = "columnName";
@@ -60,6 +57,16 @@ public class ColumnsTestEnv {
 
         public EntityWithManyGetters(String id) {
             super(id);
+        }
+
+        @Column
+        public boolean isBoolean() {
+            return true;
+        }
+
+        @Column
+        public int isNonBoolean() {
+            return 1;
         }
 
         @Column(name = CUSTOM_COLUMN_NAME)


### PR DESCRIPTION
This PR handles the issue #848.

Our entity columns lookup is based on the [Java Bean](https://download.oracle.com/otndocs/jcp/7224-javabeans-1.01-fr-spec-oth-JSpec/) getter spec which allows prefix `is` for `boolean` properties only.

The `Column` doc and the tests were updated accordingly.