### PR TITLE
Tighten system entity state validation

### DIFF
--- a/core/src/main/java/io/spine/core/MessageId.java
+++ b/core/src/main/java/io/spine/core/MessageId.java
@@ -18,49 +18,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.server.entity;
+package io.spine.core;
 
+import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
-import io.spine.core.MessageId;
-import io.spine.server.event.EventDispatch;
 
 /**
- * A phase that dispatches an event to the entity in transaction.
+ * An identifier of a message.
  *
- * @param <I>
- *         the type of entity ID
- * @param <E>
- *         the type of the entity
- * @param <R>
- *         the type of the event dispatch result
+ * @see CommandId
+ * @see EventId
  */
 @Internal
-public class EventDispatchingPhase<I, E extends TransactionalEntity<I, ?, ?>, R>
-        extends Phase<I, R> {
-
-    private final EventDispatch<I, E, R> dispatch;
-
-    public EventDispatchingPhase(EventDispatch<I, E, R> dispatch,
-                                 VersionIncrement versionIncrement) {
-        super(versionIncrement);
-        this.dispatch = dispatch;
-    }
-
-    @Override
-    protected R performDispatch() {
-        R result = dispatch.perform();
-        return result;
-    }
-
-    @Override
-    public I getEntityId() {
-        return dispatch.entity()
-                       .id();
-    }
-
-    @Override
-    public MessageId getMessageId() {
-        return dispatch.event()
-                       .id();
-    }
+public interface MessageId extends Message {
 }

--- a/core/src/main/proto/spine/core/command.proto
+++ b/core/src/main/proto/spine/core/command.proto
@@ -36,6 +36,8 @@ import "spine/core/actor_context.proto";
 
 // Command identifier.
 message CommandId {
+    option (is).java_type = "io.spine.core.MessageId";
+
     string uuid = 1;
 }
 

--- a/core/src/main/proto/spine/core/event.proto
+++ b/core/src/main/proto/spine/core/event.proto
@@ -39,6 +39,7 @@ import "spine/core/enrichment.proto";
 
 // Event identifier.
 message EventId {
+    option (is).java_type = "io.spine.core.MessageId";
 
     // A value of the event identifier.
     //

--- a/server/src/main/java/io/spine/server/entity/CommandDispatchingPhase.java
+++ b/server/src/main/java/io/spine/server/entity/CommandDispatchingPhase.java
@@ -20,9 +20,9 @@
 
 package io.spine.server.entity;
 
-import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
 import io.spine.core.Event;
+import io.spine.core.MessageId;
 import io.spine.server.command.DispatchCommand;
 
 import java.util.List;
@@ -61,7 +61,7 @@ public class CommandDispatchingPhase<I> extends Phase<I, List<Event>> {
     }
 
     @Override
-    public Message getMessageId() {
+    public MessageId getMessageId() {
         return dispatch.command()
                        .id();
     }

--- a/server/src/main/java/io/spine/server/entity/EntityLifecycle.java
+++ b/server/src/main/java/io/spine/server/entity/EntityLifecycle.java
@@ -115,7 +115,7 @@ public class EntityLifecycle {
      *
      * <p>Use this constructor for test purposes <b>only</b>.
      *
-     * @see Builder
+     * @see EntityLifecycle.Builder
      */
     @VisibleForTesting
     protected EntityLifecycle(Object entityId,

--- a/server/src/main/java/io/spine/server/entity/EntityLifecycle.java
+++ b/server/src/main/java/io/spine/server/entity/EntityLifecycle.java
@@ -23,7 +23,6 @@ package io.spine.server.entity;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
-import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
 import io.spine.base.CommandMessage;
 import io.spine.base.EventMessage;
@@ -31,6 +30,7 @@ import io.spine.core.Command;
 import io.spine.core.CommandId;
 import io.spine.core.Event;
 import io.spine.core.EventId;
+import io.spine.core.MessageId;
 import io.spine.core.Version;
 import io.spine.option.EntityOption;
 import io.spine.system.server.AssignTargetToCommand;
@@ -115,7 +115,7 @@ public class EntityLifecycle {
      *
      * <p>Use this constructor for test purposes <b>only</b>.
      *
-     * @see io.spine.server.entity.EntityLifecycle.Builder
+     * @see Builder
      */
     @VisibleForTesting
     protected EntityLifecycle(Object entityId,
@@ -267,7 +267,7 @@ public class EntityLifecycle {
      *         {@link EventId EventId}s or {@link CommandId}s
      */
     public final void onStateChanged(EntityRecordChange change,
-                                     Set<? extends Message> messageIds) {
+                                     Set<? extends MessageId> messageIds) {
         Collection<DispatchedMessageId> dispatchedMessageIds = toDispatched(messageIds);
 
         postIfChanged(change, dispatchedMessageIds);
@@ -391,7 +391,7 @@ public class EntityLifecycle {
     }
 
     private static Collection<DispatchedMessageId>
-    toDispatched(Collection<? extends Message> messageIds) {
+    toDispatched(Collection<? extends MessageId> messageIds) {
         Collection<DispatchedMessageId> dispatchedMessageIds =
                 messageIds.stream()
                           .map(EntityLifecycle::dispatchedMessageId)
@@ -400,7 +400,7 @@ public class EntityLifecycle {
     }
 
     @SuppressWarnings("ChainOfInstanceofChecks")
-    private static DispatchedMessageId dispatchedMessageId(Message messageId) {
+    private static DispatchedMessageId dispatchedMessageId(MessageId messageId) {
         checkNotNull(messageId);
         DispatchedMessageIdVBuilder builder = DispatchedMessageIdVBuilder.newBuilder();
         if (messageId instanceof EventId) {

--- a/server/src/main/java/io/spine/server/entity/EntityLifecycleMonitor.java
+++ b/server/src/main/java/io/spine/server/entity/EntityLifecycleMonitor.java
@@ -25,6 +25,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
 import io.spine.base.Identifier;
+import io.spine.core.MessageId;
 import io.spine.core.Version;
 import io.spine.validate.ValidatingBuilder;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -66,7 +67,7 @@ public final class EntityLifecycleMonitor<I,
         implements TransactionListener<I, E, S, B> {
 
     private final Repository<I, ?> repository;
-    private final List<Message> acknowledgedMessageIds;
+    private final List<MessageId> acknowledgedMessageIds;
 
     private @MonotonicNonNull I entityId;
 
@@ -99,7 +100,7 @@ public final class EntityLifecycleMonitor<I,
     @Override
     public void onAfterPhase(Phase<I, ?> phase) {
         checkSameEntity(phase.getEntityId());
-        Message messageId = phase.getMessageId();
+        MessageId messageId = phase.getMessageId();
         acknowledgedMessageIds.add(messageId);
     }
 
@@ -115,7 +116,7 @@ public final class EntityLifecycleMonitor<I,
      */
     @Override
     public void onAfterCommit(EntityRecordChange change) {
-        Set<Message> messageIds = ImmutableSet.copyOf(acknowledgedMessageIds);
+        Set<MessageId> messageIds = ImmutableSet.copyOf(acknowledgedMessageIds);
         Any newEntityId = change.getPreviousValue()
                                 .getEntityId();
         I id = Identifier.unpack(newEntityId, repository.idClass());

--- a/server/src/main/java/io/spine/server/entity/Phase.java
+++ b/server/src/main/java/io/spine/server/entity/Phase.java
@@ -20,8 +20,8 @@
 
 package io.spine.server.entity;
 
-import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
+import io.spine.core.MessageId;
 
 /**
  * An atomic entity state change which advances the entity version.
@@ -87,5 +87,5 @@ public abstract class Phase<I, R> {
     /**
      * Returns the dispatched {@code Message} ID.
      */
-    protected abstract Message getMessageId();
+    protected abstract MessageId getMessageId();
 }

--- a/server/src/main/java/io/spine/server/stand/Stand.java
+++ b/server/src/main/java/io/spine/server/stand/Stand.java
@@ -91,6 +91,14 @@ import static java.util.Collections.singleton;
 @SuppressWarnings("OverlyCoupledClass")
 public class Stand extends AbstractEventSubscriber implements AutoCloseable {
 
+    /**
+     * The event ID used as the origin of entity state change system events.
+     *
+     * @deprecated This {@code EventId} is used in {@link #post} in order to satisfy the system
+     *             event validation rules. Do not use this value in other places and/or for other
+     *             purposes.
+     */
+    @Deprecated
     private static final EventId STAND_POST_ORIGIN = EventId
             .newBuilder()
             .setValue("Stand-received-entity-update")

--- a/server/src/main/java/io/spine/server/stand/Stand.java
+++ b/server/src/main/java/io/spine/server/stand/Stand.java
@@ -34,6 +34,7 @@ import io.spine.client.QueryResponse;
 import io.spine.client.Subscription;
 import io.spine.client.SubscriptionUpdate;
 import io.spine.client.Topic;
+import io.spine.core.EventId;
 import io.spine.core.Response;
 import io.spine.core.Responses;
 import io.spine.core.TenantId;
@@ -89,6 +90,11 @@ import static java.util.Collections.singleton;
  */
 @SuppressWarnings("OverlyCoupledClass")
 public class Stand extends AbstractEventSubscriber implements AutoCloseable {
+
+    private static final EventId STAND_POST_ORIGIN = EventId
+            .newBuilder()
+            .setValue("Stand-received-entity-update")
+            .build();
 
     /**
      * Used to return an empty result collection for {@link Query}.
@@ -171,7 +177,7 @@ public class Stand extends AbstractEventSubscriber implements AutoCloseable {
                 .newBuilder()
                 .setNewValue(record)
                 .build();
-        lifecycle.onStateChanged(change, ImmutableSet.of());
+        lifecycle.onStateChanged(change, ImmutableSet.of(STAND_POST_ORIGIN));
     }
 
     /**

--- a/server/src/main/java/io/spine/system/server/CommandLifecycleAggregate.java
+++ b/server/src/main/java/io/spine/system/server/CommandLifecycleAggregate.java
@@ -59,7 +59,7 @@ final class CommandLifecycleAggregate
     }
 
     @Assign
-    TargetAssignedToCommand on(AssignTargetToCommand event) {
+    TargetAssignedToCommand handle(AssignTargetToCommand event) {
         return TargetAssignedToCommand.newBuilder()
                                       .setId(event.getId())
                                       .setTarget(event.getTarget())
@@ -94,7 +94,8 @@ final class CommandLifecycleAggregate
         CommandTimeline status = statusBuilder()
                 .setWhenAcknowledged(getCurrentTime())
                 .build();
-        builder().setStatus(status);
+        builder().setId(event.getId())
+                 .setStatus(status);
     }
 
     @Apply(allowImport = true)
@@ -103,7 +104,8 @@ final class CommandLifecycleAggregate
         CommandTimeline status = statusBuilder()
                 .setWhenScheduled(getCurrentTime())
                 .build();
-        builder().setCommand(updatedCommand)
+        builder().setId(event.getId())
+                 .setCommand(updatedCommand)
                  .setStatus(status);
     }
 
@@ -117,7 +119,8 @@ final class CommandLifecycleAggregate
         CommandTimeline status = statusBuilder()
                 .setWhenDispatched(getCurrentTime())
                 .build();
-        builder().setStatus(status);
+        builder().setId(event.getId())
+                 .setStatus(status);
     }
 
     /**
@@ -132,9 +135,10 @@ final class CommandLifecycleAggregate
         CommandTimeline status =
                 builder.getStatus()
                        .toBuilder()
-                       .setWhenTargetAssgined(getCurrentTime())
+                       .setWhenTargetAssigned(getCurrentTime())
                        .build();
-        builder.setStatus(status)
+        builder.setId(event.getId())
+               .setStatus(status)
                .setTarget(target);
     }
 
@@ -184,7 +188,7 @@ final class CommandLifecycleAggregate
         CommandTimeline.Builder newStatus =
                 state().getStatus()
                        .toBuilder()
-                       .setSubstitued(substituted);
+                       .setSubstituted(substituted);
         builder().setStatus(newStatus.build());
     }
 
@@ -197,7 +201,7 @@ final class CommandLifecycleAggregate
         CommandTimeline.Builder newStatus =
                 state().getStatus()
                        .toBuilder()
-                       .setSubstitued(substituted);
+                       .setSubstituted(substituted);
         builder().setStatus(newStatus.build());
     }
 

--- a/server/src/main/java/io/spine/system/server/CommandLifecycleAggregate.java
+++ b/server/src/main/java/io/spine/system/server/CommandLifecycleAggregate.java
@@ -74,12 +74,12 @@ final class CommandLifecycleAggregate
      */
     @Apply(allowImport = true)
     private void on(CommandReceived event) {
+        ensureId();
         CommandTimeline status = CommandTimeline
                 .newBuilder()
                 .setWhenReceived(getCurrentTime())
                 .build();
-        builder().setId(event.getId())
-                 .setCommand(event.getPayload())
+        builder().setCommand(event.getPayload())
                  .setStatus(status);
     }
 
@@ -91,21 +91,21 @@ final class CommandLifecycleAggregate
      */
     @Apply(allowImport = true)
     private void on(@SuppressWarnings("unused") CommandAcknowledged event) {
+        ensureId();
         CommandTimeline status = statusBuilder()
                 .setWhenAcknowledged(getCurrentTime())
                 .build();
-        builder().setId(event.getId())
-                 .setStatus(status);
+        builder().setStatus(status);
     }
 
     @Apply(allowImport = true)
     private void on(CommandScheduled event) {
+        ensureId();
         Command updatedCommand = updateSchedule(event.getSchedule());
         CommandTimeline status = statusBuilder()
                 .setWhenScheduled(getCurrentTime())
                 .build();
-        builder().setId(event.getId())
-                 .setCommand(updatedCommand)
+        builder().setCommand(updatedCommand)
                  .setStatus(status);
     }
 
@@ -116,11 +116,11 @@ final class CommandLifecycleAggregate
      */
     @Apply(allowImport = true)
     private void on(@SuppressWarnings("unused") CommandDispatched event) {
+        ensureId();
         CommandTimeline status = statusBuilder()
                 .setWhenDispatched(getCurrentTime())
                 .build();
-        builder().setId(event.getId())
-                 .setStatus(status);
+        builder().setStatus(status);
     }
 
     /**
@@ -130,6 +130,7 @@ final class CommandLifecycleAggregate
      */
     @Apply(allowImport = true)
     private void on(TargetAssignedToCommand event) {
+        ensureId();
         CommandTarget target = event.getTarget();
         CommandLifecycleVBuilder builder = builder();
         CommandTimeline status =
@@ -137,8 +138,7 @@ final class CommandLifecycleAggregate
                        .toBuilder()
                        .setWhenTargetAssigned(getCurrentTime())
                        .build();
-        builder.setId(event.getId())
-               .setStatus(status)
+        builder.setStatus(status)
                .setTarget(target);
     }
 
@@ -149,6 +149,7 @@ final class CommandLifecycleAggregate
      */
     @Apply(allowImport = true)
     private void on(@SuppressWarnings("unused") CommandHandled event) {
+        ensureId();
         setStatus(Responses.statusOk());
     }
 
@@ -159,6 +160,7 @@ final class CommandLifecycleAggregate
      */
     @Apply(allowImport = true)
     private void on(CommandErrored event) {
+        ensureId();
         Status status = Status
                 .newBuilder()
                 .setError(event.getError())
@@ -173,6 +175,7 @@ final class CommandLifecycleAggregate
      */
     @Apply(allowImport = true)
     private void on(CommandRejected event) {
+        ensureId();
         Status status = Status
                 .newBuilder()
                 .setRejection(event.getRejectionEvent())
@@ -182,6 +185,7 @@ final class CommandLifecycleAggregate
 
     @Apply(allowImport = true)
     private void on(CommandTransformed event) {
+        ensureId();
         Substituted.Builder substituted = Substituted
                 .newBuilder()
                 .setCommand(event.getId());
@@ -194,6 +198,7 @@ final class CommandLifecycleAggregate
 
     @Apply(allowImport = true)
     private void on(CommandSplit event) {
+        ensureId();
         Substituted.Builder substituted = Substituted
                 .newBuilder()
                 .setSequence(Sequence.newBuilder()
@@ -230,5 +235,9 @@ final class CommandLifecycleAggregate
                 .setHowHandled(status)
                 .build();
         builder().setStatus(commandStatus);
+    }
+
+    private void ensureId() {
+        builder().setId(id());
     }
 }

--- a/server/src/main/proto/spine/system/server/c/history_events.proto
+++ b/server/src/main/proto/spine/system/server/c/history_events.proto
@@ -136,7 +136,7 @@ message EntityStateChanged {
     google.protobuf.Any new_state = 2 [(required) = true];
 
     // The IDs of the messages which caused the mutation.
-    repeated DispatchedMessageId message_id = 3;
+    repeated DispatchedMessageId message_id = 3 [(required) = true, (valid) = true];
 
     // The instant when the entity was changed.
     google.protobuf.Timestamp when = 4;
@@ -153,7 +153,7 @@ message EntityArchived {
     EntityHistoryId id = 1 [(required) = true];
 
     // The IDs of the messages which caused the mutation.
-    repeated DispatchedMessageId message_id = 2;
+    repeated DispatchedMessageId message_id = 2 [(required) = true, (valid) = true];
 
     // The instant when the entity was archived.
     google.protobuf.Timestamp when = 3;
@@ -170,7 +170,7 @@ message EntityDeleted {
     EntityHistoryId id = 1 [(required) = true];
 
     // The IDs of the messages which caused the mutation.
-    repeated DispatchedMessageId message_id = 2;
+    repeated DispatchedMessageId message_id = 2 [(required) = true, (valid) = true];
 
     // The instant when the entity was deleted.
     google.protobuf.Timestamp when = 3;
@@ -187,7 +187,7 @@ message EntityExtractedFromArchive {
     EntityHistoryId id = 1 [(required) = true];
 
     // The IDs of the messages which caused the mutation.
-    repeated DispatchedMessageId message_id = 2;
+    repeated DispatchedMessageId message_id = 2 [(required) = true, (valid) = true];
 
     // The instant when the entity was extracted.
     google.protobuf.Timestamp when = 3;
@@ -204,7 +204,7 @@ message EntityRestored {
     EntityHistoryId id = 1 [(required) = true];
 
     // The IDs of the messages which caused the mutation.
-    repeated DispatchedMessageId message_id = 2;
+    repeated DispatchedMessageId message_id = 2 [(required) = true, (valid) = true];
 
     // The instant when the entity was restored.
     google.protobuf.Timestamp when = 3;

--- a/server/src/main/proto/spine/system/server/command_lifecycle.proto
+++ b/server/src/main/proto/spine/system/server/command_lifecycle.proto
@@ -40,15 +40,14 @@ import "spine/client/filters.proto";
 
 // The current status of a command in a system.
 //
-// All the commands in the system have a corresponding lifecycle instance. The only excpetion are
-// the commads of the `System` bounded contexts, which do not have an explicit lifecycle.
+// All the commands in the system have a corresponding lifecycle instance. The only exception are
+// the commands of the `System` bounded contexts, which do not have an explicit lifecycle.
 //
 message CommandLifecycle {
     option (entity).kind = AGGREGATE;
 
     // The ID of the command.
-    //TODO:2018-10-31:dmytro.grankin: make the ID required, see https://github.com/SpineEventEngine/core-java/issues/877
-    spine.core.CommandId id = 1 [(required) = false];
+    spine.core.CommandId id = 1;
 
     // The command.
     spine.core.Command command = 2;
@@ -91,7 +90,7 @@ message CommandTimeline {
     google.protobuf.Timestamp when_dispatched = 4;
 
     // The instant when the command target is assigned to the command.
-    google.protobuf.Timestamp when_target_assgined = 5;
+    google.protobuf.Timestamp when_target_assigned = 5;
 
     // The instant when the command processing is completed, successfully or otherwise.
     google.protobuf.Timestamp when_handled = 6 [(goes).with = "how_handled"];
@@ -108,7 +107,7 @@ message CommandTimeline {
         spine.core.Status how_handled = 8 [(goes).with = "when_handled"];
 
         // Other commands were generated instead.
-        Substituted substitued = 9 [(goes).with = "when_substituted"];
+        Substituted substituted = 9 [(goes).with = "when_substituted"];
     }
 }
 

--- a/server/src/main/proto/spine/system/server/entity_history.proto
+++ b/server/src/main/proto/spine/system/server/entity_history.proto
@@ -61,7 +61,7 @@ message EntityHistoryId {
 message EntityHistory {
     option (entity).kind = AGGREGATE;
 
-    EntityHistoryId id = 1 [(set_once) = false];
+    EntityHistoryId id = 1;
 
     // The kind of the entity.
     EntityOption.Kind kind = 2;

--- a/server/src/test/java/io/spine/server/SubscriptionServiceTest.java
+++ b/server/src/test/java/io/spine/server/SubscriptionServiceTest.java
@@ -245,7 +245,6 @@ class SubscriptionServiceTest {
 
         Topic topic = requestFactory.topic()
                                     .forTarget(target);
-
         // Subscribe to the topic.
         MemoizingObserver<Subscription> subscriptionObserver = new MemoizingObserver<>();
         subscriptionService.subscribe(topic, subscriptionObserver);

--- a/server/src/test/java/io/spine/server/entity/AbstractEventSubscriberTest.java
+++ b/server/src/test/java/io/spine/server/entity/AbstractEventSubscriberTest.java
@@ -25,6 +25,7 @@ import com.google.protobuf.Message;
 import io.spine.base.Identifier;
 import io.spine.base.Time;
 import io.spine.client.EntityId;
+import io.spine.core.EventId;
 import io.spine.core.UserId;
 import io.spine.server.BoundedContext;
 import io.spine.server.event.model.InsufficientVisibilityError;
@@ -39,6 +40,7 @@ import io.spine.server.organizations.Organization;
 import io.spine.server.organizations.OrganizationId;
 import io.spine.server.transport.memory.InMemoryTransportFactory;
 import io.spine.server.type.given.GivenEvent;
+import io.spine.system.server.DispatchedMessageId;
 import io.spine.system.server.EntityHistoryId;
 import io.spine.system.server.EntityStateChanged;
 import io.spine.system.server.SystemBoundedContexts;
@@ -94,6 +96,7 @@ class AbstractEventSubscriberTest {
                 .setId(historyId(Group.class))
                 .setWhen(Time.getCurrentTime())
                 .setNewState(pack(state))
+                .addMessageId(dispatchedMessageId())
                 .build();
         SystemBoundedContexts.systemOf(groupsContext)
                              .eventBus()
@@ -120,6 +123,7 @@ class AbstractEventSubscriberTest {
                 .setId(historyId(Organization.class))
                 .setWhen(Time.getCurrentTime())
                 .setNewState(pack(state))
+                .addMessageId(dispatchedMessageId())
                 .build();
         SystemBoundedContexts.systemOf(organizationsContext)
                              .eventBus()
@@ -154,7 +158,6 @@ class AbstractEventSubscriberTest {
         assertThrows(InsufficientVisibilityError.class, HiddenEntitySubscriber::new);
     }
 
-
     private static EntityHistoryId historyId(Class<? extends Message> type) {
         EntityId entityId = EntityId
                 .newBuilder()
@@ -166,5 +169,12 @@ class AbstractEventSubscriberTest {
                 .setTypeUrl(TypeUrl.of(type).value())
                 .build();
         return historyId;
+    }
+
+    private static DispatchedMessageId dispatchedMessageId() {
+        return DispatchedMessageId
+                .newBuilder()
+                .setEventId(EventId.getDefaultInstance())
+                .build();
     }
 }

--- a/server/src/test/java/io/spine/server/event/model/SubscriberSignatureTest.java
+++ b/server/src/test/java/io/spine/server/event/model/SubscriberSignatureTest.java
@@ -33,7 +33,7 @@ import static io.spine.server.event.model.given.SubscriberSignatureTestEnv.findM
 import static io.spine.server.event.model.given.SubscriberSignatureTestEnv.findMessageAndContext;
 import static io.spine.server.event.model.given.SubscriberSignatureTestEnv.findMessageOnly;
 import static io.spine.server.event.model.given.SubscriberSignatureTestEnv.findReturnsValue;
-import static io.spine.server.event.model.given.SubscriberSignatureTestEnv.findThrowsUnchckedException;
+import static io.spine.server.event.model.given.SubscriberSignatureTestEnv.findThrowsUncheckedException;
 
 class SubscriberSignatureTest extends MethodSignatureTest<SubscriberSignature> {
 
@@ -51,7 +51,7 @@ class SubscriberSignatureTest extends MethodSignatureTest<SubscriberSignature> {
         return Stream.of(findReturnsValue(),
                          findContextArgumentMismatch(),
                          findFirstArgumentMismatch(),
-                         findThrowsUnchckedException());
+                         findThrowsUncheckedException());
     }
 
     @Override

--- a/server/src/test/java/io/spine/server/event/model/given/SubscriberSignatureTestEnv.java
+++ b/server/src/test/java/io/spine/server/event/model/given/SubscriberSignatureTestEnv.java
@@ -91,7 +91,7 @@ public class SubscriberSignatureTestEnv {
         return method;
     }
 
-    public static Method findThrowsUnchckedException() {
+    public static Method findThrowsUncheckedException() {
         Method method = findInvalidMethod("throwsUncheckedException");
         return method;
     }

--- a/server/src/test/java/io/spine/server/groups/FilteredStateSubscriber.java
+++ b/server/src/test/java/io/spine/server/groups/FilteredStateSubscriber.java
@@ -32,7 +32,7 @@ public class FilteredStateSubscriber extends AbstractEventSubscriber {
     @Subscribe(
             filter = @ByField(path = "head.value", value = "42") // <-- Error here. Shouldn't have a filter.
     )
-    public void on(Organization organization) {
+    void on(Organization organization) {
         fail(FilteredStateSubscriber.class.getSimpleName() +
                      " should not be able to receive any updates.");
     }

--- a/server/src/test/java/io/spine/server/groups/WronglyDomesticSubscriber.java
+++ b/server/src/test/java/io/spine/server/groups/WronglyDomesticSubscriber.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class WronglyDomesticSubscriber extends AbstractEventSubscriber {
 
     @Subscribe // <-- Error here. Should be external.
-    public void on(Organization organization) {
+    void on(Organization organization) {
         fail(WronglyDomesticSubscriber.class.getSimpleName() +
                      " should not be able to receive external updates.");
     }

--- a/server/src/test/java/io/spine/server/groups/WronglyExternalSubscriber.java
+++ b/server/src/test/java/io/spine/server/groups/WronglyExternalSubscriber.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class WronglyExternalSubscriber extends AbstractEventSubscriber {
 
     @Subscribe(external = true) // <-- Error here. Should be domestic.
-    public void on(Group group) {
+    void on(Group group) {
         fail(WronglyExternalSubscriber.class.getSimpleName() +
                      " should not be able to receive domestic updates.");
     }

--- a/server/src/test/java/io/spine/server/projection/ProjectionRepositoryTest.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionRepositoryTest.java
@@ -78,6 +78,7 @@ import static io.spine.core.Events.getMessage;
 import static io.spine.protobuf.AnyPacker.pack;
 import static io.spine.server.projection.ProjectionRepository.nullToDefault;
 import static io.spine.server.projection.given.ProjectionRepositoryTestEnv.GivenEventMessage.projectCreated;
+import static io.spine.server.projection.given.ProjectionRepositoryTestEnv.dispatchedMessageId;
 import static io.spine.testing.TestValues.randomString;
 import static io.spine.testing.server.Assertions.assertEventClasses;
 import static io.spine.testing.server.TestEventFactory.newInstance;
@@ -349,6 +350,7 @@ class ProjectionRepositoryTest
                     .setId(historyId)
                     .setWhen(getCurrentTime())
                     .setNewState(newState)
+                    .addMessageId(dispatchedMessageId())
                     .build();
             EntitySubscriberProjection.Repository repository =
                     new EntitySubscriberProjection.Repository();

--- a/server/src/test/java/io/spine/server/projection/e2e/ProjectionEndToEndTest.java
+++ b/server/src/test/java/io/spine/server/projection/e2e/ProjectionEndToEndTest.java
@@ -62,6 +62,7 @@ import java.util.Set;
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.base.Time.getCurrentTime;
 import static io.spine.protobuf.AnyPacker.pack;
+import static io.spine.server.projection.given.ProjectionRepositoryTestEnv.dispatchedMessageId;
 import static io.spine.testing.server.blackbox.verify.state.VerifyState.exactlyOne;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -149,6 +150,7 @@ class ProjectionEndToEndTest {
                 .setId(historyId)
                 .setNewState(pack(newState))
                 .setWhen(getCurrentTime())
+                .addMessageId(dispatchedMessageId())
                 .build();
         Timestamp producedAt = Time.getCurrentTime();
         EventContext eventContext = EventContext

--- a/server/src/test/java/io/spine/server/projection/given/ProjectionRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/projection/given/ProjectionRepositoryTestEnv.java
@@ -54,6 +54,9 @@ public class ProjectionRepositoryTestEnv {
     private ProjectionRepositoryTestEnv() {
     }
 
+    /**
+     * Creates a new {@code DispatchedMessageId} with a random {@code EventId}.
+     */
     public static DispatchedMessageId dispatchedMessageId() {
         EventId eventId = EventId
                 .newBuilder()

--- a/server/src/test/java/io/spine/server/projection/given/ProjectionRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/projection/given/ProjectionRepositoryTestEnv.java
@@ -22,6 +22,7 @@ package io.spine.server.projection.given;
 
 import io.spine.base.Identifier;
 import io.spine.core.EventContext;
+import io.spine.core.EventId;
 import io.spine.core.Subscribe;
 import io.spine.core.UserId;
 import io.spine.server.organizations.OrganizationEstablished;
@@ -29,6 +30,7 @@ import io.spine.server.organizations.OrganizationId;
 import io.spine.server.projection.Projection;
 import io.spine.server.projection.ProjectionRepository;
 import io.spine.server.type.MessageEnvelope;
+import io.spine.system.server.DispatchedMessageId;
 import io.spine.test.projection.Project;
 import io.spine.test.projection.ProjectId;
 import io.spine.test.projection.ProjectTaskNames;
@@ -43,12 +45,24 @@ import io.spine.test.projection.event.PrjTaskAdded;
 import io.spine.testing.core.given.GivenUserId;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import static io.spine.base.Identifier.newUuid;
 import static io.spine.testing.TestValues.randomString;
 
 public class ProjectionRepositoryTestEnv {
 
     /** Prevent instantiation of this utility class. */
     private ProjectionRepositoryTestEnv() {
+    }
+
+    public static DispatchedMessageId dispatchedMessageId() {
+        EventId eventId = EventId
+                .newBuilder()
+                .setValue(newUuid())
+                .build();
+        return DispatchedMessageId
+                .newBuilder()
+                .setEventId(eventId)
+                .build();
     }
 
     /**

--- a/server/src/test/java/io/spine/system/server/MirrorRepositoryTest.java
+++ b/server/src/test/java/io/spine/system/server/MirrorRepositoryTest.java
@@ -59,6 +59,7 @@ import static io.spine.server.storage.LifecycleFlagField.archived;
 import static io.spine.server.storage.LifecycleFlagField.deleted;
 import static io.spine.system.server.SystemBoundedContexts.systemOf;
 import static io.spine.system.server.given.mirror.RepositoryTestEnv.archived;
+import static io.spine.system.server.given.mirror.RepositoryTestEnv.cause;
 import static io.spine.system.server.given.mirror.RepositoryTestEnv.deleted;
 import static io.spine.system.server.given.mirror.RepositoryTestEnv.entityStateChanged;
 import static io.spine.system.server.given.mirror.RepositoryTestEnv.event;
@@ -262,11 +263,12 @@ class MirrorRepositoryTest {
                     .setEntityId(entityId)
                     .setTypeUrl(type.value())
                     .build();
-            EntityStateChanged event = EntityStateChanged
+            EntityStateChanged event = EntityStateChangedVBuilder
                     .newBuilder()
                     .setId(historyId)
                     .setWhen(getCurrentTime())
                     .setNewState(pack(state))
+                    .addMessageId(cause())
                     .build();
             dispatchEvent(event(event));
         }


### PR DESCRIPTION
This PR ends a number of temporary freedoms in the System context model validation.

`CommandLifecycle` ID is now required and set upon each new event.
Origin message IDs are now required in `EntityHistory` events. Those events describe mutations of an entity. The IDs reference the messages (commands or/and events) which caused those mutations.

Also, this PR fixes a number of typos, including those in the System model.

Fixes #877.
Fixes #755.