### PR TITLE
Run slow tests on AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
   - chmod 600 deploy_key_rsa
 
 script:
-  - ./gradlew check slowTest --stacktrace
+  - ./gradlew check allTest --stacktrace
 
   # The publishing script should be executed in `script` section in order to
   # fail the Travis build if execution of this script is failed.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ build_script:
   - gradlew assemble --stacktrace
 
 test_script:
-  - gradlew check slowTest --stacktrace
+  - gradlew check allTest --stacktrace
 
 after_build:
   # upload test results via rest-api

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,10 @@ before_build:
   - git submodule update --init --recursive
 
 build_script:
-  - gradlew build --stacktrace
+  - gradlew assemble --stacktrace
 
 test_script:
-  - gradlew check --stacktrace
+  - gradlew check slowTest --stacktrace
 
 after_build:
   # upload test results via rest-api


### PR DESCRIPTION
Since recently, the build separates slow tests and fast tests. Slow tests are run via a separate Gradle task.

This PR adds the invocation of the `slowTest` task when running the build on AppVeyor.