### PR TITLE
Fix ignoring errors in tasks given to executors

### DIFF
--- a/server/src/main/java/io/spine/server/commandbus/ExecutorCommandScheduler.java
+++ b/server/src/main/java/io/spine/server/commandbus/ExecutorCommandScheduler.java
@@ -22,6 +22,7 @@ package io.spine.server.commandbus;
 
 import com.google.protobuf.Duration;
 import io.spine.core.Command;
+import io.spine.logging.Logging;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -32,12 +33,12 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 /**
  * The command scheduler implementation which uses basic Java task scheduling features.
  *
- * <p><b>NOTE:</b> please use <a href="https://github.com/SpineEventEngine/gae-java">another implementation</a>
- * in applications running under the Google App Engine.
+ * <p><b>NOTE:</b> please use <a href="https://github.com/SpineEventEngine/gcloud-java">
+ * another implementation</a> in applications running under the Google App Engine.
  *
  * @see ScheduledExecutorService
  */
-public class ExecutorCommandScheduler extends CommandScheduler {
+public class ExecutorCommandScheduler extends CommandScheduler implements Logging {
 
     private static final int MIN_THREAD_POOL_SIZE = 5;
     private static final int NANOS_IN_MILLISECOND = 1_000_000;
@@ -50,11 +51,34 @@ public class ExecutorCommandScheduler extends CommandScheduler {
         super();
     }
 
+    @SuppressWarnings("FutureReturnValueIgnored") // Error handling is done manually.
     @Override
     protected void doSchedule(Command command) {
         final long delayMillis = getDelayMilliseconds(command);
-        executorService.schedule(() -> post(command),
+        executorService.schedule(() -> safePost(command),
                                  delayMillis, MILLISECONDS);
+    }
+
+    /**
+     * Posts a command catching all errors along the way.
+     *
+     * @apiNote
+     * Such post operation is required for the {@link ScheduledExecutorService} as any uncaught
+     * throwable in its action will lead to the worker thread silently halting. This method logs an
+     * error and keeps the thread "alive".
+     */
+    private void safePost(Command command) {
+        try {
+            post(command);
+        } catch (Throwable t) {
+            _error(t,
+                   "Error scheduling command `{}` with ID `{}`: {}",
+                   command.getMessage()
+                          .getTypeUrl(),
+                   command.getId()
+                          .getUuid(),
+                   t.getLocalizedMessage());
+        }
     }
 
     private static long getDelayMilliseconds(Command command) {

--- a/server/src/main/java/io/spine/server/transport/memory/SingleThreadInMemSubscriber.java
+++ b/server/src/main/java/io/spine/server/transport/memory/SingleThreadInMemSubscriber.java
@@ -19,11 +19,16 @@
  */
 package io.spine.server.transport.memory;
 
+import io.spine.base.Identifier;
+import io.spine.logging.Logging;
 import io.spine.server.integration.ChannelId;
 import io.spine.server.integration.ExternalMessage;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Function;
 
 /**
  * The in-memory subscriber, which uses single-thread delivery of messages.
@@ -33,10 +38,8 @@ import java.util.concurrent.Executors;
  *
  * <p>This implementation should not be used in production environments, as it is not designed
  * to operate with external transport.
- *
- * @author Alex Tymchenko
  */
-class SingleThreadInMemSubscriber extends InMemorySubscriber {
+class SingleThreadInMemSubscriber extends InMemorySubscriber implements Logging {
 
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
@@ -44,23 +47,26 @@ class SingleThreadInMemSubscriber extends InMemorySubscriber {
         super(channelId);
     }
 
+    @SuppressWarnings("FutureReturnValueIgnored") // Error handling is done manually.
     @Override
     public void onMessage(ExternalMessage message) {
-        executor.submit(new SubmissionJob(message));
+        CompletableFuture.runAsync(() -> callObservers(message), executor)
+                         .exceptionally(throwable -> logError(throwable, message));
     }
 
-    private final class SubmissionJob implements Runnable {
-
-        private final ExternalMessage message;
-
-        private SubmissionJob(ExternalMessage message) {
-            this.message = message;
-        }
-
-        @Override
-        public void run() {
-            callObservers(message);
-        }
+    /**
+     * Conveniently logs an error in {@link CompletableFuture#exceptionally(Function)}.
+     *
+     * @return {@code null} always
+     */
+    private @Nullable Void logError(Throwable throwable, ExternalMessage message) {
+        Object id = Identifier.unpack(message.getId());
+        _error(throwable,
+               "Error dispatching an external message {} with ID {} to observers: {}",
+               message.getOriginalMessage().getTypeUrl(),
+               id,
+               throwable.getLocalizedMessage());
+        return null;
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/transport/memory/SingleThreadInMemSubscriber.java
+++ b/server/src/main/java/io/spine/server/transport/memory/SingleThreadInMemSubscriber.java
@@ -62,7 +62,7 @@ class SingleThreadInMemSubscriber extends InMemorySubscriber implements Logging 
     private @Nullable Void logError(Throwable throwable, ExternalMessage message) {
         Object id = Identifier.unpack(message.getId());
         _error(throwable,
-               "Error dispatching an external message {} with ID {} to observers: {}",
+               "Error dispatching an external message `{}` with ID `{}`: {}",
                message.getOriginalMessage().getTypeUrl(),
                id,
                throwable.getLocalizedMessage());

--- a/server/src/test/java/io/spine/server/commandbus/ExecutorCommandSchedulerTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/ExecutorCommandSchedulerTest.java
@@ -127,8 +127,8 @@ class ExecutorCommandSchedulerTest {
     }
 
     @Test
-    @MuteLogging
     @DisplayName("continue scheduling commands after error in `post`")
+    @MuteLogging
     void recoverFromPostFail() {
         doThrow(new IllegalStateException("Post failed"))
                 .when(commandBus)

--- a/server/src/test/java/io/spine/server/commandbus/ExecutorCommandSchedulerTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/ExecutorCommandSchedulerTest.java
@@ -127,8 +127,8 @@ class ExecutorCommandSchedulerTest {
     }
 
     @Test
-    @DisplayName("continue scheduling commands after error in `post`")
     @MuteLogging
+    @DisplayName("continue scheduling commands after error in `post`")
     void recoverFromPostFail() {
         doThrow(new IllegalStateException("Post failed"))
                 .when(commandBus)

--- a/server/src/test/java/io/spine/server/commandbus/ExecutorCommandSchedulerTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/ExecutorCommandSchedulerTest.java
@@ -29,6 +29,7 @@ import io.spine.system.server.NoOpSystemWriteSide;
 import io.spine.system.server.SystemWriteSide;
 import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.testing.core.given.GivenCommandContext;
+import io.spine.testing.logging.MuteLogging;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -42,6 +43,8 @@ import static io.spine.server.commandbus.Given.CommandMessage.createProjectMessa
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -62,6 +65,7 @@ class ExecutorCommandSchedulerTest {
             TestActorRequestFactory.newInstance(ExecutorCommandSchedulerTest.class)
                                    .command();
 
+    private CommandBus commandBus;
     private CommandScheduler scheduler;
     private CommandContext context;
 
@@ -70,7 +74,8 @@ class ExecutorCommandSchedulerTest {
         scheduler = spy(ExecutorCommandScheduler.class);
         context = GivenCommandContext.withScheduledDelayOf(DELAY);
 
-        scheduler.setCommandBus(mock(CommandBus.class));
+        commandBus = mock(CommandBus.class);
+        scheduler.setCommandBus(commandBus);
 
         // System BC integration is NOT tested in this suite.
         SystemWriteSide systemWriteSide = NoOpSystemWriteSide.INSTANCE;
@@ -119,6 +124,27 @@ class ExecutorCommandSchedulerTest {
 
         verify(scheduler, timeout(DELAY_MS + WAIT_FOR_PROPAGATION_MS)).post(any(Command.class));
         verify(scheduler, never()).post(extraCmd);
+    }
+
+    @Test
+    @MuteLogging
+    @DisplayName("continue scheduling commands after error in `post`")
+    void recoverFromPostFail() {
+        doThrow(new IllegalStateException("Post failed"))
+                .when(commandBus)
+                .postPreviouslyScheduled(any());
+        Command cmd1 =
+                commandFactory.createBasedOnContext(createProjectMessage(), context);
+        scheduler.schedule(cmd1);
+        verify(scheduler, timeout(DELAY_MS + WAIT_FOR_PROPAGATION_MS)).post(any(Command.class));
+
+        doCallRealMethod()
+                .when(commandBus)
+                .postPreviouslyScheduled(any());
+        Command cmd2 =
+                commandFactory.createBasedOnContext(createProjectMessage(), context);
+        scheduler.schedule(cmd2);
+        verify(commandBus, timeout(DELAY_MS + WAIT_FOR_PROPAGATION_MS)).dispatch(any());
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/stand/given/StandTestEnv.java
+++ b/server/src/test/java/io/spine/server/stand/given/StandTestEnv.java
@@ -122,7 +122,8 @@ public class StandTestEnv {
          * {@code SubscriptionUpdate}.
          */
         @SuppressWarnings({"SwitchStatementWithoutDefaultBranch",
-                "EnumSwitchStatementWhichMissesCases"})
+                "EnumSwitchStatementWhichMissesCases",
+                "MissingCasesInEnumSwitch"})
         // OK for this test class.
         @Override
         public void accept(SubscriptionUpdate update) {

--- a/server/src/test/java/io/spine/server/transport/memory/SingleThreadInMemSubscriberTest.java
+++ b/server/src/test/java/io/spine/server/transport/memory/SingleThreadInMemSubscriberTest.java
@@ -26,6 +26,7 @@ import io.spine.base.Identifier;
 import io.spine.server.integration.ChannelId;
 import io.spine.server.integration.ExternalMessage;
 import io.spine.server.transport.memory.given.SingleThreadInMemSubscriberTestEnv.ThrowingObserver;
+import io.spine.testing.logging.MuteLogging;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -39,6 +40,7 @@ class SingleThreadInMemSubscriberTest {
     @SuppressWarnings("unchecked") // OK for testing mocks.
     @Test
     @DisplayName("not halt after observer throws an error")
+    @MuteLogging
     void recoverFromObserverError() {
         SingleThreadInMemSubscriber subscriber =
                 new SingleThreadInMemSubscriber(ChannelId.getDefaultInstance());

--- a/server/src/test/java/io/spine/server/transport/memory/SingleThreadInMemSubscriberTest.java
+++ b/server/src/test/java/io/spine/server/transport/memory/SingleThreadInMemSubscriberTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.transport.memory;
+
+import com.google.protobuf.Any;
+import io.grpc.stub.StreamObserver;
+import io.spine.base.Identifier;
+import io.spine.server.integration.ChannelId;
+import io.spine.server.integration.ExternalMessage;
+import io.spine.server.transport.memory.given.SingleThreadInMemSubscriberTestEnv.ThrowingObserver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.spine.base.Identifier.newUuid;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("SingleThreadInMemSubscriber should")
+class SingleThreadInMemSubscriberTest {
+
+    @SuppressWarnings("unchecked") // OK for testing mocks.
+    @Test
+    @DisplayName("not halt after observer throws an error")
+    void recoverFromObserverError() {
+        SingleThreadInMemSubscriber subscriber =
+                new SingleThreadInMemSubscriber(ChannelId.getDefaultInstance());
+
+        StreamObserver<ExternalMessage> throwingObserver = new ThrowingObserver();
+        subscriber.addObserver(throwingObserver);
+
+        Any id = Identifier.pack(newUuid());
+        ExternalMessage externalMessage = ExternalMessage
+                .newBuilder()
+                .setId(id)
+                .build();
+        subscriber.onMessage(externalMessage);
+
+        subscriber.removeObserver(throwingObserver);
+
+        StreamObserver observerMock = mock(StreamObserver.class);
+        subscriber.addObserver(observerMock);
+        subscriber.onMessage(externalMessage);
+        verify(observerMock).onNext(externalMessage);
+    }
+}

--- a/server/src/test/java/io/spine/server/transport/memory/SingleThreadInMemSubscriberTest.java
+++ b/server/src/test/java/io/spine/server/transport/memory/SingleThreadInMemSubscriberTest.java
@@ -39,8 +39,8 @@ class SingleThreadInMemSubscriberTest {
 
     @SuppressWarnings("unchecked") // OK for testing mocks.
     @Test
-    @DisplayName("not halt after observer throws an error")
     @MuteLogging
+    @DisplayName("not halt after observer throws an error")
     void recoverFromObserverError() {
         SingleThreadInMemSubscriber subscriber =
                 new SingleThreadInMemSubscriber(ChannelId.getDefaultInstance());

--- a/server/src/test/java/io/spine/server/transport/memory/given/SingleThreadInMemSubscriberTestEnv.java
+++ b/server/src/test/java/io/spine/server/transport/memory/given/SingleThreadInMemSubscriberTestEnv.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.transport.memory.given;
+
+import io.grpc.stub.StreamObserver;
+import io.spine.server.integration.ExternalMessage;
+
+import static io.spine.util.Exceptions.newIllegalArgumentException;
+
+public final class SingleThreadInMemSubscriberTestEnv {
+
+    /** Prevents instantiation of this test env class. */
+    private SingleThreadInMemSubscriberTestEnv() {
+    }
+
+    public static class ThrowingObserver implements StreamObserver<ExternalMessage> {
+
+        private static final String ERROR_MESSAGE = "Observer failed";
+
+        @Override
+        public void onNext(ExternalMessage value) {
+            throw newIllegalArgumentException(ERROR_MESSAGE);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            // NO-OP.
+        }
+
+        @Override
+        public void onCompleted() {
+            // NO-OP.
+        }
+    }
+}

--- a/server/src/test/java/io/spine/server/transport/memory/given/package-info.java
+++ b/server/src/test/java/io/spine/server/transport/memory/given/package-info.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test environment classes for the in-memory
+ * {@linkplain io.spine.server.transport.memory.InMemoryTransportFactory transport} implementations.
+ */
+
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.server.transport.memory.given;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
This PR fixes #856.

In several places of the code, the errors from executors were ignored.

Now, we catch such errors manually and log them.