### PR TITLE
Enable Model Compiler defaults

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,3 +1,0 @@
----
-exclude_paths:
-  - "**/src/test/**/*.*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ script:
 after_success:
   # See: https://github.com/codecov/example-java/blob/master/.travis.yml
   - bash <(curl -s https://codecov.io/bash)
-  - chmod +x ./scripts/report-coverage.sh
-  - ./scripts/report-coverage.sh
   - |
     if [[ $TRAVIS_BRANCH == master ]] && [[ $TRAVIS_PULL_REQUEST == false ]]; then
       chmod +x ./scripts/dependent-repositories/update-dependent-repositories.sh

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ ext {
 
     credentialsPropertyFile = 'credentials.properties'
     publishPlugin = "$rootDir/config/gradle/publish.gradle"
+    modelCompilerConfiguration = "$rootDir/config/gradle/model-compiler.gradle"
     projectsToPublish = ["core",
                          "client",
                          "server",
@@ -117,6 +118,7 @@ subprojects {
     apply plugin: spineProtobufPluginId
 
     apply from: deps.scripts.javacArgs
+    apply from: modelCompilerConfiguration
 
     // Specific setup for a Travis build,
     // which prevents appearing of warning messages in build logs.

--- a/client/src/main/java/io/spine/client/CommandFactory.java
+++ b/client/src/main/java/io/spine/client/CommandFactory.java
@@ -168,13 +168,15 @@ public final class CommandFactory {
      * Creates a copy of the passed {@code CommandContext} updated with the current time.
      */
     private static CommandContext withCurrentTime(CommandContext value) {
-        ActorContext.Builder withCurrentTime =
+        ActorContext withCurrentTime =
                 value.getActorContext()
-                     .toBuilder()
-                     .setTimestamp(currentTime());
-        CommandContext.Builder result =
-                value.toBuilder()
-                     .setActorContext(withCurrentTime);
-        return result.build();
+                     .toVBuilder()
+                     .setTimestamp(currentTime())
+                     .build();
+        CommandContext result =
+                value.toVBuilder()
+                     .setActorContext(withCurrentTime)
+                     .build();
+        return result;
     }
 }

--- a/client/src/main/java/io/spine/client/Queries.java
+++ b/client/src/main/java/io/spine/client/Queries.java
@@ -53,7 +53,7 @@ public final class Queries {
 
     public static QueryId generateId() {
         String formattedId = format(QUERY_ID_FORMAT, Identifier.newUuid());
-        return QueryId.newBuilder()
+        return QueryId.vBuilder()
                       .setValue(formattedId)
                       .build();
     }

--- a/client/src/main/java/io/spine/client/QueryBuilder.java
+++ b/client/src/main/java/io/spine/client/QueryBuilder.java
@@ -139,9 +139,9 @@ public final class QueryBuilder extends AbstractTargetBuilder<Query, QueryBuilde
         if (limit == 0) {
             return Optional.empty();
         }
-        Pagination result = PaginationVBuilder.newBuilder()
-                                              .setPageSize(limit)
-                                              .build();
+        Pagination result = Pagination.vBuilder()
+                                      .setPageSize(limit)
+                                      .build();
         return Optional.of(result);
     }
 
@@ -149,10 +149,10 @@ public final class QueryBuilder extends AbstractTargetBuilder<Query, QueryBuilde
         if (orderingColumn == null) {
             return Optional.empty();
         }
-        OrderBy result = OrderByVBuilder.newBuilder()
-                                        .setColumn(orderingColumn)
-                                        .setDirection(direction)
-                                        .build();
+        OrderBy result = OrderBy.vBuilder()
+                                .setColumn(orderingColumn)
+                                .setDirection(direction)
+                                .build();
         return Optional.of(result);
     }
 

--- a/client/src/main/java/io/spine/client/Targets.java
+++ b/client/src/main/java/io/spine/client/Targets.java
@@ -104,8 +104,8 @@ public final class Targets {
         boolean includeAll = (ids == null && filters == null);
 
         TypeUrl typeUrl = TypeUrl.of(targetClass);
-        TargetVBuilder builder = TargetVBuilder.newBuilder()
-                                               .setType(typeUrl.value());
+        TargetVBuilder builder = Target.vBuilder()
+                                       .setType(typeUrl.value());
         if (includeAll) {
             builder.setIncludeAll(true);
         } else {
@@ -132,9 +132,9 @@ public final class Targets {
     }
 
     private static IdFilter idFilter(List<Any> ids) {
-        return IdFilterVBuilder.newBuilder()
-                               .addAllIds(ids)
-                               .build();
+        return IdFilter.vBuilder()
+                       .addAllIds(ids)
+                       .build();
     }
 
     /**
@@ -154,10 +154,10 @@ public final class Targets {
     }
 
     private static TargetFilters targetFilters(List<CompositeFilter> filters, IdFilter idFilter) {
-        return TargetFiltersVBuilder.newBuilder()
-                                    .setIdFilter(idFilter)
-                                    .addAllFilter(filters)
-                                    .build();
+        return TargetFilters.vBuilder()
+                            .setIdFilter(idFilter)
+                            .addAllFilter(filters)
+                            .build();
     }
 
     /**

--- a/core/src/main/java/io/spine/core/Events.java
+++ b/core/src/main/java/io/spine/core/Events.java
@@ -88,7 +88,8 @@ public final class Events {
     /**
      * Sorts the given event record list by the event timestamps.
      *
-     * @param events the event record list to sort
+     * @param events
+     *         the event record list to sort
      */
     public static void sort(List<Event> events) {
         checkNotNull(events);
@@ -116,7 +117,8 @@ public final class Events {
     /**
      * Extracts the event message from the passed event.
      *
-     * @param event an event to get message from
+     * @param event
+     *         an event to get message from
      */
     public static EventMessage getMessage(Event event) {
         checkNotNull(event);
@@ -129,7 +131,7 @@ public final class Events {
      * Extract event messages from the passed events.
      */
     public static List<? extends EventMessage> toMessages(List<Event> events) {
-       checkNotNull(events);
+        checkNotNull(events);
         List<EventMessage> result =
                 events.stream()
                       .map(Events::getMessage)
@@ -177,7 +179,8 @@ public final class Events {
     /**
      * Obtains event producer ID from the passed {@code EventContext}.
      *
-     * @param context the event context to to get the event producer ID
+     * @param context
+     *         the event context to to get the event producer ID
      * @return the producer ID
      */
     public static Object getProducer(EventContext context) {
@@ -187,11 +190,12 @@ public final class Events {
 
     /**
      * Obtains the ID of the root command, which lead to this event.
-     * 
-     * <p> In case the passed {@code Event} instance is a reaction to another {@code Event}, 
+     *
+     * <p> In case the passed {@code Event} instance is a reaction to another {@code Event},
      * the identifier of the very first command in this chain is returned.
      *
-     * @param event the event to get the root command ID for
+     * @param event
+     *         the event to get the root command ID for
      * @return the root command ID
      */
     public static CommandId getRootCommandId(Event event) {
@@ -211,8 +215,10 @@ public final class Events {
     /**
      * Ensures that the passed ID is valid.
      *
-     * @param id an ID to check
-     * @throws IllegalArgumentException if the ID string value is empty or blank
+     * @param id
+     *         an ID to check
+     * @throws IllegalArgumentException
+     *         if the ID string value is empty or blank
      */
     public static EventId checkValid(EventId id) {
         checkNotNull(id);
@@ -223,14 +229,14 @@ public final class Events {
     /**
      * Checks whether or not the given event is a rejection event.
      *
-     * @param event the event to check
+     * @param event
+     *         the event to check
      * @return {@code true} if the given event is a rejection, {@code false} otherwise
      */
     public static boolean isRejection(Event event) {
         checkNotNull(event);
         EventContext context = event.getContext();
-        boolean result = context.hasRejection()
-                      || !isDefault(context.getRejection());
+        boolean result = context.hasRejection() || !isDefault(context.getRejection());
         return result;
     }
 
@@ -238,8 +244,10 @@ public final class Events {
      * Constructs a new {@link RejectionEventContext} from the given command message and
      * {@link ThrowableMessage}.
      *
-     * @param commandMessage   rejected command
-     * @param throwableMessage thrown rejection
+     * @param commandMessage
+     *         rejected command
+     * @param throwableMessage
+     *         thrown rejection
      * @return new instance of {@code RejectionEventContext}
      */
     public static RejectionEventContext rejectionContext(CommandMessage commandMessage,
@@ -293,7 +301,8 @@ public final class Events {
      *
      * <p>This method is useful for returning empty result from reacting methods.
      *
-     * @param <M> the type of messages
+     * @param <M>
+     *         the type of messages
      * @return empty {@link Iterable}
      */
     public static <M extends EventMessage> Iterable<M> nothing() {
@@ -304,7 +313,8 @@ public final class Events {
      * Analyzes the event context and determines if the event has been produced outside
      * of the current {@code BoundedContext}.
      *
-     * @param context the context of event
+     * @param context
+     *         the context of event
      * @return {@code true} if the event is external, {@code false} otherwise
      */
     @Internal
@@ -327,23 +337,25 @@ public final class Events {
      * <p>Enrichments will not be removed from second-level and deeper origins,
      * because it's a heavy performance operation.
      *
-     * @param event the event to clear enrichments
+     * @param event
+     *         the event to clear enrichments
      * @return the event without enrichments
      */
     @SuppressWarnings("CheckReturnValue") // calling builder
     @Internal
     public static Event clearEnrichments(Event event) {
         EventContext context = event.getContext();
-        EventContext.Builder resultContext = context.toBuilder()
-                                                          .clearEnrichment();
-        EventContext.OriginCase originCase = resultContext.getOriginCase();
+        EventContext.OriginCase originCase = context.getOriginCase();
+        EventContextVBuilder resultContext = context.toVBuilder()
+                                                    .clearEnrichment();
         if (originCase == EVENT_CONTEXT) {
             resultContext.setEventContext(context.getEventContext()
-                                                 .toBuilder()
-                                                 .clearEnrichment());
+                                                 .toVBuilder()
+                                                 .clearEnrichment()
+                                                 .build());
         }
-        Event result = event.toBuilder()
-                            .setContext(resultContext)
+        Event result = event.toVBuilder()
+                            .setContext(resultContext.build())
                             .build();
         return result;
     }
@@ -351,17 +363,19 @@ public final class Events {
     /**
      * Replaces the event version with the given {@code newVersion}.
      *
-     * @param event      original event
-     * @param newVersion the version to set
+     * @param event
+     *         original event
+     * @param newVersion
+     *         the version to set
      * @return the copy of the original event but with the new version
      */
     @Internal
     public static Event substituteVersion(Event event, Version newVersion) {
         EventContext newContext = event.getContext()
-                                       .toBuilder()
+                                       .toVBuilder()
                                        .setVersion(newVersion)
                                        .build();
-        Event result = event.toBuilder()
+        Event result = event.toVBuilder()
                             .setContext(newContext)
                             .build();
         return result;
@@ -393,9 +407,9 @@ public final class Events {
      * <p>The context is obtained by traversing the events origin for a valid context source.
      * There can be three sources for the actor context:
      * <ol>
-     *     <li>The command context set as the event origin.
-     *     <li>The command context of an event which is an origin of this event.
-     *     <li>The import context if the event is imported to an aggregate.
+     * <li>The command context set as the event origin.
+     * <li>The command context of an event which is an origin of this event.
+     * <li>The import context if the event is imported to an aggregate.
      * </ol>
      *
      * <p>If at some point the event origin is not set, an {@link IllegalArgumentException} is

--- a/core/src/main/java/io/spine/core/Events.java
+++ b/core/src/main/java/io/spine/core/Events.java
@@ -97,8 +97,7 @@ public final class Events {
     }
 
     /**
-     * Returns comparator which compares events by their timestamp
-     * in chronological order.
+     * Returns comparator which compares events by their timestamp in chronological order.
      */
     public static Comparator<Event> eventComparator() {
         return eventComparator;
@@ -407,9 +406,9 @@ public final class Events {
      * <p>The context is obtained by traversing the events origin for a valid context source.
      * There can be three sources for the actor context:
      * <ol>
-     * <li>The command context set as the event origin.
-     * <li>The command context of an event which is an origin of this event.
-     * <li>The import context if the event is imported to an aggregate.
+     *     <li>The command context set as the event origin.
+     *     <li>The command context of an event which is an origin of this event.
+     *     <li>The import context if the event is imported to an aggregate.
      * </ol>
      *
      * <p>If at some point the event origin is not set, an {@link IllegalArgumentException} is

--- a/core/src/main/proto/spine/core/event.proto
+++ b/core/src/main/proto/spine/core/event.proto
@@ -119,7 +119,7 @@ message EventContext {
     google.protobuf.Any producer_id = 3 [(required) = true];
 
     // The version of the entity after the event was applied.
-    Version version = 4 [(required) = true];
+    Version version = 4 [(valid) = true];
 
     // Optional enrichment of the event.
     Enrichment enrichment = 5;
@@ -134,7 +134,7 @@ message EventContext {
     //
     RejectionEventContext rejection = 10;
 
-    // An ID of the origin messsage.
+    // An ID of the origin message.
     //
     // The case of this `oneof` is always the same as the case of `origin` (except for
     // the `import_context`, which does not have a corresponding field in `origin_id`).

--- a/core/src/main/proto/spine/core/event.proto
+++ b/core/src/main/proto/spine/core/event.proto
@@ -87,19 +87,20 @@ message Event {
 // Meta-information for an event.
 message EventContext {
     option (is).java_type = "io.spine.core.EnrichableMessageContext";
+    option (required_field) = "command_context | event_context | import_context";
 
     // When the event occurred.
     google.protobuf.Timestamp timestamp = 1 [(required) = true];
 
     oneof origin {
         // The context of the command which generated this event.
-        CommandContext command_context = 2 [(required) = true];
+        CommandContext command_context = 2 [(valid) = true];
 
         // The context of the event which generated this event.
-        EventContext event_context = 6 [(required) = true];
+        EventContext event_context = 6 [(valid) = true];
 
         // The event was imported using this `ActorContext`.
-        ActorContext import_context = 11 [(required) = true];
+        ActorContext import_context = 11 [(valid) = true];
     }
 
     // An ID of the root command, which lead to this event.

--- a/model/model-verifier/src/test/resources/build.gradle
+++ b/model/model-verifier/src/test/resources/build.gradle
@@ -82,6 +82,7 @@ apply plugin: 'io.spine.tools.spine-model-verifier'
 
 // NOTE: this file is copied from the root project in the test setup.
 apply from: "$enclosingRootDir/version.gradle"
+apply from: "$enclosingRootDir/config/gradle/model-compiler.gradle"
 
 repositories {
     mavenLocal()

--- a/server/src/main/java/io/spine/server/commandbus/CommandScheduler.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandScheduler.java
@@ -97,8 +97,10 @@ public abstract class CommandScheduler implements BusFilter<CommandEnvelope> {
      *
      * <p>A command with the same ID cannot be scheduled again.
      *
-     * @param command a command to deliver later
-     * @throws IllegalStateException if the scheduler is shut down
+     * @param command
+     *         a command to deliver later
+     * @throws IllegalStateException
+     *         if the scheduler is shut down
      */
     public void schedule(Command command) {
         checkState(isActive, "Scheduler is shut down.");
@@ -116,8 +118,9 @@ public abstract class CommandScheduler implements BusFilter<CommandEnvelope> {
     /**
      * Obtains {@code CommandBus} associated with this scheduler.
      *
-     * @throws IllegalStateException if {@code CommandBus} was not
-     * {@linkplain #setCommandBus(CommandBus) set} prior to calling this method
+     * @throws IllegalStateException
+     *         if {@code CommandBus} was not {@linkplain #setCommandBus(CommandBus) set} prior
+     *         to calling this method
      */
     protected CommandBus commandBus() {
         checkState(commandBus != null, "CommandBus is not set.");
@@ -133,7 +136,8 @@ public abstract class CommandScheduler implements BusFilter<CommandEnvelope> {
      * Schedules a command and delivers it to the target according to
      * the scheduling options set to a context.
      *
-     * @param command a command to deliver later
+     * @param command
+     *         a command to deliver later
      * @see #post(Command)
      */
     protected abstract void doSchedule(Command command);
@@ -141,7 +145,8 @@ public abstract class CommandScheduler implements BusFilter<CommandEnvelope> {
     /**
      * Delivers a scheduled command to a target.
      *
-     * @param command a command to deliver
+     * @param command
+     *         a command to deliver
      */
     protected void post(Command command) {
         commandBus().postPreviouslyScheduled(command);
@@ -172,8 +177,10 @@ public abstract class CommandScheduler implements BusFilter<CommandEnvelope> {
      * Sets a new scheduling time in the {@linkplain CommandContext.Schedule context}
      * of the passed command.
      *
-     * @param command        a command to update
-     * @param schedulingTime the time when the command was scheduled by the {@code CommandScheduler}
+     * @param command
+     *         a command to update
+     * @param schedulingTime
+     *         the time when the command was scheduled by the {@code CommandScheduler}
      * @return an updated command
      */
     static Command setSchedulingTime(Command command, Timestamp schedulingTime) {
@@ -190,9 +197,12 @@ public abstract class CommandScheduler implements BusFilter<CommandEnvelope> {
     /**
      * Updates {@linkplain CommandContext.Schedule command schedule}.
      *
-     * @param command        a command to update
-     * @param delay          a {@linkplain CommandContext.Schedule#getDelay() delay} to set
-     * @param schedulingTime the time when the command was scheduled by the {@code CommandScheduler}
+     * @param command
+     *         a command to update
+     * @param delay
+     *         a {@linkplain CommandContext.Schedule#getDelay() delay} to set
+     * @param schedulingTime
+     *         the time when the command was scheduled by the {@code CommandScheduler}
      * @return an updated command
      */
     static Command setSchedule(Command command, Duration delay, Timestamp schedulingTime) {
@@ -203,18 +213,18 @@ public abstract class CommandScheduler implements BusFilter<CommandEnvelope> {
 
         CommandContext context = command.getContext();
         CommandContext.Schedule scheduleUpdated = context.getSchedule()
-                                                         .toBuilder()
+                                                         .toVBuilder()
                                                          .setDelay(delay)
                                                          .build();
-        CommandContext contextUpdated = context.toBuilder()
+        CommandContext contextUpdated = context.toVBuilder()
                                                .setSchedule(scheduleUpdated)
                                                .build();
 
         Command.SystemProperties sysProps = command.getSystemProperties()
-                                                   .toBuilder()
+                                                   .toVBuilder()
                                                    .setSchedulingTime(schedulingTime)
                                                    .build();
-        Command result = command.toBuilder()
+        Command result = command.toVBuilder()
                                 .setContext(contextUpdated)
                                 .setSystemProperties(sysProps)
                                 .build();

--- a/server/src/main/java/io/spine/server/entity/AbstractEntity.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractEntity.java
@@ -328,7 +328,7 @@ public abstract class AbstractEntity<I, S extends Message> implements Entity<I, 
      * Sets {@code archived} status flag to the passed value.
      */
     protected void setArchived(boolean archived) {
-        setLifecycleFlags(lifecycleFlags().toBuilder()
+        setLifecycleFlags(lifecycleFlags().toVBuilder()
                                           .setArchived(archived)
                                           .build());
     }
@@ -347,7 +347,7 @@ public abstract class AbstractEntity<I, S extends Message> implements Entity<I, 
      * Sets {@code deleted} status flag to the passed value.
      */
     protected void setDeleted(boolean deleted) {
-        setLifecycleFlags(lifecycleFlags().toBuilder()
+        setLifecycleFlags(lifecycleFlags().toVBuilder()
                                           .setDeleted(deleted)
                                           .build());
     }

--- a/server/src/main/java/io/spine/server/entity/EntityLifecycle.java
+++ b/server/src/main/java/io/spine/server/entity/EntityLifecycle.java
@@ -402,7 +402,7 @@ public class EntityLifecycle {
     @SuppressWarnings("ChainOfInstanceofChecks")
     private static DispatchedMessageId dispatchedMessageId(MessageId messageId) {
         checkNotNull(messageId);
-        DispatchedMessageIdVBuilder builder = DispatchedMessageIdVBuilder.newBuilder();
+        DispatchedMessageIdVBuilder builder = DispatchedMessageId.vBuilder();
         if (messageId instanceof EventId) {
             EventId eventId = (EventId) messageId;
             return builder.setEventId(eventId)

--- a/server/src/main/java/io/spine/server/entity/EventFieldFilter.java
+++ b/server/src/main/java/io/spine/server/entity/EventFieldFilter.java
@@ -73,7 +73,7 @@ public final class EventFieldFilter implements EventFilter {
     private Event maskEvent(Event event) {
         EventMessage message = Events.getMessage(event);
         EventMessage masked = mask(message);
-        return event.toBuilder()
+        return event.toVBuilder()
                     .setMessage(pack(masked))
                     .build();
     }

--- a/server/src/main/java/io/spine/server/entity/EventFilter.java
+++ b/server/src/main/java/io/spine/server/entity/EventFilter.java
@@ -38,8 +38,8 @@ import static io.spine.protobuf.AnyPacker.pack;
  * <p>A filter may {@linkplain #allowAll() allow any event}, reject certain types of events, or
  * change the event content.
  *
- * @apiNote This type is a {@link FunctionalInterface}, so that an event filter may be defined
- *          with a lambda expression.
+ * @apiNote This type is a {@link FunctionalInterface}, so that an event filter may be
+ *         defined with a lambda expression.
  */
 @SPI
 @FunctionalInterface
@@ -69,8 +69,8 @@ public interface EventFilter {
      * @param event
      *         the event to apply the filter to
      * @return processed event or {@link Optional#empty()} if the event should not be posted
-     * @apiNote This method may never return a present value or return a value not derived from
-     *          the input event. See the implementations for the details for each case.
+     * @apiNote This method may never return a present value or return a value not derived
+     *         from the input event. See the implementations for the details for each case.
      */
     Optional<? extends EventMessage> filter(EventMessage event);
 
@@ -81,7 +81,7 @@ public interface EventFilter {
      *         the events to apply the filter to
      * @return non-empty filtering results for the given events
      * @apiNote This method should have the same behaviour in any descendant.
-     *          Override this method <b>only</b> for performance improvement.
+     *         Override this method <b>only</b> for performance improvement.
      */
     default ImmutableCollection<Event> filter(Collection<Event> events) {
         ImmutableCollection<Event> filteredEvents = events
@@ -89,7 +89,7 @@ public interface EventFilter {
                 .map(event -> {
                     EventMessage eventMessage = getMessage(event);
                     Optional<? extends EventMessage> filtered = filter(eventMessage);
-                    Optional<Event> result = filtered.map(message -> event.toBuilder()
+                    Optional<Event> result = filtered.map(message -> event.toVBuilder()
                                                                           .setMessage(pack(message))
                                                                           .build());
                     return result;

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -71,9 +71,9 @@ import static java.lang.String.format;
 @SuppressWarnings("ClassWithTooManyMethods")
 @Internal
 public abstract class Transaction<I,
-                                  E extends TransactionalEntity<I, S, B>,
-                                  S extends Message,
-                                  B extends ValidatingBuilder<S, ? extends Message.Builder>> {
+        E extends TransactionalEntity<I, S, B>,
+        S extends Message,
+        B extends ValidatingBuilder<S, ? extends Message.Builder>> {
 
     /**
      * The entity, which state and attributes are modified in this transaction.
@@ -287,7 +287,7 @@ public abstract class Transaction<I,
 
             throw invalidStateException;
         } catch (@SuppressWarnings("OverlyBroadCatchBlock") // Catch all unexpected exceptions.
-                 RuntimeException genericException) {
+                RuntimeException genericException) {
             rollback(genericException);
             throw illegalStateWithCauseOf(genericException);
         } finally {
@@ -304,7 +304,7 @@ public abstract class Transaction<I,
         S unchanged = entity().state();
         Version pendingVersion = version();
         beforeCommit(unchanged, pendingVersion);
-        if(!pendingVersion.equals(entity.version())) {
+        if (!pendingVersion.equals(entity.version())) {
             entity.updateState(unchanged, pendingVersion);
         }
         commitAttributeChanges();
@@ -380,7 +380,7 @@ public abstract class Transaction<I,
 
     private S currentBuilderState() {
         @SuppressWarnings("unchecked")  // OK, as `AbstractValidatingBuilder` is the only subclass.
-        AbstractValidatingBuilder<S, ?> abstractBuilder = (AbstractValidatingBuilder<S, ?>) builder;
+                AbstractValidatingBuilder<S, ?> abstractBuilder = (AbstractValidatingBuilder<S, ?>) builder;
         return abstractBuilder.internalBuild();
     }
 
@@ -454,8 +454,8 @@ public abstract class Transaction<I,
 
         int versionNumber = this.version.getNumber();
         if (versionNumber > 0) {
-            String errMsg =
-                    format("initVersion() called on an entity with non-zero version number (%d).",
+            String errMsg = format(
+                    "initVersion() called on an entity with non-zero version number (%d).",
                     versionNumber
             );
             throw new IllegalStateException(errMsg);
@@ -486,13 +486,13 @@ public abstract class Transaction<I,
     }
 
     public void setArchived(boolean archived) {
-        lifecycleFlags = lifecycleFlags.toBuilder()
+        lifecycleFlags = lifecycleFlags.toVBuilder()
                                        .setArchived(archived)
                                        .build();
     }
 
     public void setDeleted(boolean deleted) {
-        lifecycleFlags = lifecycleFlags.toBuilder()
+        lifecycleFlags = lifecycleFlags.toVBuilder()
                                        .setDeleted(deleted)
                                        .build();
     }

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -380,7 +380,7 @@ public abstract class Transaction<I,
 
     private S currentBuilderState() {
         @SuppressWarnings("unchecked")  // OK, as `AbstractValidatingBuilder` is the only subclass.
-                AbstractValidatingBuilder<S, ?> abstractBuilder = (AbstractValidatingBuilder<S, ?>) builder;
+        AbstractValidatingBuilder<S, ?> abstractBuilder = (AbstractValidatingBuilder<S, ?>) builder;
         return abstractBuilder.internalBuild();
     }
 

--- a/server/src/main/java/io/spine/server/event/EventFactory.java
+++ b/server/src/main/java/io/spine/server/event/EventFactory.java
@@ -161,7 +161,7 @@ public class EventFactory {
         checkNotNull(context);
         Any packed = pack(message);
         Event result = Event
-                .newBuilder()
+                .vBuilder()
                 .setId(id)
                 .setMessage(packed)
                 .setContext(context)

--- a/server/src/main/java/io/spine/server/event/RejectionEnvelope.java
+++ b/server/src/main/java/io/spine/server/event/RejectionEnvelope.java
@@ -181,7 +181,7 @@ public final class RejectionEnvelope
         Any commandMessage = rejectionContext.getCommandMessage();
         CommandContext commandContext = context.getCommandContext();
         DispatchedCommand result = DispatchedCommand
-                .newBuilder()
+                .vBuilder()
                 .setMessage(commandMessage)
                 .setContext(commandContext)
                 .build();

--- a/server/src/main/java/io/spine/server/event/model/EntitySubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/EntitySubscriberMethod.java
@@ -83,7 +83,7 @@ public final class EntitySubscriberMethod extends SubscriberMethod implements Lo
     @Override
     public MessageFilter filter() {
         return MessageFilter
-                .newBuilder()
+                .vBuilder()
                 .setField(TYPE_URL_PATH)
                 .setValue(typeUrlAsAny)
                 .build();

--- a/server/src/main/java/io/spine/server/event/model/EventSubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/EventSubscriberMethod.java
@@ -58,7 +58,7 @@ public final class EventSubscriberMethod extends SubscriberMethod {
         Object expectedValue = fromString(byFieldFilter.value(), fieldType);
         Any packedValue = toAny(expectedValue);
         MessageFilter messageFilter = MessageFilter
-                .newBuilder()
+                .vBuilder()
                 .setField(fieldPath)
                 .setValue(packedValue)
                 .build();

--- a/server/src/main/java/io/spine/server/event/model/SubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/SubscriberMethod.java
@@ -70,7 +70,7 @@ public abstract class SubscriberMethod extends AbstractHandlerMethod<EventSubscr
         FieldPath fieldPath = filter.getField();
         return fieldPath.getFieldNameList().isEmpty()
                ? typeBasedToken
-               : typeBasedToken.toBuilder()
+               : typeBasedToken.toVBuilder()
                                .setFilter(filter)
                                .build();
     }

--- a/server/src/main/java/io/spine/server/event/store/QueryToFilters.java
+++ b/server/src/main/java/io/spine/server/event/store/QueryToFilters.java
@@ -22,8 +22,10 @@ package io.spine.server.event.store;
 
 import com.google.protobuf.Timestamp;
 import io.spine.client.CompositeFilter;
+import io.spine.client.CompositeFilterVBuilder;
 import io.spine.client.Filter;
 import io.spine.client.TargetFilters;
+import io.spine.client.TargetFiltersVBuilder;
 import io.spine.server.event.EventFilter;
 import io.spine.server.event.EventStreamQuery;
 
@@ -43,7 +45,7 @@ import static io.spine.client.Filters.lt;
 final class QueryToFilters {
 
     private final EventStreamQuery query;
-    private final TargetFilters.Builder builder;
+    private final TargetFiltersVBuilder builder;
 
     /**
      * Creates an instance of {@link TargetFilters} from the given {@link EventStreamQuery}.
@@ -63,7 +65,7 @@ final class QueryToFilters {
 
     private QueryToFilters(EventStreamQuery query) {
         this.query = query;
-        this.builder = TargetFilters.newBuilder();
+        this.builder = TargetFilters.vBuilder();
     }
 
     private TargetFilters convert() {
@@ -74,8 +76,8 @@ final class QueryToFilters {
 
     @SuppressWarnings("CheckReturnValue") // calling builder
     private void addTimeFilter() {
-        CompositeFilter.Builder timeFilter = CompositeFilter
-                .newBuilder()
+        CompositeFilterVBuilder timeFilter = CompositeFilter
+                .vBuilder()
                 .setOperator(ALL);
         String createdColumn = ColumnName.created.name();
         if (query.hasAfter()) {
@@ -93,8 +95,8 @@ final class QueryToFilters {
 
     @SuppressWarnings("CheckReturnValue") // calling builder
     private void addTypeFilter() {
-        CompositeFilter.Builder typeFilter = CompositeFilter
-                .newBuilder()
+        CompositeFilterVBuilder typeFilter = CompositeFilter
+                .vBuilder()
                 .setOperator(EITHER);
         String typeColumn = ColumnName.type.name();
         for (EventFilter eventFilter : query.getFilterList()) {
@@ -109,8 +111,8 @@ final class QueryToFilters {
     }
 
     @SuppressWarnings("CheckReturnValue") // calling builder
-    private void add(CompositeFilter.Builder filter) {
-        boolean filterIsEmpty = filter.getFilterList()
+    private void add(CompositeFilterVBuilder filter) {
+        boolean filterIsEmpty = filter.getFilter()
                                       .isEmpty();
         if (!filterIsEmpty) {
             builder.addFilter(filter.build());

--- a/server/src/main/java/io/spine/server/integration/EventBusAdapter.java
+++ b/server/src/main/java/io/spine/server/integration/EventBusAdapter.java
@@ -25,6 +25,7 @@ import io.spine.base.EventMessage;
 import io.spine.core.BoundedContextName;
 import io.spine.core.Event;
 import io.spine.core.EventContext;
+import io.spine.core.EventVBuilder;
 import io.spine.server.event.EventBus;
 import io.spine.server.event.EventDispatcher;
 import io.spine.server.type.EventClass;
@@ -61,9 +62,9 @@ final class EventBusAdapter extends BusAdapter<EventEnvelope, EventDispatcher<?>
     ExternalMessageEnvelope markExternal(ExternalMessage externalMsg) {
         Any packedEvent = externalMsg.getOriginalMessage();
         Event event = unpack(packedEvent, Event.class);
-        Event.Builder eventBuilder = event.toBuilder();
+        EventVBuilder eventBuilder = event.toVBuilder();
         EventContext modifiedContext = eventBuilder.getContext()
-                                                   .toBuilder()
+                                                   .toVBuilder()
                                                    .setExternal(true)
                                                    .build();
 

--- a/server/src/main/java/io/spine/server/model/MessageHandlerMap.java
+++ b/server/src/main/java/io/spine/server/model/MessageHandlerMap.java
@@ -53,8 +53,8 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
  */
 @Immutable(containerOf = {"M", "H"})
 public final class MessageHandlerMap<M extends MessageClass<?>,
-                                     P extends MessageClass<?>,
-                                     H extends HandlerMethod<?, M, ?, P, ?>>
+        P extends MessageClass<?>,
+        H extends HandlerMethod<?, M, ?, P, ?>>
         implements Serializable {
 
     private static final long serialVersionUID = 0L;
@@ -79,8 +79,8 @@ public final class MessageHandlerMap<M extends MessageClass<?>,
      *         signature
      */
     public static <M extends MessageClass<?>,
-                   P extends MessageClass<?>,
-                   H extends HandlerMethod<?, M, ?, P, ?>>
+            P extends MessageClass<?>,
+            H extends HandlerMethod<?, M, ?, P, ?>>
     MessageHandlerMap<M, P, H> create(Class<?> declaringClass, MethodSignature<H, ?> signature) {
         checkNotNull(declaringClass);
         checkNotNull(signature);
@@ -167,10 +167,10 @@ public final class MessageHandlerMap<M extends MessageClass<?>,
                 .setOriginType(typeUrl(originClass).value())
                 .build();
         HandlerTypeInfo presentKey = map.containsKey(keyWithOrigin)
-                                 ? keyWithOrigin
-                                 : keyWithOrigin.toBuilder()
-                                                .clearOriginType()
-                                                .build();
+                                     ? keyWithOrigin
+                                     : keyWithOrigin.toVBuilder()
+                                                    .clearOriginType()
+                                                    .build();
         return getMethods(presentKey);
     }
 
@@ -213,7 +213,8 @@ public final class MessageHandlerMap<M extends MessageClass<?>,
      * <p>If there is no such method or several such methods, an {@link IllegalStateException} is
      * thrown.
      *
-     * @param messageClass the message class of the handled message
+     * @param messageClass
+     *         the message class of the handled message
      * @return a handler method
      * @throws IllegalStateException
      *         if there is no such method or several such methods found in the map

--- a/server/src/main/java/io/spine/server/storage/RecordStorage.java
+++ b/server/src/main/java/io/spine/server/storage/RecordStorage.java
@@ -54,7 +54,8 @@ import static io.spine.util.Exceptions.newIllegalStateException;
 /**
  * A storage keeping messages with identity.
  *
- * @param <I> the type of entity IDs
+ * @param <I>
+ *         the type of entity IDs
  */
 public abstract class RecordStorage<I>
         extends AbstractStorage<I, EntityRecord, RecordReadRequest<I>>
@@ -65,6 +66,7 @@ public abstract class RecordStorage<I>
      * The cache for entity columns.
      *
      * <p>Is {@code null} for instances that do not support entity columns.
+     *
      * @see RecordStorage(boolean)
      */
     private final @MonotonicNonNull EntityColumnCache entityColumnCache;
@@ -96,7 +98,8 @@ public abstract class RecordStorage<I>
     /**
      * Reads a record, which matches the specified {@linkplain RecordReadRequest request}.
      *
-     * @param  request the request to read the record
+     * @param request
+     *         the request to read the record
      * @return a record instance or {@code Optional.empty()} if there is no record with this ID
      */
     @Override
@@ -112,11 +115,13 @@ public abstract class RecordStorage<I>
      * Reads a record, which matches the specified {@linkplain RecordReadRequest request}
      * and applies a {@link FieldMask} to it.
      *
-     * @param  request   the request to read the record
-     * @param  fieldMask fields to read.
+     * @param request
+     *         the request to read the record
+     * @param fieldMask
+     *         fields to read.
      * @return the item with the given ID and with the {@code FieldMask} applied
      *         or {@code Optional.empty()} if there is no record matching this request
-     * @see    #read(RecordReadRequest)
+     * @see #read(RecordReadRequest)
      */
     @SuppressWarnings("CheckReturnValue") // calling builder method
     public Optional<EntityRecord> read(RecordReadRequest<I> request, FieldMask fieldMask) {
@@ -142,10 +147,13 @@ public abstract class RecordStorage<I>
      *
      * <p>Rewrites it if a record with this ID already exists in the storage.
      *
-     * @param  id     the ID for the record
-     * @param  record a record to store
-     * @throws IllegalStateException if the storage is closed
-     * @see   #write(Object, EntityRecord)
+     * @param id
+     *         the ID for the record
+     * @param record
+     *         a record to store
+     * @throws IllegalStateException
+     *         if the storage is closed
+     * @see #write(Object, EntityRecord)
      */
     public void write(I id, EntityRecordWithColumns record) {
         checkNotNull(id);
@@ -167,8 +175,10 @@ public abstract class RecordStorage<I>
      *
      * <p>Rewrites it if a record with this ID already exists in the storage.
      *
-     * @param  records an ID to record map with the entries to store
-     * @throws IllegalStateException if the storage is closed
+     * @param records
+     *         an ID to record map with the entries to store
+     * @throws IllegalStateException
+     *         if the storage is closed
      */
     public void write(Map<I, EntityRecordWithColumns> records) {
         checkNotNull(records);
@@ -190,15 +200,15 @@ public abstract class RecordStorage<I>
         Optional<EntityRecord> optional = read(request);
         if (optional.isPresent()) {
             EntityRecord record = optional.get();
-            EntityRecord updated = record.toBuilder()
+            EntityRecord updated = record.toVBuilder()
                                          .setLifecycleFlags(flags)
                                          .build();
             write(id, updated);
         } else {
             // The AggregateStateId is a special case, which is not handled by the Identifier class.
             String idStr = id instanceof AggregateStateId
-                              ? id.toString()
-                              : Identifier.toString(id);
+                           ? id.toString()
+                           : Identifier.toString(id);
             throw newIllegalStateException("Unable to load record for entity with ID: %s", idStr);
         }
     }
@@ -206,7 +216,8 @@ public abstract class RecordStorage<I>
     /**
      * Deletes the record with the passed ID.
      *
-     * @param id the record to delete
+     * @param id
+     *         the record to delete
      * @return {@code true} if the operation succeeded, {@code false} otherwise
      */
     public abstract boolean delete(I id);
@@ -248,7 +259,8 @@ public abstract class RecordStorage<I>
     /**
      * Reads all active items from the storage and apply {@link FieldMask} to each of the results.
      *
-     * @param fieldMask the {@code FieldMask} to apply
+     * @param fieldMask
+     *         the {@code FieldMask} to apply
      * @return all items from this repository with the given {@code FieldMask} applied
      */
     public Iterator<EntityRecord> readAll(FieldMask fieldMask) {
@@ -261,12 +273,14 @@ public abstract class RecordStorage<I>
      * Reads all the records matching the given {@link EntityQuery} and applies the given
      * {@link FieldMask} to the resulting record states.
      *
-     * <p>By default, the entities supporting lifecycle will be returned only if they are active. 
-     * To get inactive entities, the lifecycle attribute must be set to the 
+     * <p>By default, the entities supporting lifecycle will be returned only if they are active.
+     * To get inactive entities, the lifecycle attribute must be set to the
      * {@linkplain EntityQuery provided query}.
      *
-     * @param  query     the query to execute
-     * @param  fieldMask the fields to retrieve
+     * @param query
+     *         the query to execute
+     * @param fieldMask
+     *         the fields to retrieve
      * @return the matching records mapped upon their IDs
      */
     public Iterator<EntityRecord> readAll(EntityQuery<I> query, FieldMask fieldMask) {
@@ -285,7 +299,8 @@ public abstract class RecordStorage<I>
      * supports them, all the resulting records are active. Otherwise the records obey
      * the constraints provided by the query.
      *
-     * @param  query     the query to execute
+     * @param query
+     *         the query to execute
      * @return the matching records mapped upon their IDs
      */
     public Iterator<EntityRecord> readAll(EntityQuery<I> query) {
@@ -311,7 +326,8 @@ public abstract class RecordStorage<I>
      * by this storage.
      *
      * @return a {@code Map} of managed {@link Entity} lifecycle columns
-     * @throws IllegalArgumentException if a lifecycle field is not present
+     * @throws IllegalArgumentException
+     *         if a lifecycle field is not present
      *         in the managed {@link Entity} class
      * @see EntityColumn
      * @see Columns
@@ -331,8 +347,9 @@ public abstract class RecordStorage<I>
     /**
      * Obtains the entity column cache.
      *
-     * @throws IllegalStateException if the storage {@linkplain RecordStorage#RecordStorage(boolean)
-     * does not support} the cache
+     * @throws IllegalStateException
+     *         if the storage {@linkplain RecordStorage#RecordStorage(boolean) does not support}
+     *         the cache
      */
     @Internal
     public EntityColumnCache entityColumnCache() {
@@ -352,15 +369,16 @@ public abstract class RecordStorage<I>
     /**
      * Reads a record from the storage by the passed ID.
      *
-     * @param id the ID of the record to load
+     * @param id
+     *         the ID of the record to load
      * @return a record instance or {@code null} if there is no record with this ID
      */
     protected abstract Optional<EntityRecord> readRecord(I id);
 
     /**
      * Obtains an iterator for reading multiple records by IDs.
-     * 
-     * <p>The size of the returned {@code Iterator} matches the size of the given {@code ids}, 
+     *
+     * <p>The size of the returned {@code Iterator} matches the size of the given {@code ids},
      * with nulls in place of missing or inactive entities.
      *
      * @see BulkStorageOperationsMixin#readMultiple(java.lang.Iterable)
@@ -371,7 +389,7 @@ public abstract class RecordStorage<I>
      * Obtains an iterator for reading multiple records by IDs, and
      * applying the passed field mask to the results.
      *
-     * <p>The size of the returned {@code Iterator} matches the size of the given {@code ids}, 
+     * <p>The size of the returned {@code Iterator} matches the size of the given {@code ids},
      * with nulls in place of missing or inactive entities.
      *
      * @see BulkStorageOperationsMixin#readMultiple(java.lang.Iterable)
@@ -381,7 +399,7 @@ public abstract class RecordStorage<I>
 
     /**
      * Obtains an iterator for reading all records.
-     * 
+     *
      * <p>Only active entities are returned.
      *
      * @see BulkStorageOperationsMixin#readAll()
@@ -391,7 +409,7 @@ public abstract class RecordStorage<I>
     /**
      * Obtains an iterator for reading all records, and applying the passed field mask to
      * the results.
-     * 
+     *
      * <p>Only active entities are returned.
      *
      * @see BulkStorageOperationsMixin#readAll()
@@ -401,23 +419,25 @@ public abstract class RecordStorage<I>
     /**
      * Obtains an iterator for reading records matching the query,
      * and applying the passed field mask to the results.
-     * 
+     *
      * <p>Returns only active entities if the query does not specify the {@linkplain LifecycleFlags
      * lifecycle flags}. In order to read inactive entities, the corresponding filters must be set
      * to the provided {@link EntityQuery query}.
      *
      * @see #readAll(EntityQuery, FieldMask)
      */
-    protected abstract
-    Iterator<EntityRecord> readAllRecords(EntityQuery<I> query, FieldMask fieldMask);
+    protected abstract Iterator<EntityRecord> readAllRecords(EntityQuery<I> query,
+                                                             FieldMask fieldMask);
 
     /**
      * Writes a record and the associated {@link EntityColumn} values into the storage.
      *
      * <p>Rewrites it if a record with this ID already exists in the storage.
      *
-     * @param id     an ID of the record
-     * @param record a record to store
+     * @param id
+     *         an ID of the record
+     * @param record
+     *         a record to store
      */
     protected abstract void writeRecord(I id, EntityRecordWithColumns record);
 
@@ -426,7 +446,8 @@ public abstract class RecordStorage<I>
      *
      * <p>Rewrites it if a record with this ID already exists in the storage.
      *
-     * @param records an ID to record map with the entries to store
+     * @param records
+     *         an ID to record map with the entries to store
      */
     protected abstract void writeRecords(Map<I, EntityRecordWithColumns> records);
 }

--- a/server/src/main/java/io/spine/server/storage/memory/TenantRecords.java
+++ b/server/src/main/java/io/spine/server/storage/memory/TenantRecords.java
@@ -140,7 +140,7 @@ class TenantRecords<I> implements TenantStorage<I, EntityRecordWithColumns> {
         EntityRecord record = recordWithColumns.getRecord();
         Any recordState = record.getState();
         Any maskedState = new FieldMaskApplier(fieldMask).maskAny(recordState);
-        EntityRecord maskedRecord = record.toBuilder()
+        EntityRecord maskedRecord = record.toVBuilder()
                                           .setState(maskedState)
                                           .build();
         return maskedRecord;

--- a/server/src/main/java/io/spine/server/type/EventEnvelope.java
+++ b/server/src/main/java/io/spine/server/type/EventEnvelope.java
@@ -112,8 +112,8 @@ public final class EventEnvelope
      *
      * <p>In particular:
      * <ul>
-     * <li>the root command identifier replicates the one defined in the enclosed event;
-     * <li>the context of the enclosed event is set as the origin.
+     *     <li>the root command identifier replicates the one defined in the enclosed event;
+     *     <li>the context of the enclosed event is set as the origin.
      * </ul>
      *
      * @param builder

--- a/server/src/main/java/io/spine/server/type/EventEnvelope.java
+++ b/server/src/main/java/io/spine/server/type/EventEnvelope.java
@@ -44,8 +44,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public final class EventEnvelope
         extends AbstractMessageEnvelope<EventId, Event, EventContext>
         implements
-            ActorMessageEnvelope<EventId, Event, EventContext>,
-            EnrichableMessageEnvelope<EventId, Event, EventMessage, EventContext, EventEnvelope> {
+        ActorMessageEnvelope<EventId, Event, EventContext>,
+        EnrichableMessageEnvelope<EventId, Event, EventMessage, EventContext, EventEnvelope> {
 
     private final EventMessage eventMessage;
     private final EventClass eventClass;
@@ -112,11 +112,12 @@ public final class EventEnvelope
      *
      * <p>In particular:
      * <ul>
-     *     <li>the root command identifier replicates the one defined in the enclosed event;
-     *     <li>the context of the enclosed event is set as the origin.
+     * <li>the root command identifier replicates the one defined in the enclosed event;
+     * <li>the context of the enclosed event is set as the origin.
      * </ul>
      *
-     * @param builder event context builder into which the origin related fields are set
+     * @param builder
+     *         event context builder into which the origin related fields are set
      */
     @SuppressWarnings("CheckReturnValue") // calling builder
     @Override
@@ -150,7 +151,7 @@ public final class EventEnvelope
      * the type of rejected command.
      *
      * @return the class of origin message or {@link EmptyClass} if the origin message type is
-     * unknown
+     *         unknown
      */
     public MessageClass originClass() {
         if (isRejection()) {
@@ -201,11 +202,13 @@ public final class EventEnvelope
     }
 
     private EventEnvelope withEnrichment(Enrichment enrichment) {
-        EventContext context = this.context().toBuilder()
+        EventContext context = this.context()
+                                   .toVBuilder()
                                    .setEnrichment(enrichment)
                                    .build();
-        Event.Builder enrichedCopy = outerObject().toBuilder()
-                                                  .setContext(context);
-        return of(enrichedCopy.build());
+        Event enrichedCopy = outerObject().toVBuilder()
+                                          .setContext(context)
+                                          .build();
+        return of(enrichedCopy);
     }
 }

--- a/server/src/main/java/io/spine/system/server/EntityHistoryAggregate.java
+++ b/server/src/main/java/io/spine/system/server/EntityHistoryAggregate.java
@@ -28,6 +28,7 @@ import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.Apply;
 import io.spine.server.command.Assign;
 import io.spine.server.entity.LifecycleFlags;
+import io.spine.server.entity.LifecycleFlagsVBuilder;
 import io.spine.system.server.command.DispatchCommandToHandler;
 import io.spine.system.server.command.DispatchEventToReactor;
 import io.spine.system.server.command.DispatchEventToSubscriber;
@@ -194,25 +195,25 @@ final class EntityHistoryAggregate
         }
     }
 
-    private void updateLifecycleFlags(UnaryOperator<LifecycleFlags.Builder> mutation) {
+    private void updateLifecycleFlags(UnaryOperator<LifecycleFlagsVBuilder> mutation) {
         LifecycleHistory oldLifecycleHistory = builder().getLifecycle();
-        LifecycleFlags.Builder flagsBuilder =
+        LifecycleFlagsVBuilder flagsBuilder =
                 oldLifecycleHistory.getLifecycleFlags()
-                                   .toBuilder();
+                                   .toVBuilder();
         LifecycleFlags newFlags = mutation.apply(flagsBuilder)
                                           .build();
         LifecycleHistory newLifecycleHistory =
-                oldLifecycleHistory.toBuilder()
+                oldLifecycleHistory.toVBuilder()
                                    .setLifecycleFlags(newFlags)
                                    .build();
         builder().setLifecycle(newLifecycleHistory);
     }
 
-    private void updateLifecycleTimestamp(UnaryOperator<LifecycleHistory.Builder> mutation) {
+    private void updateLifecycleTimestamp(UnaryOperator<LifecycleHistoryVBuilder> mutation) {
         EntityHistoryVBuilder builder = builder();
-        LifecycleHistory.Builder history =
+        LifecycleHistoryVBuilder history =
                 builder.getLifecycle()
-                       .toBuilder();
+                       .toVBuilder();
         LifecycleHistory newHistory =
                 mutation.apply(history)
                         .build();
@@ -235,11 +236,11 @@ final class EntityHistoryAggregate
         }
     }
 
-    private void updateDispatchingHistory(UnaryOperator<DispatchingHistory.Builder> mutation) {
+    private void updateDispatchingHistory(UnaryOperator<DispatchingHistoryVBuilder> mutation) {
         EntityHistoryVBuilder builder = builder();
-        DispatchingHistory.Builder history =
+        DispatchingHistoryVBuilder history =
                 builder.getDispatching()
-                       .toBuilder();
+                       .toVBuilder();
         DispatchingHistory newHistory =
                 mutation.apply(history)
                         .build();

--- a/server/src/main/java/io/spine/system/server/MirrorProjection.java
+++ b/server/src/main/java/io/spine/system/server/MirrorProjection.java
@@ -59,10 +59,9 @@ import static java.util.stream.Collectors.toList;
  * <p>The projection defines an {@link io.spine.server.entity.storage.EntityColumn EntityColumn}
  * which stored the {@linkplain #getAggregateType() type URL} of the state, which is mirrored.
  *
- * @implNote
- * Many subscriber methods of this class ignore their arguments. The argument of a subscriber method
- * is an event used by the framework to bind the method to the event type. The content of the event,
- * in those cases, is irrelevant.
+ * @implNote Many subscriber methods of this class ignore their arguments. The argument of a
+ *         subscriber method is an event used by the framework to bind the method to the event type.
+ *         The content of the event, in those cases, is irrelevant.
  */
 public final class MirrorProjection extends Projection<MirrorId, Mirror, MirrorVBuilder> {
 
@@ -85,7 +84,7 @@ public final class MirrorProjection extends Projection<MirrorId, Mirror, MirrorV
         MirrorVBuilder builder = builder();
         LifecycleFlags flags = builder
                 .getLifecycle()
-                .toBuilder()
+                .toVBuilder()
                 .setArchived(true)
                 .build();
         builder.setId(id())
@@ -99,7 +98,7 @@ public final class MirrorProjection extends Projection<MirrorId, Mirror, MirrorV
         MirrorVBuilder builder = builder();
         LifecycleFlags flags = builder
                 .getLifecycle()
-                .toBuilder()
+                .toVBuilder()
                 .setDeleted(true)
                 .build();
         builder.setId(id())
@@ -113,7 +112,7 @@ public final class MirrorProjection extends Projection<MirrorId, Mirror, MirrorV
         MirrorVBuilder builder = builder();
         LifecycleFlags flags = builder
                 .getLifecycle()
-                .toBuilder()
+                .toVBuilder()
                 .setArchived(false)
                 .build();
         builder.setId(id())
@@ -127,7 +126,7 @@ public final class MirrorProjection extends Projection<MirrorId, Mirror, MirrorV
         MirrorVBuilder builder = builder();
         LifecycleFlags flags = builder
                 .getLifecycle()
-                .toBuilder()
+                .toVBuilder()
                 .setDeleted(false)
                 .build();
         builder.setId(id())
@@ -149,7 +148,7 @@ public final class MirrorProjection extends Projection<MirrorId, Mirror, MirrorV
         TargetFilters filters = target.getFilters();
         CompositeFilter typeFilter = all(eq(TYPE_COLUMN_QUERY_NAME, target.getType()));
         TargetFilters appendedFilters = filters
-                .toBuilder()
+                .toVBuilder()
                 .setIdFilter(idFilter)
                 .addFilter(typeFilter)
                 .build();
@@ -204,7 +203,8 @@ public final class MirrorProjection extends Projection<MirrorId, Mirror, MirrorV
      */
     final Any aggregateState(FieldMask fields) {
         Any completeState = aggregateState();
-        if (isDefault(fields) || fields.getPathsList().isEmpty()) {
+        if (isDefault(fields) || fields.getPathsList()
+                                       .isEmpty()) {
             return completeState;
         }
         Message unpacked = unpack(completeState);

--- a/server/src/main/java/io/spine/system/server/ScheduledCommand.java
+++ b/server/src/main/java/io/spine/system/server/ScheduledCommand.java
@@ -51,11 +51,11 @@ final class ScheduledCommand
     private static Command withSchedule(Command source, CommandContext.Schedule schedule) {
         CommandContext updatedContext =
                 source.getContext()
-                      .toBuilder()
+                      .toVBuilder()
                       .setSchedule(schedule)
                       .build();
         Command updatedCommand =
-                source.toBuilder()
+                source.toVBuilder()
                       .setContext(updatedContext)
                       .build();
         return updatedCommand;

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageTest.java
@@ -78,9 +78,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AggregateStorageTest
         extends AbstractStorageTest<ProjectId,
-        AggregateHistory,
-        AggregateReadRequest<ProjectId>,
-        AggregateStorage<ProjectId>> {
+                                    AggregateHistory,
+                                    AggregateReadRequest<ProjectId>,
+                                    AggregateStorage<ProjectId>> {
 
     private static final Function<AggregateEventRecord, Event> TO_EVENT =
             record -> record != null ? record.getEvent() : null;

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/TestAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/TestAggregate.java
@@ -94,7 +94,7 @@ public class TestAggregate
     AggTaskAdded handle(AggAddTask cmd, CommandContext ctx) {
         isAddTaskCommandHandled = true;
         AggTaskAdded event = taskAdded(cmd.getProjectId());
-        return event.toBuilder()
+        return event.toVBuilder()
                     .setTask(cmd.getTask())
                     .build();
     }

--- a/server/src/test/java/io/spine/server/entity/TransactionalEntityTest.java
+++ b/server/src/test/java/io/spine/server/entity/TransactionalEntityTest.java
@@ -187,7 +187,7 @@ class TransactionalEntityTest {
         TransactionalEntity entity = entityWithInactiveTx();
         LifecycleFlags originalFlags = entity.lifecycleFlags();
 
-        LifecycleFlags modifiedFlags = originalFlags.toBuilder()
+        LifecycleFlags modifiedFlags = originalFlags.toVBuilder()
                                                     .setDeleted(true)
                                                     .build();
 
@@ -220,7 +220,7 @@ class TransactionalEntityTest {
             Message originalState = entity.builderFromState()
                                           .build();
 
-            EmptyEntity newState = EmptyEntity.newBuilder()
+            EmptyEntity newState = EmptyEntity.vBuilder()
                                               .setId(newUuidValue().getValue())
                                               .build();
             assertNotEquals(originalState, newState);

--- a/server/src/test/java/io/spine/server/event/store/EventStoreTest.java
+++ b/server/src/test/java/io/spine/server/event/store/EventStoreTest.java
@@ -31,10 +31,12 @@ import io.spine.core.Event;
 import io.spine.core.EventContext;
 import io.spine.core.TenantId;
 import io.spine.grpc.MemoizingObserver;
+import io.spine.protobuf.AnyPacker;
 import io.spine.server.event.EventFilter;
 import io.spine.server.event.EventStreamQuery;
 import io.spine.server.event.given.EventStoreTestEnv.ResponseObserver;
 import io.spine.test.event.TaskAdded;
+import io.spine.testing.TestValues;
 import io.spine.type.TypeName;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -266,10 +268,14 @@ public class EventStoreTest {
             Event event = projectCreated(Time.currentTime());
             CommandContext commandContext = event.getContext()
                                                  .getCommandContext();
-            EventContext.Builder originContext =
-                    EventContext.newBuilder()
+            EventContext originContext =
+                    EventContext.vBuilder()
                                 .setEnrichment(withOneAttribute())
-                                .setCommandContext(commandContext);
+                                .setCommandContext(commandContext)
+                                .setTimestamp(event.getContext()
+                                                   .getTimestamp())
+                                .setProducerId(AnyPacker.pack(TestValues.newUuidValue()))
+                                .build();
             Event enriched = event.toBuilder()
                                   .setContext(event.getContext()
                                                    .toBuilder()

--- a/server/src/test/java/io/spine/server/procman/given/repo/TestProcessManager.java
+++ b/server/src/test/java/io/spine/server/procman/given/repo/TestProcessManager.java
@@ -84,7 +84,7 @@ public class TestProcessManager
     }
 
     private void handleProjectCreated(ProjectId projectId) {
-        Project newState = state().toBuilder()
+        Project newState = state().toVBuilder()
                                   .setId(projectId)
                                   .setStatus(Project.Status.CREATED)
                                   .build();
@@ -92,14 +92,14 @@ public class TestProcessManager
     }
 
     private void handleTaskAdded(Task task) {
-        Project newState = state().toBuilder()
+        Project newState = state().toVBuilder()
                                   .addTask(task)
                                   .build();
         builder().mergeFrom(newState);
     }
 
     private void handleProjectStarted() {
-        Project newState = state().toBuilder()
+        Project newState = state().toVBuilder()
                                   .setStatus(Project.Status.STARTED)
                                   .build();
         builder().mergeFrom(newState);

--- a/server/src/test/java/io/spine/server/projection/given/TestProjection.java
+++ b/server/src/test/java/io/spine/server/projection/given/TestProjection.java
@@ -87,7 +87,7 @@ public class TestProjection
         // Keep the event message for further inspection in tests.
         keep(event);
 
-        Project newState = state().toBuilder()
+        Project newState = state().toVBuilder()
                                   .setId(event.getProjectId())
                                   .setStatus(Project.Status.CREATED)
                                   .setName(event.getName())
@@ -114,7 +114,7 @@ public class TestProjection
     void on(PrjProjectStarted event,
                    @SuppressWarnings("UnusedParameters") EventContext ignored) {
         keep(event);
-        Project newState = state().toBuilder()
+        Project newState = state().toVBuilder()
                                   .setStatus(Project.Status.STARTED)
                                   .build();
         builder().mergeFrom(newState);

--- a/server/src/test/java/io/spine/system/server/given/schedule/TestCommandScheduler.java
+++ b/server/src/test/java/io/spine/system/server/given/schedule/TestCommandScheduler.java
@@ -43,7 +43,7 @@ public final class TestCommandScheduler extends CommandScheduler {
     public void assertScheduled(Command command) {
         // System properties are modified by the framework.
         boolean found = scheduledCommands.stream()
-                                         .map(cmd -> cmd.toBuilder()
+                                         .map(cmd -> cmd.toVBuilder()
                                                         .clearSystemProperties()
                                                         .build())
                                          .anyMatch(command::equals);

--- a/testutil-client/src/main/java/io/spine/testing/client/TestActorRequestFactory.java
+++ b/testutil-client/src/main/java/io/spine/testing/client/TestActorRequestFactory.java
@@ -70,11 +70,11 @@ public class TestActorRequestFactory extends ActorRequestFactory {
 
     /**
      * Deprecated.
+     *
      * @deprecated use {@link #TestActorRequestFactory(String, ZoneId)}
      */
     @Deprecated
-    public static
-    TestActorRequestFactory newInstance(String actor, ZoneId zoneId) {
+    public static TestActorRequestFactory newInstance(String actor, ZoneId zoneId) {
         return new TestActorRequestFactory(actor, zoneId);
     }
 
@@ -82,13 +82,13 @@ public class TestActorRequestFactory extends ActorRequestFactory {
         this(GivenUserId.of(actor), zoneId);
     }
 
-    public static
-    TestActorRequestFactory newInstance(UserId actor, ZoneId zoneId) {
+    public static TestActorRequestFactory newInstance(UserId actor, ZoneId zoneId) {
         return new TestActorRequestFactory(actor, zoneId);
     }
 
     /**
      * Deprecated.
+     *
      * @deprecated use {@link #TestActorRequestFactory(Class)}
      */
     @Deprecated
@@ -102,6 +102,7 @@ public class TestActorRequestFactory extends ActorRequestFactory {
 
     /**
      * Deprecated.
+     *
      * @deprecated use {@link #TestActorRequestFactory(UserId)}
      */
     @Deprecated
@@ -115,6 +116,7 @@ public class TestActorRequestFactory extends ActorRequestFactory {
 
     /**
      * Deprecated.
+     *
      * @deprecated use {@link #TestActorRequestFactory(UserId, TenantId)}
      */
     @Deprecated
@@ -128,6 +130,7 @@ public class TestActorRequestFactory extends ActorRequestFactory {
 
     /**
      * Deprecated.
+     *
      * @deprecated use {@link #TestActorRequestFactory(Class, TenantId)}
      */
     @Deprecated
@@ -161,15 +164,18 @@ public class TestActorRequestFactory extends ActorRequestFactory {
     }
 
     private static Command withTimestamp(Command command, Timestamp timestamp) {
-        CommandContext context = command.getContext();
-        ActorContext.Builder withTime = context.getActorContext()
-                                               .toBuilder()
-                                               .setTimestamp(timestamp);
-        Command.Builder commandBuilder =
-                command.toBuilder()
-                       .setContext(context.toBuilder()
-                                          .setActorContext(withTime));
-        return commandBuilder.build();
+        CommandContext origin = command.getContext();
+        ActorContext withTime = origin.getActorContext()
+                                      .toVBuilder()
+                                      .setTimestamp(timestamp)
+                                      .build();
+        CommandContext resultContext = origin.toVBuilder()
+                                             .setActorContext(withTime)
+                                             .build();
+        Command result = command.toVBuilder()
+                                .setContext(resultContext)
+                                .build();
+        return result;
     }
 
     public Command createCommand(CommandMessage message) {
@@ -185,7 +191,7 @@ public class TestActorRequestFactory extends ActorRequestFactory {
         @SuppressWarnings("MagicNumber")
         String randomSuffix = String.format("%04d", TestValues.random(10_000));
         TestCommandMessage msg = TestCommandMessage
-                .newBuilder()
+                .vBuilder()
                 .setId("random-number-" + randomSuffix)
                 .build();
         return createCommand(msg);

--- a/testutil-core/src/main/java/io/spine/testing/core/given/GivenCommandContext.java
+++ b/testutil-core/src/main/java/io/spine/testing/core/given/GivenCommandContext.java
@@ -25,6 +25,7 @@ import com.google.protobuf.Timestamp;
 import io.spine.core.ActorContext;
 import io.spine.core.CommandContext;
 import io.spine.core.CommandContext.Schedule;
+import io.spine.core.CommandContextVBuilder;
 import io.spine.core.TenantId;
 import io.spine.core.UserId;
 
@@ -58,13 +59,15 @@ public final class GivenCommandContext {
      */
     public static CommandContext withActorAndTime(UserId actor, Timestamp when) {
         TenantId tenantId = GivenTenantId.newUuid();
-        ActorContext.Builder actorContext = ActorContext.newBuilder()
-                                                        .setActor(actor)
-                                                        .setTimestamp(when)
-                                                        .setTenantId(tenantId);
-        CommandContext.Builder builder = CommandContext.newBuilder()
-                                                       .setActorContext(actorContext);
-        return builder.build();
+        ActorContext actorContext = ActorContext.vBuilder()
+                                                .setActor(actor)
+                                                .setTimestamp(when)
+                                                .setTenantId(tenantId)
+                                                .build();
+        CommandContext result = CommandContext.vBuilder()
+                                              .setActorContext(actorContext)
+                                              .build();
+        return result;
     }
 
     /**
@@ -75,7 +78,7 @@ public final class GivenCommandContext {
      * @return a new {@code CommandContext} instance
      */
     public static CommandContext withScheduledDelayOf(Duration delay) {
-        Schedule schedule = Schedule.newBuilder()
+        Schedule schedule = Schedule.vBuilder()
                                     .setDelay(delay)
                                     .build();
         return withSchedule(schedule);
@@ -89,7 +92,7 @@ public final class GivenCommandContext {
      * @return a new {@code CommandContext} instance
      */
     private static CommandContext withSchedule(Schedule schedule) {
-        CommandContext.Builder builder = withRandomActor().toBuilder()
+        CommandContextVBuilder builder = withRandomActor().toVBuilder()
                                                           .setSchedule(schedule);
         return builder.build();
     }

--- a/testutil-core/src/test/java/io/spine/testing/core/given/GivenCommandContextTest.java
+++ b/testutil-core/src/test/java/io/spine/testing/core/given/GivenCommandContextTest.java
@@ -22,6 +22,7 @@ package io.spine.testing.core.given;
 import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
+import io.spine.base.Time;
 import io.spine.core.ActorContext;
 import io.spine.core.CommandContext;
 import io.spine.core.CommandContext.Schedule;
@@ -49,8 +50,8 @@ class GivenCommandContextTest extends UtilityClassTest<GivenCommandContext> {
     @Override
     protected void configure(NullPointerTester tester) {
         super.configure(tester);
-        tester.setDefault(UserId.class, UserId.getDefaultInstance())
-              .setDefault(Timestamp.class, Timestamp.getDefaultInstance());
+        tester.setDefault(UserId.class, GivenUserId.generated())
+              .setDefault(Timestamp.class, Time.currentTime());
     }
 
     @Test

--- a/testutil-server/src/main/java/io/spine/testing/server/EventReactionTest.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/EventReactionTest.java
@@ -40,15 +40,19 @@ import java.util.List;
  * <li>the state of an entity is correctly changed after the events are emitted.
  * </ol>
  *
- * @param <I> ID message of the command and the handling entity
- * @param <M> the type of the event message to test
- * @param <S> state message of the handling entity
- * @param <E> the type of the {@link CommandHandlingEntity} being tested
+ * @param <I>
+ *         ID message of the command and the handling entity
+ * @param <M>
+ *         the type of the event message to test
+ * @param <S>
+ *         state message of the handling entity
+ * @param <E>
+ *         the type of the {@link CommandHandlingEntity} being tested
  */
 public abstract class EventReactionTest<I,
-                                        M extends EventMessage,
-                                        S extends Message,
-                                        E extends CommandHandlingEntity<I, S, ?>>
+        M extends EventMessage,
+        S extends Message,
+        E extends CommandHandlingEntity<I, S, ?>>
         extends MessageHandlerTest<I, M, S, E, EventReactorExpected<S>> {
 
     private final TestEventFactory eventFactory = TestEventFactory.newInstance(getClass());
@@ -68,16 +72,17 @@ public abstract class EventReactionTest<I,
     /**
      * Creates {@link Event} from the given message and supplies it with {@link EventContext}.
      *
-     * @param message an event message
+     * @param message
+     *         an event message
      * @return a new {@link Event}
      */
     protected final Event createEvent(M message) {
         Event event = eventFactory.createEvent(message);
         EventContext context = event.getContext()
-                                    .toBuilder()
+                                    .toVBuilder()
                                     .setExternal(externalMessage())
                                     .build();
-        return event.toBuilder()
+        return event.toVBuilder()
                     .setContext(context)
                     .build();
     }

--- a/testutil-server/src/main/java/io/spine/testing/server/TestEventFactory.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/TestEventFactory.java
@@ -59,8 +59,8 @@ public class TestEventFactory extends EventFactory {
         return newInstance(id, new TestActorRequestFactory(testSuiteClass));
     }
 
-    public static
-    TestEventFactory newInstance(Message producerId, TestActorRequestFactory requestFactory) {
+    public static TestEventFactory newInstance(Message producerId,
+                                               TestActorRequestFactory requestFactory) {
         checkNotNull(requestFactory);
         Any id = toAny(producerId);
         CommandEnvelope cmd = CommandEnvelope.of(requestFactory.generateCommand());
@@ -93,10 +93,10 @@ public class TestEventFactory extends EventFactory {
         checkNotNull(atTime);
         Event event = createEvent(message, version);
         EventContext context = event.getContext()
-                                    .toBuilder()
+                                    .toVBuilder()
                                     .setTimestamp(atTime)
                                     .build();
-        Event result = event.toBuilder()
+        Event result = event.toVBuilder()
                             .setContext(context)
                             .build();
         return result;

--- a/testutil-server/src/main/java/io/spine/testing/server/projection/ProjectionTest.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/projection/ProjectionTest.java
@@ -60,11 +60,11 @@ public abstract class ProjectionTest<I,
         Event sourceEvent = createEvent();
         EventContext context =
                 sourceEvent.getContext()
-                           .toBuilder()
+                           .toVBuilder()
                            .setEnrichment(enrichment())
                            .build();
         Event enrichedEvent =
-                sourceEvent.toBuilder()
+                sourceEvent.toVBuilder()
                            .setContext(context)
                            .build();
         dispatch(entity, enrichedEvent);


### PR DESCRIPTION
With this PR I have enabled the Model Compiler default configurations and changed `EventContext` validation rules:
1. `origin` oneof field now uses `required_field` syntax as per [base#378](https://github.com/SpineEventEngine/base/issues/378).
1. `version` field is not `required` anymore, but instead should be `valid` if set. Further analysis is required here, see #999 for details.

Also, I've switch non-test Protobuf messages to `vBuilder` and `toVBuilder` usage. As a result, some tests were also modified to create actually valid messages.

Further migration to `vBuilder` usage will be done in a separate PR.