### PR TITLE
Cleanup `todo` items and migrate to the new dependencies

### DIFF
--- a/client/src/main/proto/spine/client/query.proto
+++ b/client/src/main/proto/spine/client/query.proto
@@ -169,7 +169,6 @@ message QueryResponse {
 //
 message EntityStateWithVersion {
 
-    //TODO:2017-02-20:alexander.yevsyukov: Use EntityRecord instead of Any.
     // The state of the entity packed as `Any`.
     //
     google.protobuf.Any state = 1;

--- a/server/src/test/proto/spine/test/model/contexts/orders/order.proto
+++ b/server/src/test/proto/spine/test/model/contexts/orders/order.proto
@@ -37,8 +37,10 @@ message Order {
     repeated Item item = 3;
 }
 
-//TODO:2018-12-24:alexander.yevsyukov: Move this message back under the Order once generation of
+// This message has to be moved back under the Order once generation of
 // Validating Builders for nested messages is suppported.
+//
+// See https://github.com/SpineEventEngine/base/issues/364.
 message Item {
     string name = 1 [(required) = true];
     string description = 2;

--- a/server/src/test/proto/spine/test/model/contexts/orders/order.proto
+++ b/server/src/test/proto/spine/test/model/contexts/orders/order.proto
@@ -38,7 +38,7 @@ message Order {
 }
 
 // This message has to be moved back under the Order once generation of
-// Validating Builders for nested messages is suppported.
+// Validating Builders for nested messages is supported.
 //
 // See https://github.com/SpineEventEngine/base/issues/364.
 message Item {


### PR DESCRIPTION
This PR removes the outdated `todo` items, removing some of them and replacing the rest with the links to the respective issues.

Also, the new [common dependencies](https://github.com/SpineEventEngine/config/pull/49) are used.