### PR TITLE
Drop usage of (enrichment) option

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -493,7 +493,6 @@
         <extension name="JUnit4MethodNamingConvention" enabled="true">
           <option name="m_regex" value="[a-z][A-Za-z\d]*" />
           <option name="m_minLength" value="2" />
-          <option name="m_maxLength" value="64" />
         </extension>
       </scope>
       <scope name="Production" level="WARNING" enabled="true">
@@ -643,6 +642,7 @@
       <option name="ignoreCloneable" value="false" />
     </inspection_tool>
     <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="RedundantSuppression" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
@@ -712,6 +712,9 @@
     <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SwitchStatementWithTooFewBranches" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="m_limit" value="2" />
+    </inspection_tool>
     <inspection_tool class="SwitchStatementsWithoutDefault" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreFullyCoveredEnums" value="true" />
     </inspection_tool>
@@ -824,17 +827,6 @@
     <inspection_tool class="UnsecureRandomNumberGeneration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnstableApiUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="Tests" level="WEAK WARNING" enabled="false" />
-      <option name="unstableApiAnnotations">
-        <set>
-          <option value="io.reactivex.annotations.Beta" />
-          <option value="io.reactivex.annotations.Experimental" />
-          <option value="org.apache.http.annotation.Beta" />
-          <option value="org.gradle.api.Incubating" />
-          <option value="org.jetbrains.annotations.ApiStatus.Experimental" />
-          <option value="rx.annotations.Beta" />
-          <option value="rx.annotations.Experimental" />
-        </set>
-      </option>
     </inspection_tool>
     <inspection_tool class="UnusedCatchParameter" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreCatchBlocksWithComments" value="true" />

--- a/server/src/main/proto/spine/system/server/c/command_lifecycle_events.proto
+++ b/server/src/main/proto/spine/system/server/c/command_lifecycle_events.proto
@@ -58,7 +58,6 @@ message CommandAcknowledged {
 // An event emitted when the command is scheduled.
 //
 message CommandScheduled {
-    option (enrichment) = "spine.system.server.CommandEnrichment";
 
     // The ID of the command.
     spine.core.CommandId id = 1;

--- a/server/src/main/proto/spine/system/server/c/enrichments.proto
+++ b/server/src/main/proto/spine/system/server/c/enrichments.proto
@@ -45,5 +45,5 @@ message CommandEnrichment {
     // The purpose of using an enrichment in the `CommandScheduled` event is to avoid storing
     // an instance of `Command` in the event stream multiple times.
     //
-    spine.core.Command command = 1 [(by) = "*.id"];
+    spine.core.Command command = 1 [(by) = "id"];
 }


### PR DESCRIPTION
This PR removes usage of `(enrichment)` option which support was dropped with the [PR from `base`](https://github.com/SpineEventEngine/base/pull/312).