### PR TITLE
Close System context

### DIFF
--- a/scripts/assemble-proto.gradle
+++ b/scripts/assemble-proto.gradle
@@ -56,7 +56,7 @@ buildscript {
     }
 }
 
-println "Assembling Protobuf definitions in ${project.name}."
+logger.debug "Assembling Protobuf definitions in ${project.name}."
 
 /**
  * Collects all the directories from current project and its dependencies (including zip tree

--- a/server/src/main/java/io/spine/server/BoundedContextBuilder.java
+++ b/server/src/main/java/io/spine/server/BoundedContextBuilder.java
@@ -308,7 +308,7 @@ public final class BoundedContextBuilder implements Logging {
         TransportFactory transport = transportFactory()
                 .orElseGet(InMemoryTransportFactory::newInstance);
         SystemContext system = buildSystem(transport);
-        BoundedContext result = buildDefault(system, transport);
+        BoundedContext result = buildDomain(system, transport);
         log().debug("{} created.", result.nameForLogging());
 
         registerRepositories(result);
@@ -322,7 +322,7 @@ public final class BoundedContextBuilder implements Logging {
         }
     }
 
-    private BoundedContext buildDefault(SystemContext system, TransportFactory transport) {
+    private BoundedContext buildDomain(SystemContext system, TransportFactory transport) {
         SystemClient systemClient = system.createClient();
         Function<BoundedContextBuilder, DomainContext> instanceFactory =
                 builder -> DomainContext.newInstance(builder, systemClient);

--- a/server/src/main/java/io/spine/system/server/DefaultSystemClient.java
+++ b/server/src/main/java/io/spine/system/server/DefaultSystemClient.java
@@ -58,8 +58,7 @@ final class DefaultSystemClient implements SystemClient {
 
     @Override
     public void closeSystemContext() throws Exception {
-        // TODO:2018-10-18:dmytro.dashenkov: Close system context.
-        // todo            https://github.com/SpineEventEngine/core-java/issues/872
+        context.close();
     }
 
     @VisibleForTesting

--- a/server/src/test/java/io/spine/server/BoundedContextTest.java
+++ b/server/src/test/java/io/spine/server/BoundedContextTest.java
@@ -406,7 +406,6 @@ class BoundedContextTest {
     void noExternalDescendants() {
         assertThrows(
                 IllegalStateException.class,
-
                 () ->
                 new BoundedContext(BoundedContext.newBuilder()) {
                     @SuppressWarnings("ReturnOfNull") // OK for this test dummy.

--- a/server/src/test/java/io/spine/server/BoundedContextTest.java
+++ b/server/src/test/java/io/spine/server/BoundedContextTest.java
@@ -91,10 +91,6 @@ import static org.slf4j.event.Level.DEBUG;
  *     <li>spine/test/bc/command_factory_test.proto — commands
  *     <li>spine/test/bc/events.proto — events.
  * </ul>
- *
- * @author Alexander Litus
- * @author Alexander Yevsyukov
- * @author Dmitry Ganzha
  */
 @SuppressWarnings({"InnerClassMayBeStatic", "ClassCanBeStatic"
         /* JUnit nested classes cannot be static. */,

--- a/server/src/test/java/io/spine/server/bc/given/ProjectReport.java
+++ b/server/src/test/java/io/spine/server/bc/given/ProjectReport.java
@@ -37,7 +37,7 @@ public class ProjectReport
 
     @Subscribe
     @SuppressWarnings("unused")
-    public void on(BcProjectCreated event, EventContext context) {
+    void on(BcProjectCreated event, EventContext context) {
         // Do nothing. We have the method so that there's one event class exposed
         // by the repository.
     }


### PR DESCRIPTION
Currently, System context is not closed upon the domain context `close()`.

This debt was caused by some kind of an error in message delivery. Right now, this error is gone, thus, in this PR, we make System context close when its domain counterpart is closed.

Fixes #872.