### PR TITLE
API comments revised and edited in io.spine.server.transport.memory package

### DIFF
--- a/server/src/main/java/io/spine/server/transport/memory/InMemoryPublisher.java
+++ b/server/src/main/java/io/spine/server/transport/memory/InMemoryPublisher.java
@@ -62,7 +62,7 @@ public final class InMemoryPublisher extends AbstractChannel implements Publishe
     }
 
     /**
-     * Always returns {@code false}, as publishers don't get stale.
+     * Always returns {@code false} as publishers don't get stale.
      *
      * @return {@code false} always.
      */

--- a/server/src/main/java/io/spine/server/transport/memory/InMemoryTransportFactory.java
+++ b/server/src/main/java/io/spine/server/transport/memory/InMemoryTransportFactory.java
@@ -76,7 +76,7 @@ public class InMemoryTransportFactory implements TransportFactory {
      * <p>The descendants may override this method to customize the implementation of subscribers
      * to use within this {@code TransportFactory} instance.
      *
-     * @param channelId a channel ID to create a subscriber for
+     * @param channelId the channel ID to create a subscriber for
      * @return an instance of subscriber
      */
     protected Subscriber newSubscriber(ChannelId channelId) {
@@ -84,7 +84,7 @@ public class InMemoryTransportFactory implements TransportFactory {
     }
 
     /**
-     * Wraps currently registered in-memory subscribers into a function, that returns a subset
+     * Wraps currently registered in-memory subscribers into a function that returns a subset
      * of subscribers per channel ID.
      *
      * @param subscribers currently registered subscribers and their channel identifiers

--- a/server/src/main/java/io/spine/server/transport/memory/SingleThreadInMemTransportFactory.java
+++ b/server/src/main/java/io/spine/server/transport/memory/SingleThreadInMemTransportFactory.java
@@ -23,7 +23,7 @@ import io.spine.server.integration.ChannelId;
 import io.spine.server.transport.Subscriber;
 
 /**
- * The implementation of {@link io.spine.server.transport.TransportFactory TransportFactory},
+ * The implementation of {@link io.spine.server.transport.TransportFactory TransportFactory}
  * which uses {@linkplain SingleThreadInMemSubscriber single-thread subscribers}.
  */
 public class SingleThreadInMemTransportFactory extends InMemoryTransportFactory {


### PR DESCRIPTION
Some language-, grammar- and style-related fixes in API comments of `io.spine.server.transport.memory` package.