### PR TITLE
Unify query and storage names of EntityColumns

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -398,23 +398,23 @@
      * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
      * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
@@ -464,16 +464,12 @@
      * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
      * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 
-1. **Group:** org.slf4j **Name:** slf4j-jdk14 **Version:** 1.7.26
-     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
-     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
-
     
         
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jul 24 12:49:05 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 25 13:54:45 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -822,23 +818,23 @@ This report was generated on **Wed Jul 24 12:49:05 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
      * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
@@ -888,16 +884,12 @@ This report was generated on **Wed Jul 24 12:49:05 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
      * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 
-1. **Group:** org.slf4j **Name:** slf4j-jdk14 **Version:** 1.7.26
-     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
-     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
-
     
         
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jul 24 12:49:06 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 25 13:54:46 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1282,23 +1274,23 @@ This report was generated on **Wed Jul 24 12:49:06 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
      * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
@@ -1348,16 +1340,12 @@ This report was generated on **Wed Jul 24 12:49:06 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
      * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 
-1. **Group:** org.slf4j **Name:** slf4j-jdk14 **Version:** 1.7.26
-     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
-     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
-
     
         
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jul 24 12:49:06 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 25 13:54:47 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1899,23 +1887,23 @@ This report was generated on **Wed Jul 24 12:49:06 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/junit-pioneer/junit-pioneer](https://github.com/junit-pioneer/junit-pioneer)
      * **POM License: The MIT License** - [https://github.com/junit-pioneer/junit-pioneer/blob/master/LICENSE](https://github.com/junit-pioneer/junit-pioneer/blob/master/LICENSE)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
@@ -1965,10 +1953,6 @@ This report was generated on **Wed Jul 24 12:49:06 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
      * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 
-1. **Group:** org.slf4j **Name:** slf4j-jdk14 **Version:** 1.7.26
-     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
-     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
-
 1. **Group:** org.sonatype.sisu **Name:** sisu-guice **Version:** 3.1.0
      * **Manifest Project URL:** [http://code.google.com/p/google-guice/](http://code.google.com/p/google-guice/)
      * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1979,7 +1963,7 @@ This report was generated on **Wed Jul 24 12:49:06 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jul 24 12:49:07 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 25 13:54:48 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2442,23 +2426,23 @@ This report was generated on **Wed Jul 24 12:49:07 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
      * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
@@ -2508,16 +2492,12 @@ This report was generated on **Wed Jul 24 12:49:07 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
      * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 
-1. **Group:** org.slf4j **Name:** slf4j-jdk14 **Version:** 1.7.26
-     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
-     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
-
     
         
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jul 24 12:49:08 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 25 13:54:48 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2686,15 +2666,15 @@ This report was generated on **Wed Jul 24 12:49:08 EEST 2019** using [Gradle-Lic
 1. **Group:** org.hamcrest **Name:** hamcrest-core **Version:** 1.3
      * **POM License: New BSD License** - [http://www.opensource.org/licenses/bsd-license.php](http://www.opensource.org/licenses/bsd-license.php)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
@@ -2978,23 +2958,23 @@ This report was generated on **Wed Jul 24 12:49:08 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
      * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
@@ -3044,16 +3024,12 @@ This report was generated on **Wed Jul 24 12:49:08 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
      * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 
-1. **Group:** org.slf4j **Name:** slf4j-jdk14 **Version:** 1.7.26
-     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
-     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
-
     
         
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jul 24 12:49:08 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 25 13:54:49 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3222,23 +3198,23 @@ This report was generated on **Wed Jul 24 12:49:08 EEST 2019** using [Gradle-Lic
 1. **Group:** org.hamcrest **Name:** hamcrest-core **Version:** 1.3
      * **POM License: New BSD License** - [http://www.opensource.org/licenses/bsd-license.php](http://www.opensource.org/licenses/bsd-license.php)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
@@ -3522,23 +3498,23 @@ This report was generated on **Wed Jul 24 12:49:08 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
      * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
@@ -3588,16 +3564,12 @@ This report was generated on **Wed Jul 24 12:49:08 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
      * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 
-1. **Group:** org.slf4j **Name:** slf4j-jdk14 **Version:** 1.7.26
-     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
-     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
-
     
         
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jul 24 12:49:09 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 25 13:54:49 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3766,15 +3738,15 @@ This report was generated on **Wed Jul 24 12:49:09 EEST 2019** using [Gradle-Lic
 1. **Group:** org.hamcrest **Name:** hamcrest-core **Version:** 1.3
      * **POM License: New BSD License** - [http://www.opensource.org/licenses/bsd-license.php](http://www.opensource.org/licenses/bsd-license.php)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
@@ -4112,23 +4084,23 @@ This report was generated on **Wed Jul 24 12:49:09 EEST 2019** using [Gradle-Lic
      * **Manifest license URL:** [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
      * **POM License: Eclipse Public License v1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-api **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-engine **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.0
+1. **Group:** org.junit.jupiter **Name:** junit-jupiter-params **Version:** 5.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
-1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.0
+1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
@@ -4178,13 +4150,9 @@ This report was generated on **Wed Jul 24 12:49:09 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
      * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
 
-1. **Group:** org.slf4j **Name:** slf4j-jdk14 **Version:** 1.7.26
-     * **POM Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
-     * **POM License: MIT License** - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
-
     
         
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jul 24 12:49:10 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 25 13:54:50 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -469,7 +469,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jul 25 13:54:45 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 25 15:36:06 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -889,7 +889,7 @@ This report was generated on **Thu Jul 25 13:54:45 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jul 25 13:54:46 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 25 15:36:06 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1345,7 +1345,7 @@ This report was generated on **Thu Jul 25 13:54:46 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jul 25 13:54:47 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 25 15:36:07 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1963,7 +1963,7 @@ This report was generated on **Thu Jul 25 13:54:47 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jul 25 13:54:48 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 25 15:36:07 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2497,7 +2497,7 @@ This report was generated on **Thu Jul 25 13:54:48 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jul 25 13:54:48 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 25 15:36:08 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3029,7 +3029,7 @@ This report was generated on **Thu Jul 25 13:54:48 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jul 25 13:54:49 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 25 15:36:08 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3569,7 +3569,7 @@ This report was generated on **Thu Jul 25 13:54:49 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jul 25 13:54:49 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 25 15:36:09 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4155,4 +4155,4 @@ This report was generated on **Thu Jul 25 13:54:49 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jul 25 13:54:50 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jul 25 15:36:09 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,6 @@ all modules and does not describe the project structure per-subproject.
     <scope>compile</scope>
   </dependency>
   <dependency>
-    <groupId>org.slf4j</groupId>
-    <artifactId>slf4j-api</artifactId>
-    <version>1.7.26</version>
-    <scope>compile</scope>
-  </dependency>
-  <dependency>
     <groupId>com.google.auto.service</groupId>
     <artifactId>auto-service</artifactId>
     <version>1.0-rc5</version>
@@ -172,31 +166,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-api</artifactId>
-    <version>5.5.0</version>
+    <version>5.5.1</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-engine</artifactId>
-    <version>5.5.0</version>
+    <version>5.5.1</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-params</artifactId>
-    <version>5.5.0</version>
+    <version>5.5.1</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>org.mockito</groupId>
     <artifactId>mockito-core</artifactId>
     <version>2.12.0</version>
-    <scope>test</scope>
-  </dependency>
-  <dependency>
-    <groupId>org.slf4j</groupId>
-    <artifactId>slf4j-jdk14</artifactId>
-    <version>1.7.26</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/server/src/main/java/io/spine/server/entity/storage/Column.java
+++ b/server/src/main/java/io/spine/server/entity/storage/Column.java
@@ -48,11 +48,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface Column {
 
     /**
-     * (Optional) The custom {@linkplain EntityColumn#storedName() name} of the column
+     * (Optional) The custom {@linkplain EntityColumn#name() name} of the column
      * to be persisted.
      *
-     * <p>Defaults to the {@linkplain EntityColumn#name() name} extracted from the getter
-     * which is used for querying.
+     * <p>Defaults to the name extracted from the getter which is used for querying.
      *
      * <p>This value does not changes a {@linkplain EntityColumn#name() name} of column
      * that should be used for {@linkplain EntityQueries querying}.

--- a/server/src/main/java/io/spine/server/entity/storage/Column.java
+++ b/server/src/main/java/io/spine/server/entity/storage/Column.java
@@ -29,13 +29,11 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * An annotation which is used to mark getters for {@linkplain EntityColumn entity columns}.
  *
- * <p>The properties of the annotation affect how the column will be persisted.
+ * <p>The properties of the annotation affect how the column is seen by the storage and clients.
  *
  * <p>The annotation will have effect only if it's applied to a {@code public} instance getter,
- * meaning a method without parameters and with {@code get-} prefix. An {@code is-} prefix is also
- * supported but only for properties of {@code boolean} and {@code Boolean} types.
- *
- * <p>The class declaring an entity column <b>must</b> as well be {@code public}.
+ * meaning a method without parameters and with {@code get-} prefix. The {@code is-} prefix is
+ * supported for primitive {@code boolean} or boxed {@code Boolean} columns.
  *
  * <p>A {@link #name()} allows to specify a custom column name to be persisted in a {@code Storage}.
  *
@@ -48,13 +46,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface Column {
 
     /**
-     * (Optional) The custom {@linkplain EntityColumn#name() name} of the column
-     * to be persisted.
+     * The custom {@linkplain EntityColumn#name() name} of the column.
      *
      * <p>Defaults to the name extracted from the getter which is used for querying.
-     *
-     * <p>This value does not changes a {@linkplain EntityColumn#name() name} of column
-     * that should be used for {@linkplain EntityQueries querying}.
      */
     String name() default "";
 }

--- a/server/src/main/java/io/spine/server/entity/storage/ColumnReader.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ColumnReader.java
@@ -133,7 +133,6 @@ final class ColumnReader {
                 .stream(properties)
                 .map(PropertyDescriptor::getReadMethod)
                 .filter(Objects::nonNull);
-
         MethodDescriptor[] methodDescriptors = entityDescriptor.getMethodDescriptors();
         Stream<Method> booleanWrapperGetters = Arrays
                 .stream(methodDescriptors)

--- a/server/src/main/java/io/spine/server/entity/storage/ColumnReader.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ColumnReader.java
@@ -162,7 +162,7 @@ final class ColumnReader {
     private void checkRepeatedColumnNames(Iterable<EntityColumn> columns) {
         Collection<String> checkedNames = newLinkedList();
         for (EntityColumn column : columns) {
-            String columnName = column.storedName();
+            String columnName = column.name();
             if (checkedNames.contains(columnName)) {
                 throw newIllegalStateException(
                         "The entity `%s` has columns with the same name for storing `%s`.",

--- a/server/src/main/java/io/spine/server/entity/storage/ColumnRecords.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ColumnRecords.java
@@ -52,9 +52,8 @@ public final class ColumnRecords {
      * @param registry
      *        the {@link io.spine.server.storage.Storage Storage} {@link ColumnTypeRegistry}
      * @param mapColumnIdentifier
-     *        a {@linkplain Function} mapping the column name
-     *        {@linkplain EntityColumn#storedName()} for storing} to the database specific
-     *        column identifier
+     *        a {@linkplain Function} mapping the column {@linkplain EntityColumn#name() name} to
+     *        the database specific column identifier
      * @param <D>
      *        the type of the database record
      * @param <I>

--- a/server/src/main/java/io/spine/server/entity/storage/ColumnValueExtractor.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ColumnValueExtractor.java
@@ -75,14 +75,14 @@ class ColumnValueExtractor {
      * Extracts the {@linkplain EntityColumn column} values for the processed {@link Entity} using
      * specified {@linkplain EntityColumn entity columns}.
      *
-     * @return a {@code Map} of the column {@linkplain EntityColumn#storedName()
-     *         names for storing} to their {@linkplain EntityColumn.MemoizedValue memoized values}
+     * @return a {@code Map} of the column {@linkplain EntityColumn#name() names} to their
+     *         {@linkplain EntityColumn.MemoizedValue memoized values}
      * @see EntityColumn.MemoizedValue
      */
     Map<String, EntityColumn.MemoizedValue> extractColumnValues() {
         Map<String, EntityColumn.MemoizedValue> values = new HashMap<>(entityColumns.size());
         for (EntityColumn column : entityColumns) {
-            String name = column.storedName();
+            String name = column.name();
             EntityColumn.MemoizedValue value = column.memoizeFor(entity);
             values.put(name, value);
         }

--- a/server/src/main/java/io/spine/server/entity/storage/EntityColumn.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityColumn.java
@@ -54,11 +54,9 @@ import static java.lang.String.format;
  * <p>An entity can inherit the columns from its parent classes and interfaces.
  * In this case column getter is annotated only once when it is first declared.
  *
- * <p>A {@linkplain #name() name} for working with {@linkplain EntityQueries queries} and storing
- * the column values is determined by the {@link Column#name()} annotation  property.
- * If the property is not defined, the name is extracted from the column getter method, for
- * example, {@code value} for {@code getValue()}. A client should specify the column name via
- * {@linkplain io.spine.client.TargetFilters column filters}.
+ * <p>The {@linkplain #name() name} of a column is determined by the {@link Column#name()}
+ * annotation property. If the property is not defined, the name is extracted from the column getter
+ * method, for example, {@code value} for {@code getValue()}.
  *
  * <h1>Examples</h1>
  *

--- a/server/src/main/java/io/spine/server/entity/storage/EntityColumn.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityColumn.java
@@ -54,19 +54,13 @@ import static java.lang.String.format;
  * <p>An entity can inherit the columns from its parent classes and interfaces.
  * In this case column getter is annotated only once when it is first declared.
  *
- * <h1>Column names</h1>
+ * <p>A {@linkplain #name() name} for working with {@linkplain EntityQueries queries} and storing
+ * the column values is determined by the {@link Column#name()} annotation  property.
+ * If the property is not defined, the name is extracted from the column getter method, for
+ * example, {@code value} for {@code getValue()}. A client should specify the column name via
+ * {@linkplain io.spine.client.TargetFilters column filters}.
  *
- * <p>A column can have different names for storing and for querying.
- *
- * <p>A {@linkplain #name() name} for working with {@linkplain EntityQueries queries}
- * is determined by a name of column getter, for example, {@code value} for {@code getValue()}.
- * A client should specify this value to a {@linkplain io.spine.client.TargetFilters
- * column filters}.
- *
- * <p>A {@linkplain #storedName() stored name} is used as a {@code Storage} column name
- * an is defined by the column annotation {@linkplain Column#name() property}.
- *
- * <h2>Examples</h2>
+ * <h1>Examples</h1>
  *
  * <p>These methods represent the columns:
  * <pre>
@@ -132,7 +126,7 @@ import static java.lang.String.format;
  *
  * <h1>Type policy</h1>
  *
- * <p>An entity column can be of any type. Most common types are already supported if an existing 
+ * <p>An entity column can be of any type. Most common types are already supported if an existing
  * implementation of the {@link io.spine.server.storage.Storage Spine Storage} is used.
  * However, their behavior can be overriden using {@link ColumnTypeRegistry}.
  *
@@ -141,13 +135,15 @@ import static java.lang.String.format;
  * into the {@link io.spine.server.storage.StorageFactory StorageFactory} upon creation.
  *
  * <p>Note that the column type must either be a primitive or implement {@link Serializable}.
- * To order the query results on a column value, it is also required to implement {@link Comparable}.
+ * To order the query results on a column value, it is also required to implement
+ * {@link Comparable}.
  *
  * <h1>Nullability</h1>
  *
- * <p>A column may contain {@code null} value if the getter which declares it is annotated as
- * {@link javax.annotation.Nullable javax.annotation.Nullable}.
- * Otherwise, the entity column is considered non-null.
+ * <p>A column may contain {@code null} value if the getter which declares it is marked as nullable.
+ * More formally, if the getter method is annotated with an annotation the simple name of which is
+ * {@code CheckForNull}, {@code Nullable}, {@code NullableDecl}, or {@code NullableType}, the column
+ * may be null. Otherwise, the entity column is considered non-null.
  *
  * <p>If a non-null getter method returns {@code null} when trying to get the value of a column,
  * a {@link RuntimeException} is thrown. See {@link #isNullable()}.
@@ -166,9 +162,9 @@ import static java.lang.String.format;
  *     }
  * </pre>
  *
- * <p>This class is effectively {@code final} since it has a single {@code private} constructor.
- * Though the modifier "{@code final}" is absent to make it possible to create mocks for testing.
- *
+ * @implNote This class is effectively {@code final} since it has a single {@code private}
+ *         constructor. Though the modifier "{@code final}" is absent to make it possible to create
+ *         mocks for testing.
  * @see ColumnType
  */
 @Immutable
@@ -201,8 +197,6 @@ public class EntityColumn implements Serializable {
 
     private final String name;
 
-    private final String storedName;
-
     private final boolean nullable;
 
     /**
@@ -219,7 +213,6 @@ public class EntityColumn implements Serializable {
 
     private EntityColumn(Method getter,
                          String name,
-                         String storedName,
                          boolean nullable) {
         this.getter = getter;
         // To allow calling on non-public classes.
@@ -227,7 +220,6 @@ public class EntityColumn implements Serializable {
         this.entityType = getter.getDeclaringClass();
         this.getterMethodName = getter.getName();
         this.name = name;
-        this.storedName = storedName;
         this.nullable = nullable;
         this.valueConverter = ColumnValueConverters.of(getter);
     }
@@ -245,10 +237,10 @@ public class EntityColumn implements Serializable {
     @VisibleForTesting
     public static EntityColumn from(Method getter) {
         checkAnnotatedGetter(getter);
-        String nameForQuery = nameFromGetter(getter);
-        String nameForStore = nameFromAnnotation(getter).orElse(nameForQuery);
+        String nameForStore = nameFromAnnotation(getter)
+                .orElseGet(() -> nameFromGetter(getter));
         boolean nullable = mayReturnNull(getter);
-        return new EntityColumn(getter, nameForQuery, nameForStore, nullable);
+        return new EntityColumn(getter, nameForStore, nullable);
     }
 
     /**
@@ -261,19 +253,6 @@ public class EntityColumn implements Serializable {
      */
     public String name() {
         return name;
-    }
-
-    /**
-     * Obtains the name of the column which is used to store it in a {@code Storage}.
-     *
-     * <p>The value is obtained from the annotation {@linkplain Column#name() property}.
-     * If the property value is empty, the value is equal
-     * to {@linkplain #name() name for querying}.
-     *
-     * @return the column name for storing
-     */
-    public String storedName() {
-        return storedName;
     }
 
     /**
@@ -358,7 +337,8 @@ public class EntityColumn implements Serializable {
      * The output value type will be the same as {@link #persistedType()}.
      *
      * <p>As the column value may be {@linkplain #isNullable() nullable}, and all {@code null}
-     * values are persisted in the data storage as {@code null}, for example, without any conversion.
+     * values are persisted in the data storage as {@code null}, for example, without any
+     * conversion.
      * For the {@code null} input argument this method will always return {@code null}.
      *
      * <p>The method is accessible outside of the {@code EntityColumn} class to enable the proper
@@ -464,7 +444,8 @@ public class EntityColumn implements Serializable {
     /**
      * A value of the associated {@code EntityColumn} saved at some point of time.
      *
-     * <p>The class associates the column value with its metadata, for example, {@linkplain EntityColumn}.
+     * <p>The class associates the column value with its metadata, for example,
+     * {@link EntityColumn}.
      *
      * @see EntityColumn#memoizeFor(Entity)
      */
@@ -532,7 +513,7 @@ public class EntityColumn implements Serializable {
             return (a, b) -> {
                 checkNotNull(a);
                 checkNotNull(b);
-                checkArgument(columnTypeOf(a).equals(columnTypeOf(b)),
+                checkArgument(a.columnType().equals(b.columnType()),
                               "Memoized value compared to mismatching value type.");
 
                 Serializable aValue = a.value();
@@ -568,10 +549,8 @@ public class EntityColumn implements Serializable {
             return COMPARATOR;
         }
 
-        private static Class columnTypeOf(MemoizedValue value) {
-            checkNotNull(value);
-            return value.sourceColumn()
-                        .type();
+        private Class columnType() {
+            return sourceColumn().type();
         }
 
         @Override

--- a/server/src/main/java/io/spine/server/entity/storage/EntityRecordWithColumns.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityRecordWithColumns.java
@@ -128,7 +128,7 @@ public final class EntityRecordWithColumns implements WithLifecycle, Serializabl
     }
 
     /**
-     * Obtains entity column {@linkplain EntityColumn#storedName() names} for the record.
+     * Obtains entity column {@linkplain EntityColumn#name() names} for the record.
      *
      * @return the entity column names
      */
@@ -138,7 +138,7 @@ public final class EntityRecordWithColumns implements WithLifecycle, Serializabl
 
     /**
      * Obtains the memorized value of the entity column
-     * by the specified {@linkplain EntityColumn#storedName() name}.
+     * by the specified {@linkplain EntityColumn#name() name}.
      *
      * @param columnName the stored column name
      * @return the memoized value of the column

--- a/server/src/main/java/io/spine/server/entity/storage/QueryParameters.java
+++ b/server/src/main/java/io/spine/server/entity/storage/QueryParameters.java
@@ -93,8 +93,8 @@ public final class QueryParameters implements Iterable<CompositeQueryParameter>,
         EntityColumn archivedColumn = lifecycleColumns.get(archived.name());
         EntityColumn deletedColumn = lifecycleColumns.get(deleted.name());
         CompositeQueryParameter lifecycleParameter = CompositeQueryParameter.from(
-                ImmutableMultimap.of(archivedColumn, eq(archivedColumn.storedName(), false),
-                                     deletedColumn, eq(deletedColumn.storedName(), false)),
+                ImmutableMultimap.of(archivedColumn, eq(archivedColumn.name(), false),
+                                     deletedColumn, eq(deletedColumn.name(), false)),
                 ALL
         );
         return newBuilder().add(lifecycleParameter).build();

--- a/server/src/main/java/io/spine/server/storage/memory/EntityQueryMatcher.java
+++ b/server/src/main/java/io/spine/server/storage/memory/EntityQueryMatcher.java
@@ -162,7 +162,7 @@ final class EntityQueryMatcher<I> implements Predicate<@Nullable EntityRecordWit
 
     private static Optional<MemoizedValue> columnValue(EntityRecordWithColumns record,
                                                        EntityColumn column) {
-        String storedName = column.storedName();
+        String storedName = column.name();
         if (!record.getColumnNames()
                    .contains(storedName)) {
             return Optional.empty();

--- a/server/src/main/java/io/spine/system/server/MirrorProjection.java
+++ b/server/src/main/java/io/spine/system/server/MirrorProjection.java
@@ -66,7 +66,6 @@ import static java.util.stream.Collectors.toList;
 final class MirrorProjection extends Projection<MirrorId, Mirror, Mirror.Builder> {
 
     private static final String TYPE_COLUMN_NAME = "aggregate_type";
-    private static final String TYPE_COLUMN_QUERY_NAME = "aggregateType";
 
     MirrorProjection(MirrorId id) {
         super(id);
@@ -134,7 +133,7 @@ final class MirrorProjection extends Projection<MirrorId, Mirror, Mirror.Builder
     static TargetFilters buildFilters(Target target) {
         IdFilter idFilter = buildIdFilter(target);
         TargetFilters filters = target.getFilters();
-        CompositeFilter typeFilter = all(eq(TYPE_COLUMN_QUERY_NAME, target.getType()));
+        CompositeFilter typeFilter = all(eq(TYPE_COLUMN_NAME, target.getType()));
         TargetFilters appendedFilters = filters
                 .toBuilder()
                 .setIdFilter(idFilter)

--- a/server/src/test/java/io/spine/server/entity/storage/ColumnReaderTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ColumnReaderTest.java
@@ -44,6 +44,7 @@ import static io.spine.server.entity.storage.ColumnReader.forClass;
 import static io.spine.server.entity.storage.ColumnTests.assertContainsColumns;
 import static io.spine.server.entity.storage.ColumnTests.assertNotContainsColumns;
 import static io.spine.server.entity.storage.ColumnTests.defaultColumns;
+import static io.spine.server.entity.storage.given.column.EntityWithManyGetters.CUSTOM_COLUMN_NAME;
 import static io.spine.server.storage.LifecycleFlagField.archived;
 import static io.spine.server.storage.LifecycleFlagField.deleted;
 import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
@@ -92,7 +93,7 @@ class ColumnReaderTest {
             assertContainsColumns(
                     entityColumns,
                     archived.name(), deleted.name(),
-                    "boolean", "booleanWrapper", "someMessage", "integerFieldValue", "floatNull"
+                    "boolean", "booleanWrapper", "someMessage", "floatNull", CUSTOM_COLUMN_NAME
             );
         }
 

--- a/server/src/test/java/io/spine/server/entity/storage/ColumnReaderTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ColumnReaderTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 import java.util.Collection;
+import java.util.List;
 import java.util.function.Predicate;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -136,6 +137,18 @@ class ColumnReaderTest {
                                   archived.name(), deleted.name(),
                                   "integerFieldValue");
         }
+
+        @Test
+        @DisplayName("from a private entity class")
+        void fromPrivateClass() {
+            ColumnReader columnReader = forClass(PrivateEntity.class);
+            Collection<EntityColumn> entityColumns = columnReader.readColumns();
+            assertThat(entityColumns).isNotEmpty();
+            List<String> columnNames = entityColumns.stream()
+                                                    .map(EntityColumn::name)
+                                                    .collect(toList());
+            assertThat(columnNames).contains(PrivateEntity.ANSWER_COLUMN);
+        }
     }
 
     @Test
@@ -232,6 +245,26 @@ class ColumnReaderTest {
         private Method method(String name, Class<?>... parameterTypes)
                 throws NoSuchMethodException {
             return EntityWithBooleanColumns.class.getDeclaredMethod(name, parameterTypes);
+        }
+    }
+
+    /**
+     * A private entity class which defines columns.
+     *
+     * <p>This class is placed inside the test case instead of being an upper level class in
+     * the {@code given} package so that it is accessible at compile time.
+     */
+    private static final class PrivateEntity extends EntityWithManyGetters {
+
+        private static final String ANSWER_COLUMN = "the_answer";
+
+        private PrivateEntity(String id) {
+            super(id);
+        }
+
+        @Column(name = ANSWER_COLUMN)
+        public String get42() {
+            return "42";
         }
     }
 }

--- a/server/src/test/java/io/spine/server/entity/storage/ColumnTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ColumnTest.java
@@ -309,8 +309,7 @@ class ColumnTest {
         @DisplayName("custom if specified")
         void custom() {
             EntityColumn column = forMethod("getValue", EntityWithCustomColumnNameForStoring.class);
-            assertEquals("value", column.name());
-            assertEquals(CUSTOM_COLUMN_NAME.trim(), column.storedName());
+            assertEquals(CUSTOM_COLUMN_NAME.trim(), column.name());
         }
 
         @Test
@@ -320,7 +319,7 @@ class ColumnTest {
                                             EntityWithDefaultColumnNameForStoring.class);
             String expectedName = "value";
             assertEquals(expectedName, column.name());
-            assertEquals(expectedName, column.storedName());
+            assertEquals(expectedName, column.name());
         }
     }
 

--- a/server/src/test/java/io/spine/server/entity/storage/ColumnsTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ColumnsTest.java
@@ -102,7 +102,7 @@ class ColumnsTest {
         assertContainsColumns(
                 entityColumns,
                 archived.name(), deleted.name(),
-                "boolean", "booleanWrapper", "someMessage", "integerFieldValue", "floatNull"
+                "boolean", "booleanWrapper", "someMessage", "floatNull", CUSTOM_COLUMN_NAME
         );
     }
 

--- a/server/src/test/java/io/spine/server/entity/storage/QueryParametersTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/QueryParametersTest.java
@@ -215,13 +215,13 @@ class QueryParametersTest {
         RecordStorage storage = mock(RecordStorage.class);
         Map<String, EntityColumn> columns = new HashMap<>();
 
-        String archivedStoredName = "archived-stored";
-        EntityColumn archivedColumn = mockColumn(archived, archivedStoredName);
-        columns.put(archived.name(), archivedColumn);
+        String archivedName = archived.name();
+        EntityColumn archivedColumn = mockColumn(archivedName);
+        columns.put(archivedName, archivedColumn);
 
-        String deletedStoredName = "deleted-stored";
-        EntityColumn deletedColumn = mockColumn(deleted, deletedStoredName);
-        columns.put(deleted.name(), deletedColumn);
+        String deletedName = deleted.name();
+        EntityColumn deletedColumn = mockColumn(deletedName);
+        columns.put(deletedName, deletedColumn);
 
         when(storage.entityLifecycleColumns()).thenReturn(columns);
 
@@ -238,12 +238,12 @@ class QueryParametersTest {
 
         ImmutableCollection<Filter> archivedFilters = filters.get(archivedColumn);
         UnmodifiableIterator<Filter> archivedFilterIterator = archivedFilters.iterator();
-        assertEquals(eq(archivedStoredName, false), archivedFilterIterator.next());
+        assertEquals(eq(archivedName, false), archivedFilterIterator.next());
         assertFalse(archivedFilterIterator.hasNext());
 
         ImmutableCollection<Filter> deletedFilters = filters.get(deletedColumn);
         UnmodifiableIterator<Filter> deletedFilterIterator = deletedFilters.iterator();
-        assertEquals(eq(deletedStoredName, false), deletedFilterIterator.next());
+        assertEquals(eq(deletedName, false), deletedFilterIterator.next());
         assertFalse(deletedFilterIterator.hasNext());
     }
 

--- a/server/src/test/java/io/spine/server/entity/storage/given/QueryParametersTestEnv.java
+++ b/server/src/test/java/io/spine/server/entity/storage/given/QueryParametersTestEnv.java
@@ -21,7 +21,6 @@
 package io.spine.server.entity.storage.given;
 
 import io.spine.server.entity.storage.EntityColumn;
-import io.spine.server.storage.LifecycleFlagField;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -35,10 +34,9 @@ public class QueryParametersTestEnv {
         // Prevent instantiation of this utility class.
     }
 
-    public static EntityColumn mockColumn(LifecycleFlagField flag, String storedName) {
+    public static EntityColumn mockColumn(String name) {
         EntityColumn column = mock(EntityColumn.class);
-        when(column.storedName()).thenReturn(storedName);
-        when(column.name()).thenReturn(flag.name());
+        when(column.name()).thenReturn(name);
         return column;
     }
 

--- a/server/src/test/java/io/spine/server/storage/given/RecordStorageTestEnv.java
+++ b/server/src/test/java/io/spine/server/storage/given/RecordStorageTestEnv.java
@@ -155,7 +155,7 @@ public class RecordStorageTestEnv {
 
         private int counter = 0;
 
-        public TestCounterEntity(ProjectId id) {
+        private TestCounterEntity(ProjectId id) {
             super(id);
         }
 

--- a/server/src/test/java/io/spine/server/storage/given/RecordStorageTestEnv.java
+++ b/server/src/test/java/io/spine/server/storage/given/RecordStorageTestEnv.java
@@ -180,8 +180,7 @@ public class RecordStorageTestEnv {
             return id().toString();
         }
 
-        @Column(name = "COUNTER_VERSION" /* Custom name for storing
-                                            to check that querying is correct. */)
+        @Column
         public Version getCounterVersion() {
             return Version.newBuilder()
                           .setNumber(counter)
@@ -262,7 +261,7 @@ public class RecordStorageTestEnv {
         }
 
         public String columnName() {
-            return column.storedName();
+            return column.name();
         }
     }
 }

--- a/server/src/test/java/io/spine/server/storage/memory/EntityQueryMatcherTest.java
+++ b/server/src/test/java/io/spine/server/storage/memory/EntityQueryMatcherTest.java
@@ -105,7 +105,7 @@ class EntityQueryMatcherTest {
         Serializable acceptedValue = true;
         EntityColumn target = mock(EntityColumn.class);
         when(target.isNullable()).thenReturn(true);
-        when(target.storedName()).thenReturn(targetName);
+        when(target.name()).thenReturn(targetName);
         when(target.type()).thenReturn(Boolean.class);
         when(target.toPersistedValue(any())).thenReturn(acceptedValue);
 
@@ -151,7 +151,7 @@ class EntityQueryMatcherTest {
 
         EntityColumn column = mock(EntityColumn.class);
         when(column.type()).thenReturn(Any.class);
-        when(column.storedName()).thenReturn(columnName);
+        when(column.name()).thenReturn(columnName);
         when(column.toPersistedValue(any())).thenReturn(actualValue);
 
         EntityColumn.MemoizedValue value = mock(EntityColumn.MemoizedValue.class);


### PR DESCRIPTION
Previously, an entity column had 2 different names:
 - a stored name — the name used to persist the column value in a database;
 - a query name — the name used to reference the column in a query.

This approach had its drawbacks. Primarily, there was a need in conversion between the two names when querying an entity.

Now, each entity column has a single name for both querying and persistence.