### PR TITLE
Obtain sub-subject of generated messages

### DIFF
--- a/core/src/main/java/io/spine/core/Commands.java
+++ b/core/src/main/java/io/spine/core/Commands.java
@@ -42,7 +42,6 @@ import java.util.function.Predicate;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.core.CommandContext.Schedule;
-import static io.spine.protobuf.AnyPacker.unpack;
 import static io.spine.validate.Validate.isNotDefault;
 
 /**
@@ -70,7 +69,7 @@ public final class Commands {
      */
     public static CommandMessage getMessage(Command command) {
         checkNotNull(command);
-        CommandMessage result = (CommandMessage) unpack(command.getMessage());
+        CommandMessage result = (CommandMessage) command.enclosedMessage();
         return result;
     }
 

--- a/core/src/main/java/io/spine/core/EnrichableMessageContext.java
+++ b/core/src/main/java/io/spine/core/EnrichableMessageContext.java
@@ -21,6 +21,7 @@
 package io.spine.core;
 
 import com.google.protobuf.Message;
+import io.spine.annotation.GeneratedMixin;
 import io.spine.base.MessageContext;
 import io.spine.core.Enrichment.Container;
 
@@ -31,6 +32,7 @@ import static io.spine.core.Enrichments.containerIn;
 /**
  * A common interface for message contexts that hold enrichments.
  */
+@GeneratedMixin
 public interface EnrichableMessageContext extends MessageContext {
 
     /**

--- a/core/src/main/java/io/spine/core/EnrichableMessageContext.java
+++ b/core/src/main/java/io/spine/core/EnrichableMessageContext.java
@@ -20,6 +20,7 @@
 
 package io.spine.core;
 
+import com.google.errorprone.annotations.Immutable;
 import com.google.protobuf.Message;
 import io.spine.annotation.GeneratedMixin;
 import io.spine.base.MessageContext;
@@ -33,6 +34,7 @@ import static io.spine.core.Enrichments.containerIn;
  * A common interface for message contexts that hold enrichments.
  */
 @GeneratedMixin
+@Immutable
 public interface EnrichableMessageContext extends MessageContext {
 
     /**

--- a/core/src/main/java/io/spine/core/Events.java
+++ b/core/src/main/java/io/spine/core/Events.java
@@ -129,7 +129,6 @@ public final class Events {
      */
     public static EventMessage getMessage(Event event) {
         checkNotNull(event);
-        Any any = event.getMessage();
         EventMessage result = (EventMessage) event.enclosedMessage();
         return result;
     }

--- a/core/src/main/java/io/spine/core/Events.java
+++ b/core/src/main/java/io/spine/core/Events.java
@@ -43,7 +43,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Throwables.getStackTraceAsString;
 import static io.spine.core.EventContext.OriginCase.EVENT_CONTEXT;
 import static io.spine.protobuf.AnyPacker.pack;
-import static io.spine.protobuf.AnyPacker.unpack;
 import static io.spine.util.Exceptions.newIllegalArgumentException;
 import static io.spine.validate.Validate.checkNotEmptyOrBlank;
 import static io.spine.validate.Validate.isDefault;
@@ -131,7 +130,7 @@ public final class Events {
     public static EventMessage getMessage(Event event) {
         checkNotNull(event);
         Any any = event.getMessage();
-        EventMessage result = (EventMessage) unpack(any);
+        EventMessage result = (EventMessage) event.enclosedMessage();
         return result;
     }
 

--- a/core/src/main/java/io/spine/core/MessageWithContext.java
+++ b/core/src/main/java/io/spine/core/MessageWithContext.java
@@ -23,7 +23,10 @@ package io.spine.core;
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import io.spine.base.MessageContext;
+import io.spine.protobuf.AnyPacker;
 import io.spine.type.TypeUrl;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Base interfaces for outer objects of messages with contexts, such as commands or events.
@@ -48,9 +51,30 @@ public interface MessageWithContext extends Message {
     MessageContext getContext();
 
     /**
+     * Obtains the unpacked form of the enclosed message.
+     *
+     * <p>The method {@link #getMessage()} returns the packed version.
+     */
+    default Message enclosedMessage() {
+        Message enclosed = AnyPacker.unpack(getMessage());
+        return enclosed;
+    }
+
+    /**
      * Obtains the type URL of the enclosed message.
      */
     default TypeUrl typeUrl() {
         return TypeUrl.ofEnclosed(getMessage());
+    }
+
+    /**
+     * Verifies if the enclosed message has the same type as the passed, or the passed type
+     * is the super-type of the message.
+     */
+    default boolean hasType(Class<? extends Message> enclosedMessageClass) {
+        checkNotNull(enclosedMessageClass);
+        Message enclosed = enclosedMessage();
+        boolean result = enclosedMessageClass.isAssignableFrom(enclosed.getClass());
+        return result;
     }
 }

--- a/core/src/main/java/io/spine/core/MessageWithContext.java
+++ b/core/src/main/java/io/spine/core/MessageWithContext.java
@@ -22,6 +22,7 @@ package io.spine.core;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
+import io.spine.annotation.GeneratedMixin;
 import io.spine.base.MessageContext;
 import io.spine.protobuf.AnyPacker;
 import io.spine.type.TypeUrl;
@@ -33,6 +34,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @apiNote Some methods use the {@code 'get'} prefix to mix-in with the generated code.
  */
+@GeneratedMixin
 public interface MessageWithContext extends Message {
 
     /**
@@ -41,7 +43,9 @@ public interface MessageWithContext extends Message {
     Message getId();
 
     /**
-     * Obtains the enclosed message.
+     * Obtains the packed version of the enclosed message.
+     *
+     * @see #enclosedMessage()
      */
     Any getMessage();
 
@@ -53,7 +57,7 @@ public interface MessageWithContext extends Message {
     /**
      * Obtains the unpacked form of the enclosed message.
      *
-     * <p>The method {@link #getMessage()} returns the packed version.
+     * @see #getMessage()
      */
     default Message enclosedMessage() {
         Message enclosed = AnyPacker.unpack(getMessage());
@@ -71,7 +75,7 @@ public interface MessageWithContext extends Message {
      * Verifies if the enclosed message has the same type as the passed, or the passed type
      * is the super-type of the message.
      */
-    default boolean hasType(Class<? extends Message> enclosedMessageClass) {
+    default boolean is(Class<? extends Message> enclosedMessageClass) {
         checkNotNull(enclosedMessageClass);
         Message enclosed = enclosedMessage();
         boolean result = enclosedMessageClass.isAssignableFrom(enclosed.getClass());

--- a/core/src/test/java/io/spine/core/MessageWithContextTest.java
+++ b/core/src/test/java/io/spine/core/MessageWithContextTest.java
@@ -38,11 +38,11 @@ class MessageWithContextTest {
     void checkType() {
         Event event = stubEvent();
 
-        assertThat(event.hasType(ProjectCreated.class))
+        assertThat(event.is(ProjectCreated.class))
                 .isTrue();
-        assertThat(event.hasType(EventMessage.class))
+        assertThat(event.is(EventMessage.class))
                 .isTrue();
-        assertThat(event.hasType(TaskAssigned.class))
+        assertThat(event.is(TaskAssigned.class))
                 .isFalse();
     }
 

--- a/core/src/test/java/io/spine/core/MessageWithContextTest.java
+++ b/core/src/test/java/io/spine/core/MessageWithContextTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.core;
+
+import io.spine.base.EventMessage;
+import io.spine.protobuf.AnyPacker;
+import io.spine.test.core.ProjectCreated;
+import io.spine.test.core.ProjectId;
+import io.spine.test.core.TaskAssigned;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@DisplayName("MessageWithContext should")
+class MessageWithContextTest {
+
+    @Test
+    @DisplayName("verify type of the enclosed message")
+    void checkType() {
+        Event event = stubEvent();
+
+        assertThat(event.hasType(ProjectCreated.class))
+                .isTrue();
+        assertThat(event.hasType(EventMessage.class))
+                .isTrue();
+        assertThat(event.hasType(TaskAssigned.class))
+                .isFalse();
+    }
+
+    /**
+     * Creates a stub instance of {@code Event} with the type {@link ProjectCreated}.
+     */
+    private Event stubEvent() {
+        Event event = Event
+                .newBuilder()
+                .setMessage(AnyPacker.pack(
+                        ProjectCreated
+                                .newBuilder()
+                                .setProjectId(ProjectId.newBuilder()
+                                                       .setId(getClass().getName()))
+                                .build()))
+                .build();
+        return event;
+    }
+}

--- a/core/src/test/java/io/spine/core/MessageWithContextTest.java
+++ b/core/src/test/java/io/spine/core/MessageWithContextTest.java
@@ -50,14 +50,17 @@ class MessageWithContextTest {
      * Creates a stub instance of {@code Event} with the type {@link ProjectCreated}.
      */
     private Event stubEvent() {
+        ProjectId project = ProjectId
+                .newBuilder()
+                .setId(getClass().getName())
+                .build();
+        ProjectCreated message = ProjectCreated
+                .newBuilder()
+                .setProjectId(project)
+                .build();
         Event event = Event
                 .newBuilder()
-                .setMessage(AnyPacker.pack(
-                        ProjectCreated
-                                .newBuilder()
-                                .setProjectId(ProjectId.newBuilder()
-                                                       .setId(getClass().getName()))
-                                .build()))
+                .setMessage(AnyPacker.pack(message))
                 .build();
         return event;
     }

--- a/testutil-server/src/main/java/io/spine/testing/server/CommandSubject.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/CommandSubject.java
@@ -43,6 +43,11 @@ public final class CommandSubject
         return CommandSubject::new;
     }
 
+    @Override
+    protected Factory<CommandSubject, Iterable<Command>> factory() {
+        return commands();
+    }
+
     /** Creates the subject for asserting passed commands. */
     public static CommandSubject assertThat(@NullableDecl Iterable<Command> actual) {
         return assertAbout(commands()).that(actual);

--- a/testutil-server/src/main/java/io/spine/testing/server/EmittedMessageSubject.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/EmittedMessageSubject.java
@@ -143,7 +143,7 @@ public abstract class EmittedMessageSubject<S extends EmittedMessageSubject<S, T
         } else {
             List<T> filtered =
                     Streams.stream(actual)
-                           .filter(m -> m.hasType(messageClass))
+                           .filter(m -> m.is(messageClass))
                            .collect(toImmutableList());
             return check().about(factory())
                           .that(filtered);

--- a/testutil-server/src/main/java/io/spine/testing/server/EmittedMessageSubject.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/EmittedMessageSubject.java
@@ -21,7 +21,9 @@
 package io.spine.testing.server;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Streams;
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.IterableSubject;
 import com.google.common.truth.Subject;
@@ -34,6 +36,9 @@ import io.spine.core.MessageWithContext;
 import io.spine.protobuf.AnyPacker;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Fact.fact;
 import static com.google.common.truth.extensions.proto.ProtoTruth.protos;
 
@@ -42,23 +47,40 @@ import static com.google.common.truth.extensions.proto.ProtoTruth.protos;
  * a Bounded Context under the test.
  *
  * @param <S>
- *          the self-type for return type covariance
+ *         the self-type for return type covariance
  * @param <T>
- *          the type of the outer objects of the checked messages,
- *          such as {@link io.spine.core.Command Command} or {@link io.spine.core.Event Event}
+ *         the type of the outer objects of the checked messages,
+ *         such as {@link io.spine.core.Command Command} or {@link io.spine.core.Event Event}
  * @param <M>
- *          the type of emitted messages, such as {@link io.spine.base.CommandMessage CommandMessage}
- *          or {@link io.spine.base.EventMessage EventMessage}.
+ *         the type of emitted messages, such as {@link io.spine.base.CommandMessage CommandMessage}
+ *         or {@link io.spine.base.EventMessage EventMessage}.
  */
 public abstract class EmittedMessageSubject<S extends EmittedMessageSubject<S, T, M>,
                                             T extends MessageWithContext,
                                             M extends SerializableMessage>
         extends Subject<S, Iterable<T>> {
 
+    /**
+     * Key strings for Truth facts.
+     */
     @VisibleForTesting
-    static final String MESSAGE_COUNT_FACT_KEY = "the count of the generated messages is";
-    @VisibleForTesting
-    static final String REQUESTED_INDEX_FACT_KEY = "but the requested index was";
+    enum FactKey {
+
+        MESSAGE_COUNT("the count of the generated messages is"),
+        REQUESTED_INDEX("but the requested index was"),
+        @SuppressWarnings("DuplicateStringLiteralInspection")
+        ACTUAL("actual");
+
+        private final String value;
+
+        FactKey(String value) {
+            this.value = value;
+        }
+
+        String value() {
+            return value;
+        }
+    }
 
     protected EmittedMessageSubject(FailureMetadata metadata, @NullableDecl Iterable<T> actual) {
         super(metadata, actual);
@@ -92,8 +114,8 @@ public abstract class EmittedMessageSubject<S extends EmittedMessageSubject<S, T
         int size = Iterables.size(actual());
         if (index >= size) {
             failWithActual(
-                    fact(MESSAGE_COUNT_FACT_KEY, size),
-                    fact(REQUESTED_INDEX_FACT_KEY, index)
+                    fact(FactKey.MESSAGE_COUNT.value, size),
+                    fact(FactKey.REQUESTED_INDEX.value, index)
             );
             return ignoreCheck().about(protos())
                                 .that(Empty.getDefaultInstance());
@@ -101,6 +123,30 @@ public abstract class EmittedMessageSubject<S extends EmittedMessageSubject<S, T
             T outerObject = Iterables.get(actual(), index);
             Message unpacked = AnyPacker.unpack(outerObject.getMessage());
             return ProtoTruth.assertThat(unpacked);
+        }
+    }
+
+    /**
+     * Provides factory for creating the same type of subject on a subset of messages.
+     */
+    protected abstract Subject.Factory<S, Iterable<T>> factory();
+
+    /**
+     * Obtains the subject over outer objects that contain messages of the passed class.
+     */
+    public final S withType(Class<? extends M> messageClass) {
+        Iterable<T> actual = actual();
+        if (actual == null) {
+            failWithActual(fact(FactKey.ACTUAL.value, null));
+            return ignoreCheck().about(factory())
+                                .that(ImmutableList.of());
+        } else {
+            List<T> filtered =
+                    Streams.stream(actual)
+                           .filter(m -> m.hasType(messageClass))
+                           .collect(toImmutableList());
+            return check().about(factory())
+                          .that(filtered);
         }
     }
 }

--- a/testutil-server/src/main/java/io/spine/testing/server/EventSubject.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/EventSubject.java
@@ -42,6 +42,11 @@ public final class EventSubject extends EmittedMessageSubject<EventSubject, Even
         return EventSubject::new;
     }
 
+    @Override
+    protected Factory<EventSubject, Iterable<Event>> factory() {
+        return events();
+    }
+
     /** Creates the subject for asserting passed events. */
     public static EventSubject assertThat(@NullableDecl Iterable<Event> actual) {
         return assertAbout(events()).that(actual);

--- a/testutil-server/src/test/java/io/spine/testing/server/CommandSubjectTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/CommandSubjectTest.java
@@ -21,18 +21,21 @@
 package io.spine.testing.server;
 
 import com.google.common.truth.Subject;
+import io.spine.base.CommandMessage;
 import io.spine.client.CommandFactory;
 import io.spine.core.Command;
 import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.testing.server.given.entity.TuTaskId;
 import io.spine.testing.server.given.entity.command.TuAddComment;
+import io.spine.testing.server.given.entity.command.TuCreateTask;
 import org.junit.jupiter.api.DisplayName;
 
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.testing.server.CommandSubject.commands;
 
 @DisplayName("CommandSubject should")
-class CommandSubjectTest extends EmittedMessageSubjectTest<CommandSubject, Command> {
+class CommandSubjectTest
+        extends EmittedMessageSubjectTest<CommandSubject, Command, CommandMessage> {
 
     private static final CommandFactory commands =
             new TestActorRequestFactory(CommandSubjectTest.class).command();
@@ -49,14 +52,32 @@ class CommandSubjectTest extends EmittedMessageSubjectTest<CommandSubject, Comma
 
     @Override
     Command createMessage() {
-        TuTaskId taskId = TuTaskId
+        return newCommand(
+                TuAddComment
+                        .vBuilder()
+                        .setId(generateTaskId())
+                        .build()
+        );
+    }
+
+    @Override
+    Command createAnotherMessage() {
+        return newCommand(
+                TuCreateTask
+                        .vBuilder()
+                        .setId(generateTaskId())
+                        .build()
+        );
+    }
+
+    private static Command newCommand(CommandMessage msg) {
+        return commands.create(msg);
+    }
+
+    private static TuTaskId generateTaskId() {
+        return TuTaskId
                 .vBuilder()
                 .setValue(newUuid())
                 .build();
-        TuAddComment event = TuAddComment
-                .vBuilder()
-                .setId(taskId)
-                .build();
-        return commands.create(event);
     }
 }

--- a/testutil-server/src/test/java/io/spine/testing/server/EmittedMessageSubjectTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/EmittedMessageSubjectTest.java
@@ -151,6 +151,8 @@ abstract class EmittedMessageSubjectTest<S extends EmittedMessageSubject<S, W, M
     @DisplayName("fail when trying to obtain filtered sub-subject over null actual")
     void failWithNull() {
         Class<M> cls1 = typeOf(createMessage());
+        @SuppressWarnings("CheckReturnValue") /* The call to `withType()` should fail,
+            we don't need its result. */
         AssertionError error = expectFailure(whenTesting -> whenTesting.that(null)
                                                                        .withType(cls1));
         TruthFailureSubject assertError = assertThat(error);

--- a/testutil-server/src/test/java/io/spine/testing/server/EmittedMessageSubjectTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/EmittedMessageSubjectTest.java
@@ -150,11 +150,11 @@ abstract class EmittedMessageSubjectTest<S extends EmittedMessageSubject<S, W, M
     @Test
     @DisplayName("fail when trying to obtain filtered sub-subject over null actual")
     void failWithNull() {
-        Class<M> cls1 = typeOf(createMessage());
+        Class<M> type = typeOf(createMessage());
         @SuppressWarnings("CheckReturnValue") /* The call to `withType()` should fail,
             we don't need its result. */
         AssertionError error = expectFailure(whenTesting -> whenTesting.that(null)
-                                                                       .withType(cls1));
+                                                                       .withType(type));
         TruthFailureSubject assertError = assertThat(error);
         assertError.factValue(FactKey.ACTUAL.value())
                    .isEqualTo("null");

--- a/testutil-server/src/test/java/io/spine/testing/server/EmittedMessageSubjectTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/EmittedMessageSubjectTest.java
@@ -135,16 +135,16 @@ abstract class EmittedMessageSubjectTest<S extends EmittedMessageSubject<S, W, M
                 .addAll(messages(otherMessageCount, this::createAnotherMessage))
                 .build();
 
-        Class<M> cls1 = typeOf(createMessage());
-        Class<M> cls2 = typeOf(createAnotherMessage());
+        Class<M> type = typeOf(createMessage());
+        Class<M> anotherType = typeOf(createAnotherMessage());
 
         S subject = assertWithSubjectThat(outerObjects);
 
-        S subSubject1 = subject.withType(cls1);
-        subSubject1.hasSize(messageCount);
+        S subSubject = subject.withType(type);
+        subSubject.hasSize(messageCount);
 
-        S subSubject2 = subject.withType(cls2);
-        subSubject2.hasSize(otherMessageCount);
+        S anotherSubSubject = subject.withType(anotherType);
+        anotherSubSubject.hasSize(otherMessageCount);
     }
 
     @Test

--- a/testutil-server/src/test/java/io/spine/testing/server/EmittedMessageSubjectTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/EmittedMessageSubjectTest.java
@@ -20,30 +20,41 @@
 
 package io.spine.testing.server;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.truth.TruthFailureSubject;
 import com.google.common.truth.extensions.proto.ProtoSubject;
 import com.google.protobuf.Any;
+import io.spine.base.SerializableMessage;
 import io.spine.core.MessageWithContext;
+import io.spine.testing.server.EmittedMessageSubject.FactKey;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.function.Supplier;
+
 import static com.google.common.truth.ExpectFailure.assertThat;
 import static com.google.common.truth.Truth.assertThat;
-import static io.spine.testing.server.EmittedMessageSubject.MESSAGE_COUNT_FACT_KEY;
-import static io.spine.testing.server.EmittedMessageSubject.REQUESTED_INDEX_FACT_KEY;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.generate;
 
-abstract class EmittedMessageSubjectTest<S extends EmittedMessageSubject<S, M, ?>,
-                                         M extends MessageWithContext>
-        extends SubjectTest<S, Iterable<M>> {
+abstract class EmittedMessageSubjectTest<S extends EmittedMessageSubject<S, W, M>,
+                                         W extends MessageWithContext,
+                                         M extends SerializableMessage>
+        extends SubjectTest<S, Iterable<W>> {
 
-    abstract S assertWithSubjectThat(Iterable<M> messages);
+    abstract S assertWithSubjectThat(Iterable<W> messages);
 
-    abstract M createMessage();
+    abstract W createMessage();
 
-    private Iterable<M> messages(int messageCount) {
-        return generate(this::createMessage)
+    abstract W createAnotherMessage();
+
+    private Iterable<W> messages(int messageCount) {
+        Supplier<W> supplier = this::createMessage;
+        return messages(messageCount, supplier);
+    }
+
+    private Iterable<W> messages(int messageCount, Supplier<W> supplier) {
+        return generate(supplier)
                 .limit(messageCount)
                 .collect(toList());
     }
@@ -52,7 +63,7 @@ abstract class EmittedMessageSubjectTest<S extends EmittedMessageSubject<S, M, ?
     @DisplayName("check message count")
     void checkSize() {
         int messageCount = 42;
-        Iterable<M> messages = messages(messageCount);
+        Iterable<W> messages = messages(messageCount);
         assertWithSubjectThat(messages).hasSize(messageCount);
         AssertionError error = expectFailure(
                 whenTesting -> whenTesting.that(messages)
@@ -69,7 +80,7 @@ abstract class EmittedMessageSubjectTest<S extends EmittedMessageSubject<S, M, ?
     @DisplayName("check if there is no messages")
     void checkIfAbsent() {
         int messageCount = 0;
-        Iterable<M> messages = messages(messageCount);
+        Iterable<W> messages = messages(messageCount);
         assertWithSubjectThat(messages).isEmpty();
         expectSomeFailure(whenTesting -> whenTesting.that(messages)
                                                     .isNotEmpty());
@@ -79,7 +90,7 @@ abstract class EmittedMessageSubjectTest<S extends EmittedMessageSubject<S, M, ?
     @DisplayName("check if there are some messages")
     void checkIfPresent() {
         int messageCount = 1;
-        Iterable<M> messages = messages(messageCount);
+        Iterable<W> messages = messages(messageCount);
         assertWithSubjectThat(messages).isNotEmpty();
         expectSomeFailure(whenTesting -> whenTesting.that(messages)
                                                     .isEmpty());
@@ -89,7 +100,7 @@ abstract class EmittedMessageSubjectTest<S extends EmittedMessageSubject<S, M, ?
     @DisplayName("retrieve a subject of an emitted message by its index")
     void retrieveMessage() {
         int messageCount = 3;
-        Iterable<M> messages = messages(messageCount);
+        Iterable<W> messages = messages(messageCount);
         ProtoSubject<?, ?> protoSubject = assertWithSubjectThat(messages).message(2);
         assertThat(protoSubject).isNotNull();
         protoSubject.isNotEqualToDefaultInstance();
@@ -101,15 +112,58 @@ abstract class EmittedMessageSubjectTest<S extends EmittedMessageSubject<S, M, ?
     @DisplayName("check the message count when obtaining a ProtoSubject")
     void failOnIndexOutOfBounds() {
         int messageCount = 5;
-        Iterable<M> messages = messages(messageCount);
+        Iterable<W> messages = messages(messageCount);
         int index = 13;
         @SuppressWarnings("CheckReturnValue")
         AssertionError error = expectFailure(whenTesting -> whenTesting.that(messages)
                                                                        .message(index));
         TruthFailureSubject assertError = assertThat(error);
-        assertError.factValue(MESSAGE_COUNT_FACT_KEY)
+        assertError.factValue(FactKey.MESSAGE_COUNT.value())
                    .isEqualTo(String.valueOf(messageCount));
-        assertError.factValue(REQUESTED_INDEX_FACT_KEY)
+        assertError.factValue(FactKey.REQUESTED_INDEX.value())
                    .isEqualTo(String.valueOf(index));
+    }
+
+    @Test
+    @DisplayName("obtain derived subject with messages of type")
+    void subSubjectByType() {
+        int messageCount = 3;
+        int otherMessageCount = 2;
+        Iterable<W> outerObjects = ImmutableList
+                .<W>builder()
+                .addAll(messages(messageCount))
+                .addAll(messages(otherMessageCount, this::createAnotherMessage))
+                .build();
+
+        Class<M> cls1 = typeOf(createMessage());
+        Class<M> cls2 = typeOf(createAnotherMessage());
+
+        S subject = assertWithSubjectThat(outerObjects);
+
+        S subSubject1 = subject.withType(cls1);
+        subSubject1.hasSize(messageCount);
+
+        S subSubject2 = subject.withType(cls2);
+        subSubject2.hasSize(otherMessageCount);
+
+    }
+
+    @Test
+    @DisplayName("fail when trying to obtain filtered sub-subject over null actual")
+    void failWithNull() {
+        Class<M> cls1 = typeOf(createMessage());
+        AssertionError error = expectFailure(whenTesting -> whenTesting.that(null)
+                                                                       .withType(cls1));
+        TruthFailureSubject assertError = assertThat(error);
+        assertError.factValue(FactKey.ACTUAL.value())
+                   .isEqualTo("null");
+    }
+
+    private Class<M> typeOf(W outerObject) {
+        @SuppressWarnings("unchecked") Class<M> /* The cast is protected by matching outer type
+            (such as `Event` or `Command`) to corresponding enclosed message type (such as
+            `EventMessage` or `CommandMessage`) in the generic parameters of the derived classes. */
+        result = (Class<M>) outerObject.enclosedMessage().getClass();
+        return result;
     }
 }

--- a/testutil-server/src/test/java/io/spine/testing/server/EmittedMessageSubjectTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/EmittedMessageSubjectTest.java
@@ -145,7 +145,6 @@ abstract class EmittedMessageSubjectTest<S extends EmittedMessageSubject<S, W, M
 
         S subSubject2 = subject.withType(cls2);
         subSubject2.hasSize(otherMessageCount);
-
     }
 
     @Test

--- a/testutil-server/src/test/java/io/spine/testing/server/EventSubjectTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/EventSubjectTest.java
@@ -21,16 +21,18 @@
 package io.spine.testing.server;
 
 import com.google.common.truth.Subject;
+import io.spine.base.EventMessage;
 import io.spine.core.Event;
 import io.spine.testing.server.given.entity.TuTaskId;
 import io.spine.testing.server.given.entity.event.TuCommentAdded;
+import io.spine.testing.server.given.entity.event.TuTaskCreated;
 import org.junit.jupiter.api.DisplayName;
 
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.testing.server.EventSubject.events;
 
 @DisplayName("EventSubject should")
-class EventSubjectTest extends EmittedMessageSubjectTest<EventSubject, Event> {
+class EventSubjectTest extends EmittedMessageSubjectTest<EventSubject, Event, EventMessage> {
 
     private static final TestEventFactory events =
             TestEventFactory.newInstance(EventSubjectTest.class);
@@ -47,14 +49,32 @@ class EventSubjectTest extends EmittedMessageSubjectTest<EventSubject, Event> {
 
     @Override
     Event createMessage() {
-        TuTaskId taskId = TuTaskId
-                .vBuilder()
-                .setValue(newUuid())
-                .build();
+        TuTaskId taskId = generateTaskId();
         TuCommentAdded event = TuCommentAdded
                 .vBuilder()
                 .setId(taskId)
                 .build();
-        return events.createEvent(event);
+        return newEvent(event);
+    }
+
+    @Override
+    Event createAnotherMessage() {
+        TuTaskId taskId = generateTaskId();
+        TuTaskCreated event = TuTaskCreated
+                .vBuilder()
+                .setId(taskId)
+                .build();
+        return newEvent(event);
+    }
+
+    private static Event newEvent(EventMessage msg) {
+        return events.createEvent(msg);
+    }
+
+    private static TuTaskId generateTaskId() {
+        return TuTaskId
+                .vBuilder()
+                .setValue(newUuid())
+                .build();
     }
 }


### PR DESCRIPTION
This PR:
  * Extends `MessageWithContext` interface with an ability to obtain unpacked message and test its type.
  * Extends `EmittedMessageSubject` with an ability to create a subject of the same type on messages filtered by the passed type.
