### PR TITLE
Clarify the API of `...Endpoint`s

### DIFF
--- a/server/src/main/java/io/spine/server/aggregate/AggregateEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateEndpoint.java
@@ -48,11 +48,11 @@ abstract class AggregateEndpoint<I,
     }
 
     @Override
-    protected final void deliverNowTo(I aggregateId) {
+    protected final void dispatchInTx(I aggregateId) {
         A aggregate = loadOrCreate(aggregateId);
         LifecycleFlags flagsBefore = aggregate.getLifecycleFlags();
 
-        List<Event> produced = dispatchInTx(aggregate);
+        List<Event> produced = runTransactionWith(aggregate);
 
         // Update lifecycle flags only if the message was handled successfully and flags changed.
         LifecycleFlags flagsAfter = aggregate.getLifecycleFlags();
@@ -69,8 +69,8 @@ abstract class AggregateEndpoint<I,
     }
 
     @CanIgnoreReturnValue
-    final List<Event> dispatchInTx(A aggregate) {
-        List<Event> events = doDispatch(aggregate, envelope());
+    final List<Event> runTransactionWith(A aggregate) {
+        List<Event> events = invokeDispatcher(aggregate, envelope());
         AggregateTransaction tx = startTransaction(aggregate);
         List<Event> producedEvents = aggregate.apply(events);
         tx.commit();

--- a/server/src/main/java/io/spine/server/aggregate/AggregateEventReactionEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateEventReactionEndpoint.java
@@ -39,7 +39,7 @@ final class AggregateEventReactionEndpoint<I, A extends Aggregate<I, ?, ?>>
     }
 
     @Override
-    protected List<Event> doDispatch(A aggregate, EventEnvelope envelope) {
+    protected List<Event> invokeDispatcher(A aggregate, EventEnvelope envelope) {
         repository().onDispatchEvent(aggregate.getId(), envelope.getOuterObject());
         return aggregate.reactOn(envelope);
     }

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -387,10 +387,6 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
         bus.post(filteredEvents);
     }
 
-    private void updateStand(TenantId tenantId, A aggregate) {
-        getStand().post(tenantId, aggregate);
-    }
-
     /**
      * Returns the number of events until a next {@code Snapshot} is made.
      *
@@ -520,7 +516,8 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      */
     void onModifiedAggregate(TenantId tenantId, A aggregate) {
         store(aggregate);
-        updateStand(tenantId, aggregate);
+        Stand stand = getBoundedContext().getStand();
+        stand.post(tenantId, aggregate);
     }
 
     /**
@@ -539,11 +536,6 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
     public Optional<A> find(I id) throws IllegalStateException {
         Optional<A> result = load(id);
         return result;
-    }
-
-    /** The Stand instance for sending updated aggregate states. */
-    private Stand getStand() {
-        return getBoundedContext().getStand();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/aggregate/AggregateTestSupport.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateTestSupport.java
@@ -99,13 +99,13 @@ public final class AggregateTestSupport {
         checkArguments(repository, aggregate, event);
         InvocationGuard.allowOnly(ALLOWED_CALLER_CLASS);
         EventImportEndpoint<I, A> endpoint = new EventImportEndpoint<>(repository, event);
-        endpoint.dispatchInTx(aggregate);
+        endpoint.runTransactionWith(aggregate);
     }
 
     private static <I, A extends Aggregate<I, ?, ?>> List<Message>
     dispatchAndCollect(AggregateEndpoint<I, A, ?> endpoint, A aggregate) {
         List<Message> result =
-                endpoint.dispatchInTx(aggregate)
+                endpoint.runTransactionWith(aggregate)
                         .stream()
                         .map(Events::getMessage)
                         .collect(toList());

--- a/server/src/main/java/io/spine/server/aggregate/EventImportEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/EventImportEndpoint.java
@@ -50,10 +50,10 @@ class EventImportEndpoint<I, A extends Aggregate<I, ?, ?>>
      * @return the list with one {@code Event} which is being imported
      * @implNote We do not need to perform anything with the aggregate and the passed event.
      * The aggregate would consume the passed event when dispatching result is
-     * {@link io.spine.server.aggregate.AggregateEndpoint#dispatchInTx(Aggregate) applied}.
+     * {@link io.spine.server.aggregate.AggregateEndpoint#runTransactionWith(Aggregate) applied}.
      */
     @Override
-    protected List<Event> doDispatch(A aggregate, EventEnvelope envelope) {
+    protected List<Event> invokeDispatcher(A aggregate, EventEnvelope envelope) {
         Event event = envelope.getOuterObject();
         return ImmutableList.of(event);
     }

--- a/server/src/main/java/io/spine/server/entity/EntityMessageEndpoint.java
+++ b/server/src/main/java/io/spine/server/entity/EntityMessageEndpoint.java
@@ -22,14 +22,11 @@ package io.spine.server.entity;
 
 import io.spine.annotation.Internal;
 import io.spine.core.ActorMessageEnvelope;
-import io.spine.core.CommandClass;
-import io.spine.core.CommandEnvelope;
 import io.spine.core.Event;
 
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.util.Exceptions.newIllegalStateException;
 
 /**
  * Abstract base for endpoints handling messages sent to entities.
@@ -50,7 +47,7 @@ public abstract class EntityMessageEndpoint<I,
     /** The repository which created this endpoint. */
     private final Repository<I, E> repository;
 
-    /** The message which needs to handled. */
+    /** The message which needs to dispatched. */
     private final M envelope;
 
     protected EntityMessageEndpoint(Repository<I, E> repository, M envelope) {
@@ -59,21 +56,22 @@ public abstract class EntityMessageEndpoint<I,
     }
 
     /**
-     * Dispatches the message to the entity with the passed ID according to the delivery strategy.
+     * Dispatches the message to the entity with the passed ID and takes care of errors
+     * during dispatching.
+     *
+     * <p>Error handling is delegated to
+     * {@link #onError(io.spine.core.ActorMessageEnvelope, RuntimeException)
+     * onError(envelope, exception)} method.
      *
      * @param entityId the ID of the entity which to dispatch the message to
      */
-    public void dispatchTo(I entityId) {
+    public final void dispatchTo(I entityId) {
         checkNotNull(entityId);
         try {
-            doDispatchTo(entityId);
+            dispatchInTx(entityId);
         } catch (RuntimeException exception) {
             onError(envelope(), exception);
         }
-    }
-
-    private void doDispatchTo(I entityId) {
-        deliverNowTo(entityId);
     }
 
     /**
@@ -85,12 +83,12 @@ public abstract class EntityMessageEndpoint<I,
      *
      * @param entityId the ID of the entity which to dispatch the message to
      */
-    protected abstract void deliverNowTo(I entityId);
+    protected abstract void dispatchInTx(I entityId);
 
     /**
      * Invokes entity-specific method for dispatching the message.
      */
-    protected abstract List<Event> doDispatch(E entity, M envelope);
+    protected abstract List<Event> invokeDispatcher(E entity, M envelope);
 
     /**
      * Stores the entity if it was modified during message dispatching.
@@ -139,28 +137,5 @@ public abstract class EntityMessageEndpoint<I,
      */
     protected Repository<I, E> repository() {
         return repository;
-    }
-
-    /**
-     * Throws {@link IllegalStateException} with the diagnostics message on the unhandled command.
-     *
-     * @param  entity the entity which failed to handle the command
-     * @param  cmd    the envelope with the command
-     * @param  format the format string with the following parameters
-     *                <ol>
-     *                   <li>the name of the entity class
-     *                   <li>the ID of the entity
-     *                   <li>the name of the command class
-     *                   <li>the ID of the command
-     *                </ol>
-     * @throws IllegalStateException always
-     */
-    protected void onUnhandledCommand(Entity<I, ?> entity, CommandEnvelope cmd, String format) {
-        String entityId = entity.idAsString();
-        String entityClass = entity.getClass()
-                                   .getName();
-        String commandId = cmd.idAsString();
-        CommandClass commandClass = cmd.getMessageClass();
-        throw newIllegalStateException(format, entityClass, entityId, commandClass, commandId);
     }
 }

--- a/server/src/main/java/io/spine/server/procman/PmCommandEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmCommandEndpoint.java
@@ -52,7 +52,7 @@ public class PmCommandEndpoint<I, P extends ProcessManager<I, ?, ?>>
     }
 
     @Override
-    protected List<Event> doDispatch(P processManager, CommandEnvelope envelope) {
+    protected List<Event> invokeDispatcher(P processManager, CommandEnvelope envelope) {
         EntityLifecycle lifecycle = repository().lifecycleOf(processManager.getId());
         DispatchCommand<I> dispatch = operationFor(lifecycle, processManager, envelope);
         PmTransaction<I, ?, ?> tx = (PmTransaction<I, ?, ?>) processManager.tx();

--- a/server/src/main/java/io/spine/server/procman/PmEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmEndpoint.java
@@ -61,17 +61,17 @@ abstract class PmEndpoint<I,
     }
 
     @Override
-    protected void deliverNowTo(I id) {
+    protected void dispatchInTx(I id) {
         ProcessManagerRepository<I, P, ?> repository = repository();
         P manager = repository.findOrCreate(id);
-        List<Event> events = dispatchInTx(manager);
+        List<Event> events = runTransactionFor(manager);
         store(manager);
         repository.postEvents(events);
     }
 
-    protected List<Event> dispatchInTx(P processManager) {
+    protected List<Event> runTransactionFor(P processManager) {
         PmTransaction<?, ?, ?> tx = repository().beginTransactionFor(processManager);
-        List<Event> events = doDispatch(processManager, envelope());
+        List<Event> events = invokeDispatcher(processManager, envelope());
         tx.commit();
         return events;
     }

--- a/server/src/main/java/io/spine/server/procman/PmEventEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmEventEndpoint.java
@@ -48,7 +48,7 @@ public class PmEventEndpoint<I, P extends ProcessManager<I, ?, ?>>
     }
 
     @Override
-    protected List<Event> doDispatch(P processManager, EventEnvelope envelope) {
+    protected List<Event> invokeDispatcher(P processManager, EventEnvelope envelope) {
         PmTransaction<I, ?, ?> tx = (PmTransaction<I, ?, ?>) processManager.tx();
         List<Event> events = tx.dispatchEvent(envelope);
         return events;

--- a/testutil-server/src/main/java/io/spine/testing/server/procman/PmDispatcher.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/procman/PmDispatcher.java
@@ -109,7 +109,7 @@ public final class PmDispatcher {
         private static <I, P extends ProcessManager<I, S, ?>, S extends Message>
         List<Event> dispatch(P manager, CommandEnvelope envelope) {
             TestPmCommandEndpoint<I, P, S> endpoint = new TestPmCommandEndpoint<>(envelope);
-            List<Event> events = endpoint.dispatchInTx(manager);
+            List<Event> events = endpoint.runTransactionFor(manager);
             return events;
         }
     }
@@ -134,7 +134,7 @@ public final class PmDispatcher {
         private static <I, P extends ProcessManager<I, S, ?>, S extends Message>
         List<Event> dispatch(P manager, EventEnvelope envelope) {
             TestPmEventEndpoint<I, P, S> endpoint = new TestPmEventEndpoint<>(envelope);
-            List<Event> events = endpoint.dispatchInTx(manager);
+            List<Event> events = endpoint.runTransactionFor(manager);
             return events;
         }
     }

--- a/testutil-server/src/main/java/io/spine/testing/server/projection/ProjectionEventDispatcher.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/projection/ProjectionEventDispatcher.java
@@ -89,7 +89,7 @@ public class ProjectionEventDispatcher {
         private static <I, P extends Projection<I, S, ?>, S extends Message> void
         dispatch(P projection, EventEnvelope envelope) {
             TestProjectionEndpoint<I, P, S> endpoint = new TestProjectionEndpoint<>(envelope);
-            endpoint.dispatchInTx(projection);
+            endpoint.runTransactionFor(projection);
         }
     }
 


### PR DESCRIPTION
`EntityMessageEndpoint` had numerous `dispatchNow`, `dispatchTo`, `deliverNow` etc methods that serve different purposes, but are named in very similar manner.

This changeset is devoted to renaming and/or removing these methods in accordance with their purpose. 

Also, the internal structure of repositories, which communicate with endpoints is slightly modified.

This is the second PR in a chain of requests leading to `Inbox` introduction. In the following requests the hierarchy of `EntityMessageEndpoint` descendants will be modified even further to work with `Inbox`-provided routines.