### PR TITLE
Process nested contexts in `Events.getActor`

### DIFF
--- a/core/src/main/java/io/spine/core/Events.java
+++ b/core/src/main/java/io/spine/core/Events.java
@@ -158,7 +158,7 @@ public final class Events {
      * <ul>
      *     <li>For the events generated from commands, the actor context is taken from the
      *         enclosing command context.
-     *     <li>For the event react chain, the command context of the most root event context is
+     *     <li>For the event react chain, the command context of the topmost event context is
      *         used.
      *     <li>For the imported events, the separate import context contains information about an
      *         actor.

--- a/core/src/main/java/io/spine/core/Events.java
+++ b/core/src/main/java/io/spine/core/Events.java
@@ -160,8 +160,8 @@ public final class Events {
      *         enclosing command context.
      *     <li>For the event react chain, the command context of the most root event context is
      *         used.
-     *     <li>For the imported events, the separate import context contains all necessary
-     *         information.
+     *     <li>For the imported events, the separate import context contains information about an
+     *         actor.
      * </ul>
      *
      * <p>If the given event context contains no origin, the {@link IllegalArgumentException} is

--- a/core/src/main/java/io/spine/core/Events.java
+++ b/core/src/main/java/io/spine/core/Events.java
@@ -164,8 +164,9 @@ public final class Events {
      *         actor.
      * </ul>
      *
-     * <p>If the given event context contains no origin, the {@link IllegalArgumentException} is
-     * thrown as it contradicts the Spine validation rules.
+     * <p>If the given event context contains no origin, an {@link IllegalArgumentException} is
+     * thrown as it contradicts the Spine validation rules. See {@link EventContext} proto
+     * declaration.
      */
     public static UserId getActor(EventContext context) {
         checkNotNull(context);
@@ -398,9 +399,8 @@ public final class Events {
      *     <li>The import context if the event is imported to an aggregate.
      * </ol>
      *
-     * <p>If at some point the event origin is not set, the {@link IllegalArgumentException} is
-     * thrown as it contradicts the Spine validation rules. See {@link EventContext} proto
-     * declaration.
+     * <p>If at some point the event origin is not set, an {@link IllegalArgumentException} is
+     * thrown as it contradicts the Spine validation rules.
      */
     private static ActorContext retrieveActorContext(EventContext eventContext) {
         ActorContext actorContext = null;

--- a/core/src/main/java/io/spine/core/Events.java
+++ b/core/src/main/java/io/spine/core/Events.java
@@ -35,7 +35,6 @@ import io.spine.string.StringifierRegistry;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -43,6 +42,7 @@ import static com.google.common.base.Throwables.getStackTraceAsString;
 import static io.spine.core.EventContext.OriginCase.EVENT_CONTEXT;
 import static io.spine.protobuf.AnyPacker.pack;
 import static io.spine.protobuf.AnyPacker.unpack;
+import static io.spine.util.Exceptions.newIllegalArgumentException;
 import static io.spine.validate.Validate.checkNotEmptyOrBlank;
 import static io.spine.validate.Validate.isDefault;
 import static java.util.stream.Collectors.toList;
@@ -50,6 +50,7 @@ import static java.util.stream.Collectors.toList;
 /**
  * Utility class for working with {@link Event} objects.
  */
+@SuppressWarnings("ClassWithTooManyMethods") // Lots of event-related utility methods.
 public final class Events {
 
     /** Compares two events by their timestamps. */
@@ -151,16 +152,26 @@ public final class Events {
     /**
      * Obtains the actor user ID from the passed {@code EventContext}.
      *
-     * <p>The 'actor' is the user who sent the command, which generated the event which context is
-     * passed to this method.
+     * <p>The 'actor' is the user responsible for producing the given event.
      *
-     * <p>This is a convenience method for obtaining actor in event subscriber methods.
+     * <p>It is obtained as follows:
+     * <ul>
+     *     <li>For the events generated from commands, the actor context is taken from the
+     *         enclosing command context.
+     *     <li>For the event react chain, the command context of the most root event context is
+     *         used.
+     *     <li>For the imported events, the separate import context contains all necessary
+     *         information.
+     * </ul>
+     *
+     * <p>If the given event context contains no origin, the {@link IllegalArgumentException} is
+     * thrown as it contradicts the Spine validation rules.
      */
     public static UserId getActor(EventContext context) {
         checkNotNull(context);
-        CommandContext commandContext = context.getCommandContext();
-        return commandContext.getActorContext()
-                             .getActor();
+        ActorContext actorContext = retrieveActorContext(context);
+        UserId result = actorContext.getActor();
+        return result;
     }
 
     /**
@@ -273,12 +284,8 @@ public final class Events {
     public static ActorContext getActorContext(Event event) {
         checkNotNull(event);
         EventContext eventContext = event.getContext();
-        Optional<CommandContext> commandContext = findCommandContext(eventContext);
-        if (commandContext.isPresent()) {
-            return commandContext.get()
-                                 .getActorContext();
-        }
-        return eventContext.getImportContext();
+        ActorContext result = retrieveActorContext(eventContext);
+        return result;
     }
 
     /**
@@ -381,37 +388,41 @@ public final class Events {
     }
 
     /**
-     * Obtains a context of the command, which lead to this event.
+     * Obtains an actor context for the given event.
      *
      * <p>The context is obtained by traversing the events origin for a valid context source.
-     * There can be two sources for the command context:
+     * There can be three sources for the actor context:
      * <ol>
      *     <li>The command context set as the event origin.
-     *     <li>The command set as a field of a rejection context if an event was generated in a
-     *     response to a rejection.
+     *     <li>The command context of an event which is an origin of this event.
+     *     <li>The import context if the event is imported to an aggregate.
      * </ol>
      *
-     * <p>If at some point the event origin is not set the {@link Optional#empty()} is returned.
+     * <p>If at some point the event origin is not set, the {@link IllegalArgumentException} is
+     * thrown as it contradicts the Spine validation rules. See {@link EventContext} proto
+     * declaration.
      */
-    private static Optional<CommandContext> findCommandContext(EventContext eventContext) {
-        CommandContext commandContext = null;
+    private static ActorContext retrieveActorContext(EventContext eventContext) {
+        ActorContext actorContext = null;
         EventContext ctx = eventContext;
 
-        while (commandContext == null) {
+        while (actorContext == null) {
             switch (ctx.getOriginCase()) {
                 case EVENT_CONTEXT:
                     ctx = ctx.getEventContext();
                     break;
                 case COMMAND_CONTEXT:
-                    commandContext = ctx.getCommandContext();
+                    actorContext = ctx.getCommandContext()
+                                      .getActorContext();
                     break;
                 case IMPORT_CONTEXT:
+                    actorContext = ctx.getImportContext();
+                    break;
                 case ORIGIN_NOT_SET:
-                default:
-                    return Optional.empty();
+                    throw newIllegalArgumentException(
+                            "The provided event context has no origin set");
             }
         }
-
-        return Optional.of(commandContext);
+        return actorContext;
     }
 }

--- a/core/src/main/java/io/spine/core/Events.java
+++ b/core/src/main/java/io/spine/core/Events.java
@@ -165,8 +165,7 @@ public final class Events {
      * </ul>
      *
      * <p>If the given event context contains no origin, an {@link IllegalArgumentException} is
-     * thrown as it contradicts the Spine validation rules. See {@link EventContext} proto
-     * declaration.
+     * thrown as it contradicts the Spine validation rules.
      */
     public static UserId getActor(EventContext context) {
         checkNotNull(context);
@@ -400,7 +399,8 @@ public final class Events {
      * </ol>
      *
      * <p>If at some point the event origin is not set, an {@link IllegalArgumentException} is
-     * thrown as it contradicts the Spine validation rules.
+     * thrown as it contradicts the Spine validation rules. See {@link EventContext} proto
+     * declaration.
      */
     private static ActorContext retrieveActorContext(EventContext eventContext) {
         ActorContext actorContext = null;

--- a/core/src/main/java/io/spine/core/Events.java
+++ b/core/src/main/java/io/spine/core/Events.java
@@ -158,8 +158,7 @@ public final class Events {
      * <ul>
      *     <li>For the events generated from commands, the actor context is taken from the
      *         enclosing command context.
-     *     <li>For the event react chain, the command context of the topmost event context is
-     *         used.
+     *     <li>For the event react chain, the command context of the topmost event is used.
      *     <li>For the imported events, the separate import context contains information about an
      *         actor.
      * </ul>

--- a/server/src/test/java/io/spine/core/EventsTest.java
+++ b/server/src/test/java/io/spine/core/EventsTest.java
@@ -238,34 +238,28 @@ public class EventsTest extends UtilityClassTest<Events> {
         assertEquals(eventId, checkValid(eventId));
     }
 
+    @SuppressWarnings({"CheckReturnValue", "ResultOfMethodCallIgnored"})
+    // Method called to throw exception.
     @Nested
-    @DisplayName("return default tenant ID")
-    class ReturnDefaultTenantId {
+    @DisplayName("throw IAE when reading tenant ID")
+    class ThrowIaeOnRead {
 
         @Test
         @DisplayName("for event without origin")
-        void forNoOrigin() {
+        void forEventWithoutOrigin() {
             EventContext context = contextWithoutOrigin().build();
             Event event = EventsTestEnv.event(context);
-
-            TenantId tenantId = Events.getTenantId(event);
-
-            TenantId defaultTenantId = TenantId.getDefaultInstance();
-            assertEquals(defaultTenantId, tenantId);
+            assertThrows(IllegalArgumentException.class, () -> Events.getTenantId(event));
         }
 
         @Test
         @DisplayName("for event with event context without origin")
         void forEventContextWithoutOrigin() {
-            EventContext context = contextWithoutOrigin().setEventContext(
-                    contextWithoutOrigin())
-                                                         .build();
+            EventContext context = contextWithoutOrigin()
+                    .setEventContext(contextWithoutOrigin())
+                    .build();
             Event event = EventsTestEnv.event(context);
-
-            TenantId tenantId = Events.getTenantId(event);
-
-            TenantId defaultTenantId = TenantId.getDefaultInstance();
-            assertEquals(defaultTenantId, tenantId);
+            assertThrows(IllegalArgumentException.class, () -> Events.getTenantId(event));
         }
     }
 

--- a/server/src/test/java/io/spine/core/EventsTest.java
+++ b/server/src/test/java/io/spine/core/EventsTest.java
@@ -245,7 +245,7 @@ public class EventsTest extends UtilityClassTest<Events> {
     class ThrowIaeOnRead {
 
         @Test
-        @DisplayName("for event without origin")
+        @DisplayName("of the event without origin")
         void forEventWithoutOrigin() {
             EventContext context = contextWithoutOrigin().build();
             Event event = EventsTestEnv.event(context);
@@ -253,7 +253,7 @@ public class EventsTest extends UtilityClassTest<Events> {
         }
 
         @Test
-        @DisplayName("for event with event context without origin")
+        @DisplayName("of the event whose event context has no origin")
         void forEventContextWithoutOrigin() {
             EventContext context = contextWithoutOrigin()
                     .setEventContext(contextWithoutOrigin())

--- a/server/src/test/java/io/spine/server/event/EventStoreTest.java
+++ b/server/src/test/java/io/spine/server/event/EventStoreTest.java
@@ -250,6 +250,7 @@ public class EventStoreTest {
     @Nested
     @DisplayName("not store enrichment for")
     class NotStoreEnrichmentFor {
+
         @Test
         @DisplayName("EventContext")
         void eventContext() {
@@ -271,10 +272,13 @@ public class EventStoreTest {
         @Test
         @DisplayName("origin of EventContext type")
         void eventContextOrigin() {
+            Event event = projectCreated(Time.getCurrentTime());
+            CommandContext commandContext = event.getContext()
+                                                 .getCommandContext();
             EventContext.Builder originContext =
                     EventContext.newBuilder()
-                                .setEnrichment(withOneAttribute());
-            Event event = projectCreated(Time.getCurrentTime());
+                                .setEnrichment(withOneAttribute())
+                                .setCommandContext(commandContext);
             Event enriched = event.toBuilder()
                                   .setContext(event.getContext()
                                                    .toBuilder()

--- a/server/src/test/java/io/spine/server/projection/e2e/ProjectionEndToEndTest.java
+++ b/server/src/test/java/io/spine/server/projection/e2e/ProjectionEndToEndTest.java
@@ -25,6 +25,7 @@ import com.google.protobuf.StringValue;
 import com.google.protobuf.Timestamp;
 import io.spine.base.Time;
 import io.spine.client.EntityId;
+import io.spine.core.ActorContext;
 import io.spine.core.Event;
 import io.spine.core.EventContext;
 import io.spine.core.EventEnvelope;
@@ -152,6 +153,7 @@ class ProjectionEndToEndTest {
                 .newBuilder()
                 .setTimestamp(producedAt)
                 .setExternal(true)
+                .setImportContext(ActorContext.getDefaultInstance())
                 .build();
         Event event = Event
                 .newBuilder()


### PR DESCRIPTION
This PR fixes issue #921.

Previously, `Events.getActor(EventContext)` worked properly only for events generated from commands, as it did not traverse any nested contexts of the event.

Now, we analyze the origin of the event to retrieve any nested context and thus actor ID.

Also, the events without origin set are not allowed as an input to this method. Such events are not valid according to our [model](https://github.com/SpineEventEngine/core-java/blob/master/core/src/main/proto/spine/core/event.proto#L83) and the only way to create them is to use non-validating `Builder`. Some tests where this was overlooked had to be repaired.