### PR TITLE
Enable PMD static code analysis during the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ subprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'java-library'
     apply plugin: 'net.ltgt.errorprone'
+    apply plugin: 'pmd'
     apply plugin: spineProtobufPluginId
 
     apply from: deps.scripts.javacArgs
@@ -241,6 +242,8 @@ subprojects {
     if (shouldPublishJavadoc(project)) {
         apply from: updateDocsPlugin
     }
+    
+    apply from: deps.scripts.pmd
 }
 
 apply from: publishPlugin

--- a/client/src/main/java/io/spine/client/CommandFactory.java
+++ b/client/src/main/java/io/spine/client/CommandFactory.java
@@ -22,7 +22,6 @@ package io.spine.client;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Any;
-import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
 import io.spine.base.CommandMessage;
 import io.spine.core.ActorContext;
@@ -43,8 +42,9 @@ import static io.spine.validate.Validate.checkValid;
  * such as the actor, the tenant, etc.
  *
  * <p>The command messages passed to the factory are
- * {@linkplain io.spine.validate.Validate#checkValid(Message) validated} according to their
- * Proto definitions. If a given message is invalid, a {@link ValidationException} is thrown.
+ * {@linkplain io.spine.validate.Validate#checkValid(com.google.protobuf.Message) validated}
+ * according to their Proto definitions. If a given message is invalid,
+ * a {@link ValidationException} is thrown.
  *
  * @see ActorRequestFactory#command()
  */

--- a/client/src/main/java/io/spine/client/QueryBuilder.java
+++ b/client/src/main/java/io/spine/client/QueryBuilder.java
@@ -105,6 +105,7 @@ public final class QueryBuilder extends AbstractTargetBuilder<Query, QueryBuilde
         return self();
     }
 
+    @SuppressWarnings("PMD.UnusedPrivateMethod")  /* See https://github.com/pmd/pmd/issues/770. */
     private static void checkLimit(Number count) {
         checkArgument(count.longValue() > 0, "A Query limit must be more than 0.");
     }

--- a/server/src/main/java/io/spine/server/commandbus/CommandDispatcherDelegate.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandDispatcherDelegate.java
@@ -22,7 +22,6 @@ package io.spine.server.commandbus;
 import io.spine.annotation.Internal;
 import io.spine.core.CommandClass;
 import io.spine.core.CommandEnvelope;
-import io.spine.core.MessageEnvelope;
 
 import java.util.Set;
 
@@ -44,7 +43,7 @@ import java.util.Set;
  * returned.
  *
  * <p>The same interference takes place in attempt to implement
- * {@link io.spine.server.bus.UnicastDispatcher#dispatch(MessageEnvelope)
+ * {@link io.spine.server.bus.UnicastDispatcher#dispatch(io.spine.core.MessageEnvelope)
  * UnicastDispatcher.dispatch(MessageEnvelope)} method with the different types of
  * {@code MessageEnvelope}s dispatches simultaneously.
  *

--- a/server/src/main/java/io/spine/server/entity/CommandDispatchingPhase.java
+++ b/server/src/main/java/io/spine/server/entity/CommandDispatchingPhase.java
@@ -22,7 +22,6 @@ package io.spine.server.entity;
 
 import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
-import io.spine.core.CommandEnvelope;
 import io.spine.core.Event;
 import io.spine.server.command.DispatchCommand;
 
@@ -33,7 +32,8 @@ import java.util.List;
  *
  * <p>The result of such dispatch is always a {@link List} of {@linkplain Event events} as
  * described in the {@code CommandHandlingEntity}
- * {@linkplain io.spine.server.command.CommandHandlingEntity#dispatchCommand(CommandEnvelope)
+ * {@linkplain
+ * io.spine.server.command.CommandHandlingEntity#dispatchCommand(io.spine.core.CommandEnvelope)
  * contract}.
  *
  * @param <I>

--- a/server/src/main/java/io/spine/system/server/CommandLifecycleAggregate.java
+++ b/server/src/main/java/io/spine/system/server/CommandLifecycleAggregate.java
@@ -38,10 +38,11 @@ import static io.spine.base.Time.getCurrentTime;
  *
  * <p>All the commands in the system (except the commands in the {@code System} bounded context)
  * have an associated {@code CommandLifecycle}.
- *
- * @author Dmytro Dashenkov
  */
-@SuppressWarnings({"OverlyCoupledClass", "ClassWithTooManyMethods"}) // OK for an aggregate class.
+@SuppressWarnings({
+        "OverlyCoupledClass"  /* OK for an aggregate class. */,
+        "PMD.MissingStaticMethodInNonInstantiatableClass" /* Instantiated via reflection. */
+})
 final class CommandLifecycleAggregate
         extends Aggregate<CommandId, CommandLifecycle, CommandLifecycleVBuilder> {
 


### PR DESCRIPTION
This PR enables and configures PMD code analysis at  build-time.

Some of the discovered issues were fixes, others were suppressed with an explanation.

