### PR TITLE
Add a test for event reaction product routing

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -469,7 +469,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jul 25 15:36:06 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 29 17:32:07 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -889,7 +889,7 @@ This report was generated on **Thu Jul 25 15:36:06 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jul 25 15:36:06 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 29 17:32:10 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1345,7 +1345,7 @@ This report was generated on **Thu Jul 25 15:36:06 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jul 25 15:36:07 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 29 17:32:13 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1963,7 +1963,7 @@ This report was generated on **Thu Jul 25 15:36:07 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jul 25 15:36:07 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 29 17:32:17 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2497,7 +2497,7 @@ This report was generated on **Thu Jul 25 15:36:07 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jul 25 15:36:08 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 29 17:32:21 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3029,7 +3029,7 @@ This report was generated on **Thu Jul 25 15:36:08 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jul 25 15:36:08 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 29 17:32:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3569,7 +3569,7 @@ This report was generated on **Thu Jul 25 15:36:08 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jul 25 15:36:09 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 29 17:32:28 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4155,4 +4155,4 @@ This report was generated on **Thu Jul 25 15:36:09 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Jul 25 15:36:09 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 29 17:32:32 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/server/src/test/java/io/spine/server/route/EventRoutingIntegrationTest.java
+++ b/server/src/test/java/io/spine/server/route/EventRoutingIntegrationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.route;
+
+import io.spine.core.UserId;
+import io.spine.server.DefaultRepository;
+import io.spine.server.route.given.user.SessionProjection;
+import io.spine.server.route.given.user.SessionRepository;
+import io.spine.server.route.given.user.UserAggregate;
+import io.spine.server.route.given.user.event.UserSignedIn;
+import io.spine.test.event.Session;
+import io.spine.test.event.SessionId;
+import io.spine.testing.core.given.GivenUserId;
+import io.spine.testing.server.blackbox.BlackBoxBoundedContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Event routing should")
+class EventRoutingIntegrationTest {
+
+    @Test
+    @DisplayName("only occur after the event origin has already been dispatched")
+    void occurAfterOriginDispatched() {
+        UserId userId = GivenUserId.generated();
+        SessionId sessionId = SessionId.generate();
+        UserSignedIn event = UserSignedIn
+                .newBuilder()
+                .setUserId(userId)
+                .setSessionId(sessionId)
+                .build();
+        Session session = Session
+                .newBuilder()
+                .setId(sessionId)
+                .setUserId(userId)
+                .setUserConsentRequested(true)
+                .build();
+
+        // If the routing of `UserConsentRequested` event is done before its origin
+        // (`UserSignedIn`) is dispatched, the repository won't be able to route the event
+        // properly, making the corresponding field `false`.
+        BlackBoxBoundedContext.singleTenant()
+                              .with(DefaultRepository.of(UserAggregate.class))
+                              .with(new SessionRepository())
+                              .receivesEvent(event)
+                              .assertEntity(SessionProjection.class, sessionId)
+                              .hasStateThat()
+                              .comparingExpectedFieldsOnly()
+                              .isEqualTo(session);
+    }
+}

--- a/server/src/test/java/io/spine/server/route/EventRoutingIntegrationTest.java
+++ b/server/src/test/java/io/spine/server/route/EventRoutingIntegrationTest.java
@@ -36,6 +36,16 @@ import org.junit.jupiter.api.Test;
 @DisplayName("Event routing should")
 class EventRoutingIntegrationTest {
 
+    //
+
+    /**
+     * A test that verifies that the {@linkplain io.spine.core.Event event} routing occurs at the
+     * right moment in time.
+     *
+     * <p>If the routing of `UserConsentRequested` event is done before its origin (`UserSignedIn`)
+     * is dispatched, the repository won't be able to route the event properly, making the
+     * corresponding field `false`.
+     */
     @Test
     @DisplayName("only occur after the event origin has already been dispatched")
     void occurAfterOriginDispatched() {
@@ -53,9 +63,6 @@ class EventRoutingIntegrationTest {
                 .setUserConsentRequested(true)
                 .build();
 
-        // If the routing of `UserConsentRequested` event is done before its origin
-        // (`UserSignedIn`) is dispatched, the repository won't be able to route the event
-        // properly, making the corresponding field `false`.
         BlackBoxBoundedContext.singleTenant()
                               .with(DefaultRepository.of(UserAggregate.class))
                               .with(new SessionRepository())

--- a/server/src/test/java/io/spine/server/route/EventRoutingIntegrationTest.java
+++ b/server/src/test/java/io/spine/server/route/EventRoutingIntegrationTest.java
@@ -25,9 +25,9 @@ import io.spine.server.DefaultRepository;
 import io.spine.server.route.given.user.SessionProjection;
 import io.spine.server.route.given.user.SessionRepository;
 import io.spine.server.route.given.user.UserAggregate;
-import io.spine.server.route.given.user.event.UserSignedIn;
-import io.spine.test.event.Session;
-import io.spine.test.event.SessionId;
+import io.spine.server.route.given.user.event.RUserSignedIn;
+import io.spine.test.event.RSession;
+import io.spine.test.event.RSessionId;
 import io.spine.testing.core.given.GivenUserId;
 import io.spine.testing.server.blackbox.BlackBoxBoundedContext;
 import org.junit.jupiter.api.DisplayName;
@@ -50,13 +50,13 @@ class EventRoutingIntegrationTest {
     @DisplayName("only occur after the event origin has already been dispatched")
     void occurAfterOriginDispatched() {
         UserId userId = GivenUserId.generated();
-        SessionId sessionId = SessionId.generate();
-        UserSignedIn event = UserSignedIn
+        RSessionId sessionId = RSessionId.generate();
+        RUserSignedIn event = RUserSignedIn
                 .newBuilder()
                 .setUserId(userId)
                 .setSessionId(sessionId)
                 .build();
-        Session session = Session
+        RSession session = RSession
                 .newBuilder()
                 .setId(sessionId)
                 .setUserId(userId)

--- a/server/src/test/java/io/spine/server/route/EventRoutingIntegrationTest.java
+++ b/server/src/test/java/io/spine/server/route/EventRoutingIntegrationTest.java
@@ -42,9 +42,9 @@ class EventRoutingIntegrationTest {
      * A test that verifies that the {@linkplain io.spine.core.Event event} routing occurs at the
      * right moment in time.
      *
-     * <p>If the routing of `UserConsentRequested` event is done before its origin (`UserSignedIn`)
-     * is dispatched, the repository won't be able to route the event properly, making the
-     * corresponding field `false`.
+     * <p>If the routing of `RUserConsentRequested` event is done before its origin
+     * (`RUserSignedIn`) is dispatched, the repository won't be able to route the event properly,
+     * making the corresponding field `false`.
      */
     @Test
     @DisplayName("only occur after the event origin has already been dispatched")

--- a/server/src/test/java/io/spine/server/route/given/user/SessionProjection.java
+++ b/server/src/test/java/io/spine/server/route/given/user/SessionProjection.java
@@ -22,21 +22,21 @@ package io.spine.server.route.given.user;
 
 import io.spine.core.Subscribe;
 import io.spine.server.projection.Projection;
-import io.spine.server.route.given.user.event.UserConsentRequested;
-import io.spine.server.route.given.user.event.UserSignedIn;
-import io.spine.test.event.Session;
-import io.spine.test.event.SessionId;
+import io.spine.server.route.given.user.event.RUserConsentRequested;
+import io.spine.server.route.given.user.event.RUserSignedIn;
+import io.spine.test.event.RSession;
+import io.spine.test.event.RSessionId;
 
-public class SessionProjection extends Projection<SessionId, Session, Session.Builder> {
+public class SessionProjection extends Projection<RSessionId, RSession, RSession.Builder> {
 
     @Subscribe
-    void on(UserSignedIn event) {
+    void on(RUserSignedIn event) {
         builder().setId(event.getSessionId())
                  .setUserId(event.getUserId());
     }
 
     @Subscribe
-    void on(UserConsentRequested event) {
+    void on(RUserConsentRequested event) {
         builder().setUserConsentRequested(true);
     }
 }

--- a/server/src/test/java/io/spine/server/route/given/user/SessionProjection.java
+++ b/server/src/test/java/io/spine/server/route/given/user/SessionProjection.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.route.given.user;
+
+import io.spine.core.Subscribe;
+import io.spine.server.projection.Projection;
+import io.spine.server.route.given.user.event.UserConsentRequested;
+import io.spine.server.route.given.user.event.UserSignedIn;
+import io.spine.test.event.Session;
+import io.spine.test.event.SessionId;
+
+public class SessionProjection extends Projection<SessionId, Session, Session.Builder> {
+
+    @Subscribe
+    void on(UserSignedIn event) {
+        builder().setId(event.getSessionId())
+                 .setUserId(event.getUserId());
+    }
+
+    @Subscribe
+    void on(UserConsentRequested event) {
+        builder().setUserConsentRequested(true);
+    }
+}

--- a/server/src/test/java/io/spine/server/route/given/user/SessionRepository.java
+++ b/server/src/test/java/io/spine/server/route/given/user/SessionRepository.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.route.given.user;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
+import io.spine.core.UserId;
+import io.spine.server.projection.ProjectionRepository;
+import io.spine.server.route.EventRouting;
+import io.spine.server.route.given.user.event.UserConsentRequested;
+import io.spine.server.route.given.user.event.UserSignedIn;
+import io.spine.test.event.Session;
+import io.spine.test.event.SessionId;
+
+import java.util.Iterator;
+import java.util.Set;
+
+import static com.google.common.collect.Streams.stream;
+import static java.util.stream.Collectors.toSet;
+
+public class SessionRepository
+        extends ProjectionRepository<SessionId, SessionProjection, Session> {
+
+    @OverridingMethodsMustInvokeSuper
+    @Override
+    protected void setupEventRouting(EventRouting<SessionId> routing) {
+        super.setupEventRouting(routing);
+        routing.route(UserSignedIn.class,
+                      (message, context) -> ImmutableSet.of(message.getSessionId()))
+               .route(UserConsentRequested.class,
+                      (message, context) -> findByUserId(message.getUserId()));
+    }
+
+    private Set<SessionId> findByUserId(UserId id) {
+        Iterator<SessionProjection> iterator =
+                iterator(projection -> projection.state()
+                                                 .getUserId()
+                                                 .equals(id));
+        Set<SessionId> ids = stream(iterator)
+                .map(SessionProjection::id)
+                .collect(toSet());
+        return ids;
+    }
+}

--- a/server/src/test/java/io/spine/server/route/given/user/SessionRepository.java
+++ b/server/src/test/java/io/spine/server/route/given/user/SessionRepository.java
@@ -25,10 +25,10 @@ import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import io.spine.core.UserId;
 import io.spine.server.projection.ProjectionRepository;
 import io.spine.server.route.EventRouting;
-import io.spine.server.route.given.user.event.UserConsentRequested;
-import io.spine.server.route.given.user.event.UserSignedIn;
-import io.spine.test.event.Session;
-import io.spine.test.event.SessionId;
+import io.spine.server.route.given.user.event.RUserConsentRequested;
+import io.spine.server.route.given.user.event.RUserSignedIn;
+import io.spine.test.event.RSession;
+import io.spine.test.event.RSessionId;
 
 import java.util.Iterator;
 import java.util.Set;
@@ -37,24 +37,24 @@ import static com.google.common.collect.Streams.stream;
 import static java.util.stream.Collectors.toSet;
 
 public class SessionRepository
-        extends ProjectionRepository<SessionId, SessionProjection, Session> {
+        extends ProjectionRepository<RSessionId, SessionProjection, RSession> {
 
     @OverridingMethodsMustInvokeSuper
     @Override
-    protected void setupEventRouting(EventRouting<SessionId> routing) {
+    protected void setupEventRouting(EventRouting<RSessionId> routing) {
         super.setupEventRouting(routing);
-        routing.route(UserSignedIn.class,
+        routing.route(RUserSignedIn.class,
                       (message, context) -> ImmutableSet.of(message.getSessionId()))
-               .route(UserConsentRequested.class,
+               .route(RUserConsentRequested.class,
                       (message, context) -> findByUserId(message.getUserId()));
     }
 
-    private Set<SessionId> findByUserId(UserId id) {
+    private Set<RSessionId> findByUserId(UserId id) {
         Iterator<SessionProjection> iterator =
                 iterator(projection -> projection.state()
                                                  .getUserId()
                                                  .equals(id));
-        Set<SessionId> ids = stream(iterator)
+        Set<RSessionId> ids = stream(iterator)
                 .map(SessionProjection::id)
                 .collect(toSet());
         return ids;

--- a/server/src/test/java/io/spine/server/route/given/user/UserAggregate.java
+++ b/server/src/test/java/io/spine/server/route/given/user/UserAggregate.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.route.given.user;
+
+import io.spine.core.UserId;
+import io.spine.server.aggregate.Aggregate;
+import io.spine.server.aggregate.Apply;
+import io.spine.server.event.React;
+import io.spine.server.route.given.user.event.UserConsentRequested;
+import io.spine.server.route.given.user.event.UserSignedIn;
+import io.spine.test.event.User;
+
+public class UserAggregate extends Aggregate<UserId, User, User.Builder> {
+
+    @React
+    UserConsentRequested on(UserSignedIn event) {
+        UserConsentRequested react = UserConsentRequested
+                .newBuilder()
+                .setUserId(event.getUserId())
+                .build();
+        return react;
+    }
+
+    @Apply
+    private void on(UserConsentRequested event) {
+        builder().setUserConsentRequested(true);
+    }
+}

--- a/server/src/test/java/io/spine/server/route/given/user/UserAggregate.java
+++ b/server/src/test/java/io/spine/server/route/given/user/UserAggregate.java
@@ -24,15 +24,15 @@ import io.spine.core.UserId;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.Apply;
 import io.spine.server.event.React;
-import io.spine.server.route.given.user.event.UserConsentRequested;
-import io.spine.server.route.given.user.event.UserSignedIn;
-import io.spine.test.event.User;
+import io.spine.server.route.given.user.event.RUserConsentRequested;
+import io.spine.server.route.given.user.event.RUserSignedIn;
+import io.spine.test.event.RUser;
 
-public class UserAggregate extends Aggregate<UserId, User, User.Builder> {
+public class UserAggregate extends Aggregate<UserId, RUser, RUser.Builder> {
 
     @React
-    UserConsentRequested on(UserSignedIn event) {
-        UserConsentRequested react = UserConsentRequested
+    RUserConsentRequested on(RUserSignedIn event) {
+        RUserConsentRequested react = RUserConsentRequested
                 .newBuilder()
                 .setUserId(event.getUserId())
                 .build();
@@ -40,7 +40,7 @@ public class UserAggregate extends Aggregate<UserId, User, User.Builder> {
     }
 
     @Apply
-    private void on(UserConsentRequested event) {
+    private void on(RUserConsentRequested event) {
         builder().setUserConsentRequested(true);
     }
 }

--- a/server/src/test/java/io/spine/server/route/given/user/package-info.java
+++ b/server/src/test/java/io/spine/server/route/given/user/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * This package provides test environment for the event routing order test.
+ */
+
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.server.route.given.user;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/test/proto/spine/test/route/user/events.proto
+++ b/server/src/test/proto/spine/test/route/user/events.proto
@@ -31,11 +31,11 @@ option java_multiple_files = true;
 import "spine/core/user_id.proto";
 import "spine/test/route/user/user.proto";
 
-message UserSignedIn {
+message RUserSignedIn {
     spine.core.UserId user_id = 1;
-    SessionId session_id = 2 [(required) = true];
+    RSessionId session_id = 2 [(required) = true];
 }
 
-message UserConsentRequested {
+message RUserConsentRequested {
     spine.core.UserId user_id = 1;
 }

--- a/server/src/test/proto/spine/test/route/user/events.proto
+++ b/server/src/test/proto/spine/test/route/user/events.proto
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+syntax = "proto3";
+
+package spine.test.route.user;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.server.route.given.user.event";
+option java_outer_classname = "EventsProto";
+option java_multiple_files = true;
+
+import "spine/core/user_id.proto";
+import "spine/test/route/user/user.proto";
+
+message UserSignedIn {
+    spine.core.UserId user_id = 1;
+    SessionId session_id = 2 [(required) = true];
+}
+
+message UserConsentRequested {
+    spine.core.UserId user_id = 1;
+}

--- a/server/src/test/proto/spine/test/route/user/user.proto
+++ b/server/src/test/proto/spine/test/route/user/user.proto
@@ -29,7 +29,7 @@ option java_multiple_files = true;
 
 import "spine/core/user_id.proto";
 
-message User {
+message RUser {
     option (entity).kind = AGGREGATE;
 
     core.UserId id = 1;
@@ -37,14 +37,14 @@ message User {
     bool user_consent_requested = 2;
 }
 
-message SessionId {
+message RSessionId {
     string uuid = 1;
 }
 
-message Session {
+message RSession {
     option (entity).kind = PROJECTION;
 
-    SessionId id = 1;
+    RSessionId id = 1;
 
     core.UserId user_id = 2 [(required) = true];
 

--- a/server/src/test/proto/spine/test/route/user/user.proto
+++ b/server/src/test/proto/spine/test/route/user/user.proto
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+syntax = "proto3";
+
+package spine.test.route.user;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package="io.spine.test.event";
+option java_multiple_files = true;
+
+import "spine/core/user_id.proto";
+
+message User {
+    option (entity).kind = AGGREGATE;
+
+    core.UserId id = 1;
+
+    bool user_consent_requested = 2;
+}
+
+message SessionId {
+    string uuid = 1;
+}
+
+message Session {
+    option (entity).kind = PROJECTION;
+
+    SessionId id = 1;
+
+    core.UserId user_id = 2 [(required) = true];
+
+    bool user_consent_requested = 3;
+}


### PR DESCRIPTION
This PR addresses #925.

With the current Spine version the problem is not reproducible anymore.

This PR adds a test for the scenario described in the issue, to make sure the problem won't return again.