### PR TITLE
Release `1.0.0-pre5`

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '1.0.0-SNAPSHOT'
+def final SPINE_VERSION = '1.0.0-pre5'
 
 ext {
     // The version of the modules in this project.


### PR DESCRIPTION
This pull request updates the library version and its dependency on `base` and `time` to `1.0.0-pre5`.