### PR TITLE
Set once adjustments

### DIFF
--- a/server/src/main/proto/spine/system/server/entity_history.proto
+++ b/server/src/main/proto/spine/system/server/entity_history.proto
@@ -44,7 +44,7 @@ import "spine/server/entity/entity.proto";
 message EntityHistoryId {
 
     // The ID of the entity.
-    spine.client.EntityId entity_id = 1 [(set_once) = false];
+    spine.client.EntityId entity_id = 1;
 
     // The type URL of the entity state.
     string type_url = 2;

--- a/server/src/main/proto/spine/system/server/entity_history.proto
+++ b/server/src/main/proto/spine/system/server/entity_history.proto
@@ -60,7 +60,7 @@ message EntityHistoryId {
 message EntityHistory {
     option (entity).kind = AGGREGATE;
 
-    EntityHistoryId id = 1;
+    EntityHistoryId id = 1 [(set_once) = false];
 
     // The kind of the entity.
     EntityOption.Kind kind = 2;

--- a/server/src/main/proto/spine/system/server/entity_history.proto
+++ b/server/src/main/proto/spine/system/server/entity_history.proto
@@ -44,7 +44,7 @@ import "spine/server/entity/entity.proto";
 message EntityHistoryId {
 
     // The ID of the entity.
-    spine.client.EntityId entity_id = 1;
+    spine.client.EntityId entity_id = 1 [(set_once) = false];
 
     // The type URL of the entity state.
     string type_url = 2;

--- a/server/src/main/proto/spine/system/server/q/mirror.proto
+++ b/server/src/main/proto/spine/system/server/q/mirror.proto
@@ -18,7 +18,7 @@ import "spine/server/entity/entity.proto";
 message Mirror {
     option (entity).kind = PROJECTION;
 
-    MirrorId id = 1 [(required) = true, (valid) = true], (set_once) = false;
+    MirrorId id = 1 [(required) = true, (valid) = true], (set_once) = false];
 
     // The state of the aggregate.
     google.protobuf.Any state = 2 [(required) = false, (valid) = true];

--- a/server/src/main/proto/spine/system/server/q/mirror.proto
+++ b/server/src/main/proto/spine/system/server/q/mirror.proto
@@ -18,7 +18,7 @@ import "spine/server/entity/entity.proto";
 message Mirror {
     option (entity).kind = PROJECTION;
 
-    MirrorId id = 1 [(required) = true, (valid) = true], (set_once) = false];
+    MirrorId id = 1 [(required) = true, (valid) = true, (set_once) = false];
 
     // The state of the aggregate.
     google.protobuf.Any state = 2 [(required) = false, (valid) = true];

--- a/server/src/main/proto/spine/system/server/q/mirror.proto
+++ b/server/src/main/proto/spine/system/server/q/mirror.proto
@@ -18,7 +18,7 @@ import "spine/server/entity/entity.proto";
 message Mirror {
     option (entity).kind = PROJECTION;
 
-    MirrorId id = 1 [(required) = true, (valid) = true];
+    MirrorId id = 1 [(required) = true, (valid) = true], (set_once) = false;
 
     // The state of the aggregate.
     google.protobuf.Any state = 2 [(required) = false, (valid) = true];

--- a/server/src/test/proto/spine/test/projection/project.proto
+++ b/server/src/test/proto/spine/test/projection/project.proto
@@ -67,7 +67,7 @@ message Task {
 message ProjectTaskNames {
     option (entity).kind = PROJECTION;
 
-    ProjectId project_id = 1 [(required) = false];
+    ProjectId project_id = 1 [(required) = false, (set_once) = false];
 
     string project_name = 2;
 

--- a/server/src/test/proto/spine/test/projection/project.proto
+++ b/server/src/test/proto/spine/test/projection/project.proto
@@ -36,7 +36,7 @@ message Project {
     // Keep the message generic. It is used both as an aggregate and a projection state.
     option (entity).kind = ENTITY;
 
-    ProjectId id = 1 [(required) = false];
+    ProjectId id = 1 [(required) = false, (set_once) = false];
 
     string name = 2;
 

--- a/server/src/test/proto/spine/test/system/server/command_lifecycle_test.proto
+++ b/server/src/test/proto/spine/test/system/server/command_lifecycle_test.proto
@@ -49,7 +49,7 @@ message Company {
 message CompanyEstablishing {
     option (entity).kind = PROCESS_MANAGER;
 
-    CompanyId id = 1;
+    CompanyId id = 1 [(set_once) = false];
 
     string proposed_name = 2;
 }

--- a/server/src/test/proto/spine/test/system/server/entity_history_test.proto
+++ b/server/src/test/proto/spine/test/system/server/entity_history_test.proto
@@ -51,7 +51,7 @@ message Person {
 message PersonCreation {
     option (entity).kind = PROCESS_MANAGER;
 
-    PersonId id = 1 [(required) = false];
+    PersonId id = 1 [(required) = false, (set_once) = false];
 
     bool created = 2;
 }
@@ -71,7 +71,7 @@ message PersonFirstName {
 message PersonDetails {
     option (entity).kind = PROJECTION;
 
-    PersonId id = 1 [(required) = false];
+    PersonId id = 1 [(required) = false, (set_once) = false];
 
     spine.people.PersonName name = 2;
 }


### PR DESCRIPTION
This PR adjusts the current codebase to the changes brought by https://github.com/SpineEventEngine/base/pull/275.

## `MirrorProjection`

`MirrorProjection`'s state message - `Mirror`, now has an explicit `(set_once) = false` applied to its identifier.
This is the case because the creation of a `Mirror` can happen in one of the multiple ways, and thus, its identifier has to be updated in every case, sometimes overlapping.

## `EntityHistoryAggregate`

`EntityHistoryAggregate`'s state message -`EntityHistory`, is now also explicitly `(set_once) = false`.


### Test entities

Some entities used for testing underwent the same change - had their `(set_once)` options set to be `false`.
