### PR TITLE
Test for the Bus dead lock

### DIFF
--- a/client/src/main/proto/spine/client/query.proto
+++ b/client/src/main/proto/spine/client/query.proto
@@ -115,7 +115,7 @@ message Query {
     // Defines the entity of interest, e.g. entity type URL and a set of fetch criteria.
     //
     Target target = 2 [(required) = true,
-                       (valid) = true,
+                       (validate) = true,
                        (if_invalid).msg_format = "Invalid query target"];
 
     // Field mask to be applied to the items of the query result.
@@ -125,17 +125,17 @@ message Query {
     // Service information about the environment in which the query was created.
     //
     core.ActorContext context = 4 [(required) = true,
-                                   (valid) = true,
+                                   (validate) = true,
                                    (if_invalid).msg_format = "Invalid actor context"];
 
     // An order for entities returned by the Query.
     //
-    OrderBy orderBy = 5 [(valid) = true,
+    OrderBy orderBy = 5 [(validate) = true,
                          (if_invalid).msg_format = "Invalid query order"];
 
     // A specification for a way to paginate the Query results.
     //
-    Pagination pagination = 6 [(valid) = true,
+    Pagination pagination = 6 [(validate) = true,
                                (goes).with = "order",
                                (if_invalid).msg_format = "Invalid query pagination"];
 

--- a/client/src/main/proto/spine/client/subscription.proto
+++ b/client/src/main/proto/spine/client/subscription.proto
@@ -59,7 +59,7 @@ message Topic {
     // Defines the target of interest, e.g. event/entity type URL and a set of subscription
     // criteria.
     Target target = 2 [(required) = true,
-                       (valid) = true,
+                       (validate) = true,
                        (if_invalid).msg_format = "Invalid topic target"];
 
     // Field mask to be applied to the subscription updates.
@@ -67,7 +67,7 @@ message Topic {
 
     // Service information about the environment in which the topic was created.
     core.ActorContext context = 4 [(required) = true,
-                                   (valid) = true,
+                                   (validate) = true,
                                    (if_invalid).msg_format = "Invalid actor context"];
 
     // Reserved for utility fields.
@@ -115,7 +115,7 @@ message SubscriptionUpdate {
 message EntityUpdates {
 
     // The entity state update list.
-    repeated EntityStateUpdate updates = 1 [(valid) = true];
+    repeated EntityStateUpdate updates = 1 [(validate) = true];
 }
 
 // The pair of the entity ID and the entity state both packed as Any.
@@ -135,7 +135,7 @@ message EntityStateUpdate {
 message EventUpdates {
 
     // The event list.
-    repeated core.Event events = 1 [(valid) = true];
+    repeated core.Event events = 1 [(validate) = true];
 }
 
 // Subscription identifier.
@@ -162,7 +162,7 @@ message Subscription {
     SubscriptionId id = 1 [(required) = true];
 
     // Represents the original topic for this subscription.
-    Topic topic = 2 [(required) = true, (valid) = true, (if_invalid).msg_format = "Invalid topic"];
+    Topic topic = 2 [(required) = true, (validate) = true, (if_invalid).msg_format = "Invalid topic"];
 
     // Reserved for subscription attributes.
     reserved 3 to 10;

--- a/core/src/main/proto/spine/core/event.proto
+++ b/core/src/main/proto/spine/core/event.proto
@@ -78,7 +78,7 @@ message Event {
     EventId id = 1 [(required) = true];
 
     // The message of the event wrapped into `Any`.
-    google.protobuf.Any message = 2 [(required) = true, (valid) = true];
+    google.protobuf.Any message = 2 [(required) = true, (validate) = true];
 
     // The context of the event.
     EventContext context = 3 [(required) = true];
@@ -94,13 +94,13 @@ message EventContext {
 
     oneof origin {
         // The context of the command which generated this event.
-        CommandContext command_context = 2 [(valid) = true];
+        CommandContext command_context = 2 [(validate) = true];
 
         // The context of the event which generated this event.
-        EventContext event_context = 6 [(valid) = true];
+        EventContext event_context = 6 [(validate) = true];
 
         // The event was imported using this `ActorContext`.
-        ActorContext import_context = 11 [(valid) = true];
+        ActorContext import_context = 11 [(validate) = true];
     }
 
     // An ID of the root command, which lead to this event.
@@ -120,7 +120,7 @@ message EventContext {
     google.protobuf.Any producer_id = 3 [(required) = true];
 
     // The version of the entity after the event was applied.
-    Version version = 4 [(valid) = true];
+    Version version = 4 [(validate) = true];
 
     // Optional enrichment of the event.
     Enrichment enrichment = 5;

--- a/license-report.md
+++ b/license-report.md
@@ -431,7 +431,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 21 18:52:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed May 22 15:17:37 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -821,7 +821,7 @@ This report was generated on **Tue May 21 18:52:40 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 21 18:52:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed May 22 15:17:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1359,7 +1359,7 @@ This report was generated on **Tue May 21 18:52:40 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 21 18:52:41 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed May 22 15:17:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2059,7 +2059,7 @@ This report was generated on **Tue May 21 18:52:41 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 21 18:52:41 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed May 22 15:17:39 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2609,7 +2609,7 @@ This report was generated on **Tue May 21 18:52:41 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 21 18:52:42 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed May 22 15:17:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3114,7 +3114,7 @@ This report was generated on **Tue May 21 18:52:42 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 21 18:52:42 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed May 22 15:17:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3627,7 +3627,7 @@ This report was generated on **Tue May 21 18:52:42 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 21 18:52:42 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed May 22 15:17:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4240,4 +4240,4 @@ This report was generated on **Tue May 21 18:52:42 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 21 18:52:43 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed May 22 15:17:41 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -431,7 +431,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon May 20 18:17:59 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 21 18:52:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -821,7 +821,7 @@ This report was generated on **Mon May 20 18:17:59 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon May 20 18:18:00 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 21 18:52:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1359,7 +1359,7 @@ This report was generated on **Mon May 20 18:18:00 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon May 20 18:18:03 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 21 18:52:41 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2059,7 +2059,7 @@ This report was generated on **Mon May 20 18:18:03 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon May 20 18:18:07 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 21 18:52:41 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2609,7 +2609,7 @@ This report was generated on **Mon May 20 18:18:07 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon May 20 18:18:08 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 21 18:52:42 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3114,7 +3114,7 @@ This report was generated on **Mon May 20 18:18:08 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon May 20 18:18:08 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 21 18:52:42 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3627,7 +3627,7 @@ This report was generated on **Mon May 20 18:18:08 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon May 20 18:18:09 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 21 18:52:42 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4240,4 +4240,4 @@ This report was generated on **Mon May 20 18:18:09 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon May 20 18:18:09 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 21 18:52:43 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -431,7 +431,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed May 22 15:17:37 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 23 13:33:16 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -821,7 +821,7 @@ This report was generated on **Wed May 22 15:17:37 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed May 22 15:17:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 23 13:33:16 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1359,7 +1359,7 @@ This report was generated on **Wed May 22 15:17:38 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed May 22 15:17:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 23 13:33:17 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2059,7 +2059,7 @@ This report was generated on **Wed May 22 15:17:38 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed May 22 15:17:39 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 23 13:33:18 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2609,7 +2609,7 @@ This report was generated on **Wed May 22 15:17:39 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed May 22 15:17:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 23 13:33:18 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3114,7 +3114,7 @@ This report was generated on **Wed May 22 15:17:40 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed May 22 15:17:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 23 13:33:19 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3627,7 +3627,7 @@ This report was generated on **Wed May 22 15:17:40 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed May 22 15:17:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 23 13:33:19 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4240,4 +4240,4 @@ This report was generated on **Wed May 22 15:17:40 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed May 22 15:17:41 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 23 13:33:20 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/server/src/main/java/io/spine/server/aggregate/ImportBus.java
+++ b/server/src/main/java/io/spine/server/aggregate/ImportBus.java
@@ -104,11 +104,6 @@ public final class ImportBus
     }
 
     @Override
-    protected Registry createRegistry() {
-        return new Registry();
-    }
-
-    @Override
     protected EventEnvelope toEnvelope(Event wrapper) {
         return EventEnvelope.of(wrapper);
     }
@@ -172,11 +167,20 @@ public final class ImportBus
     /**
      * The builder for {@link ImportBus}.
      */
-    public static class Builder extends BusBuilder<EventEnvelope, Event, Builder> {
+    public static class Builder extends BusBuilder<Builder,
+                                                   Event,
+                                                   EventEnvelope,
+                                                   EventClass,
+                                                   EventImportDispatcher<?>> {
 
         /** Prevents direct instantiation. */
         private Builder() {
             super();
+        }
+
+        @Override
+        protected Registry newRegistry() {
+            return new Registry();
         }
 
         @Override

--- a/server/src/main/java/io/spine/server/bus/BusBuilder.java
+++ b/server/src/main/java/io/spine/server/bus/BusBuilder.java
@@ -28,6 +28,7 @@ import io.spine.annotation.Internal;
 import io.spine.server.tenant.TenantIndex;
 import io.spine.server.type.MessageEnvelope;
 import io.spine.system.server.SystemWriteSide;
+import io.spine.type.MessageClass;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Deque;
@@ -50,9 +51,11 @@ import static java.util.Optional.ofNullable;
  * @param <B> the own type of the builder
  */
 @CanIgnoreReturnValue
-public abstract class BusBuilder<E extends MessageEnvelope<?, T, ?>,
+public abstract class BusBuilder<B extends BusBuilder<B, T, E, C, D>,
                                  T extends Message,
-                                 B extends BusBuilder<E, T, B>> {
+                                 E extends MessageEnvelope<?, T, ?>,
+                                 C extends MessageClass<? extends Message>,
+                                 D extends MessageDispatcher<C, E, ?>> {
 
     private final ChainBuilder<E> chainBuilder;
     private final Set<Consumer<E>> listeners = new HashSet<>();
@@ -165,6 +168,8 @@ public abstract class BusBuilder<E extends MessageEnvelope<?, T, ?>,
     ChainBuilder<E> chainBuilderCopy() {
         return chainBuilder.copy();
     }
+
+    protected abstract DispatcherRegistry<C, E, D> newRegistry();
 
     /**
      * Creates new instance of {@code Bus} with the set parameters.

--- a/server/src/main/java/io/spine/server/bus/Listeners.java
+++ b/server/src/main/java/io/spine/server/bus/Listeners.java
@@ -36,16 +36,16 @@ final class Listeners<E extends MessageEnvelope<?, ?, ?>> implements Consumer<E>
 
     private final ImmutableSet<Consumer<E>> listeners;
 
-    Listeners(BusBuilder<E, ?, ?> builder) {
+    Listeners(BusBuilder<?, ?, E, ?, ?> builder) {
         checkNotNull(builder);
         this.listeners = ImmutableSet.copyOf(builder.listeners());
     }
 
     @Override
     public void accept(E envelope) {
-        listeners.forEach(l -> {
+        listeners.forEach(listener -> {
             try {
-                l.accept(envelope);
+                listener.accept(envelope);
             } catch (RuntimeException ignored) {
                 // Do nothing.
             }

--- a/server/src/main/java/io/spine/server/bus/MulticastBus.java
+++ b/server/src/main/java/io/spine/server/bus/MulticastBus.java
@@ -39,7 +39,7 @@ public abstract class MulticastBus<M extends Message,
                                    D extends MessageDispatcher<C, E, ?>>
         extends Bus<M, E, C, D> {
 
-    protected MulticastBus(BusBuilder<E, M, ?> builder) {
+    protected MulticastBus(BusBuilder<?, M, E, C, D> builder) {
         super(builder);
     }
 

--- a/server/src/main/java/io/spine/server/bus/UnicastBus.java
+++ b/server/src/main/java/io/spine/server/bus/UnicastBus.java
@@ -35,9 +35,10 @@ import static io.spine.util.Exceptions.newIllegalStateException;
 public abstract class UnicastBus<T extends Message,
                                  E extends MessageEnvelope<?, T, ?>,
                                  C extends MessageClass<? extends Message>,
-                                 D extends MessageDispatcher<C, E, ?>> extends Bus<T, E, C, D> {
+                                 D extends MessageDispatcher<C, E, ?>>
+        extends Bus<T, E, C, D> {
 
-    protected UnicastBus(BusBuilder<E, T, ?> builder) {
+    protected UnicastBus(BusBuilder<?, T, E, C, D> builder) {
         super(builder);
     }
 

--- a/server/src/main/java/io/spine/server/commandbus/CommandBus.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandBus.java
@@ -134,11 +134,6 @@ public class CommandBus extends UnicastBus<Command,
         return scheduler;
     }
 
-    @Override
-    protected CommandDispatcherRegistry createRegistry() {
-        return new CommandDispatcherRegistry();
-    }
-
     @SuppressWarnings("ReturnOfCollectionOrArrayField") // OK for a protected factory method
     @Override
     protected Collection<BusFilter<CommandEnvelope>> filterChainTail() {
@@ -262,7 +257,11 @@ public class CommandBus extends UnicastBus<Command,
      * The {@code Builder} for {@code CommandBus}.
      */
     @CanIgnoreReturnValue
-    public static class Builder extends BusBuilder<CommandEnvelope, Command, Builder> {
+    public static class Builder extends BusBuilder<Builder,
+                                                   Command,
+                                                   CommandEnvelope,
+                                                   CommandClass,
+                                                   CommandDispatcher<?>> {
 
         /**
          * The multi-tenancy flag for the {@code CommandBus} to build.
@@ -288,6 +287,11 @@ public class CommandBus extends UnicastBus<Command,
         /** Prevents direct instantiation. */
         private Builder() {
             super();
+        }
+
+        @Override
+        protected CommandDispatcherRegistry newRegistry() {
+            return new CommandDispatcherRegistry();
         }
 
         @Internal

--- a/server/src/main/java/io/spine/server/entity/EntityLifecycleMonitor.java
+++ b/server/src/main/java/io/spine/server/entity/EntityLifecycleMonitor.java
@@ -28,7 +28,7 @@ import io.spine.base.Identifier;
 import io.spine.core.MessageId;
 import io.spine.core.Version;
 import io.spine.protobuf.ValidatingBuilder;
-import io.spine.validate.NotValidated;
+import io.spine.validate.NonValidated;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import java.util.List;
@@ -128,7 +128,7 @@ public final class EntityLifecycleMonitor<I,
     @Override
     public void onTransactionFailed(Throwable t,
                                     E entity,
-                                    @NotValidated S state,
+                                    @NonValidated S state,
                                     Version version,
                                     LifecycleFlags lifecycleFlags) {
         // NOP.

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -29,7 +29,7 @@ import io.spine.base.Identifier;
 import io.spine.core.Version;
 import io.spine.protobuf.ValidatingBuilder;
 import io.spine.server.entity.TransactionListener.SilentWitness;
-import io.spine.validate.NotValidated;
+import io.spine.validate.NonValidated;
 import io.spine.validate.ValidationException;
 
 import java.util.List;
@@ -276,7 +276,7 @@ public abstract class Transaction<I,
      * @param newState
      *         the new state of the entity
      */
-    private void commitChangedState(@NotValidated S newState) {
+    private void commitChangedState(@NonValidated S newState) {
         try {
             markStateChanged();
             Version pendingVersion = version();
@@ -342,7 +342,7 @@ public abstract class Transaction<I,
      */
     void rollback(Throwable cause) {
         beforeRollback(cause);
-        @NotValidated S currentState = currentBuilderState();
+        @NonValidated S currentState = currentBuilderState();
         TransactionListener<I, E, S, B> listener = listener();
         listener.onTransactionFailed(cause, entity(), currentState, version(), lifecycleFlags());
         this.active = false;
@@ -379,11 +379,11 @@ public abstract class Transaction<I,
     }
 
     private InvalidEntityStateException of(ValidationException exception) {
-        @NotValidated Message invalidState = currentBuilderState();
+        @NonValidated Message invalidState = currentBuilderState();
         return onConstraintViolations(invalidState, exception.getConstraintViolations());
     }
 
-    private @NotValidated S currentBuilderState() {
+    private @NonValidated S currentBuilderState() {
         return builder.buildPartial();
     }
 

--- a/server/src/main/java/io/spine/server/entity/TransactionListener.java
+++ b/server/src/main/java/io/spine/server/entity/TransactionListener.java
@@ -23,7 +23,7 @@ import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
 import io.spine.core.Version;
 import io.spine.protobuf.ValidatingBuilder;
-import io.spine.validate.NotValidated;
+import io.spine.validate.NonValidated;
 
 /**
  * A common contract for the {@linkplain Transaction transaction} listeners.
@@ -59,7 +59,7 @@ public interface TransactionListener<I,
      * @param lifecycleFlags a lifecycle flags to set to the entity during the commit
      */
     void onBeforeCommit(E entity,
-                        @NotValidated S state,
+                        @NonValidated S state,
                         Version version,
                         LifecycleFlags lifecycleFlags);
 
@@ -72,7 +72,7 @@ public interface TransactionListener<I,
      * @param version        a version to set to the entity during the commit
      * @param lifecycleFlags a lifecycle flags to set to the entity during the commit
      */
-    void onTransactionFailed(Throwable t, E entity, @NotValidated S state,
+    void onTransactionFailed(Throwable t, E entity, @NonValidated S state,
                              Version version, LifecycleFlags lifecycleFlags);
 
     /**

--- a/server/src/main/java/io/spine/server/event/EventBus.java
+++ b/server/src/main/java/io/spine/server/event/EventBus.java
@@ -36,6 +36,7 @@ import io.spine.grpc.LoggingObserver;
 import io.spine.grpc.LoggingObserver.Level;
 import io.spine.server.bus.BusBuilder;
 import io.spine.server.bus.DeadMessageHandler;
+import io.spine.server.bus.DispatcherRegistry;
 import io.spine.server.bus.EnvelopeValidator;
 import io.spine.server.bus.MulticastBus;
 import io.spine.server.enrich.Enricher;
@@ -157,11 +158,6 @@ public class EventBus extends MulticastBus<Event, EventEnvelope, EventClass, Eve
     }
 
     @Override
-    protected EventDispatcherRegistry createRegistry() {
-        return new EventDispatcherRegistry();
-    }
-
-    @Override
     protected EventEnvelope toEnvelope(Event message) {
         return EventEnvelope.of(message);
     }
@@ -248,7 +244,8 @@ public class EventBus extends MulticastBus<Event, EventEnvelope, EventClass, Eve
 
     /** The {@code Builder} for {@code EventBus}. */
     @CanIgnoreReturnValue
-    public static class Builder extends BusBuilder<EventEnvelope, Event, Builder> {
+    public static class Builder
+            extends BusBuilder<Builder, Event, EventEnvelope, EventClass, EventDispatcher<?>> {
 
         private static final String MSG_EVENT_STORE_CONFIGURED = "EventStore already configured.";
 
@@ -299,6 +296,11 @@ public class EventBus extends MulticastBus<Event, EventEnvelope, EventClass, Eve
         /** Prevents direct instantiation. */
         private Builder() {
             super();
+        }
+
+        @Override
+        protected DispatcherRegistry<EventClass, EventEnvelope, EventDispatcher<?>> newRegistry() {
+            return new EventDispatcherRegistry();
         }
 
         /**

--- a/server/src/main/java/io/spine/server/integration/IntegrationBus.java
+++ b/server/src/main/java/io/spine/server/integration/IntegrationBus.java
@@ -105,7 +105,6 @@ import static java.lang.String.format;
  * external message. The event will be dispatched to the external event handler of
  * {@code ProjectListView} projection.
  */
-@SuppressWarnings("OverlyCoupledClass")
 public class IntegrationBus extends MulticastBus<ExternalMessage,
                                                  ExternalMessageEnvelope,
                                                  ExternalMessageClass,
@@ -165,11 +164,6 @@ public class IntegrationBus extends MulticastBus<ExternalMessage,
     /** Creates a new builder for this bus. */
     public static Builder newBuilder() {
         return new Builder();
-    }
-
-    @Override
-    protected DomesticDispatcherRegistry createRegistry() {
-        return new DomesticDispatcherRegistry();
     }
 
     @Override
@@ -368,8 +362,11 @@ public class IntegrationBus extends MulticastBus<ExternalMessage,
      * A {@code Builder} for {@code IntegrationBus} instances.
      */
     @CanIgnoreReturnValue
-    public static class Builder
-            extends BusBuilder<ExternalMessageEnvelope, ExternalMessage, Builder> {
+    public static class Builder extends BusBuilder<Builder,
+                                                   ExternalMessage,
+                                                   ExternalMessageEnvelope,
+                                                   ExternalMessageClass,
+                                                   ExternalMessageDispatcher<?>> {
 
         /**
          * Buses that act inside the bounded context, for example {@code EventBus}, which allow
@@ -414,6 +411,11 @@ public class IntegrationBus extends MulticastBus<ExternalMessage,
 
         public Optional<TransportFactory> getTransportFactory() {
             return Optional.ofNullable(transportFactory);
+        }
+
+        @Override
+        protected DomesticDispatcherRegistry newRegistry() {
+            return new DomesticDispatcherRegistry();
         }
 
         @Override

--- a/server/src/main/java/io/spine/server/stand/EntitySubscriptionCallback.java
+++ b/server/src/main/java/io/spine/server/stand/EntitySubscriptionCallback.java
@@ -53,7 +53,7 @@ final class EntitySubscriptionCallback extends SubscriptionCallback {
                 .setSubscription(subscription())
                 .setResponse(Responses.ok())
                 .setEntityUpdates(updates)
-                .build();
+                .vBuild();
         return result;
     }
 
@@ -66,11 +66,11 @@ final class EntitySubscriptionCallback extends SubscriptionCallback {
                 .newBuilder()
                 .setId(packedEntityId)
                 .setState(packedEntityState)
-                .build();
+                .vBuild();
         EntityUpdates result = EntityUpdates
                 .newBuilder()
                 .addUpdates(stateUpdate)
-                .build();
+                .vBuild();
         return result;
     }
 }

--- a/server/src/main/proto/spine/server/model/message_handler.proto
+++ b/server/src/main/proto/spine/server/model/message_handler.proto
@@ -22,10 +22,10 @@ import "spine/base/field_path.proto";
 message HandlerId {
 
     // The information about the handled message type.
-    HandlerTypeInfo type = 1 [(valid) = true];
+    HandlerTypeInfo type = 1 [(validate) = true];
 
     // The filter which the handled messages must match.
-    MessageFilter filter = 2 [(required) = false, (valid) = true];
+    MessageFilter filter = 2 [(required) = false, (validate) = true];
 }
 
 // A message handler type information.
@@ -44,8 +44,8 @@ message HandlerTypeInfo {
 message MessageFilter {
 
     // The path to the field.
-    base.FieldPath field = 1 [(valid) = true];
+    base.FieldPath field = 1 [(validate) = true];
 
     // The expected value of the field.
-    google.protobuf.Any value = 2 [(valid) = true];
+    google.protobuf.Any value = 2 [(validate) = true];
 }

--- a/server/src/main/proto/spine/server/tenant/events.proto
+++ b/server/src/main/proto/spine/server/tenant/events.proto
@@ -37,5 +37,5 @@ import "spine/core/tenant_id.proto";
 message TenantAdded {
 
     // The new tenant ID.
-    spine.core.TenantId id = 1 [(required) = true, (valid) = true];
+    spine.core.TenantId id = 1 [(required) = true, (validate) = true];
 }

--- a/server/src/main/proto/spine/system/server/command_lifecycle.proto
+++ b/server/src/main/proto/spine/system/server/command_lifecycle.proto
@@ -64,7 +64,7 @@ message CommandLifecycle {
 message CommandTarget {
 
     // The ID of the entity which the command is dispatched to.
-    spine.client.EntityId entity_id = 1 [(valid) = true];
+    spine.client.EntityId entity_id = 1 [(validate) = true];
 
     // The state type URL of the entity which receives the command.
     string type_url = 2 [(required) = true];

--- a/server/src/main/proto/spine/system/server/command_lifecycle_commands.proto
+++ b/server/src/main/proto/spine/system/server/command_lifecycle_commands.proto
@@ -46,7 +46,7 @@ message ScheduleCommand {
     core.CommandId id = 1;
 
     // The schedule to execute the command.
-    core.CommandContext.Schedule schedule = 2 [(valid) = true];
+    core.CommandContext.Schedule schedule = 2 [(validate) = true];
 }
 
 // Assigns a target to a command.
@@ -60,5 +60,5 @@ message AssignTargetToCommand {
     core.CommandId id = 1;
 
     // The command target.
-    CommandTarget target = 2 [(valid) = true];
+    CommandTarget target = 2 [(validate) = true];
 }

--- a/server/src/main/proto/spine/system/server/command_lifecycle_events.proto
+++ b/server/src/main/proto/spine/system/server/command_lifecycle_events.proto
@@ -63,7 +63,7 @@ message CommandScheduled {
     core.CommandId id = 1;
 
     // The schedule to execute the command.
-    core.CommandContext.Schedule schedule = 2 [(valid) = true];
+    core.CommandContext.Schedule schedule = 2 [(validate) = true];
 }
 
 // An event emitted when a command is passed to a dispatcher after being acknowledged.
@@ -84,7 +84,7 @@ message TargetAssignedToCommand {
     core.CommandId id = 1;
 
     // The target of the command.
-    CommandTarget target = 2 [(valid) = true];
+    CommandTarget target = 2 [(validate) = true];
 }
 
 // An event emitted when a command is successfully handled.
@@ -103,7 +103,7 @@ message CommandErrored {
     core.CommandId id = 1;
 
     // The runtime error.
-    base.Error error = 2 [(valid) = true];
+    base.Error error = 2 [(validate) = true];
 }
 
 // An event emitted if the handler rejects the command.
@@ -114,7 +114,7 @@ message CommandRejected {
     core.CommandId id = 1;
 
     // The command rejection event.
-    core.Event rejection_event = 2 [(valid) = true];
+    core.Event rejection_event = 2 [(validate) = true];
 }
 
 // An event emitted when another command was generated in response to a received command.

--- a/server/src/main/proto/spine/system/server/history_commands.proto
+++ b/server/src/main/proto/spine/system/server/history_commands.proto
@@ -47,7 +47,7 @@ message DispatchEventToSubscriber {
     EntityHistoryId receiver = 1;
 
     // The event to dispatch.
-    core.Event event = 2 [(valid) = true];
+    core.Event event = 2 [(validate) = true];
 }
 
 // A command to dispatch an event to a reactor.
@@ -60,7 +60,7 @@ message DispatchEventToReactor {
     EntityHistoryId receiver = 1;
 
     // The event to dispatch.
-    core.Event event = 2 [(valid) = true];
+    core.Event event = 2 [(validate) = true];
 }
 
 // A command to dispatch a command to a command handler.
@@ -73,5 +73,5 @@ message DispatchCommandToHandler {
     EntityHistoryId receiver = 1;
 
     // The command to dispatch.
-    core.Command command = 2 [(valid) = true];
+    core.Command command = 2 [(validate) = true];
 }

--- a/server/src/main/proto/spine/system/server/history_events.proto
+++ b/server/src/main/proto/spine/system/server/history_events.proto
@@ -59,7 +59,7 @@ message EventDispatchedToSubscriber {
     EntityHistoryId receiver = 1 [(required) = true];
 
     // The dispatched event.
-    core.Event payload = 2 [(valid) = true];
+    core.Event payload = 2 [(validate) = true];
 
     // The time when the event was dispatched.
     //
@@ -79,7 +79,7 @@ message EventDispatchedToReactor {
     EntityHistoryId receiver = 1 [(required) = true];
 
     // The dispatched event.
-    core.Event payload = 2 [(valid) = true];
+    core.Event payload = 2 [(validate) = true];
 
     // The time when the event was dispatched.
     //
@@ -99,7 +99,7 @@ message CommandDispatchedToHandler {
     EntityHistoryId receiver = 1 [(required) = true];
 
     // The dispatched command.
-    core.Command payload = 2 [(valid) = true];
+    core.Command payload = 2 [(validate) = true];
 
     // The time when the command was dispatched.
     //
@@ -116,10 +116,10 @@ message EventImported {
     EntityHistoryId receiver = 1 [(required) = true];
 
     // The info about the event.
-    core.EventId event_id = 2 [(required) = true, (valid) = true];
+    core.EventId event_id = 2 [(required) = true, (validate) = true];
 
     // The time when the event was imported.
-    google.protobuf.Timestamp when_imported = 3 [(required) = true, (valid) = true];
+    google.protobuf.Timestamp when_imported = 3 [(required) = true, (validate) = true];
 }
 
 // A state of an entity changed.
@@ -135,7 +135,7 @@ message EntityStateChanged {
     google.protobuf.Any new_state = 2 [(required) = true];
 
     // The IDs of the messages which caused the mutation.
-    repeated DispatchedMessageId message_id = 3 [(required) = true, (valid) = true];
+    repeated DispatchedMessageId message_id = 3 [(required) = true, (validate) = true];
 
     // The instant when the entity was changed.
     google.protobuf.Timestamp when = 4;
@@ -151,7 +151,7 @@ message EntityArchived {
     EntityHistoryId id = 1 [(required) = true];
 
     // The IDs of the messages which caused the mutation.
-    repeated DispatchedMessageId message_id = 2 [(required) = true, (valid) = true];
+    repeated DispatchedMessageId message_id = 2 [(required) = true, (validate) = true];
 
     // The instant when the entity was archived.
     google.protobuf.Timestamp when = 3;
@@ -167,7 +167,7 @@ message EntityDeleted {
     EntityHistoryId id = 1 [(required) = true];
 
     // The IDs of the messages which caused the mutation.
-    repeated DispatchedMessageId message_id = 2 [(required) = true, (valid) = true];
+    repeated DispatchedMessageId message_id = 2 [(required) = true, (validate) = true];
 
     // The instant when the entity was deleted.
     google.protobuf.Timestamp when = 3;
@@ -183,7 +183,7 @@ message EntityUnarchived {
     EntityHistoryId id = 1 [(required) = true];
 
     // The IDs of the messages which caused the mutation.
-    repeated DispatchedMessageId message_id = 2 [(required) = true, (valid) = true];
+    repeated DispatchedMessageId message_id = 2 [(required) = true, (validate) = true];
 
     // The instant when the entity was extracted.
     google.protobuf.Timestamp when = 3;
@@ -199,7 +199,7 @@ message EntityRestored {
     EntityHistoryId id = 1 [(required) = true];
 
     // The IDs of the messages which caused the mutation.
-    repeated DispatchedMessageId message_id = 2 [(required) = true, (valid) = true];
+    repeated DispatchedMessageId message_id = 2 [(required) = true, (validate) = true];
 
     // The instant when the entity was restored.
     google.protobuf.Timestamp when = 3;

--- a/server/src/main/proto/spine/system/server/history_rejections.proto
+++ b/server/src/main/proto/spine/system/server/history_rejections.proto
@@ -41,10 +41,10 @@ import "spine/system/server/entity_history.proto";
 message CannotDispatchEventTwice {
 
     // The receiver of the event.
-    EntityHistoryId receiver = 1 [(valid) = true];
+    EntityHistoryId receiver = 1 [(validate) = true];
 
     // The duplicate event.
-    core.Event payload = 2 [(valid) = true];
+    core.Event payload = 2 [(validate) = true];
 
     // The time when the event was dispatched.
     //
@@ -59,10 +59,10 @@ message CannotDispatchEventTwice {
 message CannotDispatchCommandTwice {
 
     // The receiver of the command.
-    EntityHistoryId receiver = 1 [(valid) = true];
+    EntityHistoryId receiver = 1 [(validate) = true];
 
     // The duplicate command.
-    core.Command payload = 2 [(valid) = true];
+    core.Command payload = 2 [(validate) = true];
 
     // The time when the event was dispatched.
     //

--- a/server/src/main/proto/spine/system/server/mirror.proto
+++ b/server/src/main/proto/spine/system/server/mirror.proto
@@ -19,10 +19,10 @@ import "spine/server/entity/entity.proto";
 message Mirror {
     option (entity).kind = PROJECTION;
 
-    MirrorId id = 1 [(required) = true, (valid) = true];
+    MirrorId id = 1 [(required) = true, (validate) = true];
 
     // The state of the aggregate.
-    google.protobuf.Any state = 2 [(required) = false, (valid) = true];
+    google.protobuf.Any state = 2 [(required) = false, (validate) = true];
 
     // The lifecycle flags of the aggregate.
     //
@@ -43,7 +43,7 @@ message Mirror {
 message MirrorId {
 
     // The ID of the corresponding aggregate packed as Any.
-    google.protobuf.Any value = 1 [(required) = true, (valid) = true];
+    google.protobuf.Any value = 1 [(required) = true, (validate) = true];
 
     string type_url = 2 [(required) = true];
 }

--- a/server/src/test/java/io/spine/server/bus/BusBuilderTest.java
+++ b/server/src/test/java/io/spine/server/bus/BusBuilderTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.mock;
  * @see io.spine.server.event.EventBusBuilderTest
  * @see io.spine.server.rejection.RejectionBusBuilderTest
  */
-public abstract class BusBuilderTest<B extends BusBuilder<E, T, ?>,
+public abstract class BusBuilderTest<B extends BusBuilder<?, T, E, ?, ?>,
                                      E extends MessageEnvelope<?, T, ?>,
                                      T extends Message> {
 

--- a/server/src/test/java/io/spine/server/bus/DispatchingQueueSynchronisationTest.java
+++ b/server/src/test/java/io/spine/server/bus/DispatchingQueueSynchronisationTest.java
@@ -29,6 +29,7 @@ import io.spine.test.bus.Sell;
 import io.spine.test.bus.ShareId;
 import io.spine.testing.server.blackbox.BlackBoxBoundedContext;
 import io.spine.testing.server.blackbox.SingleTenantBlackBoxContext;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @DisplayName("When posting commands in parallel")
 class DispatchingQueueSynchronisationTest {
 
+    @Disabled("https://github.com/SpineEventEngine/core-java/issues/746")
     @Test
     @DisplayName("Bus should not lock with its system counterpart")
     void deadlock() throws InterruptedException {

--- a/server/src/test/java/io/spine/server/bus/DispatchingQueueSynchronisationTest.java
+++ b/server/src/test/java/io/spine/server/bus/DispatchingQueueSynchronisationTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.bus;
+
+import com.google.common.collect.ImmutableList;
+import io.spine.server.DefaultRepository;
+import io.spine.server.bus.given.stock.JowDonsIndex;
+import io.spine.server.bus.given.stock.ShareAggregate;
+import io.spine.test.bus.Buy;
+import io.spine.test.bus.Sell;
+import io.spine.test.bus.ShareId;
+import io.spine.testing.server.blackbox.BlackBoxBoundedContext;
+import io.spine.testing.server.blackbox.SingleTenantBlackBoxContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static io.spine.base.Identifier.newUuid;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("When posting commands in parallel")
+class DispatchingQueueSynchronisationTest {
+
+    @Test
+    @DisplayName("Bus should not lock with its system counterpart")
+    void deadlock() throws InterruptedException {
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) newFixedThreadPool(10);
+        SingleTenantBlackBoxContext context = BlackBoxBoundedContext
+                .singleTenant()
+                .with(DefaultRepository.of(ShareAggregate.class),
+                      new JowDonsIndex.Repository());
+        int taskCount = 10;
+        ImmutableList<ShareId> shares =
+                Stream.generate(() -> ShareId
+                        .newBuilder()
+                        .setValue(newUuid())
+                        .vBuild())
+                      .limit(taskCount)
+                      .collect(toImmutableList());
+        shares.forEach(share -> executor.execute(() -> {
+            Buy buy = Buy
+                    .newBuilder()
+                    .setShare(share)
+                    .setAmount(42)
+                    .vBuild();
+            context.receivesCommand(buy);
+            sleepUninterruptibly(1, SECONDS);
+            Sell sell = Sell
+                    .newBuilder()
+                    .setShare(share)
+                    .setAmount(12)
+                    .vBuild();
+            context.receivesCommand(sell);
+        }));
+        executor.awaitTermination(20, SECONDS);
+        assertEquals(shares.size(), executor.getCompletedTaskCount(),
+                     "Not all tasks have been executed. Most likely, a dead lock is reached.");
+    }
+}

--- a/server/src/test/java/io/spine/server/bus/given/stock/JowDonsIndex.java
+++ b/server/src/test/java/io/spine/server/bus/given/stock/JowDonsIndex.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.bus.given.stock;
+
+import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
+import io.spine.core.Subscribe;
+import io.spine.server.projection.Projection;
+import io.spine.server.projection.ProjectionRepository;
+import io.spine.server.route.EventRoute;
+import io.spine.server.route.EventRouting;
+import io.spine.test.bus.IndexName;
+import io.spine.test.bus.JowDons;
+import io.spine.test.bus.PriceDropped;
+import io.spine.test.bus.PriceRaised;
+
+import static java.lang.Math.round;
+
+public final class JowDonsIndex extends Projection<IndexName, JowDons, JowDons.Builder> {
+
+    public static final IndexName JOW_DONS = IndexName
+            .newBuilder()
+            .setName("Jow Dons")
+            .vBuild();
+
+    @Subscribe
+    void on(PriceRaised event) {
+        ensureName();
+        builder().setPoints(builder().getPoints() + round(event.getPercent()));
+    }
+
+    @Subscribe
+    void on(PriceDropped event) {
+        ensureName();
+        builder().setPoints(builder().getPoints() - round(event.getPercent()));
+    }
+
+    private void ensureName() {
+        builder().setName(id());
+    }
+
+    public static final class Repository
+            extends ProjectionRepository<IndexName, JowDonsIndex, JowDons> {
+
+        @OverridingMethodsMustInvokeSuper
+        @Override
+        protected void setupEventRouting(EventRouting<IndexName> routing) {
+            super.setupEventRouting(routing);
+            routing.replaceDefault((event, context) -> EventRoute.withId(JOW_DONS));
+        }
+    }
+}

--- a/server/src/test/java/io/spine/server/bus/given/stock/ShareAggregate.java
+++ b/server/src/test/java/io/spine/server/bus/given/stock/ShareAggregate.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.bus.given.stock;
+
+import io.spine.server.aggregate.Aggregate;
+import io.spine.server.aggregate.Apply;
+import io.spine.server.command.Assign;
+import io.spine.server.tuple.Pair;
+import io.spine.test.bus.Buy;
+import io.spine.test.bus.Price;
+import io.spine.test.bus.PriceDropped;
+import io.spine.test.bus.PriceRaised;
+import io.spine.test.bus.Sell;
+import io.spine.test.bus.Share;
+import io.spine.test.bus.ShareId;
+import io.spine.test.bus.ShareTraded;
+
+import java.math.BigDecimal;
+
+import static java.lang.Math.max;
+import static java.math.BigDecimal.ROUND_UP;
+
+public final class ShareAggregate extends Aggregate<ShareId, Share, Share.Builder> {
+
+    @Assign
+    Pair<ShareTraded, PriceRaised> handle(Buy command) {
+        int amount = command.getAmount();
+        ShareTraded traded = ShareTraded
+                .newBuilder()
+                .setShare(id())
+                .setAmount(amount)
+                .vBuild();
+        float percent = max(amount / 100.0f, 50.0f);
+        PriceRaised raised = PriceRaised
+                .newBuilder()
+                .setShare(id())
+                .setPercent(percent)
+                .build();
+        return Pair.of(traded, raised);
+    }
+
+    @Assign
+    Pair<ShareTraded, PriceDropped> handle(Sell command) {
+        int amount = command.getAmount();
+        ShareTraded traded = ShareTraded
+                .newBuilder()
+                .setShare(id())
+                .setAmount(amount)
+                .vBuild();
+        float percent = max(amount / 100.0f, 50.0f);
+        PriceDropped raised = PriceDropped
+                .newBuilder()
+                .setShare(id())
+                .setPercent(percent)
+                .build();
+        return Pair.of(traded, raised);
+    }
+
+    @Apply
+    private void event(ShareTraded event) {
+        builder().setId(event.getShare());
+    }
+
+    @Apply
+    private void event(PriceRaised event) {
+        Price.Builder priceBuilder = builder().getPriceBuilder();
+        float oldPrice = priceBuilder.getUsd();
+        float newPrice = oldPrice + percentage(oldPrice, event.getPercent());
+        priceBuilder.setUsd(newPrice);
+    }
+
+    @Apply
+    private void event(PriceDropped event) {
+        Price.Builder priceBuilder = builder().getPriceBuilder();
+        float oldPrice = priceBuilder.getUsd();
+        float newPrice = oldPrice - percentage(oldPrice, event.getPercent());
+        priceBuilder.setUsd(newPrice);
+    }
+
+    private static float percentage(float value, float percent) {
+        float raise = (value * percent / 100.0f);
+        BigDecimal decimalRaise = BigDecimal.valueOf(raise);
+        return decimalRaise.setScale(2, ROUND_UP)
+                           .floatValue();
+    }
+
+
+}

--- a/server/src/test/java/io/spine/server/bus/given/stock/package-info.java
+++ b/server/src/test/java/io/spine/server/bus/given/stock/package-info.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Contains the test domain of a stock market.
+ */
+
+
+@BoundedContext("Stock")
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.server.bus.given.stock;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import io.spine.server.annotation.BoundedContext;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/test/java/io/spine/server/commandbus/AbstractCommandBusTestSuite.java
+++ b/server/src/test/java/io/spine/server/commandbus/AbstractCommandBusTestSuite.java
@@ -22,6 +22,7 @@ package io.spine.server.commandbus;
 
 import com.google.common.truth.IterableSubject;
 import com.google.protobuf.Any;
+import io.spine.base.CommandMessage;
 import io.spine.base.Error;
 import io.spine.base.Identifier;
 import io.spine.client.ActorRequestFactory;
@@ -39,7 +40,6 @@ import io.spine.server.command.Assign;
 import io.spine.server.event.EventBus;
 import io.spine.server.storage.memory.InMemoryStorageFactory;
 import io.spine.server.tenant.TenantIndex;
-import io.spine.server.type.CommandEnvelope;
 import io.spine.system.server.NoOpSystemWriteSide;
 import io.spine.system.server.SystemWriteSide;
 import io.spine.test.commandbus.command.CmdBusCreateProject;
@@ -54,8 +54,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.List;
+import java.util.Set;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newHashSet;
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.core.BoundedContextNames.newName;
 import static io.spine.core.CommandValidationError.INVALID_COMMAND;
@@ -69,7 +71,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -213,20 +214,16 @@ abstract class AbstractCommandBusTestSuite {
         CommandBus spy = spy(commandBus);
         spy.post(commands, memoizingObserver());
 
-        @SuppressWarnings("unchecked") ArgumentCaptor<Iterable<Command>> storingCaptor = forClass(Iterable.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Iterable<Command>> storingCaptor = forClass(Iterable.class);
         verify(spy).store(storingCaptor.capture());
         Iterable<Command> storingArgs = storingCaptor.getValue();
         IterableSubject assertStoringArgs = assertThat(storingArgs);
         assertStoringArgs.hasSize(commands.size());
-        assertStoringArgs.containsExactly(first, second);
+        assertStoringArgs.containsExactlyElementsIn(commands);
 
-        ArgumentCaptor<CommandEnvelope> postingCaptor = forClass(CommandEnvelope.class);
-        verify(spy, times(2)).dispatch(postingCaptor.capture());
-        List<CommandEnvelope> postingArgs = postingCaptor.getAllValues();
-        assertThat(postingArgs).hasSize(commands.size());
-        assertEquals(commands.get(0), postingArgs.get(0).command());
-        assertEquals(commands.get(1), postingArgs.get(1).command());
-
+        assertTrue(createProjectHandler.received(first.enclosedMessage()));
+        assertTrue(createProjectHandler.received(second.enclosedMessage()));
         commandBus.unregister(createProjectHandler);
     }
 
@@ -248,6 +245,7 @@ abstract class AbstractCommandBusTestSuite {
     class CreateProjectHandler extends AbstractCommandHandler {
 
         private boolean handlerInvoked = false;
+        private final Set<CommandMessage> receivedCommands = newHashSet();
 
         CreateProjectHandler() {
             super(eventBus);
@@ -256,7 +254,12 @@ abstract class AbstractCommandBusTestSuite {
         @Assign
         CmdBusProjectCreated handle(CmdBusCreateProject command, CommandContext ctx) {
             handlerInvoked = true;
+            receivedCommands.add(command);
             return CmdBusProjectCreated.getDefaultInstance();
+        }
+
+        boolean received(CommandMessage command) {
+            return receivedCommands.contains(command);
         }
 
         boolean wasHandlerInvoked() {

--- a/server/src/test/java/io/spine/test/validation/FakeOption.java
+++ b/server/src/test/java/io/spine/test/validation/FakeOption.java
@@ -25,9 +25,9 @@ import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.GeneratedMessage.GeneratedExtension;
 import io.spine.option.OptionsProto;
-import io.spine.validate.Constraint;
-import io.spine.validate.FieldValidatingOption;
 import io.spine.validate.FieldValue;
+import io.spine.validate.option.Constraint;
+import io.spine.validate.option.FieldValidatingOption;
 
 /**
  * A test-only implementation of a validating option.
@@ -65,7 +65,7 @@ public final class FakeOption extends FieldValidatingOption<Void, Object> {
     }
 
     @Override
-    protected boolean shouldValidate(FieldDescriptor field) {
+    public boolean shouldValidate(FieldDescriptor field) {
         return true;
     }
 }

--- a/server/src/test/java/io/spine/test/validation/FakeOptionFactory.java
+++ b/server/src/test/java/io/spine/test/validation/FakeOptionFactory.java
@@ -25,8 +25,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
-import io.spine.validate.FieldValidatingOption;
-import io.spine.validate.ValidatingOptionFactory;
+import io.spine.validate.option.FieldValidatingOption;
+import io.spine.validate.option.ValidatingOptionFactory;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Set;

--- a/server/src/test/proto/spine/test/aggregate/project.proto
+++ b/server/src/test/proto/spine/test/aggregate/project.proto
@@ -76,7 +76,7 @@ message TaskId {
 message Task {
     option (entity) = {kind: AGGREGATE visibility: FULL};
 
-    ProjectId id = 1 [(required) = false, (valid) = false];
+    ProjectId id = 1 [(required) = false, (validate) = false];
     TaskId task_id = 2;
     string title = 3;
     string description = 4;

--- a/server/src/test/proto/spine/test/bus/stock/commands.proto
+++ b/server/src/test/proto/spine/test/bus/stock/commands.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package spine.test.bus.stock;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.test.bus";
+option java_outer_classname = "StockCommandsProto";
+option java_multiple_files = true;
+
+import "spine/test/bus/stock/share.proto";
+
+message Sell {
+
+    stock.ShareId share = 1;
+
+    uint32 amount = 2;
+}
+
+message Buy {
+
+    stock.ShareId share = 1;
+
+    uint32 amount = 2;
+}

--- a/server/src/test/proto/spine/test/bus/stock/events.proto
+++ b/server/src/test/proto/spine/test/bus/stock/events.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+package spine.test.bus.stock;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.test.bus";
+option java_outer_classname = "StockEventsProto";
+option java_multiple_files = true;
+
+import "spine/test/bus/stock/share.proto";
+
+message ShareTraded {
+
+    stock.ShareId share = 1;
+
+    int32 amount = 2;
+}
+
+message PriceRaised {
+
+    stock.ShareId share = 1;
+
+    float percent = 2;
+}
+
+message PriceDropped {
+
+    stock.ShareId share = 1;
+
+    float percent = 2;
+}
+
+message OfferPublished {
+
+    stock.ShareId share = 1;
+
+    stock.Price initial_price = 2;
+}

--- a/server/src/test/proto/spine/test/bus/stock/index.proto
+++ b/server/src/test/proto/spine/test/bus/stock/index.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package spine.test.bus.stock;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.test.bus";
+option java_outer_classname = "IndexProto";
+option java_multiple_files = true;
+
+message IndexName {
+    string name = 1;
+}
+
+message JowDons {
+    option (entity).kind = PROJECTION;
+
+    IndexName name = 1;
+
+    int64 points = 2;
+}

--- a/server/src/test/proto/spine/test/bus/stock/share.proto
+++ b/server/src/test/proto/spine/test/bus/stock/share.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package spine.test.bus.stock;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.test.bus";
+option java_outer_classname = "StockProto";
+option java_multiple_files = true;
+
+message ShareId {
+    string value = 1;
+}
+
+message Share {
+    option (entity).kind = AGGREGATE;
+
+    ShareId id = 1;
+
+    Price price = 2;
+}
+
+message Price {
+
+    float usd = 2 [(digits).fraction_max = 2];
+}

--- a/server/src/test/proto/spine/test/system/server/mirror_test.proto
+++ b/server/src/test/proto/spine/test/system/server/mirror_test.proto
@@ -26,9 +26,9 @@ message Photo {
 
     PhotoId id = 1;
 
-    spine.net.Url full_size_url = 2 [(valid) = true];
+    spine.net.Url full_size_url = 2 [(validate) = true];
 
-    spine.net.Url thumbnail_url = 3 [(valid) = true, (required) = false];
+    spine.net.Url thumbnail_url = 3 [(validate) = true, (required) = false];
 
     string alt_text = 4;
 }
@@ -38,13 +38,13 @@ message Video {
 
     VideoId id = 1;
 
-    PhotoId title_shot = 2 [(valid) = true];
+    PhotoId title_shot = 2 [(validate) = true];
 
-    spine.net.Url file_url = 3 [(valid) = true];
+    spine.net.Url file_url = 3 [(validate) = true];
 
-    map<string, spine.net.Url> soundtrack_url = 4 [(valid) = true, (required) = false];
+    map<string, spine.net.Url> soundtrack_url = 4 [(validate) = true, (required) = false];
 
-    map<string, spine.net.Url> subtitles_url = 5 [(valid) = true, (required) = false];
+    map<string, spine.net.Url> subtitles_url = 5 [(validate) = true, (required) = false];
 }
 
 message LocalizedVideo {
@@ -52,13 +52,13 @@ message LocalizedVideo {
 
     VideoId id = 1;
 
-    PhotoId title_shot = 2 [(valid) = true];
+    PhotoId title_shot = 2 [(validate) = true];
 
-    spine.net.Url file_url = 3 [(valid) = true];
+    spine.net.Url file_url = 3 [(validate) = true];
 
-    spine.net.Url sound_track_url = 4 [(valid) = true, (required) = false];
+    spine.net.Url sound_track_url = 4 [(validate) = true, (required) = false];
 
-    spine.net.Url subtitles_url = 5 [(valid) = true, (required) = false];
+    spine.net.Url subtitles_url = 5 [(validate) = true, (required) = false];
 }
 
 // This aggregate design is not complete and the aggregate is not production-ready, so

--- a/server/src/test/proto/spine/test/tuple/quintet.proto
+++ b/server/src/test/proto/spine/test/tuple/quintet.proto
@@ -62,7 +62,7 @@ message Violin {
 
     // A violin has alwas a number in both cello and viola quintets.
     // Cannot be zero.
-    InstrumentNumber number = 1 [(valid) = true];
+    InstrumentNumber number = 1 [(validate) = true];
 }
 
 message ViolinCello {


### PR DESCRIPTION
This PR adds a test for the deadlock found in the `DispatchingQueue.add(..)`.

The test is at `DispatchingQueueSynchronisationTest.deadlock()`.
The test is currently disabled, as the issue is not fixed. It is expected that the `Inbox` feature will address this dead lock.