### PR TITLE
Clean up `WithLifecycle`

### DIFF
--- a/core/src/main/proto/spine/core/command.proto
+++ b/core/src/main/proto/spine/core/command.proto
@@ -91,6 +91,7 @@ message Command {
 
 // Meta-information about the command and the environment, which generated the command.
 message CommandContext {
+    option (is) = {java_type: "io.spine.core.MessageContext" generate: true};
 
     // Information about the environment of the user who created the command.
     ActorContext actor_context = 1 [(required) = true];

--- a/core/src/main/proto/spine/core/event.proto
+++ b/core/src/main/proto/spine/core/event.proto
@@ -81,6 +81,7 @@ message Event {
 
 // Meta-information for an event.
 message EventContext {
+    option (is) = {java_type: "io.spine.core.MessageContext" generate: true};
 
     // When the event occurred.
     google.protobuf.Timestamp timestamp = 1 [(required) = true];

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -44,17 +44,3 @@ javadoc {
         }
     }
 }
-
-//TODO:2018-12-07:alexander.yevsyukov: Remove this task and dependency on it after Spine Proto Compiler
-// no longer generates interfaces mentioned in the (is) option of a proto message. Now this happens
-// always, so it's no possible to create an interface in the same package with the generated 
-// message, and then mentioned in the `is` option value.
-// That's why this task removes the automatically generated interface in favor of the manually
-// written class.
-task deleteGeneratedWithLifecycleJava(type: Delete) {
-    delete "${project.ext.generatedJavaDir}/io/spine/server/entity/WithLifecycle.java"
-}
-
-compileJava {
-    dependsOn deleteGeneratedWithLifecycleJava
-}

--- a/server/src/main/java/io/spine/server/aggregate/ImportValidator.java
+++ b/server/src/main/java/io/spine/server/aggregate/ImportValidator.java
@@ -20,7 +20,6 @@
 
 package io.spine.server.aggregate;
 
-import com.google.protobuf.Message;
 import io.spine.base.EventMessage;
 import io.spine.core.EventEnvelope;
 import io.spine.core.MessageInvalid;
@@ -33,27 +32,25 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.server.event.InvalidEventException.onConstraintViolations;
-import static java.util.Optional.ofNullable;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 
 /**
- * Checks if a message of the event to import is
- * {@linkplain MessageValidator#validate(Message) valid}
- *
- * @author Alexander Yevsyukov
+ * Checks if a message of the event to import is {@linkplain MessageValidator#validate() valid}.
  */
 final class ImportValidator implements EnvelopeValidator<EventEnvelope> {
-
-    private final MessageValidator messageValidator = MessageValidator.newInstance();
 
     @Override
     public Optional<MessageInvalid> validate(EventEnvelope envelope) {
         checkNotNull(envelope);
-        MessageInvalid result = null;
         EventMessage eventMessage = envelope.getMessage();
-        List<ConstraintViolation> violations = messageValidator.validate(eventMessage);
+        MessageValidator validator = MessageValidator.newInstance(eventMessage);
+        List<ConstraintViolation> violations = validator.validate();
         if (!violations.isEmpty()) {
-            result = onConstraintViolations(eventMessage, violations);
+            MessageInvalid result = onConstraintViolations(eventMessage, violations);
+            return of(result);
+        } else {
+            return empty();
         }
-        return ofNullable(result);
     }
 }

--- a/server/src/main/java/io/spine/server/commandbus/CommandValidator.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandValidator.java
@@ -152,8 +152,8 @@ final class CommandValidator implements EnvelopeValidator<CommandEnvelope> {
             if (isDefault(message)) {
                 addViolation("Non-default command message must be set.");
             }
-            List<ConstraintViolation> messageViolations = MessageValidator.newInstance()
-                                                                          .validate(message);
+            List<ConstraintViolation> messageViolations = MessageValidator.newInstance(message)
+                                                                          .validate();
             result.addAll(messageViolations);
         }
 

--- a/server/src/main/java/io/spine/server/commandbus/InvalidCommandException.java
+++ b/server/src/main/java/io/spine/server/commandbus/InvalidCommandException.java
@@ -31,7 +31,7 @@ import io.spine.core.CommandValidationError;
 import io.spine.core.MessageInvalid;
 import io.spine.type.TypeName;
 import io.spine.validate.ConstraintViolation;
-import io.spine.validate.ConstraintViolations.ExceptionFactory;
+import io.spine.validate.ExceptionFactory;
 
 import java.util.Map;
 
@@ -134,10 +134,11 @@ public class InvalidCommandException extends CommandException implements Message
      * command which field values violate validation constraint(s).
      */
     private static class ConstraintViolationExceptionFactory
-                                 extends ExceptionFactory<InvalidCommandException,
-                                                          Command,
-                                                          CommandClass,
-                                                          CommandValidationError> {
+            extends ExceptionFactory<InvalidCommandException,
+                                     Command,
+                                     CommandClass,
+                                     CommandValidationError> {
+
         private final CommandClass commandClass;
 
         protected ConstraintViolationExceptionFactory(Command command,

--- a/server/src/main/java/io/spine/server/entity/AbstractEntity.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractEntity.java
@@ -181,23 +181,26 @@ public abstract class AbstractEntity<I, S extends Message> implements Entity<I, 
     /**
      * Verifies the new entity state and returns {@link ConstraintViolation}s, if any.
      *
-     * <p>Default implementation uses the {@linkplain MessageValidator#validate(Message)
-     * message validation}.
+     * <p>Default implementation uses the {@linkplain MessageValidator#validate() message
+     * validation}.
      *
-     * @param  newState a state object to replace the current state
+     * @param newState
+     *         a state object to replace the current state
      * @return the violation constraints
      */
     protected List<ConstraintViolation> checkEntityState(S newState) {
         checkNotNull(newState);
-        return MessageValidator.newInstance()
-                               .validate(newState);
+        return MessageValidator.newInstance(newState)
+                               .validate();
     }
 
     /**
      * Ensures that the passed new state is valid.
      *
-     * @param   newState a state object to replace the current state
-     * @throws InvalidEntityStateException if the state is not valid
+     * @param newState
+     *         a state object to replace the current state
+     * @throws InvalidEntityStateException
+     *         if the state is not valid
      * @see #checkEntityState(Message)
      */
     private void validate(S newState) throws InvalidEntityStateException {

--- a/server/src/main/java/io/spine/server/entity/InvalidEntityStateException.java
+++ b/server/src/main/java/io/spine/server/entity/InvalidEntityStateException.java
@@ -30,17 +30,14 @@ import io.spine.protobuf.AnyPacker;
 import io.spine.server.entity.model.EntityStateClass;
 import io.spine.type.TypeName;
 import io.spine.validate.ConstraintViolation;
-import io.spine.validate.ConstraintViolations.ExceptionFactory;
+import io.spine.validate.ExceptionFactory;
 
 import java.util.Map;
 
 import static io.spine.server.entity.EntityStateValidationError.INVALID_ENTITY_STATE;
 
 /**
- * Signals that an entity state does not pass {@linkplain AbstractEntity#validate(Message)
- * validation}.
- *
- * @author Dmytro Grankin
+ * Signals that an entity state does not pass validation.
  */
 public final class InvalidEntityStateException extends RuntimeException {
 
@@ -147,7 +144,8 @@ public final class InvalidEntityStateException extends RuntimeException {
         /**
          * Returns a map with an entity state type attribute.
          *
-         * @param entityState the entity state to get the type from
+         * @param entityState
+         *         the entity state to get the type from
          */
         @Override
         protected Map<String, Value> getMessageTypeAttribute(Message entityState) {

--- a/server/src/main/java/io/spine/server/event/EventValidator.java
+++ b/server/src/main/java/io/spine/server/event/EventValidator.java
@@ -20,7 +20,6 @@
 
 package io.spine.server.event;
 
-import com.google.protobuf.Message;
 import io.spine.base.EventMessage;
 import io.spine.core.Event;
 import io.spine.core.EventEnvelope;
@@ -37,18 +36,9 @@ import static io.spine.server.event.InvalidEventException.onConstraintViolations
 import static java.util.Optional.ofNullable;
 
 /**
- * Checks if the message of the passed event is {@linkplain MessageValidator#validate(Message)
- * valid}.
- *
- * @author Dmytro Dashenkov
+ * Checks if the message of the passed event is {@linkplain MessageValidator#validate() valid}.
  */
 final class EventValidator implements EnvelopeValidator<EventEnvelope> {
-
-    private final MessageValidator messageValidator;
-
-    EventValidator(MessageValidator messageValidator) {
-        this.messageValidator = messageValidator;
-    }
 
     @Override
     public Optional<MessageInvalid> validate(EventEnvelope envelope) {
@@ -56,7 +46,8 @@ final class EventValidator implements EnvelopeValidator<EventEnvelope> {
 
         Event event = envelope.getOuterObject();
         MessageInvalid result = null;
-        List<ConstraintViolation> violations = messageValidator.validate(event);
+        MessageValidator validator = MessageValidator.newInstance(event);
+        List<ConstraintViolation> violations = validator.validate();
         if (!violations.isEmpty()) {
             EventMessage message = envelope.getMessage();
             result = onConstraintViolations(message, violations);

--- a/server/src/main/java/io/spine/server/event/InvalidEventException.java
+++ b/server/src/main/java/io/spine/server/event/InvalidEventException.java
@@ -28,7 +28,7 @@ import io.spine.core.EventClass;
 import io.spine.core.EventValidationError;
 import io.spine.core.MessageInvalid;
 import io.spine.validate.ConstraintViolation;
-import io.spine.validate.ConstraintViolations.ExceptionFactory;
+import io.spine.validate.ExceptionFactory;
 
 import java.util.Map;
 
@@ -73,10 +73,10 @@ public class InvalidEventException extends EventException implements MessageInva
      * event which field values violate validation constraint(s).
      */
     private static class ConstraintViolationExceptionFactory
-                                extends ExceptionFactory<InvalidEventException,
-                                                         EventMessage,
-                                                         EventClass,
-                                                         EventValidationError> {
+            extends ExceptionFactory<InvalidEventException,
+                                     EventMessage,
+                                     EventClass,
+                                     EventValidationError> {
 
         private final EventClass eventClass;
 

--- a/server/src/main/java/io/spine/server/stand/RequestValidator.java
+++ b/server/src/main/java/io/spine/server/stand/RequestValidator.java
@@ -140,15 +140,15 @@ abstract class RequestValidator<M extends Message> {
     }
 
     /**
-     * Checks whether the {@code Message} of the given request conforms the constraints
+     * Checks whether the {@code Message} of the given request conforms the constraints.
      *
      * @param request the request message to validate.
      * @return an instance of exception,
      * or {@code Optional.empty()} if the request message is valid.
      */
     private Optional<InvalidRequestException> validateMessage(M request) {
-        List<ConstraintViolation> violations = MessageValidator.newInstance()
-                                                               .validate(request);
+        List<ConstraintViolation> violations = MessageValidator.newInstance(request)
+                                                               .validate();
         if (violations.isEmpty()) {
             return Optional.empty();
         }

--- a/server/src/main/proto/spine/server/entity/entity.proto
+++ b/server/src/main/proto/spine/server/entity/entity.proto
@@ -37,7 +37,7 @@ import "spine/core/version.proto";
 //
 message EntityRecord {
     option (SPI_type) = true;
-    option (is) = "WithLifecycle";
+    option (is).java_type = "WithLifecycle";
 
     // The ID of the entity.
     google.protobuf.Any entity_id = 1;

--- a/server/src/test/java/io/spine/server/event/EventBusBuilderTest.java
+++ b/server/src/test/java/io/spine/server/event/EventBusBuilderTest.java
@@ -26,9 +26,7 @@ import io.spine.grpc.LoggingObserver;
 import io.spine.server.BoundedContext;
 import io.spine.server.bus.BusBuilderTest;
 import io.spine.server.storage.StorageFactory;
-import io.spine.server.storage.StorageFactorySwitch;
 import io.spine.testing.Tests;
-import io.spine.validate.MessageValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -38,10 +36,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
-import static io.spine.core.BoundedContextNames.newName;
 import static io.spine.server.event.given.EventStoreTestEnv.eventStore;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -79,13 +75,6 @@ class EventBusBuilderTest
         void eventStore() {
             assertThrows(NullPointerException.class,
                          () -> builder().setEventStore(Tests.nullRef()));
-        }
-
-        @Test
-        @DisplayName("EventValidator")
-        void eventValidator() {
-            assertThrows(NullPointerException.class,
-                         () -> builder().setEventValidator(Tests.nullRef()));
         }
     }
 
@@ -128,15 +117,6 @@ class EventBusBuilderTest
         }
 
         @Test
-        @DisplayName("EventValidator")
-        void eventValidator() {
-            MessageValidator validator = MessageValidator.newInstance();
-            assertEquals(validator, builder().setEventValidator(validator)
-                                             .getEventValidator()
-                                             .get());
-        }
-
-        @Test
         @DisplayName("Enricher")
         void enricher() {
             Enricher enricher = Enricher.newBuilder()
@@ -146,14 +126,6 @@ class EventBusBuilderTest
                                           .getEnricher()
                                           .get());
         }
-    }
-
-    @Test
-    @DisplayName("set event validator if it is not specified explicitly")
-    void setDefaultValidator() {
-        assertNotNull(builder().setStorageFactory(storageFactory)
-                               .build()
-                               .getMessageValidator());
     }
 
     @Test
@@ -244,20 +216,6 @@ class EventBusBuilderTest
                 fail("The specified executor was not used.");
             }
         }
-    }
-
-    @Test
-    @DisplayName("allow custom message validators")
-    void allowCustomValidators() {
-        StorageFactory storageFactory =
-                StorageFactorySwitch.newInstance(newName("test"), false)
-                                    .get();
-        MessageValidator validator = mock(MessageValidator.class);
-        EventBus eventBus = builder()
-                .setEventValidator(validator)
-                .setStorageFactory(storageFactory)
-                .build();
-        assertEquals(validator, eventBus.getMessageValidator());
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/event/EventValidatorTest.java
+++ b/server/src/test/java/io/spine/server/event/EventValidatorTest.java
@@ -20,50 +20,33 @@
 
 package io.spine.server.event;
 
-import com.google.protobuf.Message;
 import io.spine.base.Error;
 import io.spine.core.Event;
-import io.spine.core.EventEnvelope;
 import io.spine.core.EventValidationError;
 import io.spine.core.MessageInvalid;
 import io.spine.test.event.ProjectCreated;
-import io.spine.testdata.Sample;
-import io.spine.testing.server.TestEventFactory;
-import io.spine.validate.ConstraintViolation;
-import io.spine.validate.MessageValidator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-import static com.google.common.collect.Lists.newArrayList;
+import static io.spine.core.EventEnvelope.of;
+import static io.spine.protobuf.AnyPacker.pack;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-/**
- * @author Dmytro Dashenkov
- */
 @DisplayName("EventValidator should")
 class EventValidatorTest {
-
-    private static final TestEventFactory eventFactory =
-            TestEventFactory.newInstance(EventValidatorTest.class);
 
     @Test
     @DisplayName("validate event messages")
     void validateEventMessages() {
-        MessageValidator messageValidator = mock(MessageValidator.class);
-        when(messageValidator.validate(any(Message.class)))
-                .thenReturn(newArrayList(ConstraintViolation.getDefaultInstance(),
-                                         ConstraintViolation.getDefaultInstance()));
-        Event event = eventFactory.createEvent(Sample.messageOfType(ProjectCreated.class));
-
-        EventValidator eventValidator = new EventValidator(messageValidator);
-
-        Optional<MessageInvalid> error = eventValidator.validate(EventEnvelope.of(event));
+        Event eventWithDefaultMessage = Event
+                .newBuilder()
+                .setMessage(pack(ProjectCreated.getDefaultInstance()))
+                .build();
+        EventValidator eventValidator = new EventValidator();
+        Optional<MessageInvalid> error = eventValidator.validate(of(eventWithDefaultMessage));
         assertTrue(error.isPresent());
         Error actualError = error.get().asError();
         assertEquals(EventValidationError.getDescriptor().getFullName(), actualError.getType());

--- a/version.gradle
+++ b/version.gradle
@@ -32,8 +32,8 @@ ext {
     versionToPublish = SPINE_VERSION
 
     // Depend on `base` for the general definitions and a model compiler.
-    spineBaseVersion = '1.0.0-SNAPSHOT'
+    spineBaseVersion = SPINE_VERSION
 
     // Depend on `time` for `ZoneOffset` and other date/time types and utilities.
-    spineTimeVersion = '1.0.0-pre2'
+    spineTimeVersion = SPINE_VERSION
 }

--- a/version.gradle
+++ b/version.gradle
@@ -32,8 +32,8 @@ ext {
     versionToPublish = SPINE_VERSION
 
     // Depend on `base` for the general definitions and a model compiler.
-    spineBaseVersion = '1.0.0-pre1'
+    spineBaseVersion = '1.0.0-SNAPSHOT'
 
     // Depend on `time` for `ZoneOffset` and other date/time types and utilities.
-    spineTimeVersion = '0.11.00-SNAPSHOT'
+    spineTimeVersion = '1.0.0-pre2'
 }


### PR DESCRIPTION
### Summary

This PR removes a workaround which allowed interface `WithLifecycle` to be implemented in Protobuf message classes.

Also, versions of `base` and `time` are updated.

Fixes #909.
Fixes #818.

### `WithLifecycle`

Previously, `WithLifecycle` marker interface was both handcrafted __and__ generated by the Protobuf compiler. The generated version was then deleted in the Gradle plugin.

Since `(is)` option now allows using handcrafted interfaces instead of blindly generating them, this workaround is removed.

### `MessageContext`

`EventContext` and `CommandContext` message classes now both implement a common interface—`MessageContext`. The interface is, for now, generated by Spine Protobuf compiler plugin. Though, the contract of `MessageContext` may be changed in future if needed.

### Migration to the fresh `base`

In this PR we update the version of `base` and `time` libs to `1.0.0-SNAPSHOT`. This implies changing the API of `MessageValidator`. Previously, the validator could accept multiple messages in `validate(Message)` method. Now, the validator is created for a particular message instance and only validates that instance.

#### Removal of event validator in `EventBus`

It is now not possible to use a single `MessageValidator` for many messages. Thus, the validator instance stored in an `EventBus` does not make sense now.

It was decided not to replace the validator with some kind of new API because:
 - we have `Bus` filters to apply additional constraints to the posted events;
 - the user may declare more soft validation rules for events in order to skip some of the validation.