### PR TITLE
Test presence of repositories

### DIFF
--- a/server/src/main/java/io/spine/server/BoundedContext.java
+++ b/server/src/main/java/io/spine/server/BoundedContext.java
@@ -362,22 +362,30 @@ public abstract class BoundedContext implements AutoCloseable, Logging {
     /**
      * Verifies if there is a repository managing the passed entity class is registered
      * with this Bounded Context.
+     *
+     * <p>This method does not take into account visibility of entity states.
+     *
+     * @see #findRepository(Class)
      */
     @VisibleForTesting
     public boolean hasRepositoryOf(Class<? extends Entity<?, ?>> entityClass) {
         EntityClass<? extends Entity<?, ?>> cls = EntityClass.asEntityClass(entityClass);
-        Optional<Repository> repository = findRepository(cls.stateClass());
-        return repository.isPresent();
+        boolean result = guard.hasRepository(cls.stateClass());
+        return result;
     }
 
     /**
      * Verifies if there a repository managing entities with the state of the passed class
      * registered with this Bounded Context.
+     *
+     * <p>This method does not take into account visibility of entity states.
+     *
+     * @see #findRepository(Class)
      */
     @VisibleForTesting
     public boolean hasRepositoryOfEntityWithState(Class<? extends Message> stateClass) {
-        Optional<Repository> repository = findRepository(stateClass);
-        return repository.isPresent();
+        boolean result = guard.hasRepository(stateClass);
+        return result;
     }
 
     /** Obtains instance of {@link CommandBus} of this {@code BoundedContext}. */

--- a/server/src/main/java/io/spine/server/BoundedContext.java
+++ b/server/src/main/java/io/spine/server/BoundedContext.java
@@ -360,30 +360,28 @@ public abstract class BoundedContext implements AutoCloseable, Logging {
     }
 
     /**
-     * Verifies if there is a repository managing the passed entity class is registered
-     * with this Bounded Context.
+     * Verifies if this Bounded Context contains entities of the passed class.
      *
      * <p>This method does not take into account visibility of entity states.
      *
      * @see #findRepository(Class)
      */
     @VisibleForTesting
-    public boolean hasRepositoryOf(Class<? extends Entity<?, ?>> entityClass) {
+    public boolean hasEntitiesOfType(Class<? extends Entity<?, ?>> entityClass) {
         EntityClass<? extends Entity<?, ?>> cls = EntityClass.asEntityClass(entityClass);
         boolean result = guard.hasRepository(cls.stateClass());
         return result;
     }
 
     /**
-     * Verifies if there a repository managing entities with the state of the passed class
-     * registered with this Bounded Context.
+     * Verifies if this Bounded Context has entities with the state of the passed class.
      *
      * <p>This method does not take into account visibility of entity states.
      *
      * @see #findRepository(Class)
      */
     @VisibleForTesting
-    public boolean hasRepositoryOfEntityWithState(Class<? extends Message> stateClass) {
+    public boolean hasEntitiesWithState(Class<? extends Message> stateClass) {
         boolean result = guard.hasRepository(stateClass);
         return result;
     }

--- a/server/src/main/java/io/spine/server/BoundedContext.java
+++ b/server/src/main/java/io/spine/server/BoundedContext.java
@@ -19,6 +19,7 @@
  */
 package io.spine.server;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
 import io.spine.core.BoundedContextName;
@@ -34,6 +35,7 @@ import io.spine.server.commandbus.DelegatingCommandDispatcher;
 import io.spine.server.entity.Entity;
 import io.spine.server.entity.Repository;
 import io.spine.server.entity.VisibilityGuard;
+import io.spine.server.entity.model.EntityClass;
 import io.spine.server.event.DelegatingEventDispatcher;
 import io.spine.server.event.EventBus;
 import io.spine.server.event.EventDispatcher;
@@ -350,11 +352,32 @@ public abstract class BoundedContext implements AutoCloseable, Logging {
     public Optional<Repository> findRepository(Class<? extends Message> entityStateClass) {
         // See if there is a repository for this state at all.
         if (!guard.hasRepository(entityStateClass)) {
-            throw newIllegalStateException("No repository found for the the entity state class %s",
+            throw newIllegalStateException("No repository found for the entity state class `%s`.",
                                            entityStateClass.getName());
         }
         Optional<Repository> repository = guard.repositoryFor(entityStateClass);
         return repository;
+    }
+
+    /**
+     * Verifies if there is a repository managing the passed entity class is registered
+     * with this Bounded Context.
+     */
+    @VisibleForTesting
+    public boolean hasRepositoryOf(Class<? extends Entity<?, ?>> entityClass) {
+        EntityClass<? extends Entity<?, ?>> cls = EntityClass.asEntityClass(entityClass);
+        Optional<Repository> repository = findRepository(cls.stateClass());
+        return repository.isPresent();
+    }
+
+    /**
+     * Verifies if there a repository managing entities with the state of the passed class
+     * registered with this Bounded Context.
+     */
+    @VisibleForTesting
+    public boolean hasRepositoryOfEntityWithState(Class<? extends Message> stateClass) {
+        Optional<Repository> repository = findRepository(stateClass);
+        return repository.isPresent();
     }
 
     /** Obtains instance of {@link CommandBus} of this {@code BoundedContext}. */

--- a/server/src/main/java/io/spine/server/entity/VisibilityGuard.java
+++ b/server/src/main/java/io/spine/server/entity/VisibilityGuard.java
@@ -103,8 +103,8 @@ public final class VisibilityGuard {
         RepositoryAccess repositoryAccess = repositories.get(stateClass);
         if (repositoryAccess == null) {
             throw newIllegalArgumentException(
-                    "A repository for the state class (%s) was not registered in VisibilityGuard",
-                    stateClass.getName());
+                    "A repository for the state class (`%s`)" +
+                            " was not registered in `VisibilityGuard`.", stateClass.getName());
         }
         return repositoryAccess.get();
     }

--- a/server/src/test/java/io/spine/server/BoundedContextTest.java
+++ b/server/src/test/java/io/spine/server/BoundedContextTest.java
@@ -73,6 +73,7 @@ import java.util.stream.Stream;
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.server.event.given.EventStoreTestEnv.eventStore;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -186,16 +187,14 @@ class BoundedContextTest {
 
         <I, E extends Entity<I, ?>> void registerAndAssertRepository(Class<E> cls) {
             boundedContext.register(DefaultRepository.of(cls));
-            assertThat(boundedContext.hasEntitiesOfType(cls))
-                    .isTrue();
+            assertTrue(boundedContext.hasEntitiesOfType(cls));
         }
 
         @Test
         @DisplayName("DefaultRepository via passed entity class")
         void entityClass() {
             boundedContext.register(ProjectAggregate.class);
-            assertThat(boundedContext.hasEntitiesOfType(ProjectAggregate.class))
-                    .isTrue();
+            assertTrue(boundedContext.hasEntitiesOfType(ProjectAggregate.class));
         }
     }
 
@@ -207,8 +206,7 @@ class BoundedContextTest {
         @DisplayName("confirming visible entities")
         void visible() {
             boundedContext.register(ProjectAggregate.class);
-            assertThat(boundedContext.hasEntitiesWithState(Project.class))
-                    .isTrue();
+            assertTrue(boundedContext.hasEntitiesWithState(Project.class));
         }
 
         @Test
@@ -216,8 +214,7 @@ class BoundedContextTest {
         void invisible() {
             boundedContext.register(new SecretProjectRepository());
 
-            assertThat(boundedContext.hasEntitiesWithState(SecretProject.class))
-                    .isFalse();
+            assertFalse(boundedContext.hasEntitiesWithState(SecretProject.class));
         }
     }
 
@@ -230,7 +227,8 @@ class BoundedContextTest {
         assertTrue(stand.getExposedTypes().isEmpty());
         Repository<ProjectId, ProjectAggregate> repo = DefaultRepository.of(ProjectAggregate.class);
         boundedContext.register(repo);
-        assertThat(stand.getExposedTypes()).containsExactly(repo.entityStateType());
+        assertThat(stand.getExposedTypes())
+                .containsExactly(repo.entityStateType());
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/BoundedContextTest.java
+++ b/server/src/test/java/io/spine/server/BoundedContextTest.java
@@ -405,7 +405,6 @@ class BoundedContextTest {
                     .setMultitenant(false)
                     .build();
         }
-
     }
 
     /**

--- a/server/src/test/java/io/spine/server/BoundedContextTest.java
+++ b/server/src/test/java/io/spine/server/BoundedContextTest.java
@@ -22,7 +22,7 @@ package io.spine.server;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import com.google.protobuf.Message;
+import com.google.common.truth.Truth8;
 import io.spine.annotation.Internal;
 import io.spine.core.BoundedContextName;
 import io.spine.core.BoundedContextNames;
@@ -42,7 +42,6 @@ import io.spine.server.bc.given.TestEventSubscriber;
 import io.spine.server.commandbus.CommandBus;
 import io.spine.server.entity.Entity;
 import io.spine.server.entity.Repository;
-import io.spine.server.entity.model.EntityClass;
 import io.spine.server.event.EventBus;
 import io.spine.server.event.store.EventStore;
 import io.spine.server.stand.Stand;
@@ -66,15 +65,14 @@ import org.slf4j.helpers.SubstituteLogger;
 
 import java.util.ArrayDeque;
 import java.util.List;
-import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.server.event.given.EventStoreTestEnv.eventStore;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -188,21 +186,38 @@ class BoundedContextTest {
 
         <I, E extends Entity<I, ?>> void registerAndAssertRepository(Class<E> cls) {
             boundedContext.register(DefaultRepository.of(cls));
-            assertRegisteredRepositoryOf(cls);
+            assertThat(boundedContext.hasRepositoryOf(cls))
+                    .isTrue();
         }
 
         @Test
         @DisplayName("DefaultRepository via passed entity class")
         void entityClass() {
             boundedContext.register(ProjectAggregate.class);
-            assertRegisteredRepositoryOf(ProjectAggregate.class);
+            assertThat(boundedContext.hasRepositoryOf(ProjectAggregate.class))
+                    .isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("test presence repository by a class of an entity state")
+    class RepoByState {
+
+        @Test
+        @DisplayName("confirming visible entities")
+        void visible() {
+            boundedContext.register(ProjectAggregate.class);
+            assertThat(boundedContext.hasRepositoryOfEntityWithState(Project.class))
+                    .isTrue();
         }
 
-        void assertRegisteredRepositoryOf(Class<? extends Entity<?, ?>> entityClass) {
-            EntityClass<? extends Entity<?, ?>> cls = EntityClass.asEntityClass(entityClass);
-            Class<? extends Message> stateClass = cls.stateClass();
-            Optional<Repository> repository = boundedContext.findRepository(stateClass);
-            assertThat(repository).isNotNull();
+        @Test
+        @DisplayName("denying for invisible entities")
+        void invisible() {
+            boundedContext.register(new SecretProjectRepository());
+
+            assertThat(boundedContext.hasRepositoryOfEntityWithState(SecretProject.class))
+                    .isFalse();
         }
     }
 
@@ -324,10 +339,11 @@ class BoundedContextTest {
         void ofCommandBus() {
             CommandBus.Builder commandBus = CommandBus.newBuilder()
                                                       .setMultitenant(false);
-            assertThrows(IllegalStateException.class, () -> BoundedContext.newBuilder()
-                                                                          .setMultitenant(true)
-                                                                          .setCommandBus(commandBus)
-                                                                          .build());
+            assertThrows(IllegalStateException.class,
+                         () -> BoundedContext.newBuilder()
+                                             .setMultitenant(true)
+                                             .setCommandBus(commandBus)
+                                             .build());
         }
 
         @Test
@@ -335,10 +351,11 @@ class BoundedContextTest {
         void ofStand() {
             Stand.Builder stand = Stand.newBuilder()
                                        .setMultitenant(false);
-            assertThrows(IllegalStateException.class, () -> BoundedContext.newBuilder()
-                                                                          .setMultitenant(true)
-                                                                          .setStand(stand)
-                                                                          .build());
+            assertThrows(IllegalStateException.class,
+                         () -> BoundedContext.newBuilder()
+                                             .setMultitenant(true)
+                                             .setStand(stand)
+                                             .build());
         }
     }
 
@@ -346,41 +363,49 @@ class BoundedContextTest {
     @DisplayName("assign own multitenancy state to")
     class AssignMultitenancyState {
 
+        private BoundedContext context;
+
         @Test
         @DisplayName("CommandBus")
         void toCommandBus() {
-            BoundedContext bc = BoundedContext.newBuilder()
-                                              .setMultitenant(true)
-                                              .build();
+            context = multiTenant();
+            assertMultitenancyEqual(context::isMultitenant, context.commandBus()::isMultitenant);
 
-            assertEquals(bc.isMultitenant(), bc.commandBus()
-                                               .isMultitenant());
-
-            bc = BoundedContext.newBuilder()
-                               .setMultitenant(false)
-                               .build();
-
-            assertEquals(bc.isMultitenant(), bc.commandBus()
-                                               .isMultitenant());
+            context = singleTenant();
+            assertMultitenancyEqual(context::isMultitenant, context.commandBus()::isMultitenant);
         }
 
         @Test
         @DisplayName("Stand")
         void toStand() {
-            BoundedContext bc = BoundedContext.newBuilder()
-                                              .setMultitenant(true)
-                                              .build();
+            context = multiTenant();
 
-            assertEquals(bc.isMultitenant(), bc.stand()
-                                               .isMultitenant());
+            assertMultitenancyEqual(context::isMultitenant, context.stand()::isMultitenant);
 
-            bc = BoundedContext.newBuilder()
-                               .setMultitenant(false)
-                               .build();
+            context = singleTenant();
 
-            assertEquals(bc.isMultitenant(), bc.stand()
-                                               .isMultitenant());
+            assertMultitenancyEqual(context::isMultitenant, context.stand()::isMultitenant);
         }
+
+        void assertMultitenancyEqual(Supplier<Boolean> s1, Supplier<Boolean> s2) {
+            assertThat(s1.get())
+                    .isEqualTo(s2.get());
+        }
+
+        private BoundedContext multiTenant() {
+            return BoundedContext
+                    .newBuilder()
+                    .setMultitenant(true)
+                    .build();
+        }
+
+        private BoundedContext singleTenant() {
+            return BoundedContext
+                    .newBuilder()
+                    .setMultitenant(false)
+                    .build();
+        }
+
     }
 
     /**
@@ -393,13 +418,13 @@ class BoundedContextTest {
     @Test
     @DisplayName("obtain entity types by visibility")
     void getEntityTypesByVisibility() {
-        assertTrue(boundedContext.entityStateTypes(EntityOption.Visibility.FULL)
-                                 .isEmpty());
+        assertThat(boundedContext.entityStateTypes(EntityOption.Visibility.FULL))
+                .isEmpty();
 
         registerAll();
 
-        assertFalse(boundedContext.entityStateTypes(EntityOption.Visibility.FULL)
-                                  .isEmpty());
+        assertThat(boundedContext.entityStateTypes(EntityOption.Visibility.FULL))
+                .isNotEmpty();
     }
 
     @Test
@@ -417,8 +442,8 @@ class BoundedContextTest {
 
         boundedContext.register(new SecretProjectRepository());
 
-        assertFalse(boundedContext.findRepository(SecretProject.class)
-                                  .isPresent());
+        Truth8.assertThat(boundedContext.findRepository(SecretProject.class))
+              .isEmpty();
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/BoundedContextTest.java
+++ b/server/src/test/java/io/spine/server/BoundedContextTest.java
@@ -67,7 +67,7 @@ import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
-import java.util.function.Supplier;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Stream;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -387,9 +387,9 @@ class BoundedContextTest {
             assertMultitenancyEqual(context::isMultitenant, context.stand()::isMultitenant);
         }
 
-        void assertMultitenancyEqual(Supplier<Boolean> s1, Supplier<Boolean> s2) {
-            assertThat(s1.get())
-                    .isEqualTo(s2.get());
+        private void assertMultitenancyEqual(BooleanSupplier s1, BooleanSupplier s2) {
+            assertThat(s1.getAsBoolean())
+                    .isEqualTo(s2.getAsBoolean());
         }
 
         private BoundedContext multiTenant() {

--- a/server/src/test/java/io/spine/server/BoundedContextTest.java
+++ b/server/src/test/java/io/spine/server/BoundedContextTest.java
@@ -186,7 +186,7 @@ class BoundedContextTest {
 
         <I, E extends Entity<I, ?>> void registerAndAssertRepository(Class<E> cls) {
             boundedContext.register(DefaultRepository.of(cls));
-            assertThat(boundedContext.hasRepositoryOf(cls))
+            assertThat(boundedContext.hasEntitiesOfType(cls))
                     .isTrue();
         }
 
@@ -194,7 +194,7 @@ class BoundedContextTest {
         @DisplayName("DefaultRepository via passed entity class")
         void entityClass() {
             boundedContext.register(ProjectAggregate.class);
-            assertThat(boundedContext.hasRepositoryOf(ProjectAggregate.class))
+            assertThat(boundedContext.hasEntitiesOfType(ProjectAggregate.class))
                     .isTrue();
         }
     }
@@ -207,7 +207,7 @@ class BoundedContextTest {
         @DisplayName("confirming visible entities")
         void visible() {
             boundedContext.register(ProjectAggregate.class);
-            assertThat(boundedContext.hasRepositoryOfEntityWithState(Project.class))
+            assertThat(boundedContext.hasEntitiesWithState(Project.class))
                     .isTrue();
         }
 
@@ -216,7 +216,7 @@ class BoundedContextTest {
         void invisible() {
             boundedContext.register(new SecretProjectRepository());
 
-            assertThat(boundedContext.hasRepositoryOfEntityWithState(SecretProject.class))
+            assertThat(boundedContext.hasEntitiesWithState(SecretProject.class))
                     .isFalse();
         }
     }

--- a/server/src/test/java/io/spine/server/BoundedContextTest.java
+++ b/server/src/test/java/io/spine/server/BoundedContextTest.java
@@ -73,7 +73,6 @@ import java.util.stream.Stream;
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.server.event.given.EventStoreTestEnv.eventStore;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -199,22 +198,46 @@ class BoundedContextTest {
     }
 
     @Nested
-    @DisplayName("test presence repository by a class of an entity state")
-    class RepoByState {
+    @DisplayName("test presence of entities by")
+    class EntityTypePresence {
 
-        @Test
-        @DisplayName("confirming visible entities")
-        void visible() {
-            boundedContext.register(ProjectAggregate.class);
-            assertTrue(boundedContext.hasEntitiesWithState(Project.class));
+        @Nested
+        @DisplayName("entity state class for")
+        class EntityStateClass {
+
+            @Test
+            @DisplayName("visible entities")
+            void visible() {
+                boundedContext.register(ProjectAggregate.class);
+                assertTrue(boundedContext.hasEntitiesWithState(Project.class));
+            }
+
+            @Test
+            @DisplayName("invisible entities")
+            void invisible() {
+                boundedContext.register(new SecretProjectRepository());
+                assertTrue(boundedContext.hasEntitiesWithState(SecretProject.class));
+            }
         }
 
-        @Test
-        @DisplayName("denying for invisible entities")
-        void invisible() {
-            boundedContext.register(new SecretProjectRepository());
+        @Nested
+        @DisplayName("entity class for")
+        class EntityClass {
 
-            assertFalse(boundedContext.hasEntitiesWithState(SecretProject.class));
+            @Test
+            @DisplayName("visible entities")
+            void visible() {
+                boundedContext.register(ProjectAggregate.class);
+                assertTrue(boundedContext.hasEntitiesOfType(ProjectAggregate.class));
+            }
+
+            @Test
+            @DisplayName("invisible entities")
+            void invisible() {
+                // Process Managers are invisible by default.
+                boundedContext.register(ProjectProcessManager.class);
+                assertTrue(boundedContext.hasEntitiesOfType(ProjectProcessManager.class));
+            }
         }
     }
 


### PR DESCRIPTION
This PR adds an ability to test the presence of a repository, instead of finding it (which takes into account visibility of entity states).