### PR TITLE
Update base

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,10 +8,15 @@
 *.html text
 *.xml text
 *.css text
+*.scss text
 *.js text
 *.properties text
-*.bat text
 *.rtf text
+*.yaml text
+*.yml text
+*.md text
+
+LICENSE text
 
 # SQL scripts
 *.sql text
@@ -19,19 +24,11 @@
 # Java sources
 *.java text
 
-# Jsf sources
-*.jsf text
-*.xhtml text
-
-# Action script and Flex
-*.as text
-*.mxml text
-*.actionScriptProperties text
-*.flexLibProperties text
+# Python sources
+*.py text
 
 # Gradle build files
 *.gradle text
-gradlew.bat
 
 # Google protocol buffers
 *.proto text
@@ -40,7 +37,12 @@ gradlew.bat
 *.rb text
 
 # Declare files that will always have CRLF line endings on checkout.
-# *.sln text eol=crlf
+*.bat text eol=crlf
+
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf
+gradlew text eol=lf
+pull text eol=lf
 
 # Denote all files that are truly binary and should not be modified.
 *.png binary

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -379,7 +379,7 @@
     <inspection_tool class="JavaLangImport" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="JavaLangReflect" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="JavadocHtmlLint" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="JavadocReference" enabled="true" level="TYPO" enabled_by_default="true">
+    <inspection_tool class="JavadocReference" enabled="true" level="ERROR" enabled_by_default="true">
       <scope name="Tests" level="ERROR" enabled="false" />
     </inspection_tool>
     <inspection_tool class="LabeledStatement" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -493,7 +493,6 @@
         <extension name="JUnit4MethodNamingConvention" enabled="true">
           <option name="m_regex" value="[a-z][A-Za-z\d]*" />
           <option name="m_minLength" value="2" />
-          <option name="m_maxLength" value="64" />
         </extension>
       </scope>
       <scope name="Production" level="WARNING" enabled="true">
@@ -643,6 +642,7 @@
       <option name="ignoreCloneable" value="false" />
     </inspection_tool>
     <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="RedundantSuppression" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
@@ -712,6 +712,9 @@
     <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SwitchStatementWithTooFewBranches" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="m_limit" value="2" />
+    </inspection_tool>
     <inspection_tool class="SwitchStatementsWithoutDefault" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreFullyCoveredEnums" value="true" />
     </inspection_tool>
@@ -824,17 +827,6 @@
     <inspection_tool class="UnsecureRandomNumberGeneration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnstableApiUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="Tests" level="WEAK WARNING" enabled="false" />
-      <option name="unstableApiAnnotations">
-        <set>
-          <option value="io.reactivex.annotations.Beta" />
-          <option value="io.reactivex.annotations.Experimental" />
-          <option value="org.apache.http.annotation.Beta" />
-          <option value="org.gradle.api.Incubating" />
-          <option value="org.jetbrains.annotations.ApiStatus.Experimental" />
-          <option value="rx.annotations.Beta" />
-          <option value="rx.annotations.Experimental" />
-        </set>
-      </option>
     </inspection_tool>
     <inspection_tool class="UnusedCatchParameter" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreCatchBlocksWithComments" value="true" />

--- a/server/src/main/java/io/spine/server/enrich/Linker.java
+++ b/server/src/main/java/io/spine/server/enrich/Linker.java
@@ -23,11 +23,11 @@ package io.spine.server.enrich;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.protobuf.Message;
-import io.spine.code.proto.enrichment.ByOption;
-import io.spine.code.proto.enrichment.FieldRef;
 import io.spine.core.EventContext;
 import io.spine.logging.Logging;
 import io.spine.server.reflect.Field;
+import io.spine.type.enrichment.ByOption;
+import io.spine.type.enrichment.FieldRef;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.HashSet;

--- a/server/src/main/java/io/spine/server/enrich/Schema.java
+++ b/server/src/main/java/io/spine/server/enrich/Schema.java
@@ -26,8 +26,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.protobuf.Message;
 import io.spine.base.EventMessage;
-import io.spine.code.proto.enrichment.EnrichmentType;
 import io.spine.type.KnownTypes;
+import io.spine.type.enrichment.EnrichmentType;
 
 import java.util.Optional;
 import java.util.function.Function;

--- a/server/src/main/proto/spine/system/server/c/history_commands.proto
+++ b/server/src/main/proto/spine/system/server/c/history_commands.proto
@@ -42,7 +42,6 @@ import "spine/system/server/entity_history.proto";
 // This command is relevant only to histories of Projections.
 //
 message DispatchEventToSubscriber {
-    option (rejections) = "CannotDispatchEventTwice";
 
     // The ID of the entity, which the event is dispatched to.
     EntityHistoryId receiver = 1;
@@ -56,7 +55,6 @@ message DispatchEventToSubscriber {
 // This command is relevant to histories of Aggregates and ProcessManagers.
 //
 message DispatchEventToReactor {
-    option (rejections) = "CannotDispatchEventTwice";
 
     // The ID of the entity, which the event is dispatched to.
     EntityHistoryId receiver = 1;
@@ -70,7 +68,6 @@ message DispatchEventToReactor {
 // This command is relevant to histories of Aggregates and ProcessManagers.
 //
 message DispatchCommandToHandler {
-    option (rejections) = "CannotDispatchCommandTwice";
 
     // The ID of the entity, which the command is dispatched to.
     EntityHistoryId receiver = 1;

--- a/server/src/test/java/io/spine/server/enrich/EnrichmentAssertion.java
+++ b/server/src/test/java/io/spine/server/enrich/EnrichmentAssertion.java
@@ -23,8 +23,8 @@ package io.spine.server.enrich;
 import com.google.common.truth.IterableSubject;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Message;
-import io.spine.code.proto.enrichment.EnrichmentType;
 import io.spine.type.TypeName;
+import io.spine.type.enrichment.EnrichmentType;
 
 import static com.google.common.truth.Truth.assertThat;
 

--- a/server/src/test/proto/spine/test/system/server/c/command_lifecycle_test_commands.proto
+++ b/server/src/test/proto/spine/test/system/server/c/command_lifecycle_test_commands.proto
@@ -32,7 +32,6 @@ option java_multiple_files = true;
 import "spine/test/system/server/command_lifecycle_test.proto";
 
 message EstablishCompany {
-    option (rejections) = "CompanyNameAlreadyTaken";
 
     CompanyId id = 1;
 
@@ -45,7 +44,6 @@ message StartCompanyEstablishing {
 }
 
 message ProposeCompanyName {
-    option (rejections) = "CompanyNameAlreadyTaken";
 
     CompanyId id = 1;
 
@@ -53,7 +51,6 @@ message ProposeCompanyName {
 }
 
 message FinalizeCompanyName {
-    option (rejections) = "CompanyNameAlreadyTaken";
 
     CompanyId id = 1;
 }

--- a/testutil-client/src/main/java/io/spine/testing/client/TestActorRequestFactory.java
+++ b/testutil-client/src/main/java/io/spine/testing/client/TestActorRequestFactory.java
@@ -70,7 +70,7 @@ public class TestActorRequestFactory extends ActorRequestFactory {
 
     /**
      * Deprecated.
-     * @deprecated use {@link TestActorRequestFactory(String, ZoneId)}
+     * @deprecated use {@link #TestActorRequestFactory(String, ZoneId)}
      */
     @Deprecated
     public static
@@ -89,7 +89,7 @@ public class TestActorRequestFactory extends ActorRequestFactory {
 
     /**
      * Deprecated.
-     * @deprecated use {@link TestActorRequestFactory(Class)}
+     * @deprecated use {@link #TestActorRequestFactory(Class)}
      */
     @Deprecated
     public static TestActorRequestFactory newInstance(Class<?> testClass) {
@@ -102,7 +102,7 @@ public class TestActorRequestFactory extends ActorRequestFactory {
 
     /**
      * Deprecated.
-     * @deprecated use {@link TestActorRequestFactory(UserId)}
+     * @deprecated use {@link #TestActorRequestFactory(UserId)}
      */
     @Deprecated
     public static TestActorRequestFactory newInstance(UserId actor) {
@@ -115,7 +115,7 @@ public class TestActorRequestFactory extends ActorRequestFactory {
 
     /**
      * Deprecated.
-     * @deprecated use {@link TestActorRequestFactory(UserId, TenantId)}
+     * @deprecated use {@link #TestActorRequestFactory(UserId, TenantId)}
      */
     @Deprecated
     public static TestActorRequestFactory newInstance(UserId actor, TenantId tenantId) {

--- a/testutil-client/src/main/java/io/spine/testing/client/TestActorRequestFactory.java
+++ b/testutil-client/src/main/java/io/spine/testing/client/TestActorRequestFactory.java
@@ -128,7 +128,7 @@ public class TestActorRequestFactory extends ActorRequestFactory {
 
     /**
      * Deprecated.
-     * @deprecated use {@link TestActorRequestFactory(Class, TenantId)}
+     * @deprecated use {@link #TestActorRequestFactory(Class, TenantId)}
      */
     @Deprecated
     public static TestActorRequestFactory newInstance(Class<?> testClass, TenantId tenantId) {

--- a/testutil-client/src/main/java/io/spine/testing/client/blackbox/Acknowledgements.java
+++ b/testutil-client/src/main/java/io/spine/testing/client/blackbox/Acknowledgements.java
@@ -27,11 +27,11 @@ import com.google.errorprone.annotations.Immutable;
 import com.google.protobuf.Message;
 import io.spine.base.Error;
 import io.spine.base.RejectionMessage;
-import io.spine.code.proto.RejectionType;
 import io.spine.core.Ack;
 import io.spine.core.Event;
 import io.spine.core.Events;
 import io.spine.core.Status;
+import io.spine.type.RejectionType;
 import io.spine.type.TypeUrl;
 
 import java.util.HashMap;

--- a/testutil-client/src/main/java/io/spine/testing/client/blackbox/RejectionOfTypeCountVerify.java
+++ b/testutil-client/src/main/java/io/spine/testing/client/blackbox/RejectionOfTypeCountVerify.java
@@ -20,7 +20,8 @@
 
 package io.spine.testing.client.blackbox;
 
-import io.spine.code.proto.RejectionType;
+
+import io.spine.type.RejectionType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/testutil-client/src/main/java/io/spine/testing/client/blackbox/RejectionOfTypePresenceVerify.java
+++ b/testutil-client/src/main/java/io/spine/testing/client/blackbox/RejectionOfTypePresenceVerify.java
@@ -20,7 +20,8 @@
 
 package io.spine.testing.client.blackbox;
 
-import io.spine.code.proto.RejectionType;
+
+import io.spine.type.RejectionType;
 
 import static org.junit.jupiter.api.Assertions.fail;
 

--- a/testutil-client/src/main/java/io/spine/testing/client/blackbox/VerifyAcknowledgements.java
+++ b/testutil-client/src/main/java/io/spine/testing/client/blackbox/VerifyAcknowledgements.java
@@ -24,7 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Descriptors.Descriptor;
 import io.spine.base.Error;
 import io.spine.base.RejectionMessage;
-import io.spine.code.proto.RejectionType;
+import io.spine.type.RejectionType;
 import io.spine.type.TypeName;
 
 /**

--- a/testutil-client/src/test/java/io/spine/testing/client/blackbox/AcknowledgementsTest.java
+++ b/testutil-client/src/test/java/io/spine/testing/client/blackbox/AcknowledgementsTest.java
@@ -21,9 +21,9 @@
 package io.spine.testing.client.blackbox;
 
 import com.google.common.collect.ImmutableList;
-import io.spine.code.proto.RejectionType;
 import io.spine.core.Ack;
 import io.spine.testing.client.blackbox.given.CommandAcksTestEnv;
+import io.spine.type.RejectionType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/testutil-client/src/test/java/io/spine/testing/client/blackbox/VerifyAcknowledgementsTest.java
+++ b/testutil-client/src/test/java/io/spine/testing/client/blackbox/VerifyAcknowledgementsTest.java
@@ -21,10 +21,10 @@
 package io.spine.testing.client.blackbox;
 
 import com.google.common.collect.ImmutableList;
-import io.spine.code.proto.RejectionType;
 import io.spine.testing.client.blackbox.Rejections.BbProjectAlreadyStarted;
 import io.spine.testing.client.blackbox.Rejections.BbTaskCreatedInCompletedProject;
 import io.spine.testing.client.blackbox.Rejections.BbTaskLimitReached;
+import io.spine.type.RejectionType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '1.0.0-SNAPSHOT'
+def final SPINE_VERSION = '1.0.0-pre6'
 
 ext {
     // The version of the modules in this project.


### PR DESCRIPTION
In this PR we update `base`.

Changes:
 - `(events)` and `(rejections)` options are deleted;
 - generated checks of `(set_once)` in `VBuilder`s are changed, thus the builders must be regenerated.

Also, in this PR, some Javadoc warnings are fixed and the `config` module is updated.

Also, this PR releases version `1.0.0-pre6`.