### PR TITLE
Eliminate usages of `Options` utility.

### DIFF
--- a/server/src/main/java/io/spine/server/event/enrich/Linker.java
+++ b/server/src/main/java/io/spine/server/event/enrich/Linker.java
@@ -23,6 +23,7 @@ package io.spine.server.event.enrich;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.protobuf.Message;
+import io.spine.code.proto.enrichment.ByOption;
 import io.spine.code.proto.enrichment.FieldRef;
 import io.spine.core.EventContext;
 import io.spine.logging.Logging;
@@ -38,7 +39,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.protobuf.Descriptors.Descriptor;
 import static com.google.protobuf.Descriptors.FieldDescriptor;
 import static com.google.protobuf.Descriptors.FieldDescriptor.Type.MESSAGE;
-import static io.spine.code.proto.enrichment.FieldRef.allFrom;
 import static io.spine.protobuf.Messages.defaultInstance;
 import static io.spine.util.Exceptions.newIllegalStateException;
 import static java.lang.String.format;
@@ -123,7 +123,7 @@ final class Linker implements Logging {
     }
 
     private Set<FieldDescriptor> toSourceFields(FieldDescriptor enrichmentField) {
-        ImmutableList<FieldRef> fieldReferences = allFrom(enrichmentField.toProto());
+        ImmutableList<FieldRef> fieldReferences = ByOption.allFrom(enrichmentField);
         checkState(!fieldReferences.isEmpty(),
                    "Unable to get source field information from the enrichment field `%s`",
                    enrichmentField.getFullName());

--- a/server/src/main/java/io/spine/server/event/model/EntityStateSubscriberSpec.java
+++ b/server/src/main/java/io/spine/server/event/model/EntityStateSubscriberSpec.java
@@ -41,7 +41,6 @@ import static com.google.common.collect.Sets.immutableEnumSet;
 import static io.spine.option.EntityOption.Visibility.FULL;
 import static io.spine.option.EntityOption.Visibility.SUBSCRIBE;
 import static io.spine.option.EntityOption.Visibility.VISIBILITY_UNKNOWN;
-import static io.spine.option.Options.option;
 import static io.spine.protobuf.AnyPacker.unpack;
 import static io.spine.server.model.declare.MethodParams.consistsOfTypes;
 
@@ -111,10 +110,12 @@ enum EntityStateSubscriberSpec implements ParameterSpec<EventEnvelope> {
 
     protected abstract Object[] arrangeArguments(Message entityState, EventEnvelope event);
 
+    // TODO:2019-02-19:serhii.lekariev: https://github.com/SpineEventEngine/base/pull/333#discussion_r258035256
+    // see how this resolves and change accordingly
     private static Optional<EntityOption> getEntityOption(TypeName messageType) {
         Descriptors.Descriptor descriptor = messageType.messageDescriptor();
-        Optional<EntityOption> entityOption = option(descriptor, OptionsProto.entity);
-        return entityOption;
+        Optional<EntityOption> result = io.spine.code.proto.EntityOption.valueOf(descriptor);
+        return result;
     }
 
     private static boolean visibleForSubscription(EntityOption entity) {

--- a/server/src/main/java/io/spine/server/event/model/EntityStateSubscriberSpec.java
+++ b/server/src/main/java/io/spine/server/event/model/EntityStateSubscriberSpec.java
@@ -22,9 +22,10 @@ package io.spine.server.event.model;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
-import com.google.protobuf.Descriptors;
+import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Message;
 import io.spine.base.EventMessage;
+import io.spine.code.proto.EntityStateOption;
 import io.spine.core.EventContext;
 import io.spine.core.EventEnvelope;
 import io.spine.option.EntityOption;
@@ -109,11 +110,9 @@ enum EntityStateSubscriberSpec implements ParameterSpec<EventEnvelope> {
 
     protected abstract Object[] arrangeArguments(Message entityState, EventEnvelope event);
 
-    // TODO:2019-02-19:serhii.lekariev: https://github.com/SpineEventEngine/base/pull/333#discussion_r258035256
-    // see how this resolves and change accordingly
     private static Optional<EntityOption> getEntityOption(TypeName messageType) {
-        Descriptors.Descriptor descriptor = messageType.messageDescriptor();
-        Optional<EntityOption> result = io.spine.code.proto.EntityOption.valueOf(descriptor);
+        Descriptor descriptor = messageType.messageDescriptor();
+        Optional<EntityOption> result = EntityStateOption.valueOf(descriptor);
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/event/model/EntityStateSubscriberSpec.java
+++ b/server/src/main/java/io/spine/server/event/model/EntityStateSubscriberSpec.java
@@ -28,7 +28,6 @@ import io.spine.base.EventMessage;
 import io.spine.core.EventContext;
 import io.spine.core.EventEnvelope;
 import io.spine.option.EntityOption;
-import io.spine.option.OptionsProto;
 import io.spine.server.model.declare.ParameterSpec;
 import io.spine.system.server.EntityStateChanged;
 import io.spine.type.TypeName;

--- a/server/src/main/java/io/spine/system/server/MirrorRepository.java
+++ b/server/src/main/java/io/spine/system/server/MirrorRepository.java
@@ -27,6 +27,7 @@ import com.google.protobuf.FieldMask;
 import io.spine.client.Query;
 import io.spine.client.Target;
 import io.spine.client.TargetFilters;
+import io.spine.code.proto.EntityStateOption;
 import io.spine.option.EntityOption;
 import io.spine.option.EntityOption.Kind;
 import io.spine.type.TypeUrl;
@@ -91,8 +92,7 @@ final class MirrorRepository
     private static boolean shouldMirror(TypeUrl type) {
         Descriptor descriptor = type.toTypeName()
                                     .messageDescriptor();
-        // TODO:2019-02-19:serhii.lekariev: same as EntityStateSubscriberSpec#getEntityOption
-        Optional<EntityOption> option = io.spine.code.proto.EntityOption.valueOf(descriptor);
+        Optional<EntityOption> option = EntityStateOption.valueOf(descriptor);
         Kind kind = option.map(EntityOption::getKind)
                           .orElse(KIND_UNKNOWN);
         boolean aggregate = kind == AGGREGATE;

--- a/server/src/main/java/io/spine/system/server/MirrorRepository.java
+++ b/server/src/main/java/io/spine/system/server/MirrorRepository.java
@@ -39,8 +39,6 @@ import static com.google.common.collect.Streams.stream;
 import static com.google.protobuf.util.FieldMaskUtil.fromFieldNumbers;
 import static io.spine.option.EntityOption.Kind.AGGREGATE;
 import static io.spine.option.EntityOption.Kind.KIND_UNKNOWN;
-import static io.spine.option.Options.option;
-import static io.spine.option.OptionsProto.entity;
 import static io.spine.system.server.Mirror.ID_FIELD_NUMBER;
 import static io.spine.system.server.Mirror.STATE_FIELD_NUMBER;
 import static io.spine.system.server.MirrorProjection.buildFilters;
@@ -93,7 +91,8 @@ final class MirrorRepository
     private static boolean shouldMirror(TypeUrl type) {
         Descriptor descriptor = type.toTypeName()
                                     .messageDescriptor();
-        Optional<EntityOption> option = option(descriptor, entity);
+        // TODO:2019-02-19:serhii.lekariev: same as EntityStateSubscriberSpec#getEntityOption
+        Optional<EntityOption> option = io.spine.code.proto.EntityOption.valueOf(descriptor);
         Kind kind = option.map(EntityOption::getKind)
                           .orElse(KIND_UNKNOWN);
         boolean aggregate = kind == AGGREGATE;


### PR DESCRIPTION
This PR is a follow-up to https://github.com/SpineEventEngine/base/pull/333.

Though `Options` utility is removed from `base`, `core-java` still uses it.

This PR eliminates said usages in favor of using `Option` subclasses, namely `EntityOption`.