### PR TITLE
Remove notion of a separately stored event count

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -434,7 +434,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jun 14 13:27:26 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 14 21:00:03 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -827,7 +827,7 @@ This report was generated on **Fri Jun 14 13:27:26 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jun 14 13:27:33 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 14 21:00:09 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1368,7 +1368,7 @@ This report was generated on **Fri Jun 14 13:27:33 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jun 14 13:27:41 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 14 21:00:16 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2071,7 +2071,7 @@ This report was generated on **Fri Jun 14 13:27:41 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jun 14 13:27:52 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 14 21:00:27 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2624,7 +2624,7 @@ This report was generated on **Fri Jun 14 13:27:52 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jun 14 13:28:02 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 14 21:00:35 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3132,7 +3132,7 @@ This report was generated on **Fri Jun 14 13:28:02 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jun 14 13:28:09 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 14 21:00:42 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3648,7 +3648,7 @@ This report was generated on **Fri Jun 14 13:28:09 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jun 14 13:28:17 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 14 21:00:51 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4264,4 +4264,4 @@ This report was generated on **Fri Jun 14 13:28:17 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jun 14 13:28:26 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 14 21:01:00 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -107,9 +107,12 @@ import static io.spine.validate.Validate.isNotDefault;
  * {@link AggregateRepository} periodically stores aggregate snapshots.
  * See {@link AggregateRepository#setSnapshotTrigger(int)} for details.
  *
- * @param <I> the type for IDs of this class of aggregates
- * @param <S> the type of the state held by the aggregate
- * @param <B> the type of the aggregate state builder
+ * @param <I>
+ *         the type for IDs of this class of aggregates
+ * @param <S>
+ *         the type of the state held by the aggregate
+ * @param <B>
+ *         the type of the aggregate state builder
  */
 @SuppressWarnings("OverlyCoupledClass")
 public abstract class Aggregate<I,
@@ -123,8 +126,6 @@ public abstract class Aggregate<I,
      * the last snapshot.
      *
      * <p>This field is set in {@link #play(AggregateHistory)} and is effectively final.
-     *
-     * @see AggregateStorage#readEventCountAfterLastSnapshot(Object)
      */
     private int eventCountAfterLastSnapshot = 0;
 
@@ -221,7 +222,8 @@ public abstract class Aggregate<I,
      * <p>Dispatching the commands results in emitting event messages. All the
      * {@linkplain Empty empty} messages are filtered out from the result.
      *
-     * @param  command the envelope with the command to dispatch
+     * @param  command
+     *          the envelope with the command to dispatch
      * @return a list of event messages that the aggregate produces by handling the command
      */
     @Override
@@ -238,7 +240,8 @@ public abstract class Aggregate<I,
      * <p>Reacting on a event may result in emitting event messages.
      * All the {@linkplain Empty empty} messages are filtered out from the result.
      *
-     * @param  event the envelope with the event to dispatch
+     * @param  event
+     *          the envelope with the event to dispatch
      * @return a list of event messages that the aggregate produces in reaction to the event or
      *         an empty list if the aggregate state does not change because of the event
      */
@@ -254,7 +257,8 @@ public abstract class Aggregate<I,
     /**
      * Invokes applier method for the passed event message.
      *
-     * @param event the event to apply
+     * @param event
+     *         the event to apply
      */
     void invokeApplier(EventEnvelope event) {
         EventApplier method = thisClass().applierOf(event.messageClass());
@@ -274,7 +278,8 @@ public abstract class Aggregate<I,
      * a {@code Snapshot}) loaded by a repository and passed to the aggregate so that
      * it restores its state.
      *
-     * @param  aggregateHistory the aggregate state with events to play
+     * @param  aggregateHistory
+     *          the aggregate state with events to play
      * @throws IllegalStateException
      *         if applying events caused an exception, which is set as the {@code cause} for
      *         the thrown instance
@@ -304,7 +309,8 @@ public abstract class Aggregate<I,
      * the {@code events} list is of size 3, the applied events will have versions {@code 43},
      * {@code 44}, and {@code 45}.
      *
-     * @param events the events to apply
+     * @param events
+     *         the events to apply
      * @return the exact list of {@code events} but with adjusted versions
      */
     List<Event> apply(List<Event> events) {

--- a/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
@@ -36,8 +36,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * the batch size for event reading to be set. Typically that would be a number of
  * event records to read to encounter the most recent snapshot.
  *
- * <p>Two requests with the same {@linkplain #getRecordId() record ID} are considered equal.
- * {@linkplain #getBatchSize() Batch size} is not taken into account, because it should affect only
+ * <p>Two requests with the same {@linkplain #recordId() record ID} are considered equal.
+ * {@linkplain #batchSize() Batch size} is not taken into account, because it should affect only
  * process of reading, but resulting records should be the same.
  *
  * @param <I> the type of the record ID
@@ -55,7 +55,7 @@ public final class AggregateReadRequest<I> implements ReadRequest<I> {
     }
 
     @Override
-    public I getRecordId() {
+    public I recordId() {
         return recordId;
     }
 
@@ -64,7 +64,7 @@ public final class AggregateReadRequest<I> implements ReadRequest<I> {
      *
      * @return the events batch size
      */
-    public int getBatchSize() {
+    public int batchSize() {
         return batchSize;
     }
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -457,7 +457,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      *
      * <p>The default value is defined in {@link #DEFAULT_SNAPSHOT_TRIGGER}.
      *
-     * <p>Please <b>NOTE</b>: repository read operations are optimized around the current snapshot
+     * <p><b>NOTE</b>: repository read operations are optimized around the current snapshot
      * trigger. Setting the snapshot trigger to a new value may cause read operations to perform
      * sub-optimally, until a new snapshot is created. This doesn't apply to newly created
      * repositories.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -57,7 +57,6 @@ import static io.spine.option.EntityOption.Kind.AGGREGATE;
 import static io.spine.server.aggregate.model.AggregateClass.asAggregateClass;
 import static io.spine.server.tenant.TenantAwareRunner.with;
 import static io.spine.util.Exceptions.newIllegalStateException;
-import static java.lang.Math.max;
 
 /**
  * The repository which manages instances of {@code Aggregate}s.
@@ -458,7 +457,13 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      *
      * <p>The default value is defined in {@link #DEFAULT_SNAPSHOT_TRIGGER}.
      *
-     * @param snapshotTrigger a positive number of the snapshot trigger
+     * <p>Please <b>NOTE</b>: repository read operations are optimized around the current snapshot
+     * trigger. Setting the snapshot trigger to a new value may cause read operations to perform
+     * sub-optimally, until a new snapshot is created. This doesn't apply to newly created
+     * repositories.
+     *
+     * @param snapshotTrigger
+     *         a positive number of the snapshot trigger
      */
     protected void setSnapshotTrigger(int snapshotTrigger) {
         checkArgument(snapshotTrigger > 0);
@@ -480,7 +485,8 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
     /**
      * Loads or creates an aggregate by the passed ID.
      *
-     * @param  id the ID of the aggregate
+     * @param  id
+     *          the ID of the aggregate
      * @return loaded or created aggregate instance
      */
     final A loadOrCreate(I id) {
@@ -503,7 +509,8 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * {@linkplain #loadHistory fetched} from the storage. Then the {@code Aggregate} is
      * {@linkplain #play restored} from its state history.
      *
-     * @param id the ID of the aggregate
+     * @param id
+     *         the ID of the aggregate
      * @return the loaded instance or {@code Optional.empty()} if there is no {@code Aggregate}
      *         with the ID
      */
@@ -517,28 +524,19 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * Loads the history of the {@code Aggregate} with the given ID.
      *
      * <p>The method loads only the recent history of the aggregate.
-     * The maximum depth of the read operation is defined as the greater number between
-     * the {@linkplain AggregateStorage#readEventCountAfterLastSnapshot(Object) event count after
-     * the last snapshot} and the {@linkplain #snapshotTrigger() snapshot trigger}, plus one.
-     * This way, we secure the read operation from:
-     * <ol>
-     *     <li>snapshot trigger decrease;
-     *     <li>eventual consistency in the event count field.
-     * </ol>
      *
-     * <p>The extra one unit of depth is added in order to be sure to include the last snapshot
-     * itself.
+     * <p>The current {@link #snapshotTrigger} is used as a read operation
+     * {@linkplain AggregateReadRequest#batchSize()} batch size}, so the method will perform
+     * sub-optimally in case of a {@link #snapshotTrigger} change.
      *
-     * @param id the ID of the {@code Aggregate} to fetch
+     * @param id
+     *         the ID of the {@code Aggregate} to fetch
      * @return the {@link AggregateHistory} for the {@code Aggregate} or
      *         {@code Optional.empty()} if there is no record with the ID
      */
     private Optional<AggregateHistory> loadHistory(I id) {
         AggregateStorage<I> storage = aggregateStorage();
-
-        int eventsAfterLastSnapshot = storage.readEventCountAfterLastSnapshot(id);
-        int batchSize = max(snapshotTrigger, eventsAfterLastSnapshot) + 1;
-
+        int batchSize = snapshotTrigger + 1;
         AggregateReadRequest<I> request = new AggregateReadRequest<>(id, batchSize);
         Optional<AggregateHistory> result = storage.read(request);
         return result;
@@ -548,8 +546,10 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * Plays the given {@linkplain AggregateHistory Aggregate history} for an instance
      * of {@link Aggregate} with the given ID.
      *
-     * @param id      the ID of the {@code Aggregate} to load
-     * @param history the state record of the {@code Aggregate} to load
+     * @param id
+     *         the ID of the {@code Aggregate} to load
+     * @param history
+     *         the state record of the {@code Aggregate} to load
      * @return an instance of {@link Aggregate}
      */
     protected A play(I id, AggregateHistory history) {
@@ -568,7 +568,8 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * or {@link io.spine.server.entity.Entity#isDeleted() deleted} lifecycle
      * attribute, or both of them, are set to {@code true}.
      *
-     * @param  id the ID of the aggregate to load
+     * @param  id
+     *          the ID of the aggregate to load
      * @return the aggregate instance, or {@link Optional#empty() empty()} if there is no
      *         aggregate with such ID
      */

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -526,8 +526,8 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * <p>The method loads only the recent history of the aggregate.
      *
      * <p>The current {@link #snapshotTrigger} is used as a read operation
-     * {@linkplain AggregateReadRequest#batchSize()} batch size}, so the method will perform
-     * sub-optimally in case of a {@link #snapshotTrigger} change.
+     * {@linkplain AggregateReadRequest#batchSize()} batch size}, so the method can perform
+     * sub-optimally for some time after a {@link #snapshotTrigger} change.
      *
      * @param id
      *         the ID of the {@code Aggregate} to fetch

--- a/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
@@ -85,7 +85,7 @@ public abstract class AggregateStorage<I>
     /**
      * Writes events into the storage.
      *
-     * <p>NOTE: does not rewrite any events. Several events can be associated with one
+     * <p><b>NOTE</b>: does not rewrite any events. Several events can be associated with one
      * aggregate ID.
      *
      * @param id

--- a/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
@@ -69,7 +69,8 @@ public abstract class AggregateStorage<I>
      * Forms and returns an {@link AggregateHistory} based on the
      * {@linkplain #historyBackward(AggregateReadRequest) aggregate history}.
      *
-     * @param request the aggregate read request based on which to form a record
+     * @param request
+     *         the aggregate read request based on which to form a record
      * @return the record instance or {@code Optional.empty()} if the
      *         {@linkplain #historyBackward(AggregateReadRequest) aggregate history} is empty
      * @throws IllegalStateException if the storage was closed before
@@ -84,9 +85,11 @@ public abstract class AggregateStorage<I>
     /**
      * Writes events into the storage.
      *
-     * <p>NOTE: does not rewrite any events. Several events can be associated with one aggregate ID.
+     * <p>NOTE: does not rewrite any events. Several events can be associated with one
+     * aggregate ID.
      *
-     * @param id     the ID for the record
+     * @param id
+     *         the ID for the record
      * @param events non empty aggregate state record to store
      */
     @Override
@@ -111,8 +114,10 @@ public abstract class AggregateStorage<I>
      * <p>Before the storing, {@linkplain io.spine.core.Event#clearEnrichments() enrichments}
      * will be removed from the event.
      *
-     * @param id    the aggregate ID
-     * @param event the event to write
+     * @param id
+     *         the aggregate ID
+     * @param event
+     *         the event to write
      */
     void writeEvent(I id, Event event) {
         checkNotClosedAndArguments(id, event);
@@ -125,8 +130,10 @@ public abstract class AggregateStorage<I>
     /**
      * Writes a {@code snapshot} by an {@code aggregateId} to the storage.
      *
-     * @param aggregateId an ID of an aggregate of which the snapshot is made
-     * @param snapshot    the snapshot of the aggregate
+     * @param aggregateId
+     *         an ID of an aggregate of which the snapshot is made
+     * @param snapshot
+     *         the snapshot of the aggregate
      */
     void writeSnapshot(I aggregateId, Snapshot snapshot) {
         checkNotClosedAndArguments(aggregateId, snapshot);
@@ -166,34 +173,15 @@ public abstract class AggregateStorage<I>
                                    .build();
     }
 
-    /**
-     * Reads a count of events which were saved to the storage after
-     * the last snapshot was created,
-     * <strong>or</strong> a count of all events if there were no snapshots yet.
-     *
-     * @param id an ID of an aggregate
-     * @return an even count after the last snapshot
-     */
-    protected abstract int readEventCountAfterLastSnapshot(I id);
-
-    /**
-     * Writes a count of events which were saved to the storage after
-     * the last snapshot was created, or a count of all events if there
-     * were no snapshots yet.
-     *
-     * @param id         an ID of an aggregate
-     * @param eventCount an even count after the last snapshot
-     * @throws IllegalStateException if the storage is closed
-     */
-    protected abstract void writeEventCountAfterLastSnapshot(I id, int eventCount);
-
     // Storage implementation API.
 
     /**
      * Writes the passed record into the storage.
      *
-     * @param id     the aggregate ID
-     * @param record the record to write
+     * @param id
+     *         the aggregate ID
+     * @param record
+     *         the record to write
      */
     protected abstract void writeRecord(I id, AggregateEventRecord record);
 
@@ -203,7 +191,8 @@ public abstract class AggregateStorage<I>
      * <p>Records are sorted by timestamp descending (from newer to older).
      * The iterator is empty if there's no history for the aggregate with passed ID.
      *
-     * @param request the read request
+     * @param request
+     *         the read request
      * @return new iterator instance
      */
     protected abstract Iterator<AggregateEventRecord> historyBackward(

--- a/server/src/main/java/io/spine/server/aggregate/Write.java
+++ b/server/src/main/java/io/spine/server/aggregate/Write.java
@@ -123,7 +123,6 @@ final class Write<I> {
 
     private void commit(int eventCount) {
         aggregate.commitEvents();
-        storage.writeEventCountAfterLastSnapshot(id, eventCount);
         aggregate.setEventCountAfterLastSnapshot(eventCount);
         if (aggregate.lifecycleFlagsChanged()) {
             storage.writeLifecycleFlags(aggregate.id(), aggregate.lifecycleFlags());

--- a/server/src/main/java/io/spine/server/model/declare/MethodSignature.java
+++ b/server/src/main/java/io/spine/server/model/declare/MethodSignature.java
@@ -206,7 +206,7 @@ public abstract class MethodSignature<H extends HandlerMethod<?, ?, E, ?, ?>,
      * Match the method against the {@linkplain MatchCriterion criteria} and obtain a collection
      * of mismatches, if any.
      *
-     * <p>NOTE: this method does not test the presence of annotation.
+     * <p><b>NOTE</b>: this method does not test the presence of annotation.
      *
      * @param method
      *         the method to match.

--- a/server/src/main/java/io/spine/server/storage/ReadRequest.java
+++ b/server/src/main/java/io/spine/server/storage/ReadRequest.java
@@ -41,5 +41,5 @@ public interface ReadRequest<I> {
      *
      * @return the record ID
      */
-    I getRecordId();
+    I recordId();
 }

--- a/server/src/main/java/io/spine/server/storage/RecordReadRequest.java
+++ b/server/src/main/java/io/spine/server/storage/RecordReadRequest.java
@@ -29,7 +29,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * <p>A result of this request is a record with the specified ID.
  *
- * <p>Two requests are considered equal if they have the same {@linkplain #getRecordId() record ID}.
+ * <p>Two requests are considered equal if they have the same {@linkplain #recordId() record ID}.
  *
  * @param <I> the type of the target ID
  */
@@ -43,7 +43,7 @@ public final class RecordReadRequest<I> implements ReadRequest<I> {
     }
 
     @Override
-    public I getRecordId() {
+    public I recordId() {
         return recordId;
     }
 

--- a/server/src/main/java/io/spine/server/storage/RecordStorage.java
+++ b/server/src/main/java/io/spine/server/storage/RecordStorage.java
@@ -106,7 +106,7 @@ public abstract class RecordStorage<I>
         checkNotClosed();
         checkNotNull(request);
 
-        Optional<EntityRecord> record = readRecord(request.getRecordId());
+        Optional<EntityRecord> record = readRecord(request.recordId());
         return record;
     }
 

--- a/server/src/main/java/io/spine/server/storage/memory/InMemoryAggregateStorage.java
+++ b/server/src/main/java/io/spine/server/storage/memory/InMemoryAggregateStorage.java
@@ -67,13 +67,6 @@ class InMemoryAggregateStorage<I> extends AggregateStorage<I> {
     }
 
     @Override
-    protected int readEventCountAfterLastSnapshot(I id) {
-        checkNotClosed();
-        int result = getStorage().eventCount(id);
-        return result;
-    }
-
-    @Override
     public Optional<LifecycleFlags> readLifecycleFlags(I id) {
         checkNotClosed();
         Optional<LifecycleFlags> result = getStorage().getStatus(id);
@@ -84,12 +77,6 @@ class InMemoryAggregateStorage<I> extends AggregateStorage<I> {
     public void writeLifecycleFlags(I id, LifecycleFlags status) {
         checkNotClosed();
         getStorage().putStatus(id, status);
-    }
-
-    @Override
-    protected void writeEventCountAfterLastSnapshot(I id, int eventCount) {
-        checkNotClosed();
-        getStorage().putEventCount(id, eventCount);
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/storage/memory/InMemoryStorageFactory.java
+++ b/server/src/main/java/io/spine/server/storage/memory/InMemoryStorageFactory.java
@@ -89,7 +89,7 @@ public final class InMemoryStorageFactory implements StorageFactory {
         return this.multitenant;
     }
 
-    /** NOTE: the parameter is unused. */
+    /** <b>NOTE</b>: the parameter is unused. */
     @Override
     public <I> AggregateStorage<I> createAggregateStorage(
             Class<? extends Aggregate<I, ?, ?>> unused) {

--- a/server/src/main/java/io/spine/server/storage/memory/TenantAggregateRecords.java
+++ b/server/src/main/java/io/spine/server/storage/memory/TenantAggregateRecords.java
@@ -57,7 +57,6 @@ final class TenantAggregateRecords<I> implements TenantStorage<I, AggregateEvent
     );
 
     private final Map<I, LifecycleFlags> statuses = new HashMap<>();
-    private final Map<I, Integer> eventCounts = new HashMap<>();
 
     @Override
     public Iterator<I> index() {
@@ -84,24 +83,8 @@ final class TenantAggregateRecords<I> implements TenantStorage<I, AggregateEvent
      * @return immutable list
      */
     List<AggregateEventRecord> historyBackward(AggregateReadRequest<I> request) {
-        I id = request.getRecordId();
+        I id = request.recordId();
         return ImmutableList.copyOf(records.get(id));
-    }
-
-    /**
-     * Obtains a count of events stored for the aggregate with the passed ID.
-     *
-     * <p>If no events were stored, the method returns zero.
-     *
-     * @param id the ID of the aggregate
-     * @return the number of events stored for the aggregate or zero
-     */
-    int eventCount(I id) {
-        Integer count = eventCounts.get(id);
-        if (count == null) {
-            return 0;
-        }
-        return count;
     }
 
     /**
@@ -117,17 +100,6 @@ final class TenantAggregateRecords<I> implements TenantStorage<I, AggregateEvent
     @Override
     public void put(I id, AggregateEventRecord record) {
         records.put(id, record);
-    }
-
-    /**
-     * Stores the number of the aggregate events occurred since the last snapshot
-     * of the aggregate with the passed ID.
-     *
-     * @param id the aggregate ID
-     * @param eventCount the number of events
-     */
-    void putEventCount(I id, int eventCount) {
-        eventCounts.put(id, eventCount);
     }
 
     void putStatus(I id, LifecycleFlags status) {

--- a/server/src/test/java/io/spine/server/aggregate/AggregateReadRequestTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateReadRequestTest.java
@@ -50,7 +50,7 @@ class AggregateReadRequestTest {
     @DisplayName("consider request with same ID equal")
     void considerRequestWithSameIdEqual() {
         AggregateReadRequest<String> first = new AggregateReadRequest<>(ID, BATCH_SIZE);
-        int differentBatch = first.getBatchSize() * 2;
+        int differentBatch = first.batchSize() * 2;
         AggregateReadRequest<String> second = new AggregateReadRequest<>(ID, differentBatch);
         new EqualsTester().addEqualityGroup(first, second)
                           .testEquals();

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageTest.java
@@ -484,41 +484,6 @@ public abstract class AggregateStorageTest
         }
     }
 
-    @Nested
-    @DisplayName("properly read event count")
-    class ReadEventCount {
-
-        @Test
-        @DisplayName("set to default zero value")
-        void zeroByDefault() {
-            assertEquals(0, storage.readEventCountAfterLastSnapshot(id));
-        }
-
-        @Test
-        @DisplayName("set to specified value")
-        void setToSpecifiedValue() {
-            int expectedCount = 32;
-            storage.writeEventCountAfterLastSnapshot(id, expectedCount);
-
-            int actualCount = storage.readEventCountAfterLastSnapshot(id);
-
-            assertEquals(expectedCount, actualCount);
-        }
-
-        @Test
-        @DisplayName("updated to specified value")
-        void updated() {
-            int primaryValue = 16;
-            storage.writeEventCountAfterLastSnapshot(id, primaryValue);
-            int expectedValue = 32;
-            storage.writeEventCountAfterLastSnapshot(id, expectedValue);
-
-            int actualCount = storage.readEventCountAfterLastSnapshot(id);
-
-            assertEquals(expectedValue, actualCount);
-        }
-    }
-
     @Test
     @DisplayName("continue reading history if snapshot was not found in first batch")
     void continueReadHistoryIfSnapshotNotFound() {
@@ -528,8 +493,8 @@ public abstract class AggregateStorageTest
                                     .build();
         storage.writeSnapshot(id, snapshot);
 
-        int eventCountAfterSnapshot = 10;
-        for (int i = 0; i < eventCountAfterSnapshot; i++) {
+        int eventsAfterSnapshot = 10;
+        for (int i = 0; i < eventsAfterSnapshot; i++) {
             currentVersion = increment(currentVersion);
             Project state = Project.getDefaultInstance();
             Event event = eventFactory.createEvent(event(state), currentVersion);
@@ -543,7 +508,7 @@ public abstract class AggregateStorageTest
         assertTrue(optionalStateRecord.isPresent());
         AggregateHistory stateRecord = optionalStateRecord.get();
         assertEquals(snapshot, stateRecord.getSnapshot());
-        assertEquals(eventCountAfterSnapshot, stateRecord.getEventCount());
+        assertEquals(eventsAfterSnapshot, stateRecord.getEventCount());
     }
 
     @Nested
@@ -748,28 +713,6 @@ public abstract class AggregateStorageTest
         return optional.get();
     }
 
-    @Nested
-    @DisplayName("being closed, not allow")
-    class BeingClosedThrow {
-
-        @Test
-        @DisplayName("writing event count")
-        void onWritingEventCount() {
-            close(storage);
-
-            assertThrows(IllegalStateException.class,
-                         () -> storage.writeEventCountAfterLastSnapshot(id, 5));
-        }
-
-        @Test
-        @DisplayName("reading event count")
-        void onReadingEventCount() {
-            close(storage);
-
-            assertThrows(IllegalStateException.class,
-                         () -> storage.readEventCountAfterLastSnapshot(id));
-        }
-    }
 
     private <I> void writeAndReadEventTest(I id, AggregateStorage<I> storage) {
         Event expectedEvent = eventFactory.createEvent(event(Time.currentTime()));


### PR DESCRIPTION
This PR removes a separately stored `eventCountAfterLastSnapshot` for each aggregate.

We used this count for batch size optimization during the `Aggregate` history reads. The problem is, while the optimization itself rarely comes into play, it costs us one constant extra request to the storage during each read.

This PR removes the optimization and the notion of a separately stored event count. 

The method altering the repository snapshot trigger, which was the primary cause for optimization, now has the extra doc about performance concernings, and is left up to user judgement.