### PR TITLE
Finalize transaction methods

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,9 @@
 version: "{branch} {build}"
 
+# Do not build feature branch on additional commits with open Pull Requests.
+# See: https://help.appveyor.com/discussions/questions/18437-skip_branch_with_pr-setting-doesnt-work
+skip_branch_with_pr: true
+
 build:
   verbosity: detailed
 

--- a/license-report.md
+++ b/license-report.md
@@ -434,7 +434,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jun 14 14:53:30 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 18 19:15:50 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -827,7 +827,7 @@ This report was generated on **Fri Jun 14 14:53:30 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jun 14 14:53:31 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 18 19:15:50 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1368,7 +1368,7 @@ This report was generated on **Fri Jun 14 14:53:31 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jun 14 14:53:31 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 18 19:15:51 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2071,7 +2071,7 @@ This report was generated on **Fri Jun 14 14:53:31 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jun 14 14:53:32 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 18 19:15:52 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2624,7 +2624,7 @@ This report was generated on **Fri Jun 14 14:53:32 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jun 14 14:53:32 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 18 19:15:52 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3132,7 +3132,7 @@ This report was generated on **Fri Jun 14 14:53:32 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jun 14 14:53:33 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 18 19:15:53 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3648,7 +3648,7 @@ This report was generated on **Fri Jun 14 14:53:33 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jun 14 14:53:33 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 18 19:15:53 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4264,4 +4264,4 @@ This report was generated on **Fri Jun 14 14:53:33 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Jun 14 14:53:34 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 18 19:15:54 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -434,7 +434,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jun 18 13:39:44 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 19 16:38:51 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -827,7 +827,7 @@ This report was generated on **Tue Jun 18 13:39:44 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jun 18 13:39:50 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 19 16:38:52 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1368,7 +1368,7 @@ This report was generated on **Tue Jun 18 13:39:50 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jun 18 13:39:57 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 19 16:38:52 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2071,7 +2071,7 @@ This report was generated on **Tue Jun 18 13:39:57 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jun 18 13:40:07 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 19 16:38:53 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2624,7 +2624,7 @@ This report was generated on **Tue Jun 18 13:40:07 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jun 18 13:40:15 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 19 16:38:54 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3132,7 +3132,7 @@ This report was generated on **Tue Jun 18 13:40:15 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jun 18 13:40:22 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 19 16:38:54 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3648,7 +3648,7 @@ This report was generated on **Tue Jun 18 13:40:22 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jun 18 13:40:28 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 19 16:38:54 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4264,4 +4264,4 @@ This report was generated on **Tue Jun 18 13:40:28 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Jun 18 13:40:37 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 19 16:38:55 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,12 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 <modelVersion>4.0.0</modelVersion>
 
-<!--
-
-This file was generated using the Gradle `generatePom` task.
-This file is not suitable for `maven` build tasks. It only describes the first-level dependencies of
+<!-- 
+ 
+This file was generated using the Gradle `generatePom` task. 
+This file is not suitable for `maven` build tasks. It only describes the first-level dependencies of 
 all modules and does not describe the project structure per-subproject.
-
+ 
  -->
 
 <groupId>io.spine</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -230,18 +230,8 @@ all modules and does not describe the project structure per-subproject.
     <version>1.0.0-SNAPSHOT</version>
   </dependency>
   <dependency>
-    <groupId>net.sourceforge.pmd</groupId>
-    <artifactId>pmd-java</artifactId>
-    <version>6.13.0</version>
-  </dependency>
-  <dependency>
     <groupId>org.jacoco</groupId>
     <artifactId>org.jacoco.agent</artifactId>
-    <version>0.8.3</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jacoco</groupId>
-    <artifactId>org.jacoco.ant</artifactId>
     <version>0.8.3</version>
   </dependency>
 </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -230,8 +230,18 @@ all modules and does not describe the project structure per-subproject.
     <version>1.0.0-SNAPSHOT</version>
   </dependency>
   <dependency>
+    <groupId>net.sourceforge.pmd</groupId>
+    <artifactId>pmd-java</artifactId>
+    <version>6.13.0</version>
+  </dependency>
+  <dependency>
     <groupId>org.jacoco</groupId>
     <artifactId>org.jacoco.agent</artifactId>
+    <version>0.8.3</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jacoco</groupId>
+    <artifactId>org.jacoco.ant</artifactId>
     <version>0.8.3</version>
   </dependency>
 </dependencies>

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -256,13 +256,13 @@ public abstract class Aggregate<I,
      *
      * @param event the event to apply
      */
-    void invokeApplier(EventEnvelope event) {
+    final void invokeApplier(EventEnvelope event) {
         Applier method = thisClass().applierOf(event.messageClass());
         method.invoke(this, event);
     }
 
     @Override
-    public void play(Iterable<Event> events) {
+    public final void play(Iterable<Event> events) {
         EventPlayer.forTransactionOf(this)
                    .play(events);
     }
@@ -279,7 +279,7 @@ public abstract class Aggregate<I,
      *         if applying events caused an exception, which is set as the {@code cause} for
      *         the thrown instance
      */
-    void play(AggregateHistory aggregateHistory) {
+    final void play(AggregateHistory aggregateHistory) {
         Snapshot snapshot = aggregateHistory.getSnapshot();
         if (isNotDefault(snapshot)) {
             restore(snapshot);
@@ -307,7 +307,7 @@ public abstract class Aggregate<I,
      * @param events the events to apply
      * @return the exact list of {@code events} but with adjusted versions
      */
-    List<Event> apply(List<Event> events) {
+    final List<Event> apply(List<Event> events) {
         VersionSequence versionSequence = new VersionSequence(version());
         ImmutableList<Event> versionedEvents = versionSequence.update(events);
         play(versionedEvents);
@@ -326,7 +326,7 @@ public abstract class Aggregate<I,
      *
      * @param snapshot the snapshot with the state to restore
      */
-    void restore(Snapshot snapshot) {
+    final void restore(Snapshot snapshot) {
         @SuppressWarnings("unchecked") /* The cast is safe since the snapshot is created
             with the state of this aggregate, which is bound by the type <S>. */
         S stateToRestore = (S) unpack(snapshot.getState());
@@ -347,7 +347,7 @@ public abstract class Aggregate<I,
      * {@linkplain #remember Remembers} the uncommitted events as
      * the {@link io.spine.server.entity.RecentHistory RecentHistory} and clears them.
      */
-    void commitEvents() {
+    final void commitEvents() {
         List<Event> recentEvents = uncommittedEvents.list();
         remember(recentEvents);
         uncommittedEvents = UncommittedEvents.ofNone();
@@ -357,7 +357,7 @@ public abstract class Aggregate<I,
      * Instructs to modify the state of an aggregate only within an event applier method.
      */
     @Override
-    protected String missingTxMessage() {
+    protected final String missingTxMessage() {
         return "Modification of aggregate state or its lifecycle flags is not available this way." +
                 " Make sure to modify those only from an event applier method.";
     }
@@ -367,7 +367,7 @@ public abstract class Aggregate<I,
      *
      * @return new snapshot
      */
-    Snapshot toSnapshot() {
+    final Snapshot toSnapshot() {
         Any state = AnyPacker.pack(state());
         Snapshot.Builder builder = Snapshot
                 .newBuilder()
@@ -383,7 +383,7 @@ public abstract class Aggregate<I,
      * <p>Opens the method for the repository.
      */
     @Override
-    protected void clearRecentHistory() {
+    protected final void clearRecentHistory() {
         super.clearRecentHistory();
     }
 
@@ -396,7 +396,7 @@ public abstract class Aggregate<I,
      *
      * @return new iterator instance
      */
-    protected Iterator<Event> historyBackward() {
+    protected final Iterator<Event> historyBackward() {
         return recentHistory().iterator();
     }
 
@@ -424,14 +424,14 @@ public abstract class Aggregate<I,
     /**
      * Obtains the number of events stored in the associated storage since last snapshot.
      */
-    int eventCountAfterLastSnapshot() {
+    final int eventCountAfterLastSnapshot() {
         return eventCountAfterLastSnapshot;
     }
 
     /**
      * Updates the number of events stores in the associated storage since last snapshot.
      */
-    void setEventCountAfterLastSnapshot(int count) {
+    final void setEventCountAfterLastSnapshot(int count) {
         checkArgument(count >= 0, "Event count cannot be negative.");
         this.eventCountAfterLastSnapshot = count;
     }

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -274,17 +274,18 @@ public abstract class Aggregate<I,
      * a {@code Snapshot}) loaded by a repository and passed to the aggregate so that
      * it restores its state.
      *
-     * @param  aggregateHistory the aggregate state with events to play
+     * @param history
+     *         the aggregate state with events to play
      * @throws IllegalStateException
      *         if applying events caused an exception, which is set as the {@code cause} for
      *         the thrown instance
      */
-    final void play(AggregateHistory aggregateHistory) {
-        Snapshot snapshot = aggregateHistory.getSnapshot();
+    final void play(AggregateHistory history) {
+        Snapshot snapshot = history.getSnapshot();
         if (isNotDefault(snapshot)) {
             restore(snapshot);
         }
-        List<Event> events = aggregateHistory.getEventList();
+        List<Event> events = history.getEventList();
         eventCountAfterLastSnapshot = events.size();
         play(events);
         remember(events);

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -31,7 +31,7 @@ import io.spine.core.Version;
 import io.spine.protobuf.AnyPacker;
 import io.spine.protobuf.ValidatingBuilder;
 import io.spine.server.aggregate.model.AggregateClass;
-import io.spine.server.aggregate.model.EventApplier;
+import io.spine.server.aggregate.model.Applier;
 import io.spine.server.command.CommandHandlingEntity;
 import io.spine.server.command.model.CommandHandlerMethod;
 import io.spine.server.entity.EventPlayer;
@@ -257,7 +257,7 @@ public abstract class Aggregate<I,
      * @param event the event to apply
      */
     void invokeApplier(EventEnvelope event) {
-        EventApplier method = thisClass().applierOf(event.messageClass());
+        Applier method = thisClass().applierOf(event.messageClass());
         method.invoke(this, event);
     }
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateTransaction.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateTransaction.java
@@ -59,7 +59,7 @@ public class AggregateTransaction<I,
      * and test utilities.
      */
     @Override
-    protected void commit() {
+    protected final void commit() {
         super.commit();
     }
 

--- a/server/src/main/java/io/spine/server/aggregate/model/AggregateClass.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/AggregateClass.java
@@ -47,7 +47,7 @@ public class AggregateClass<A extends Aggregate>
 
     private static final long serialVersionUID = 0L;
 
-    private final MessageHandlerMap<EventClass, EmptyClass, EventApplier> stateEvents;
+    private final MessageHandlerMap<EventClass, EmptyClass, Applier> stateEvents;
     private final ImmutableSet<EventClass> importableEvents;
     private final ReactorClassDelegate<A> delegate;
 
@@ -55,7 +55,7 @@ public class AggregateClass<A extends Aggregate>
     protected AggregateClass(Class<A> cls) {
         super(checkNotNull(cls));
         this.stateEvents = MessageHandlerMap.create(cls, new EventApplierSignature());
-        this.importableEvents = stateEvents.messageClasses(EventApplier::allowsImport);
+        this.importableEvents = stateEvents.messageClasses(Applier::allowsImport);
         this.delegate = new ReactorClassDelegate<>(cls);
     }
 
@@ -135,7 +135,7 @@ public class AggregateClass<A extends Aggregate>
     /**
      * Obtains event applier method for the passed class of events.
      */
-    public final EventApplier applierOf(EventClass eventClass) {
+    public final Applier applierOf(EventClass eventClass) {
         return stateEvents.handlerOf(eventClass);
     }
 }

--- a/server/src/main/java/io/spine/server/aggregate/model/Applier.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/Applier.java
@@ -40,7 +40,7 @@ import java.util.function.Function;
 /**
  * A wrapper for event applier method.
  */
-public final class EventApplier
+public final class Applier
         extends AbstractHandlerMethod<Aggregate,
                                       EventMessage,
                                       EventClass,
@@ -56,8 +56,7 @@ public final class EventApplier
      * @param signature
      *         {@link ParameterSpec} which describes the method
      */
-    EventApplier(Method method,
-                 ParameterSpec<EventEnvelope> signature) {
+    Applier(Method method, ParameterSpec<EventEnvelope> signature) {
         super(method, signature);
     }
 

--- a/server/src/main/java/io/spine/server/aggregate/model/EventApplierSignature.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/EventApplierSignature.java
@@ -35,9 +35,9 @@ import java.lang.reflect.Method;
 import static io.spine.server.model.declare.MethodParams.consistsOfSingle;
 
 /**
- * The signature of the {@link EventApplier} method.
+ * The signature of the {@link Applier} method.
  */
-class EventApplierSignature extends MethodSignature<EventApplier, EventEnvelope> {
+class EventApplierSignature extends MethodSignature<Applier, EventEnvelope> {
 
     EventApplierSignature() {
         super(Apply.class);
@@ -49,8 +49,8 @@ class EventApplierSignature extends MethodSignature<EventApplier, EventEnvelope>
     }
 
     @Override
-    public EventApplier doCreate(Method method, ParameterSpec<EventEnvelope> parameterSpec) {
-        return new EventApplier(method, parameterSpec);
+    public Applier doCreate(Method method, ParameterSpec<EventEnvelope> parameterSpec) {
+        return new Applier(method, parameterSpec);
     }
 
     @Override
@@ -64,7 +64,7 @@ class EventApplierSignature extends MethodSignature<EventApplier, EventEnvelope>
     }
 
     /**
-     * Allowed combinations of parameters for {@link EventApplier} methods.
+     * Allowed combinations of parameters for {@link Applier} methods.
      */
     @VisibleForTesting
     @Immutable

--- a/server/src/main/java/io/spine/server/entity/EventDispatchingPhase.java
+++ b/server/src/main/java/io/spine/server/entity/EventDispatchingPhase.java
@@ -41,9 +41,8 @@ public class EventDispatchingPhase<I, E extends TransactionalEntity<I, ?, ?>, R>
 
     private final EventDispatch<I, E, R> dispatch;
 
-    public EventDispatchingPhase(EventDispatch<I, E, R> dispatch,
-                                 VersionIncrement versionIncrement) {
-        super(versionIncrement);
+    public EventDispatchingPhase(EventDispatch<I, E, R> dispatch, VersionIncrement increment) {
+        super(increment);
         this.dispatch = dispatch;
     }
 

--- a/server/src/main/java/io/spine/server/entity/Phase.java
+++ b/server/src/main/java/io/spine/server/entity/Phase.java
@@ -51,8 +51,8 @@ public abstract class Phase<I, R> {
 
     private boolean successful = false;
 
-    Phase(VersionIncrement versionIncrement) {
-        this.versionIncrement = versionIncrement;
+    Phase(VersionIncrement increment) {
+        this.versionIncrement = increment;
     }
 
     /**

--- a/server/src/main/java/io/spine/server/entity/SilentWitness.java
+++ b/server/src/main/java/io/spine/server/entity/SilentWitness.java
@@ -44,8 +44,7 @@ final class SilentWitness<I> implements TransactionListener<I> {
     }
 
     @Override
-    public void onTransactionFailed(Throwable t,
-                                    EntityRecord record) {
+    public void onTransactionFailed(Throwable t, EntityRecord record) {
         // Do nothing.
     }
 

--- a/server/src/main/java/io/spine/server/entity/SilentWitness.java
+++ b/server/src/main/java/io/spine/server/entity/SilentWitness.java
@@ -26,7 +26,7 @@ import io.spine.validate.NonValidated;
  * An implementation of a {@code TransactionListener} which does not set any behavior for its
  * callbacks.
  */
-public final class SilentWitness<I> implements TransactionListener<I> {
+final class SilentWitness<I> implements TransactionListener<I> {
 
     @Override
     public void onBeforePhase(Phase<I, ?> phase) {

--- a/server/src/main/java/io/spine/server/entity/SilentWitness.java
+++ b/server/src/main/java/io/spine/server/entity/SilentWitness.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.entity;
+
+import io.spine.validate.NonValidated;
+
+/**
+ * An implementation of a {@code TransactionListener} which does not set any behavior for its
+ * callbacks.
+ */
+public final class SilentWitness<I> implements TransactionListener<I> {
+
+    @Override
+    public void onBeforePhase(Phase<I, ?> phase) {
+        // Do nothing.
+    }
+
+    @Override
+    public void onAfterPhase(Phase<I, ?> phase) {
+        // Do nothing.
+    }
+
+    @Override
+    public void onBeforeCommit(@NonValidated EntityRecord entityRecord) {
+        // Do nothing.
+    }
+
+    @Override
+    public void onTransactionFailed(Throwable t,
+                                    EntityRecord record) {
+        // Do nothing.
+    }
+
+    @Override
+    public void onAfterCommit(EntityRecordChange change) {
+        // Do nothing.
+    }
+}

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -28,7 +28,6 @@ import io.spine.annotation.Internal;
 import io.spine.base.Identifier;
 import io.spine.core.Version;
 import io.spine.protobuf.ValidatingBuilder;
-import io.spine.server.entity.TransactionListener.SilentWitness;
 import io.spine.validate.NonValidated;
 
 import java.util.List;

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -321,6 +321,7 @@ public abstract class Transaction<I,
     /**
      * Turns the transaction into inactive state.
      */
+    @VisibleForTesting
     final void deactivate() {
         this.active = false;
     }

--- a/server/src/main/java/io/spine/server/entity/TransactionListener.java
+++ b/server/src/main/java/io/spine/server/entity/TransactionListener.java
@@ -82,7 +82,7 @@ public interface TransactionListener<I> {
      * An implementation of a {@code TransactionListener} which does not set any behavior for its
      * callbacks.
      */
-    class SilentWitness<I> implements TransactionListener<I> {
+    final class SilentWitness<I> implements TransactionListener<I> {
 
         @Override
         public void onBeforePhase(Phase<I, ?> phase) {

--- a/server/src/main/java/io/spine/server/entity/TransactionListener.java
+++ b/server/src/main/java/io/spine/server/entity/TransactionListener.java
@@ -77,5 +77,4 @@ public interface TransactionListener<I> {
      *         the change of the entity under transaction
      */
     void onAfterCommit(EntityRecordChange change);
-
 }

--- a/server/src/main/java/io/spine/server/entity/TransactionListener.java
+++ b/server/src/main/java/io/spine/server/entity/TransactionListener.java
@@ -78,36 +78,4 @@ public interface TransactionListener<I> {
      */
     void onAfterCommit(EntityRecordChange change);
 
-    /**
-     * An implementation of a {@code TransactionListener} which does not set any behavior for its
-     * callbacks.
-     */
-    final class SilentWitness<I> implements TransactionListener<I> {
-
-        @Override
-        public void onBeforePhase(Phase<I, ?> phase) {
-            // Do nothing.
-        }
-
-        @Override
-        public void onAfterPhase(Phase<I, ?> phase) {
-            // Do nothing.
-        }
-
-        @Override
-        public void onBeforeCommit(@NonValidated EntityRecord entityRecord) {
-            // Do nothing.
-        }
-
-        @Override
-        public void onTransactionFailed(Throwable t,
-                                        EntityRecord record) {
-            // Do nothing.
-        }
-
-        @Override
-        public void onAfterCommit(EntityRecordChange change) {
-            // Do nothing.
-        }
-    }
 }

--- a/server/src/main/java/io/spine/server/entity/TransactionalEntity.java
+++ b/server/src/main/java/io/spine/server/entity/TransactionalEntity.java
@@ -101,11 +101,11 @@ public abstract class TransactionalEntity<I,
      * @return {@code true} if the state or flags have been modified, {@code false} otherwise.
      */
     @Internal
-    public boolean isChanged() {
+    public final boolean changed() {
         boolean lifecycleFlagsChanged = lifecycleFlagsChanged();
         Transaction<?, ?, ?, ?> tx = this.transaction;
         boolean stateChanged = tx != null
-                               ? tx.isStateChanged()
+                               ? tx.stateChanged()
                                : this.stateChanged;
         return stateChanged || lifecycleFlagsChanged;
     }
@@ -200,7 +200,7 @@ public abstract class TransactionalEntity<I,
      * Updates own {@code stateChanged} flag from the underlying transaction.
      */
     final void updateStateChanged() {
-        this.stateChanged = tx().isStateChanged();
+        this.stateChanged = tx().stateChanged();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/model/MessageHandlerMap.java
+++ b/server/src/main/java/io/spine/server/model/MessageHandlerMap.java
@@ -53,8 +53,8 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
  */
 @Immutable(containerOf = {"M", "H"})
 public final class MessageHandlerMap<M extends MessageClass<?>,
-        P extends MessageClass<?>,
-        H extends HandlerMethod<?, M, ?, P, ?>>
+                                     P extends MessageClass<?>,
+                                     H extends HandlerMethod<?, M, ?, P, ?>>
         implements Serializable {
 
     private static final long serialVersionUID = 0L;

--- a/server/src/main/java/io/spine/server/procman/PmEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmEndpoint.java
@@ -44,7 +44,7 @@ abstract class PmEndpoint<I,
 
     @Override
     protected boolean isModified(P processManager) {
-        boolean result = processManager.isChanged();
+        boolean result = processManager.changed();
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/procman/PmTransaction.java
+++ b/server/src/main/java/io/spine/server/procman/PmTransaction.java
@@ -146,7 +146,7 @@ public class PmTransaction<I,
      * and test utilities.
      */
     @Override
-    protected void commit() {
+    protected final void commit() {
         super.commit();
     }
 

--- a/server/src/main/java/io/spine/server/projection/Projection.java
+++ b/server/src/main/java/io/spine/server/projection/Projection.java
@@ -110,7 +110,7 @@ public abstract class Projection<I,
         ProjectionTransaction<?, ?, ?> tx = ProjectionTransaction.start(projection);
         projection.play(events);
         tx.commit();
-        return projection.isChanged();
+        return projection.changed();
     }
 
     void apply(EventEnvelope event) {

--- a/server/src/main/java/io/spine/server/projection/ProjectionEndpoint.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionEndpoint.java
@@ -84,7 +84,7 @@ public class ProjectionEndpoint<I, P extends Projection<I, ?, ?>>
 
     @Override
     protected boolean isModified(P projection) {
-        boolean result = projection.isChanged();
+        boolean result = projection.changed();
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/projection/ProjectionTransaction.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionTransaction.java
@@ -61,7 +61,7 @@ public class ProjectionTransaction<I,
      * utilities.
      */
     @Override
-    protected void commit() {
+    protected final void commit() {
         super.commit();
     }
 

--- a/server/src/test/java/io/spine/server/aggregate/model/ApplierTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/model/ApplierTest.java
@@ -51,7 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("EventApplierMethod should")
-class EventApplierTest {
+class ApplierTest {
 
     private final EventApplierSignature signature = new EventApplierSignature();
 
@@ -61,7 +61,7 @@ class EventApplierTest {
         new NullPointerTester()
                 .setDefault(CommandContext.class, CommandContext.getDefaultInstance())
                 .setDefault(Any.class, Any.getDefaultInstance())
-                .testAllPublicStaticMethods(EventApplier.class);
+                .testAllPublicStaticMethods(Applier.class);
     }
 
     @Test
@@ -70,10 +70,10 @@ class EventApplierTest {
         Method method = new ValidApplier().getMethod();
 
 
-        Optional<EventApplier> actual = signature.create(method);
+        Optional<Applier> actual = signature.create(method);
         assertTrue(actual.isPresent());
 
-        EventApplier expected = new EventApplier(method, EventApplierParams.MESSAGE);
+        Applier expected = new Applier(method, EventApplierParams.MESSAGE);
         assertEquals(expected, actual.get());
     }
 
@@ -81,9 +81,9 @@ class EventApplierTest {
     @DisplayName("allow invocation")
     void invokeApplierMethod() {
         ValidApplier applierObject = new ValidApplier();
-        Optional<EventApplier> method = signature.create(applierObject.getMethod());
+        Optional<Applier> method = signature.create(applierObject.getMethod());
         assertTrue(method.isPresent());
-        EventApplier applier = method.get();
+        Applier applier = method.get();
         RefProjectCreated eventMessage = Sample.messageOfType(RefProjectCreated.class);
         Event event = Event
                 .newBuilder()

--- a/server/src/test/java/io/spine/server/entity/given/TeEntity.java
+++ b/server/src/test/java/io/spine/server/entity/given/TeEntity.java
@@ -29,4 +29,8 @@ public class TeEntity
     public TeEntity(Long id) {
         super(id);
     }
+
+    public void turnToDeleted() {
+        setDeleted(true);
+    }
 }

--- a/server/src/test/java/io/spine/server/projection/ProjectionShould.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionShould.java
@@ -128,7 +128,7 @@ class ProjectionShould {
         assertTrue(projection.state()
                              .getValue()
                              .contains(stringEvent.getValue()));
-        assertTrue(projection.isChanged());
+        assertTrue(projection.changed());
 
         Int32Imported integerEvent = Int32Imported
                 .newBuilder()
@@ -138,7 +138,7 @@ class ProjectionShould {
         assertTrue(projection.state()
                              .getValue()
                              .contains(String.valueOf(integerEvent.getValue())));
-        assertTrue(projection.isChanged());
+        assertTrue(projection.changed());
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/type/given/GivenEvent.java
+++ b/server/src/test/java/io/spine/server/type/given/GivenEvent.java
@@ -74,6 +74,11 @@ public final class GivenEvent {
         return withMessage(message());
     }
 
+    public static Event withVersion(Version version) {
+        Event event = eventFactory.createEvent(message(), version);
+        return event;
+    }
+
     public static Event withDisabledEnrichmentOf(EventMessage message) {
         Event event = withMessage(message);
         Event.Builder builder =

--- a/server/src/test/proto/spine/test/bus/stock/share.proto
+++ b/server/src/test/proto/spine/test/bus/stock/share.proto
@@ -23,5 +23,5 @@ message Share {
 
 message Price {
 
-    float usd = 2 [(digits).fraction_max = 2];
+    float usd = 2;
 }

--- a/testutil-server/src/main/java/io/spine/testing/server/aggregate/AggregateBuilder.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/aggregate/AggregateBuilder.java
@@ -57,7 +57,7 @@ public class AggregateBuilder<A extends Aggregate<I, S, ?>,
     @Override
     protected void setState(A result, S state, Version version) {
         TestAggregateTransaction tx = new TestAggregateTransaction(result, state, version);
-        tx.commit();
+        tx.doCommit();
     }
 
     /**
@@ -74,9 +74,8 @@ public class AggregateBuilder<A extends Aggregate<I, S, ?>,
             super(aggregate, state, version);
         }
 
-        @Override
-        protected void commit() {
-            super.commit();
+        private void doCommit() {
+            commit();
         }
     }
 }

--- a/testutil-server/src/main/java/io/spine/testing/server/procman/PmDispatcher.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/procman/PmDispatcher.java
@@ -186,10 +186,5 @@ public final class PmDispatcher {
         TestPmTransaction(ProcessManager<I, S, B> processManager, S state, Version version) {
             super(processManager, state, version);
         }
-
-        @Override
-        protected void commit() {
-            super.commit();
-        }
     }
 }

--- a/testutil-server/src/main/java/io/spine/testing/server/procman/PmDispatcher.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/procman/PmDispatcher.java
@@ -186,5 +186,9 @@ public final class PmDispatcher {
         TestPmTransaction(ProcessManager<I, S, B> processManager, S state, Version version) {
             super(processManager, state, version);
         }
+
+        void doCommit() {
+            commit();
+        }
     }
 }

--- a/testutil-server/src/main/java/io/spine/testing/server/procman/ProcessManagerBuilder.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/procman/ProcessManagerBuilder.java
@@ -61,6 +61,6 @@ public class ProcessManagerBuilder<P extends ProcessManager<I, S, B>,
     @Override
     protected void setState(P result, S state, Version version) {
         TestPmTransaction transaction = new TestPmTransaction<>(result, state, version);
-        transaction.commit();
+        transaction.doCommit();
     }
 }

--- a/testutil-server/src/main/java/io/spine/testing/server/projection/ProjectionBuilder.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/projection/ProjectionBuilder.java
@@ -58,7 +58,7 @@ public class ProjectionBuilder<P extends Projection<I, S, B>,
     protected void setState(P result, S state, Version version) {
         TestProjectionTransaction transaction =
                 new TestProjectionTransaction(result, state, version);
-        transaction.commit();
+        transaction.doCommit();
     }
 
     /**
@@ -73,9 +73,8 @@ public class ProjectionBuilder<P extends Projection<I, S, B>,
             super(projection, state, version);
         }
 
-        @Override
-        protected void commit() {
-            super.commit();
+        private void doCommit() {
+            commit();
         }
     }
 }


### PR DESCRIPTION
This PR improves the contract of the `Transaction` and `Aggregate` classes disallowing overriding most of its methods, and sorting out visibility.

`EventApplier` class was also renamed to `Applier`.
