### PR TITLE
Bus message listeners

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -493,6 +493,7 @@
         <extension name="JUnit4MethodNamingConvention" enabled="true">
           <option name="m_regex" value="[a-z][A-Za-z\d]*" />
           <option name="m_minLength" value="2" />
+          <option name="m_maxLength" value="64" />
         </extension>
       </scope>
       <scope name="Production" level="WARNING" enabled="true">
@@ -642,7 +643,6 @@
       <option name="ignoreCloneable" value="false" />
     </inspection_tool>
     <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="RedundantSuppression" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
@@ -712,9 +712,6 @@
     <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SwitchStatementWithTooFewBranches" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="m_limit" value="2" />
-    </inspection_tool>
     <inspection_tool class="SwitchStatementsWithoutDefault" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreFullyCoveredEnums" value="true" />
     </inspection_tool>
@@ -827,6 +824,17 @@
     <inspection_tool class="UnsecureRandomNumberGeneration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnstableApiUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="Tests" level="WEAK WARNING" enabled="false" />
+      <option name="unstableApiAnnotations">
+        <set>
+          <option value="io.reactivex.annotations.Beta" />
+          <option value="io.reactivex.annotations.Experimental" />
+          <option value="org.apache.http.annotation.Beta" />
+          <option value="org.gradle.api.Incubating" />
+          <option value="org.jetbrains.annotations.ApiStatus.Experimental" />
+          <option value="rx.annotations.Beta" />
+          <option value="rx.annotations.Experimental" />
+        </set>
+      </option>
     </inspection_tool>
     <inspection_tool class="UnusedCatchParameter" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreCatchBlocksWithComments" value="true" />

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -493,7 +493,6 @@
         <extension name="JUnit4MethodNamingConvention" enabled="true">
           <option name="m_regex" value="[a-z][A-Za-z\d]*" />
           <option name="m_minLength" value="2" />
-          <option name="m_maxLength" value="64" />
         </extension>
       </scope>
       <scope name="Production" level="WARNING" enabled="true">
@@ -643,6 +642,7 @@
       <option name="ignoreCloneable" value="false" />
     </inspection_tool>
     <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="RedundantSuppression" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
@@ -712,6 +712,9 @@
     <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SwitchStatementWithTooFewBranches" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="m_limit" value="2" />
+    </inspection_tool>
     <inspection_tool class="SwitchStatementsWithoutDefault" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreFullyCoveredEnums" value="true" />
     </inspection_tool>
@@ -824,17 +827,6 @@
     <inspection_tool class="UnsecureRandomNumberGeneration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnstableApiUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="Tests" level="WEAK WARNING" enabled="false" />
-      <option name="unstableApiAnnotations">
-        <set>
-          <option value="io.reactivex.annotations.Beta" />
-          <option value="io.reactivex.annotations.Experimental" />
-          <option value="org.apache.http.annotation.Beta" />
-          <option value="org.gradle.api.Incubating" />
-          <option value="org.jetbrains.annotations.ApiStatus.Experimental" />
-          <option value="rx.annotations.Beta" />
-          <option value="rx.annotations.Experimental" />
-        </set>
-      </option>
     </inspection_tool>
     <inspection_tool class="UnusedCatchParameter" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreCatchBlocksWithComments" value="true" />

--- a/core/src/main/java/io/spine/core/Commands.java
+++ b/core/src/main/java/io/spine/core/Commands.java
@@ -91,9 +91,9 @@ public final class Commands {
     /**
      * Obtains a tenant ID from the command.
      */
-    public static TenantId getTenantId(Command command) {
+    public static TenantId tenantOf(Command command) {
         checkNotNull(command);
-        TenantId result = getTenantId(command.getContext());
+        TenantId result = tenantOf(command.getContext());
         return result;
     }
 
@@ -105,7 +105,7 @@ public final class Commands {
      * a valid {@code TenantId} source inside of the {@code Event}.
      */
     @Internal
-    public static TenantId getTenantId(CommandContext context) {
+    public static TenantId tenantOf(CommandContext context) {
         return context.getActorContext()
                       .getTenantId();
     }

--- a/core/src/main/java/io/spine/core/Events.java
+++ b/core/src/main/java/io/spine/core/Events.java
@@ -262,15 +262,15 @@ public final class Events {
     }
 
     /**
-     * Obtains a {@link TenantId} from the {@linkplain #getActorContext(Event) actor context}
+     * Obtains a {@link TenantId} from the {@linkplain #actorContextOf(Event) actor context}
      * of the given {@link Event}.
      *
      * @return a tenant ID from the actor context of the event
      */
     @Internal
-    public static TenantId getTenantId(Event event) {
+    public static TenantId tenantOf(Event event) {
         checkNotNull(event);
-        ActorContext actorContext = getActorContext(event);
+        ActorContext actorContext = actorContextOf(event);
         return actorContext.getTenantId();
     }
 
@@ -288,7 +288,7 @@ public final class Events {
      * @return the actor context of the wrapped event
      */
     @Internal
-    public static ActorContext getActorContext(Event event) {
+    public static ActorContext actorContextOf(Event event) {
         checkNotNull(event);
         EventContext eventContext = event.getContext();
         ActorContext result = retrieveActorContext(eventContext);

--- a/server/src/main/java/io/spine/server/bus/Bus.java
+++ b/server/src/main/java/io/spine/server/bus/Bus.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -48,7 +49,6 @@ import static java.util.Collections.singleton;
  * @param <C> the type of message class
  * @param <D> the type of dispatches used by this bus
  */
-@SuppressWarnings("ClassWithTooManyMethods")
 public abstract class Bus<T extends Message,
                           E extends MessageEnvelope<?, T, ?>,
                           C extends MessageClass<? extends Message>,
@@ -62,15 +62,12 @@ public abstract class Bus<T extends Message,
     @LazyInit
     private @MonotonicNonNull DispatcherRegistry<C, E, D> registry;
 
-    /** The chain of filters for this bus, {@linkplain #filterChain() lazily initialized}. */
-    @LazyInit
-    private @MonotonicNonNull FilterChain<E> filterChain;
-
-    private final ChainBuilder<E> chainBuilder;
+    /** The supplier of filter chain for this bus. */
+    private final FilterChainSupplier chainSupplier;
 
     protected Bus(BusBuilder<E, T, ?> builder) {
         super();
-        this.chainBuilder = builder.chainBuilderCopy();
+        this.chainSupplier = new FilterChainSupplier(builder);
     }
 
     /**
@@ -216,42 +213,10 @@ public abstract class Bus<T extends Message,
     }
 
     /**
-     * Initializes the {@code Bus.filterChain} field upon the first invocation and obtains
-     * the value of the field.
-     *
-     * <p>Adds the {@link DeadMessageFilter} and the {@link ValidatingFilter} to the chain, so that
-     * a chain always has the following format:
-     *
-     * <pre>
-     *     Chain head -> {@link ValidatingFilter} -> {@link DeadMessageFilter} -> custom filters from {@linkplain BusBuilder Builder} -> chain tail.
-     * </pre>
-     *
-     * <p>The head and the tail of the chain are created by the {@code Bus} itself. Those are
-     * typically empty. Override {@link #filterChainHead()} and {@link #filterChainHead()} to add
-     * some filters to the respective chain side.
-     *
-     * @return the value of the bus filter chain
+     * Returns the filter chain for this bus.
      */
     private BusFilter<E> filterChain() {
-        if (filterChain == null) {
-            initChain();
-        }
-        return filterChain;
-    }
-
-    private void initChain() {
-        Collection<BusFilter<E>> tail = filterChainTail();
-        tail.forEach(chainBuilder::append);
-
-        BusFilter<E> deadMsgFilter = new DeadMessageFilter<>(deadMessageHandler(), registry());
-        BusFilter<E> validatingFilter = new ValidatingFilter<>(validator());
-
-        chainBuilder.prepend(deadMsgFilter);
-        chainBuilder.prepend(validatingFilter);
-        Collection<BusFilter<E>> head = filterChainHead();
-        head.forEach(chainBuilder::prepend);
-
-        filterChain = chainBuilder.build();
+        return chainSupplier.get();
     }
 
     /**
@@ -387,4 +352,52 @@ public abstract class Bus<T extends Message,
      * @param messages the messages to store
      */
     protected abstract void store(Iterable<T> messages);
+
+    /**
+     * Initializes the filter chain upon the first invocation and returns the initialized instance
+     * for all next calls.
+     *
+     * <p>Adds the {@link DeadMessageFilter} and the {@link ValidatingFilter} to the chain, so that
+     * a chain always has the following format:
+     *
+     * <pre>
+     *     Chain head -> {@link ValidatingFilter} -> {@link DeadMessageFilter} -> custom filters from {@linkplain BusBuilder Builder} -> chain tail.
+     * </pre>
+     *
+     * <p>The head and the tail of the chain are created by the {@code Bus} itself. Those are
+     * typically empty. Override {@link #filterChainHead()} and {@link #filterChainHead()} to add
+     * some filters to the respective chain side.
+     */
+    private class FilterChainSupplier implements Supplier<FilterChain<E>> {
+
+        private final ChainBuilder<E> chainBuilder;
+
+        @LazyInit
+        private @MonotonicNonNull FilterChain<E> chain;
+
+        private FilterChainSupplier(BusBuilder<E, T, ?> builder) {
+            this.chainBuilder = builder.chainBuilderCopy();
+        }
+
+        @Override
+        public FilterChain<E> get() {
+            if(chain == null) {
+                chain = buildChain();
+            }
+            return chain;
+        }
+        private FilterChain<E> buildChain() {
+            Collection<BusFilter<E>> tail = filterChainTail();
+            tail.forEach(chainBuilder::append);
+            BusFilter<E> deadMsgFilter = new DeadMessageFilter<>(deadMessageHandler(), registry());
+            BusFilter<E> validatingFilter = new ValidatingFilter<>(validator());
+
+            chainBuilder.prepend(deadMsgFilter);
+            chainBuilder.prepend(validatingFilter);
+            Collection<BusFilter<E>> head = filterChainHead();
+            head.forEach(chainBuilder::prepend);
+
+            return chainBuilder.build();
+        }
+    }
 }

--- a/server/src/main/java/io/spine/server/bus/Bus.java
+++ b/server/src/main/java/io/spine/server/bus/Bus.java
@@ -63,11 +63,11 @@ public abstract class Bus<T extends Message,
     private @MonotonicNonNull DispatcherRegistry<C, E, D> registry;
 
     /** The supplier of filter chain for this bus. */
-    private final FilterChainSupplier chainSupplier;
+    private final FilterChainSupplier filterChain;
 
     protected Bus(BusBuilder<E, T, ?> builder) {
         super();
-        this.chainSupplier = new FilterChainSupplier(builder);
+        this.filterChain = new FilterChainSupplier(builder);
     }
 
     /**
@@ -216,7 +216,7 @@ public abstract class Bus<T extends Message,
      * Returns the filter chain for this bus.
      */
     private BusFilter<E> filterChain() {
-        return chainSupplier.get();
+        return filterChain.get();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/bus/BusBuilder.java
+++ b/server/src/main/java/io/spine/server/bus/BusBuilder.java
@@ -81,8 +81,8 @@ public abstract class BusBuilder<E extends MessageEnvelope<?, T, ?>,
      *
      * @see #appendFilter(BusFilter)
      */
-    public final Deque<BusFilter<E>> getFilters() {
-        return chainBuilder.getFilters();
+    public final Deque<BusFilter<E>> filters() {
+        return chainBuilder.filters();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/bus/BusBuilder.java
+++ b/server/src/main/java/io/spine/server/bus/BusBuilder.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.bus;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.CheckReturnValue;
 import com.google.protobuf.Message;
@@ -30,7 +31,10 @@ import io.spine.system.server.SystemWriteSide;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -51,6 +55,7 @@ public abstract class BusBuilder<E extends MessageEnvelope<?, T, ?>,
                                  B extends BusBuilder<E, T, B>> {
 
     private final ChainBuilder<E> chainBuilder;
+    private final Set<Consumer<E>> listeners = new HashSet<>();
 
     private @Nullable SystemWriteSide systemWriteSide;
     private @Nullable TenantIndex tenantIndex;
@@ -77,12 +82,42 @@ public abstract class BusBuilder<E extends MessageEnvelope<?, T, ?>,
     }
 
     /**
-     * Obtains the {@linkplain BusFilter bus filters} of this builder.
+     * Obtains the filters added to this this builder by the time of the call.
      *
      * @see #appendFilter(BusFilter)
      */
     public final Deque<BusFilter<E>> filters() {
         return chainBuilder.filters();
+    }
+
+    /**
+     * Adds a listener of the message posted to the bus being build.
+     *
+     * <p>When a message is posted to the bus, the listeners are notified before invoking filters.
+     *
+     * <p>If an exception is thrown by a {@linkplain Consumer#accept(Object) listener code}, it
+     * will be ignored by the bus.
+     */
+    public final B addListener(Consumer<E> listener) {
+        checkNotNull(listener);
+        listeners.add(listener);
+        return self();
+    }
+
+    /**
+     * Removes the listener. If the listener was not added before, the method has no effect.
+     */
+    public final B removeListener(Consumer<E> listener) {
+        checkNotNull(listener);
+        listeners.remove(listener);
+        return self();
+    }
+
+    /**
+     * Obtains immutable set of listeners added to the builder by the time of the call.
+     */
+    public final Set<Consumer<E>> listeners() {
+        return ImmutableSet.copyOf(listeners);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/bus/ChainBuilder.java
+++ b/server/src/main/java/io/spine/server/bus/ChainBuilder.java
@@ -61,7 +61,7 @@ final class ChainBuilder<E extends MessageEnvelope<?, ?, ?>> {
      *
      * @return new {@link Deque} containing all the filters
      */
-    Deque<BusFilter<E>> getFilters() {
+    Deque<BusFilter<E>> filters() {
         return new ConcurrentLinkedDeque<>(filters);
     }
 

--- a/server/src/main/java/io/spine/server/bus/FilterChain.java
+++ b/server/src/main/java/io/spine/server/bus/FilterChain.java
@@ -47,7 +47,7 @@ final class FilterChain<E extends MessageEnvelope<?, ?, ?>> implements BusFilter
     private volatile boolean closed;
 
     FilterChain(ChainBuilder<E> builder) {
-        this.chain = builder.getFilters();
+        this.chain = builder.filters();
     }
 
     static <E extends MessageEnvelope<?, ?, ?>> ChainBuilder<E> newBuilder() {

--- a/server/src/main/java/io/spine/server/bus/Listeners.java
+++ b/server/src/main/java/io/spine/server/bus/Listeners.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.bus;
+
+import com.google.common.collect.ImmutableSet;
+import io.spine.server.type.MessageEnvelope;
+
+import java.util.function.Consumer;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Manages consumption of a message posted to the bus by its listeners.
+ *
+ * @param <E> the type of the {@link MessageEnvelope} posted by the bus
+ */
+final class Listeners<E extends MessageEnvelope<?, ?, ?>> implements Consumer<E> {
+
+    private final ImmutableSet<Consumer<E>> listeners;
+
+    Listeners(BusBuilder<E, ?, ?> builder) {
+        checkNotNull(builder);
+        this.listeners = ImmutableSet.copyOf(builder.listeners());
+    }
+
+    @Override
+    public void accept(E envelope) {
+        listeners.forEach(l -> {
+            try {
+                l.accept(envelope);
+            } catch (RuntimeException ignored) {
+                // Do nothing.
+            }
+        });
+    }
+}

--- a/server/src/main/java/io/spine/server/commandbus/CommandBus.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandBus.java
@@ -182,7 +182,7 @@ public class CommandBus extends UnicastBus<Command,
 
     private static TenantId tenantOf(Iterable<Command> commands) {
         return Streams.stream(commands)
-                      .map(Commands::getTenantId)
+                      .map(Commands::tenantOf)
                       .findAny()
                       .orElse(TenantId.getDefaultInstance());
     }

--- a/server/src/main/java/io/spine/server/event/store/EventStore.java
+++ b/server/src/main/java/io/spine/server/event/store/EventStore.java
@@ -70,7 +70,7 @@ public final class EventStore implements AutoCloseable {
     private static void ensureSameTenant(Iterable<Event> events) {
         checkNotNull(events);
         Set<TenantId> tenants = Streams.stream(events)
-                                       .map(Events::getTenantId)
+                                       .map(Events::tenantOf)
                                        .collect(toSet());
         checkArgument(tenants.size() == 1, TENANT_MISMATCH_ERROR_MSG, tenants);
     }

--- a/server/src/main/java/io/spine/server/tenant/EventOperation.java
+++ b/server/src/main/java/io/spine/server/tenant/EventOperation.java
@@ -23,7 +23,7 @@ package io.spine.server.tenant;
 import io.spine.annotation.Internal;
 import io.spine.core.Event;
 
-import static io.spine.core.Events.getTenantId;
+import static io.spine.core.Events.tenantOf;
 
 /**
  * A tenant-aware operation performed in relation to an event.
@@ -42,7 +42,7 @@ public abstract class EventOperation extends TenantAwareOperation {
      * @param event the event from which to obtain the tenant ID
      */
     protected EventOperation(Event event) {
-        super(getTenantId(event));
+        super(tenantOf(event));
         this.event = event;
     }
 

--- a/server/src/main/java/io/spine/server/type/CommandEnvelope.java
+++ b/server/src/main/java/io/spine/server/type/CommandEnvelope.java
@@ -77,7 +77,7 @@ public final class CommandEnvelope
      */
     @Override
     public TenantId tenantId() {
-        return Commands.getTenantId(command());
+        return Commands.tenantOf(command());
     }
 
     /**

--- a/server/src/main/java/io/spine/server/type/EventEnvelope.java
+++ b/server/src/main/java/io/spine/server/type/EventEnvelope.java
@@ -103,7 +103,7 @@ public final class EventEnvelope
 
     @Override
     public ActorContext actorContext() {
-        return Events.getActorContext(outerObject());
+        return Events.actorContextOf(outerObject());
     }
 
     /**

--- a/server/src/test/java/io/spine/core/EventsTest.java
+++ b/server/src/test/java/io/spine/core/EventsTest.java
@@ -254,7 +254,7 @@ public class EventsTest extends UtilityClassTest<Events> {
         void forEventWithoutOrigin() {
             EventContext context = contextWithoutOrigin().build();
             Event event = EventsTestEnv.event(context);
-            assertThrows(IllegalArgumentException.class, () -> Events.getTenantId(event));
+            assertThrows(IllegalArgumentException.class, () -> Events.tenantOf(event));
         }
 
         @Test
@@ -264,7 +264,7 @@ public class EventsTest extends UtilityClassTest<Events> {
                     .setEventContext(contextWithoutOrigin())
                     .build();
             Event event = EventsTestEnv.event(context);
-            assertThrows(IllegalArgumentException.class, () -> Events.getTenantId(event));
+            assertThrows(IllegalArgumentException.class, () -> Events.tenantOf(event));
         }
     }
 
@@ -281,7 +281,7 @@ public class EventsTest extends UtilityClassTest<Events> {
                                                          .build();
             Event event = EventsTestEnv.event(context);
 
-            TenantId tenantId = Events.getTenantId(event);
+            TenantId tenantId = Events.tenantOf(event);
 
             assertEquals(targetTenantId, tenantId);
 
@@ -299,7 +299,7 @@ public class EventsTest extends UtilityClassTest<Events> {
                                                          .build();
             Event event = EventsTestEnv.event(context);
 
-            TenantId tenantId = Events.getTenantId(event);
+            TenantId tenantId = Events.tenantOf(event);
 
             assertEquals(targetTenantId, tenantId);
         }
@@ -308,7 +308,7 @@ public class EventsTest extends UtilityClassTest<Events> {
     @Test
     @DisplayName("throw NullPointerException when getting tenant ID of null event")
     void notAcceptNullEvent() {
-        assertThrows(NullPointerException.class, () -> Events.getTenantId(Tests.nullRef()));
+        assertThrows(NullPointerException.class, () -> Events.tenantOf(Tests.nullRef()));
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/bus/BusBuilderTest.java
+++ b/server/src/test/java/io/spine/server/bus/BusBuilderTest.java
@@ -50,7 +50,7 @@ public abstract class BusBuilderTest<B extends BusBuilder<E, T, ?>,
         @SuppressWarnings("unchecked") BusFilter<E> filter = mock(BusFilter.class);
 
         assertTrue(builder().appendFilter(filter)
-                            .getFilters()
+                            .filters()
                             .contains(filter));
     }
 
@@ -64,7 +64,7 @@ public abstract class BusBuilderTest<B extends BusBuilder<E, T, ?>,
         B builder = builder();
         builder.appendFilter(first)
                .appendFilter(second);
-        Deque<BusFilter<E>> filters = builder.getFilters();
+        Deque<BusFilter<E>> filters = builder.filters();
         assertEquals(first, filters.pop());
         assertEquals(second, filters.pop());
     }

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/CommandCollector.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/CommandCollector.java
@@ -21,7 +21,6 @@
 package io.spine.testing.server.blackbox;
 
 import io.spine.core.Command;
-import io.spine.core.CommandContext;
 import io.spine.core.CommandId;
 import io.spine.core.Commands;
 import io.spine.core.TenantId;
@@ -30,8 +29,7 @@ import io.spine.server.type.CommandEnvelope;
 /**
  * Remembers commands posted to a Command Bus.
  */
-public final class CommandCollector
-        extends MessageCollector<CommandId, Command, CommandContext, CommandEnvelope> {
+public final class CommandCollector extends MessageCollector<CommandId, Command, CommandEnvelope> {
 
     @Override
     protected TenantId tenantOf(Command command) {

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/CommandCollector.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/CommandCollector.java
@@ -23,20 +23,18 @@ package io.spine.testing.server.blackbox;
 import io.spine.core.Command;
 import io.spine.core.CommandContext;
 import io.spine.core.CommandId;
+import io.spine.core.Commands;
+import io.spine.core.TenantId;
 import io.spine.server.type.CommandEnvelope;
-
-import java.util.List;
 
 /**
  * Remembers commands posted to a Command Bus.
  */
-public final class CommandMemoizingTap
-        extends MemoizingTap<CommandId, Command, CommandContext, CommandEnvelope> {
+public final class CommandCollector
+        extends MessageCollector<CommandId, Command, CommandContext, CommandEnvelope> {
 
-    /**
-     * Obtains immutable list with commands collected by the tap so far.
-     */
-    public List<Command> commands() {
-        return outerObjects();
+    @Override
+    protected TenantId tenantOf(Command command) {
+        return Commands.tenantOf(command);
     }
 }

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/EventCollector.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/EventCollector.java
@@ -23,20 +23,18 @@ package io.spine.testing.server.blackbox;
 import io.spine.core.Event;
 import io.spine.core.EventContext;
 import io.spine.core.EventId;
+import io.spine.core.Events;
+import io.spine.core.TenantId;
 import io.spine.server.type.EventEnvelope;
-
-import java.util.List;
 
 /**
  * Remembers events posted to an Event Bus.
  */
-public final class EventMemoizingTap
-        extends MemoizingTap<EventId, Event, EventContext, EventEnvelope> {
+public final class EventCollector
+        extends MessageCollector<EventId, Event, EventContext, EventEnvelope> {
 
-    /**
-     * Obtains immutable list with events collected by the tap so far.
-     */
-    public List<Event> events() {
-        return outerObjects();
+    @Override
+    protected TenantId tenantOf(Event event) {
+        return Events.tenantOf(event);
     }
 }

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/EventCollector.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/EventCollector.java
@@ -21,7 +21,6 @@
 package io.spine.testing.server.blackbox;
 
 import io.spine.core.Event;
-import io.spine.core.EventContext;
 import io.spine.core.EventId;
 import io.spine.core.Events;
 import io.spine.core.TenantId;
@@ -30,8 +29,7 @@ import io.spine.server.type.EventEnvelope;
 /**
  * Remembers events posted to an Event Bus.
  */
-public final class EventCollector
-        extends MessageCollector<EventId, Event, EventContext, EventEnvelope> {
+public final class EventCollector extends MessageCollector<EventId, Event, EventEnvelope> {
 
     @Override
     protected TenantId tenantOf(Event event) {

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/EventMemoizingTap.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/EventMemoizingTap.java
@@ -20,23 +20,23 @@
 
 package io.spine.testing.server.blackbox;
 
-import io.spine.core.Command;
-import io.spine.core.CommandContext;
-import io.spine.core.CommandId;
-import io.spine.server.type.CommandEnvelope;
+import io.spine.core.Event;
+import io.spine.core.EventContext;
+import io.spine.core.EventId;
+import io.spine.server.type.EventEnvelope;
 
 import java.util.List;
 
 /**
- * Remembers commands posted to a Command Bus.
+ * Remembers events posted to an Event Bus.
  */
-public final class CommandMemoizingTap
-        extends MemoizingTap<CommandId, Command, CommandContext, CommandEnvelope> {
+public final class EventMemoizingTap
+        extends MemoizingTap<EventId, Event, EventContext, EventEnvelope> {
 
     /**
-     * Obtains immutable list with commands collected by the tap so far.
+     * Obtains immutable list with events collected by the tap so far.
      */
-    public List<Command> commands() {
+    public List<Event> events() {
         return outerObjects();
     }
 }

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/MemoizingTap.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/MemoizingTap.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing.server.blackbox;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Message;
+import io.spine.base.MessageContext;
+import io.spine.core.Ack;
+import io.spine.core.MessageId;
+import io.spine.server.bus.BusFilter;
+import io.spine.server.type.MessageEnvelope;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Optional.ofNullable;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+
+/**
+ * Abstract base for bus filters that remember passing messages.
+ *
+ * <p>Always accepts the posted messages.
+ *
+ * @param <I>
+ *         the type of the message identifiers
+ * @param <T>
+ *         the type of the outer objects of messages
+ * @param <C>
+ *         the type of message contexts
+ * @param <E>
+ *         the type of the message envelopes
+ */
+abstract class MemoizingTap<I extends MessageId,
+                            T extends Message,
+                            C extends MessageContext,
+                            E extends MessageEnvelope<I, T, C>> implements BusFilter<E> {
+
+    private final Map<I, Message> messages = new HashMap<>();
+    private final List<T> outerObjects = new ArrayList<>();
+
+    /**
+     * Looks up the command message by the command ID.
+     */
+    public final <M extends Message> Optional<M> find(I messageId, Class<M> messageClass) {
+        Message commandMessage = messages.get(messageId);
+        assertThat(commandMessage, instanceOf(messageClass));
+        @SuppressWarnings("unchecked") // Checked with an assertion.
+                M result = (M) commandMessage;
+        return ofNullable(result);
+    }
+
+    /**
+     * Remembers the passed message and accepts its, returning empty {@code Optional}.
+     */
+    @Override
+    public final Optional<Ack> accept(E envelope) {
+        messages.put(envelope.id(), envelope.message());
+        outerObjects.add(envelope.outerObject());
+        return Optional.empty();
+    }
+
+    /**
+     * Obtains immutable list with outer objects by the tap so far.
+     */
+    final List<T> outerObjects() {
+        return ImmutableList.copyOf(outerObjects);
+    }
+}

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/MessageCollector.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/MessageCollector.java
@@ -22,7 +22,6 @@ package io.spine.testing.server.blackbox;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Message;
-import io.spine.base.MessageContext;
 import io.spine.core.MessageId;
 import io.spine.core.TenantId;
 import io.spine.server.type.MessageEnvelope;
@@ -47,18 +46,16 @@ import static org.hamcrest.Matchers.instanceOf;
  *         the type of the message identifiers
  * @param <T>
  *         the type of the outer objects of messages
- * @param <C>
- *         the type of message contexts
  * @param <E>
  *         the type of the message envelopes
  */
 abstract class MessageCollector<I extends MessageId,
                                 T extends Message,
-                                C extends MessageContext,
-                                E extends MessageEnvelope<I, T, C>> implements Consumer<E> {
+                                E extends MessageEnvelope<I, T, ?>>
+        implements Consumer<E> {
 
-    private final Map<I, Message> messages = new HashMap<>();
     private final List<T> outerObjects = new ArrayList<>();
+    private final Map<I, Message> messages = new HashMap<>();
 
     /**
      * Looks up the command message by the command ID.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/MultitenantBlackBoxContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/MultitenantBlackBoxContext.java
@@ -22,7 +22,7 @@ package io.spine.testing.server.blackbox;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.spine.core.Command;
-import io.spine.core.Commands;
+import io.spine.core.Event;
 import io.spine.core.TenantId;
 import io.spine.server.event.EventEnricher;
 import io.spine.server.tenant.TenantAwareRunner;
@@ -30,9 +30,7 @@ import io.spine.testing.client.TestActorRequestFactory;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
 
@@ -70,19 +68,14 @@ public final class MultitenantBlackBoxContext
     }
 
     @Override
-    protected EmittedCommands emittedCommands(CommandMemoizingTap commandTap) {
-        List<Command> allCommands = commandTap.commands();
-        List<Command> tenantCommands = allCommands.stream()
-                                                  .filter(new MatchesTenant(tenantId))
-                                                  .collect(Collectors.toList());
+    protected EmittedCommands emittedCommands(CommandCollector collector) {
+        List<Command> tenantCommands = collector.ofTenant(tenantId);
         return new EmittedCommands(tenantCommands);
     }
 
     @Override
-    protected EmittedEvents emittedEvents() {
-        TenantAwareRunner tenantAwareRunner = TenantAwareRunner.with(tenantId);
-        EmittedEvents events = tenantAwareRunner.evaluate(super::emittedEvents);
-        return events;
+    protected List<Event> collectedEvents(EventCollector collector) {
+        return collector.ofTenant(tenantId);
     }
 
     @Override
@@ -110,21 +103,4 @@ public final class MultitenantBlackBoxContext
         return new TestActorRequestFactory(MultitenantBlackBoxContext.class, tenantId);
     }
 
-    /**
-     * A predicate to match commands with a {@linkplain #tenantToMatch tenant ID}.
-     */
-    private static class MatchesTenant implements Predicate<Command> {
-
-        private final TenantId tenantToMatch;
-
-        private MatchesTenant(TenantId tenantToMatch) {
-            this.tenantToMatch = tenantToMatch;
-        }
-
-        @Override
-        public boolean test(Command command) {
-            TenantId commandTenant = Commands.getTenantId(command);
-            return commandTenant.equals(tenantToMatch);
-        }
-    }
 }

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/MultitenantBlackBoxContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/MultitenantBlackBoxContext.java
@@ -68,13 +68,12 @@ public final class MultitenantBlackBoxContext
     }
 
     @Override
-    protected EmittedCommands emittedCommands(CommandCollector collector) {
-        List<Command> tenantCommands = collector.ofTenant(tenantId);
-        return new EmittedCommands(tenantCommands);
+    protected List<Command> select(CommandCollector collector) {
+        return collector.ofTenant(tenantId);
     }
 
     @Override
-    protected List<Event> collectedEvents(EventCollector collector) {
+    protected List<Event> select(EventCollector collector) {
         return collector.ofTenant(tenantId);
     }
 
@@ -102,5 +101,4 @@ public final class MultitenantBlackBoxContext
     private static TestActorRequestFactory requestFactory(TenantId tenantId) {
         return new TestActorRequestFactory(MultitenantBlackBoxContext.class, tenantId);
     }
-
 }

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/SingleTenantBlackBoxContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/SingleTenantBlackBoxContext.java
@@ -22,6 +22,7 @@ package io.spine.testing.server.blackbox;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.spine.core.Command;
+import io.spine.core.Event;
 import io.spine.server.event.EventEnricher;
 import io.spine.testing.client.TestActorRequestFactory;
 
@@ -42,9 +43,13 @@ public final class SingleTenantBlackBoxContext
     }
 
     @Override
-    protected EmittedCommands emittedCommands(CommandCollector collector) {
-        List<Command> commands = collector.all();
-        return new EmittedCommands(commands);
+    protected List<Command> select(CommandCollector collector) {
+        return collector.all();
+    }
+
+    @Override
+    protected List<Event> select(EventCollector collector) {
+        return collector.all();
     }
 
     @Override

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/SingleTenantBlackBoxContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/SingleTenantBlackBoxContext.java
@@ -42,8 +42,8 @@ public final class SingleTenantBlackBoxContext
     }
 
     @Override
-    protected EmittedCommands emittedCommands(CommandMemoizingTap commandTap) {
-        List<Command> commands = commandTap.commands();
+    protected EmittedCommands emittedCommands(CommandCollector collector) {
+        List<Command> commands = collector.all();
         return new EmittedCommands(commands);
     }
 

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/verify/state/VerifyState.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/verify/state/VerifyState.java
@@ -40,7 +40,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Verifies the states of entities currently present in a bounded context.
+ * Verifies the states of entities currently present in a Bounded Context.
  */
 @VisibleForTesting
 public abstract class VerifyState {
@@ -50,7 +50,7 @@ public abstract class VerifyState {
      * {@linkplain #verify(Collection)} verifies} the results according to the pre-set expectations.
      *
      * @param boundedContext
-     *         the bounded context to query
+     *         the Bounded Context to query
      * @param queryFactory
      *         the factory to create queries
      */
@@ -102,8 +102,8 @@ public abstract class VerifyState {
      *         the expected entity states
      * @return new instance of {@code VerifyState}
      */
-    public static <T extends Message> VerifyState exactly(Class<T> entityType,
-                                                          Iterable<T> expected) {
+    public static <T extends Message>
+    VerifyState exactly(Class<T> entityType, Iterable<T> expected) {
         return new AllOfTypeMatch<>(expected, entityType);
     }
 }


### PR DESCRIPTION
This PR adds an ability to add a `Consumer` of envelopes of messages posted to a `Bus`. This is needed to avoid having a `BusFilter` which isn't filtering but simply consuming a posted message.

Other notable changes:
  * Improved method naming avoiding `get` prefixes.
  * Improved obtaining of generated events in `BlackBoxBoundedContext`. Previously, they were loaded from `EventStore`, now they are collected using Bus message listeners.
