### PR TITLE
`ColumnReader` `NullPointerException` when finding a `setSomething()` method that is not a property mutator

### DIFF
--- a/server/src/main/java/io/spine/server/entity/storage/ColumnReader.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ColumnReader.java
@@ -130,7 +130,6 @@ class ColumnReader {
      *         if columns contain repeated names
      */
     private void checkRepeatedColumnNames(Iterable<EntityColumn> columns) {
-
         Collection<String> checkedNames = newLinkedList();
         for (EntityColumn column : columns) {
             String columnName = column.getStoredName();

--- a/server/src/main/java/io/spine/server/entity/storage/ColumnReader.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ColumnReader.java
@@ -98,15 +98,15 @@ class ColumnReader {
         }
 
         PropertyDescriptor[] propertyDescriptors = entityDescriptor.getPropertyDescriptors();
-        ImmutableSet<EntityColumn> annotatedColumns = Arrays
+        ImmutableSet<EntityColumn> columns = Arrays
                 .stream(propertyDescriptors)
                 .map(PropertyDescriptor::getReadMethod)
                 .filter(Objects::nonNull)
                 .filter(ColumnReader::isAnnotated)
                 .map(EntityColumn::from)
                 .collect(toImmutableSet());
-        checkRepeatedColumnNames(annotatedColumns);
-        return annotatedColumns;
+        checkRepeatedColumnNames(columns);
+        return columns;
     }
 
     private static boolean isAnnotated(Method method) {

--- a/server/src/main/java/io/spine/server/entity/storage/ColumnReader.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ColumnReader.java
@@ -98,15 +98,13 @@ class ColumnReader {
         }
 
         PropertyDescriptor[] propertyDescriptors = entityDescriptor.getPropertyDescriptors();
-
         ImmutableSet<EntityColumn> annotatedColumns = Arrays
                 .stream(propertyDescriptors)
                 .map(PropertyDescriptor::getReadMethod)
-                .filter(Objects::isNull)
+                .filter(Objects::nonNull)
                 .filter(ColumnReader::isAnnotated)
                 .map(EntityColumn::from)
                 .collect(toImmutableSet());
-
         checkRepeatedColumnNames(annotatedColumns);
         return annotatedColumns;
     }

--- a/server/src/test/java/io/spine/server/entity/VisibilityGuardTest.java
+++ b/server/src/test/java/io/spine/server/entity/VisibilityGuardTest.java
@@ -57,9 +57,12 @@ class VisibilityGuardTest {
 
     private VisibilityGuard guard;
     private List<Repository> repositories;
+    private BoundedContext boundedContext;
 
     @BeforeEach
     void setUp() {
+        boundedContext = BoundedContext.newBuilder()
+                                       .build();
         repositories = Lists.newArrayList();
 
         guard = VisibilityGuard.newInstance();
@@ -74,7 +77,8 @@ class VisibilityGuardTest {
     }
 
     @AfterEach
-    void shutDown() {
+    void shutDown() throws Exception {
+        boundedContext.close();
         repositories.clear();
     }
 

--- a/server/src/test/java/io/spine/server/entity/VisibilityGuardTest.java
+++ b/server/src/test/java/io/spine/server/entity/VisibilityGuardTest.java
@@ -57,12 +57,9 @@ class VisibilityGuardTest {
 
     private VisibilityGuard guard;
     private List<Repository> repositories;
-    private BoundedContext boundedContext;
 
     @BeforeEach
     void setUp() {
-        boundedContext = BoundedContext.newBuilder()
-                                       .build();
         repositories = Lists.newArrayList();
 
         guard = VisibilityGuard.newInstance();
@@ -77,8 +74,7 @@ class VisibilityGuardTest {
     }
 
     @AfterEach
-    void shutDown() throws Exception {
-        boundedContext.close();
+    void shutDown() {
         repositories.clear();
     }
 

--- a/server/src/test/java/io/spine/server/entity/storage/ColumnReaderTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ColumnReaderTest.java
@@ -23,6 +23,7 @@ package io.spine.server.entity.storage;
 import com.google.common.testing.NullPointerTester;
 import com.google.common.testing.NullPointerTester.Visibility;
 import io.spine.server.entity.storage.given.ColumnsTestEnv.EntityWithColumnFromInterface;
+import io.spine.server.entity.storage.given.ColumnsTestEnv.EntityWithASetterButNoGetter;
 import io.spine.server.entity.storage.given.ColumnsTestEnv.EntityWithManyGetters;
 import io.spine.server.entity.storage.given.ColumnsTestEnv.EntityWithManyGettersDescendant;
 import io.spine.server.entity.storage.given.ColumnsTestEnv.EntityWithNoStorageFields;
@@ -112,6 +113,14 @@ class ColumnReaderTest {
             assertThat(entityColumns).hasSize(1);
             assertTrue(containsColumn(entityColumns, "integerFieldValue"));
         }
+    }
+
+    @Test
+    @DisplayName("not confuse a `setSomething()` method with a property mutator")
+    void testSetterDeclaringEntity(){
+        ColumnReader columnReader = forClass(EntityWithASetterButNoGetter.class);
+        Collection<EntityColumn> entityColumns = columnReader.readColumns();
+        assertThat(entityColumns).hasSize(1);
     }
 
     @Nested

--- a/server/src/test/java/io/spine/server/entity/storage/ColumnReaderTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ColumnReaderTest.java
@@ -116,11 +116,11 @@ class ColumnReaderTest {
     }
 
     @Test
-    @DisplayName("not confuse a `setSomething()` method with a property mutator")
+    @DisplayName("not confuse a setter method with a property mutator")
     void testSetterDeclaringEntity(){
         ColumnReader columnReader = forClass(EntityWithASetterButNoGetter.class);
         Collection<EntityColumn> entityColumns = columnReader.readColumns();
-        assertThat(entityColumns).hasSize(1);
+        assertThat(entityColumns).isEmpty();
     }
 
     @Nested

--- a/server/src/test/java/io/spine/server/entity/storage/ColumnReaderTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ColumnReaderTest.java
@@ -22,8 +22,8 @@ package io.spine.server.entity.storage;
 
 import com.google.common.testing.NullPointerTester;
 import com.google.common.testing.NullPointerTester.Visibility;
-import io.spine.server.entity.storage.given.ColumnsTestEnv.EntityWithColumnFromInterface;
 import io.spine.server.entity.storage.given.ColumnsTestEnv.EntityWithASetterButNoGetter;
+import io.spine.server.entity.storage.given.ColumnsTestEnv.EntityWithColumnFromInterface;
 import io.spine.server.entity.storage.given.ColumnsTestEnv.EntityWithManyGetters;
 import io.spine.server.entity.storage.given.ColumnsTestEnv.EntityWithManyGettersDescendant;
 import io.spine.server.entity.storage.given.ColumnsTestEnv.EntityWithNoStorageFields;
@@ -117,7 +117,7 @@ class ColumnReaderTest {
 
     @Test
     @DisplayName("not confuse a setter method with a property mutator")
-    void testSetterDeclaringEntity(){
+    void testSetterDeclaringEntity() {
         ColumnReader columnReader = forClass(EntityWithASetterButNoGetter.class);
         Collection<EntityColumn> entityColumns = columnReader.readColumns();
         assertThat(entityColumns).isEmpty();

--- a/server/src/test/java/io/spine/server/entity/storage/given/ColumnsTestEnv.java
+++ b/server/src/test/java/io/spine/server/entity/storage/given/ColumnsTestEnv.java
@@ -54,8 +54,8 @@ public class ColumnsTestEnv {
     }
 
     /**
-     * This entity declares a {@linkplain #setSecretNumber(Integer) mutator method}, however
-     * doesn't declare a respective accessor method.
+     * An entity type which declares a {@linkplain #setSecretNumber(Integer) mutator method},
+     * however doesn't declare a respective accessor method.
      *
      * <p>{@code ColumnReader} should not get confused and assume that the mutator method is
      * a property, and, therefore, a potential column.

--- a/server/src/test/java/io/spine/server/entity/storage/given/ColumnsTestEnv.java
+++ b/server/src/test/java/io/spine/server/entity/storage/given/ColumnsTestEnv.java
@@ -53,6 +53,33 @@ public class ColumnsTestEnv {
         }
     }
 
+    /**
+     * This entity declares a {@linkplain #setSecretNumber(Integer) mutator method}, however
+     * doesn't declare a respective accessor method.
+     *
+     * <p>{@code ColumnReader} should not get confused and assume that the mutator method is
+     * a property, and, therefore, a potential column.
+     */
+    @SuppressWarnings("unused") // Reflective access
+    public static class EntityWithASetterButNoGetter extends AbstractEntity<String, Any> {
+
+        private Integer secretNumber;
+
+        protected EntityWithASetterButNoGetter(String id) {
+            super(id);
+        }
+
+        @Column
+        public Integer getFortyThree(){
+            return 43;
+        }
+
+        @SuppressWarnings("WeakerAccess") // Required for a test
+        public void setSecretNumber(Integer secretNumber) {
+            this.secretNumber = secretNumber;
+        }
+    }
+
     @SuppressWarnings("unused")  // Reflective access
     public static class EntityWithManyGetters extends AbstractEntity<String, Any> {
 

--- a/server/src/test/java/io/spine/server/entity/storage/given/ColumnsTestEnv.java
+++ b/server/src/test/java/io/spine/server/entity/storage/given/ColumnsTestEnv.java
@@ -69,11 +69,6 @@ public class ColumnsTestEnv {
             super(id);
         }
 
-        @Column
-        public Integer getFortyThree(){
-            return 43;
-        }
-
         @SuppressWarnings("WeakerAccess") // Required for a test
         public void setSecretNumber(Integer secretNumber) {
             this.secretNumber = secretNumber;


### PR DESCRIPTION
This PR addresses https://github.com/SpineEventEngine/core-java/issues/912.

Before, when `ColumnReader` was scanning the class in an attempt to parse `Columns`, it has tried to get all property descriptors of that class, and once obtained, call a `getReadMethod()` on every descriptor, to check whether it's annotated with `@Column`.

If a class declares a public `setSomething(Something something)` method, `something` becomes a property, and the declared method becomes a write method for this property.

A read method, however, remains undeclared, and `getReadMethod()` returns a `null`, hence the NPE.

Now, `ColumnReader` checks whether a property has an accessor, before attempting to get that accessors annotations and check whether it's actually a `@Column`.