### PR TITLE
Supply deployment type to ServerEnvironment

### DIFF
--- a/server/src/main/java/io/spine/server/DeploymentDetector.java
+++ b/server/src/main/java/io/spine/server/DeploymentDetector.java
@@ -48,7 +48,7 @@ final class DeploymentDetector implements Supplier<DeploymentType> {
     /**
      * The deployment type is instantiated lazily to a non-{@code null} value during {@link #get()}.
      *
-     * <p>Value is never changed it is initially set.
+     * <p>Value is never changed after it is initially set.
      */
     private @MonotonicNonNull DeploymentType deploymentType;
 

--- a/server/src/main/java/io/spine/server/DeploymentDetector.java
+++ b/server/src/main/java/io/spine/server/DeploymentDetector.java
@@ -21,6 +21,7 @@
 package io.spine.server;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -43,7 +44,8 @@ class DeploymentDetector implements Supplier<DeploymentType> {
     static final String APP_ENGINE_ENVIRONMENT_PRODUCTION_VALUE = "Production";
     @VisibleForTesting
     static final String APP_ENGINE_ENVIRONMENT_DEVELOPMENT_VALUE = "Development";
-
+    
+    private @MonotonicNonNull DeploymentType deploymentType;
 
     /** Prevent instantiation from outside. */
     private DeploymentDetector() {
@@ -55,6 +57,13 @@ class DeploymentDetector implements Supplier<DeploymentType> {
 
     @Override
     public DeploymentType get() {
+        if (deploymentType == null) {
+            deploymentType = detect();
+        }
+        return deploymentType;
+    }
+
+    private static DeploymentType detect() {
         Optional<String> gaeEnvironment = getProperty(APP_ENGINE_ENVIRONMENT_PATH);
         if (gaeEnvironment.isPresent()) {
             if (APP_ENGINE_ENVIRONMENT_DEVELOPMENT_VALUE.equals(gaeEnvironment.get())) {

--- a/server/src/main/java/io/spine/server/DeploymentDetector.java
+++ b/server/src/main/java/io/spine/server/DeploymentDetector.java
@@ -44,7 +44,7 @@ class DeploymentDetector implements Supplier<DeploymentType> {
     static final String APP_ENGINE_ENVIRONMENT_PRODUCTION_VALUE = "Production";
     @VisibleForTesting
     static final String APP_ENGINE_ENVIRONMENT_DEVELOPMENT_VALUE = "Development";
-    
+
     private @MonotonicNonNull DeploymentType deploymentType;
 
     /** Prevent instantiation from outside. */

--- a/server/src/main/java/io/spine/server/DeploymentDetector.java
+++ b/server/src/main/java/io/spine/server/DeploymentDetector.java
@@ -36,7 +36,7 @@ import static java.util.Optional.ofNullable;
  * The default implementation of {@linkplain DeploymentType deployment type} 
  * {@linkplain Supplier supplier}.
  */
-class DeploymentDetector implements Supplier<DeploymentType> {
+final class DeploymentDetector implements Supplier<DeploymentType> {
 
     @VisibleForTesting
     static final String APP_ENGINE_ENVIRONMENT_PATH = "com.google.appengine.runtime.environment";
@@ -45,6 +45,11 @@ class DeploymentDetector implements Supplier<DeploymentType> {
     @VisibleForTesting
     static final String APP_ENGINE_ENVIRONMENT_DEVELOPMENT_VALUE = "Development";
 
+    /**
+     * The deployment type is instantiated lazily to a non-{@code null} value during {@link #get()}.
+     *
+     * <p>Value is never changed it is initially set.
+     */
     private @MonotonicNonNull DeploymentType deploymentType;
 
     /** Prevent instantiation from outside. */

--- a/server/src/main/java/io/spine/server/ServerEnvironment.java
+++ b/server/src/main/java/io/spine/server/ServerEnvironment.java
@@ -100,7 +100,7 @@ public final class ServerEnvironment {
     @VisibleForTesting
     public static void resetDeploymentType() {
         Supplier<DeploymentType> supplier = DeploymentDetector.newInstance();
-        supplyDeploymentType(supplier);
+        configureDeployment(supplier);
     }
 
     /**
@@ -110,7 +110,7 @@ public final class ServerEnvironment {
      * {@linkplain #resetDeploymentType() reset it} during tear down.
      */
     @VisibleForTesting
-    public static void supplyDeploymentType(Supplier<DeploymentType> supplier) {
+    public static void configureDeployment(Supplier<DeploymentType> supplier) {
         checkNotNull(supplier);
         deploymentTypeSupplier = supplier;
     }

--- a/server/src/main/java/io/spine/server/ServerEnvironment.java
+++ b/server/src/main/java/io/spine/server/ServerEnvironment.java
@@ -21,7 +21,6 @@
 package io.spine.server;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Optional;
@@ -46,8 +45,14 @@ public final class ServerEnvironment {
     private static final @Nullable String appEngineRuntimeVersion =
             emptyToNull(System.getProperty(ENV_KEY_APP_ENGINE_RUNTIME_VERSION));
 
-    private static @MonotonicNonNull Supplier<DeploymentType> deploymentTypeSupplier =
-            DeploymentDetector.newInstance();
+    /**
+     * The deployment detector is instantiated with a system {@link DeploymentDetector} and
+     * can be reassigned the value via {@link #configureDeployment(Supplier)}.
+     *
+     * <p>Value from this supplier are used to {@linkplain #getDeploymentType() get the deployment
+     * type}.
+     */
+    private static Supplier<DeploymentType> deploymentDetector = DeploymentDetector.newInstance();
 
     /** Prevents instantiation of this utility class. */
     private ServerEnvironment() {
@@ -90,7 +95,7 @@ public final class ServerEnvironment {
      * The type of the environment application is deployed to.
      */
     public static DeploymentType getDeploymentType() {
-        return deploymentTypeSupplier.get();
+        return deploymentDetector.get();
     }
 
     /**
@@ -112,6 +117,6 @@ public final class ServerEnvironment {
     @VisibleForTesting
     public static void configureDeployment(Supplier<DeploymentType> supplier) {
         checkNotNull(supplier);
-        deploymentTypeSupplier = supplier;
+        deploymentDetector = supplier;
     }
 }

--- a/server/src/test/java/io/spine/server/ServerEnvironmentTest.java
+++ b/server/src/test/java/io/spine/server/ServerEnvironmentTest.java
@@ -26,12 +26,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.server.DeploymentType.APPENGINE_CLOUD;
-import static io.spine.server.DeploymentType.APPENGINE_EMULATOR;
-import static io.spine.server.DeploymentType.STANDALONE;
 import static io.spine.server.DeploymentDetector.APP_ENGINE_ENVIRONMENT_DEVELOPMENT_VALUE;
 import static io.spine.server.DeploymentDetector.APP_ENGINE_ENVIRONMENT_PATH;
 import static io.spine.server.DeploymentDetector.APP_ENGINE_ENVIRONMENT_PRODUCTION_VALUE;
+import static io.spine.server.DeploymentType.APPENGINE_CLOUD;
+import static io.spine.server.DeploymentType.APPENGINE_EMULATOR;
+import static io.spine.server.DeploymentType.STANDALONE;
+import static io.spine.server.ServerEnvironment.resetDeploymentType;
 import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
 import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.Assert.assertFalse;
@@ -140,7 +141,7 @@ class ServerEnvironmentTest {
         void setUp() {
             initialValue = System.getProperty(APP_ENGINE_ENVIRONMENT_PATH);
             setGaeEnvironment(targetEnvironment);
-            ServerEnvironment.resetDeploymentType();
+            resetDeploymentType();
         }
 
         @AfterEach
@@ -150,6 +151,7 @@ class ServerEnvironmentTest {
             } else {
                 setGaeEnvironment(initialValue);
             }
+            resetDeploymentType();
         }
 
         void setGaeEnvironment(String value) {


### PR DESCRIPTION
This PR adds the ability to supply a custom deployment type to `ServerEnvironment`.

This is an only way to test the functionality that differs between different environments.