### PR TITLE
Update `time` version

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -35,5 +35,5 @@ ext {
     spineBaseVersion = SPINE_VERSION
 
     // Depend on `time` for `ZoneOffset` and other date/time types and utilities.
-    spineTimeVersion = '1.0.0-pre3'
+    spineTimeVersion = SPINE_VERSION
 }


### PR DESCRIPTION
This PR bumps the version of `time` from `1.0.0-pre3` to `1.0.0-SNAPSHOT`.