### PR TITLE
Make publishing configuration order-agnostic

### DIFF
--- a/.idea/dictionaries/common.xml
+++ b/.idea/dictionaries/common.xml
@@ -18,7 +18,7 @@
       <w>flushables</w>
       <w>googleapis</w>
       <w>gradle</w>
-      <w>grpc</w>                                           
+      <w>grpc</w>
       <w>handshaker</w>
       <w>hohpe</w>
       <w>idempotency</w>
@@ -39,6 +39,7 @@
       <w>onmessage</w>
       <w>onopen</w>
       <w>parameterizing</w>
+      <w>plugable</w>
       <w>processmanager</w>
       <w>procman</w>
       <w>proto's</w>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -381,7 +381,6 @@
     <inspection_tool class="JavadocHtmlLint" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="JavadocReference" enabled="true" level="ERROR" enabled_by_default="true">
       <scope name="Tests" level="ERROR" enabled="false" />
-      <option name="REPORT_INACCESSIBLE" value="false" />
     </inspection_tool>
     <inspection_tool class="LabeledStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="LengthOneStringInIndexOf" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -494,7 +493,6 @@
         <extension name="JUnit4MethodNamingConvention" enabled="true">
           <option name="m_regex" value="[a-z][A-Za-z\d]*" />
           <option name="m_minLength" value="2" />
-          <option name="m_maxLength" value="64" />
         </extension>
       </scope>
       <scope name="Production" level="WARNING" enabled="true">
@@ -644,6 +642,7 @@
       <option name="ignoreCloneable" value="false" />
     </inspection_tool>
     <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="RedundantSuppression" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
@@ -713,6 +712,9 @@
     <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SwitchStatementWithTooFewBranches" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="m_limit" value="2" />
+    </inspection_tool>
     <inspection_tool class="SwitchStatementsWithoutDefault" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreFullyCoveredEnums" value="true" />
     </inspection_tool>

--- a/scripts/assemble-proto.gradle
+++ b/scripts/assemble-proto.gradle
@@ -188,21 +188,30 @@ boolean isProtoFile(final File file) {
     return file.isFile() && file.name.endsWith(".proto")
 }
 
-final String artifactIdForPublishing = "spine-${project.name}"
-publishing {
-    publications {
-        mavenProto(MavenPublication) {
-            groupId = "${group}"
-            artifactId = "${artifactIdForPublishing}"
-            version = "${version}"
+def configurePublishing() {
+    project.publishing {
+        publications {
+            mavenProto(MavenPublication) {
+                final String artifactIdForPublishing = "spine-${project.name}"
+                
+                groupId = "${project.group}"
+                artifactId = "${artifactIdForPublishing}"
+                version = "${project.version}"
 
-            from components.java
+                from project.components.java
 
-            artifact assembleProto {
-                classifier = "proto"
+                artifact assembleProto {
+                    classifier = "proto"
+                }
             }
         }
     }
+}
+
+if (project.plugins.hasPlugin('maven-publish')) {
+    configurePublishing()
+} else {
+    project.pluginManager.withPlugin('maven-publish') { configurePublishing() }
 }
 
 /**


### PR DESCRIPTION
Gradle project configuration process is complex. The details of the process, such as the order of script execution, may differ from an environment to an environment and from a computer to a computer.

In some environments, the script `assemble-proto.gradle` is executed before the `publishing.gradle`. In others, vice versa.

This PR addresses the build crash which occurred when the `maven-publish` plugin was not yet applied to the project when the `assemble-proto.gradle` was run. In this case, the `publishing` configuration block could not be resolved.