### PR TITLE
Fix the `EnricherBuilder` duplication check

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -442,7 +442,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jun 19 19:21:09 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 21 17:54:52 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -839,7 +839,7 @@ This report was generated on **Wed Jun 19 19:21:09 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jun 19 19:21:10 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 21 17:54:59 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1388,7 +1388,7 @@ This report was generated on **Wed Jun 19 19:21:10 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jun 19 19:21:11 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 21 17:55:08 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2099,7 +2099,7 @@ This report was generated on **Wed Jun 19 19:21:11 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jun 19 19:21:12 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 21 17:55:19 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2660,7 +2660,7 @@ This report was generated on **Wed Jun 19 19:21:12 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jun 19 19:21:12 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 21 17:55:31 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3176,7 +3176,7 @@ This report was generated on **Wed Jun 19 19:21:12 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jun 19 19:21:13 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 21 17:55:39 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3700,7 +3700,7 @@ This report was generated on **Wed Jun 19 19:21:13 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jun 19 19:21:13 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 21 17:55:47 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4324,4 +4324,4 @@ This report was generated on **Wed Jun 19 19:21:13 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jun 19 19:21:14 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 21 17:55:56 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/server/src/main/java/io/spine/server/enrich/EnricherBuilder.java
+++ b/server/src/main/java/io/spine/server/enrich/EnricherBuilder.java
@@ -116,16 +116,18 @@ public abstract class EnricherBuilder<M extends Message,
         Class<? extends Message> sourceInterface = key.sourceClass();
         Class<? extends Message> enrichmentClass = key.enrichmentClass();
         functions.forEach((k, v) -> {
-            Class<? extends Message> entryCls = k.sourceClass();
+            Class<? extends Message> entrySourceCls = k.sourceClass();
+            Class<? extends Message> entryEnrichmentCls = k.enrichmentClass();
             checkArgument(
-                    !sourceInterface.isAssignableFrom(entryCls),
+                    !sourceInterface.isAssignableFrom(entrySourceCls)
+                    || !enrichmentClass.equals(entryEnrichmentCls),
                     "Unable to add a function which produces enrichments of the class `%s`" +
                     " via the interface `%s`. There is already a function which does" +
                     " this via the class `%s` which implements this interface." +
                     SUGGEST_REMOVAL,
                     enrichmentClass.getCanonicalName(),
                     sourceInterface.getCanonicalName(),
-                    entryCls.getCanonicalName()
+                    entrySourceCls.getCanonicalName()
             );
         });
     }

--- a/server/src/test/java/io/spine/server/enrich/EnricherBuilderTest.java
+++ b/server/src/test/java/io/spine/server/enrich/EnricherBuilderTest.java
@@ -74,6 +74,17 @@ class EnricherBuilderTest {
         }
     }
 
+    @Test
+    @DisplayName("allow multiple enrichment classes per source class")
+    void allowMultipleEnrichments() {
+        builder.add(EbtOrderCreated.class, StringValue.class,
+                    (e, c) -> StringValue.getDefaultInstance())
+               .add(EbtOrderCreated.class, BoolValue.class,
+                    (e, c) -> BoolValue.of(true));
+        EventEnricher enricher = builder.build();
+        assertThat(enricher).isNotNull();
+    }
+
     @Nested
     @DisplayName("not allow duplicating entries")
     class DupEntries {


### PR DESCRIPTION
This PR fixes a small issue with the `EnricherBuilder` duplication check.

Right now it is impossible to create multiple enrichments of different type for a single source class. This PR fixes it.