### PR TITLE
Fail on posting unsupported commands in `BlackBoxBoundedContext`

### DIFF
--- a/server/src/test/java/io/spine/server/route/EventRoutingIntegrationTest.java
+++ b/server/src/test/java/io/spine/server/route/EventRoutingIntegrationTest.java
@@ -36,15 +36,13 @@ import org.junit.jupiter.api.Test;
 @DisplayName("Event routing should")
 class EventRoutingIntegrationTest {
 
-    //
-
     /**
      * A test that verifies that the {@linkplain io.spine.core.Event event} routing occurs at the
      * right moment in time.
      *
-     * <p>If the routing of `RUserConsentRequested` event is done before its origin
-     * (`RUserSignedIn`) is dispatched, the repository won't be able to route the event properly,
-     * making the corresponding field `false`.
+     * <p>If the routing of {@code RUserConsentRequested} event is done before its origin
+     * ({@code RUserSignedIn}) is dispatched, the repository won't be able to route the event
+     * properly, making the corresponding field {@code false}.
      */
     @Test
     @DisplayName("only occur after the event origin has already been dispatched")

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
@@ -152,6 +152,10 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext>
 
     private final MemoizingObserver<Ack> observer;
 
+    /**
+     * A guard that verifies that unsupported commands do not get posted to the
+     * {@code BlackBoxBoundedContext}.
+     */
     private final UnsupportedGuard unsupportedGuard;
 
     private final Map<Class<? extends Message>, Repository<?, ?>> repositories;
@@ -265,6 +269,10 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext>
     }
 
     /**
+     * Throws an {@link AssertionError}.
+     *
+     * <p>Only reachable after {@code unsupportedGuard} has
+     * {@linkplain #canDispatch(EventEnvelope) detected} a violation.
      */
     @Override
     protected void handle(EventEnvelope event) {
@@ -272,7 +280,8 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext>
     }
 
     /**
-     * {@inheritDoc}
+     * Checks if the given {@link CommandErrored} message represents an unsupported command
+     * {@linkplain io.spine.server.commandbus.UnsupportedCommandException error}.
      */
     @Override
     public boolean canDispatch(EventEnvelope eventEnvelope) {
@@ -280,9 +289,6 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext>
         return unsupportedGuard.checkAndRemember(event);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Set<EventClass> messageClasses() {
         Set<EventClass> result = singleton(EventClass.from(CommandErrored.class));

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
@@ -160,7 +160,7 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext>
 
     private final Map<Class<? extends Message>, Repository<?, ?>> repositories;
 
-    @SuppressWarnings("ThisEscapedInObjectConstruction")
+    @SuppressWarnings("ThisEscapedInObjectConstruction") // to inject self as event dispatcher.
     protected BlackBoxBoundedContext(boolean multitenant,
                                      EventEnricher enricher,
                                      String name) {

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
@@ -160,6 +160,7 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext>
     protected BlackBoxBoundedContext(boolean multitenant,
                                      EventEnricher enricher,
                                      String name) {
+        super();
         this.commands = new CommandCollector();
         this.postedCommands = new HashSet<>();
         this.events = new EventCollector();

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
@@ -156,7 +156,7 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext>
      * A guard that verifies that unsupported commands do not get posted to the
      * {@code BlackBoxBoundedContext}.
      */
-    private final UnsupportedGuard unsupportedGuard;
+    private final UnsupportedCommandGuard unsupportedCommandGuard;
 
     private final Map<Class<? extends Message>, Repository<?, ?>> repositories;
 
@@ -178,7 +178,7 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext>
                 .enrichEventsUsing(enricher)
                 .build();
         this.observer = memoizingObserver();
-        this.unsupportedGuard = new UnsupportedGuard();
+        this.unsupportedCommandGuard = new UnsupportedCommandGuard();
         this.repositories = newHashMap();
         this.context.registerEventDispatcher(this);
     }
@@ -276,7 +276,7 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext>
      */
     @Override
     protected void handle(EventEnvelope event) {
-        unsupportedGuard.failTest();
+        unsupportedCommandGuard.failTest();
     }
 
     /**
@@ -286,7 +286,7 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext>
     @Override
     public boolean canDispatch(EventEnvelope eventEnvelope) {
         CommandErrored event = (CommandErrored) eventEnvelope.message();
-        return unsupportedGuard.checkAndRemember(event);
+        return unsupportedCommandGuard.checkAndRemember(event);
     }
 
     @Override

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/UnsupportedCommandGuard.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/UnsupportedCommandGuard.java
@@ -69,7 +69,7 @@ final class UnsupportedCommandGuard {
      */
     void failTest() {
         checkNotNull(commandType);
-        fail(format("Handler for commands of type %s is not registered within the context",
+        fail(format("Handler for commands of type %s is not registered within the context.",
                     commandType));
         commandType = null;
     }

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/UnsupportedCommandGuard.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/UnsupportedCommandGuard.java
@@ -71,7 +71,6 @@ final class UnsupportedCommandGuard {
         checkNotNull(commandType);
         fail(format("Handler for commands of type %s is not registered within the context.",
                     commandType));
-        commandType = null;
     }
 
     private static boolean isUnsupportedError(Error error) {

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/UnsupportedCommandGuard.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/UnsupportedCommandGuard.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * A guard that verifies that the commands posted to the {@link BlackBoxBoundedContext} are not the
  * {@linkplain io.spine.server.bus.DeadMessageHandler "dead"} messages.
  */
-final class UnsupportedGuard {
+final class UnsupportedCommandGuard {
 
     private static final String COMMAND_VALIDATION_ERROR_TYPE =
             CommandValidationError.getDescriptor()

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/UnsupportedCommandGuard.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/UnsupportedCommandGuard.java
@@ -20,6 +20,7 @@
 
 package io.spine.testing.server.blackbox;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.spine.base.Error;
 import io.spine.core.CommandValidationError;
 import io.spine.system.server.event.CommandErrored;
@@ -71,6 +72,11 @@ final class UnsupportedCommandGuard {
         checkNotNull(commandType);
         fail(format("Handler for commands of type %s is not registered within the context.",
                     commandType));
+    }
+
+    @VisibleForTesting
+    String commandType() {
+        return commandType;
     }
 
     private static boolean isUnsupportedError(Error error) {

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/UnsupportedGuard.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/UnsupportedGuard.java
@@ -31,14 +31,25 @@ import static io.spine.server.commandbus.CommandException.ATTR_COMMAND_TYPE_NAME
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.fail;
 
+/**
+ * A guard that verifies that the commands posted to the {@link BlackBoxBoundedContext} are not the
+ * {@linkplain io.spine.server.bus.DeadMessageHandler "dead"} messages.
+ */
 final class UnsupportedGuard {
 
     private static final String COMMAND_VALIDATION_ERROR_TYPE =
             CommandValidationError.getDescriptor()
                                   .getFullName();
 
+    /**
+     * A command type for which the violation occurs in printable form.
+     */
     private @Nullable String commandType;
 
+    /**
+     * Checks if the given {@link CommandErrored} event represents an "unsupported" error and,
+     * if so, remembers its data.
+     */
     boolean checkAndRemember(CommandErrored event) {
         Error error = event.getError();
         if (!isUnsupportedError(error)) {
@@ -50,10 +61,17 @@ final class UnsupportedGuard {
         return true;
     }
 
+    /**
+     * Throws an {@link AssertionError}.
+     *
+     * <p>The method is assumed to be called after a violation was found for some
+     * {@link #commandType}.
+     */
     void failTest() {
         checkNotNull(commandType);
         fail(format("Handler for commands of type %s is not registered within the context",
                     commandType));
+        commandType = null;
     }
 
     private static boolean isUnsupportedError(Error error) {

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/UnsupportedGuard.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/UnsupportedGuard.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing.server.blackbox;
+
+import io.spine.base.Error;
+import io.spine.core.CommandValidationError;
+import io.spine.system.server.event.CommandErrored;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.core.CommandValidationError.UNSUPPORTED_COMMAND_VALUE;
+import static io.spine.server.commandbus.CommandException.ATTR_COMMAND_TYPE_NAME;
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.fail;
+
+final class UnsupportedGuard {
+
+    private static final String COMMAND_VALIDATION_ERROR_TYPE =
+            CommandValidationError.getDescriptor()
+                                  .getFullName();
+
+    private @Nullable String commandType;
+
+    boolean checkAndRemember(CommandErrored event) {
+        Error error = event.getError();
+        if (!isUnsupportedError(error)) {
+            return false;
+        }
+        commandType = error.getAttributesMap()
+                           .get(ATTR_COMMAND_TYPE_NAME)
+                           .getStringValue();
+        return true;
+    }
+
+    void failTest() {
+        checkNotNull(commandType);
+        fail(format("Handler for commands of type %s is not registered within the context",
+                    commandType));
+    }
+
+    private static boolean isUnsupportedError(Error error) {
+        return COMMAND_VALIDATION_ERROR_TYPE.equals(error.getType())
+                && error.getCode() == UNSUPPORTED_COMMAND_VALUE;
+    }
+}
+

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/UnsupportedGuard.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/UnsupportedGuard.java
@@ -79,4 +79,3 @@ final class UnsupportedGuard {
                 && error.getCode() == UNSUPPORTED_COMMAND_VALUE;
     }
 }
-

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/BlackBoxBoundedContextTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/BlackBoxBoundedContextTest.java
@@ -314,6 +314,10 @@ abstract class BlackBoxBoundedContextTest<T extends BlackBoxBoundedContext<T>> {
     @DisplayName("throw `AssertionError` on receiving an unsupported command")
     class FailOnUnsupportedCommand {
 
+        /**
+         * Cleans the inbox so the erroneous commands sent in tests do not remain there and do not
+         * fail the other tests.
+         */
         @AfterEach
         void cleanInbox() {
             ServerEnvironment.instance()

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/BlackBoxBoundedContextTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/BlackBoxBoundedContextTest.java
@@ -23,7 +23,6 @@ package io.spine.testing.server.blackbox;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.truth.IterableSubject;
-import io.spine.base.Identifier;
 import io.spine.client.Query;
 import io.spine.client.QueryFactory;
 import io.spine.client.Topic;
@@ -60,7 +59,6 @@ import io.spine.testing.server.blackbox.given.RepositoryThrowingExceptionOnClose
 import io.spine.testing.server.blackbox.rejection.Rejections;
 import io.spine.testing.server.entity.EntitySubject;
 import io.spine.type.TypeName;
-import io.spine.validate.Validated;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -317,29 +315,20 @@ abstract class BlackBoxBoundedContextTest<T extends BlackBoxBoundedContext<T>> {
         @Test
         @DisplayName("from the caller")
         void fromCaller() {
-            // `BbFinalizeProject` doesn't have a handler within the context.
             BbFinalizeProject command = finalizeProject(newProjectId());
 
-            assertThrows(IllegalArgumentException.class, () -> context.receivesCommand(command));
+            assertThrows(AssertionError.class, () -> context.receivesCommand(command));
         }
 
         @Test
         @DisplayName("generated as a response to some other signal")
         void generatedWithinModel() {
-            // Should generate a `BbFinalizeProject` command in response.
             BbProjectDone event = projectDone(newProjectId());
 
-            assertThrows(IllegalArgumentException.class, () -> context.receivesEvent(event));
+            assertThrows(AssertionError.class, () -> context.receivesEvent(event));
         }
     }
-    @Test
-    @DisplayName("generated as a response to some other signal")
-    void generatedWithinModel() {
-        // Should generate a `BbFinalizeProject` command in response.
-        BbProjectDone event = projectDone(newProjectId());
 
-        assertThrows(IllegalArgumentException.class, () -> context.receivesEvent(event));
-    }
     @Test
     @DisplayName("receive and react on single event")
     void receivesEvent() {

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/BlackBoxBoundedContextTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/BlackBoxBoundedContextTest.java
@@ -30,7 +30,9 @@ import io.spine.client.TopicFactory;
 import io.spine.core.UserId;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.DefaultRepository;
+import io.spine.server.ServerEnvironment;
 import io.spine.server.commandbus.CommandDispatcher;
+import io.spine.server.delivery.Delivery;
 import io.spine.server.entity.Repository;
 import io.spine.server.event.EventDispatcher;
 import io.spine.server.event.EventEnricher;
@@ -309,11 +311,17 @@ abstract class BlackBoxBoundedContextTest<T extends BlackBoxBoundedContext<T>> {
     }
 
     @Nested
-    @DisplayName("throw IAE on receiving an unsupported command")
-    class ThrowOnUnsupportedCommand {
+    @DisplayName("throw `AssertionError` on receiving an unsupported command")
+    class FailOnUnsupportedCommand {
+
+        @AfterEach
+        void cleanInbox() {
+            ServerEnvironment.instance()
+                             .configureDelivery(Delivery.local());
+        }
 
         @Test
-        @DisplayName("from the caller")
+        @DisplayName("directly from the caller")
         void fromCaller() {
             BbFinalizeProject command = finalizeProject(newProjectId());
 

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/BlackBoxBoundedContextTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/BlackBoxBoundedContextTest.java
@@ -315,7 +315,7 @@ abstract class BlackBoxBoundedContextTest<T extends BlackBoxBoundedContext<T>> {
     class FailOnUnsupportedCommand {
 
         /**
-         * Cleans the inbox so the erroneous commands sent in tests do not remain there and do not
+         * Cleans the inbox so the erroneous commands sent in tests are not persisted and do not
          * fail the other tests.
          */
         @AfterEach

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/UnsupportedCommandGuardTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/UnsupportedCommandGuardTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing.server.blackbox;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.spine.testing.server.blackbox.given.GivenCommandError.duplicationError;
+import static io.spine.testing.server.blackbox.given.GivenCommandError.nonValidationError;
+import static io.spine.testing.server.blackbox.given.GivenCommandError.unsupportedError;
+
+@DisplayName("UnsupportedCommandGuard should")
+class UnsupportedCommandGuardTest {
+
+    private UnsupportedCommandGuard guard;
+
+    @BeforeEach
+    void initGuard() {
+        guard = new UnsupportedCommandGuard();
+    }
+
+    @Test
+    @DisplayName("check and remember the unsupported command error")
+    void checkAndRememberUnsupported() {
+        String commandType = "SomeCommand";
+        boolean result = guard.checkAndRemember(unsupportedError(commandType));
+
+        assertThat(result).isTrue();
+        assertThat(guard.commandType()).isEqualTo(commandType);
+    }
+
+    @Test
+    @DisplayName("return `false` and ignore the command validation error with the different code")
+    void ignoreGenericValidationError() {
+        boolean result = guard.checkAndRemember(duplicationError());
+
+        assertThat(result).isFalse();
+        assertThat(guard.commandType()).isNull();
+    }
+
+    @Test
+    @DisplayName("return `false` and ignore the command error of the different type")
+    void ignoreGenericCommandError() {
+        boolean result = guard.checkAndRemember(nonValidationError());
+
+        assertThat(result).isFalse();
+        assertThat(guard.commandType()).isNull();
+    }
+}

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbInitProcess.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbInitProcess.java
@@ -28,10 +28,13 @@ import io.spine.testing.server.blackbox.BbInit;
 import io.spine.testing.server.blackbox.BbProjectId;
 import io.spine.testing.server.blackbox.command.BbAssignScrumMaster;
 import io.spine.testing.server.blackbox.command.BbAssignTeam;
+import io.spine.testing.server.blackbox.command.BbFinalizeProject;
 import io.spine.testing.server.blackbox.command.BbInitProject;
+import io.spine.testing.server.blackbox.event.BbProjectDone;
 import io.spine.testing.server.blackbox.event.BbProjectInitialized;
 import io.spine.testing.server.blackbox.event.BbScrumMasterAssigned;
 import io.spine.testing.server.blackbox.event.BbTeamAssigned;
+import io.spine.validate.Validated;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Optional;
@@ -63,6 +66,15 @@ public final class BbInitProcess extends ProcessManager<BbProjectId, BbInit, BbI
                         .build()
                 : null;
         return Pair.withNullable(assignTeam, assignScrumMaster);
+    }
+
+    @Command
+    BbFinalizeProject on(BbProjectDone event) {
+        BbFinalizeProject cmd = BbFinalizeProject
+                .newBuilder()
+                .setProjectId(event.getId())
+                .vBuild();
+        return cmd;
     }
 
     @Assign

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/Given.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/Given.java
@@ -32,10 +32,12 @@ import io.spine.testing.server.blackbox.command.BbAddTask;
 import io.spine.testing.server.blackbox.command.BbAssignProject;
 import io.spine.testing.server.blackbox.command.BbCreateProject;
 import io.spine.testing.server.blackbox.command.BbCreateReport;
+import io.spine.testing.server.blackbox.command.BbFinalizeProject;
 import io.spine.testing.server.blackbox.command.BbInitProject;
 import io.spine.testing.server.blackbox.command.BbRegisterCommandDispatcher;
 import io.spine.testing.server.blackbox.command.BbStartProject;
 import io.spine.testing.server.blackbox.event.BbEventDispatcherRegistered;
+import io.spine.testing.server.blackbox.event.BbProjectDone;
 import io.spine.testing.server.blackbox.event.BbTaskAdded;
 import io.spine.testing.server.blackbox.event.BbUserDeleted;
 
@@ -168,6 +170,20 @@ public class Given {
                 .newBuilder()
                 .setId(id)
                 .addAllProject(newArrayList(projectIds))
+                .build();
+    }
+
+    public static BbProjectDone projectDone(BbProjectId projectId) {
+        return BbProjectDone
+                .newBuilder()
+                .setId(projectId)
+                .build();
+    }
+
+    public static BbFinalizeProject finalizeProject(BbProjectId projectId) {
+        return BbFinalizeProject
+                .newBuilder()
+                .setProjectId(projectId)
                 .build();
     }
 }

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/GivenCommandError.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/GivenCommandError.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing.server.blackbox.given;
+
+import com.google.protobuf.util.Values;
+import io.spine.base.Error;
+import io.spine.core.CommandId;
+import io.spine.core.CommandValidationError;
+import io.spine.system.server.event.CommandErrored;
+
+import static io.spine.core.CommandValidationError.DUPLICATE_COMMAND_VALUE;
+import static io.spine.core.CommandValidationError.UNSUPPORTED_COMMAND_VALUE;
+import static io.spine.server.commandbus.CommandException.ATTR_COMMAND_TYPE_NAME;
+
+public final class GivenCommandError {
+
+    /** Prevents instantiation of this test env class. */
+    private GivenCommandError() {
+    }
+
+    public static CommandErrored unsupportedError(String commandType) {
+        Error error = Error
+                .newBuilder()
+                .setType(CommandValidationError.getDescriptor()
+                                               .getFullName())
+                .setCode(UNSUPPORTED_COMMAND_VALUE)
+                .putAttributes(ATTR_COMMAND_TYPE_NAME, Values.of(commandType))
+                .build();
+        CommandErrored result = CommandErrored
+                .newBuilder()
+                .setId(CommandId.generate())
+                .setError(error)
+                .build();
+        return result;
+    }
+
+    public static CommandErrored duplicationError() {
+        Error error = Error
+                .newBuilder()
+                .setType(CommandValidationError.getDescriptor()
+                                               .getFullName())
+                .setCode(DUPLICATE_COMMAND_VALUE)
+                .build();
+        CommandErrored result = CommandErrored
+                .newBuilder()
+                .setId(CommandId.generate())
+                .setError(error)
+                .build();
+        return result;
+    }
+
+    public static CommandErrored nonValidationError() {
+        Error error = Error
+                .newBuilder()
+                .setType("some random type")
+                .setCode(UNSUPPORTED_COMMAND_VALUE)
+                .build();
+        CommandErrored result = CommandErrored
+                .newBuilder()
+                .setId(CommandId.generate())
+                .setError(error)
+                .build();
+        return result;
+    }
+}

--- a/testutil-server/src/test/proto/spine/testing/server/blackbox/commands.proto
+++ b/testutil-server/src/test/proto/spine/testing/server/blackbox/commands.proto
@@ -76,6 +76,10 @@ message BbAssignProject {
     spine.core.UserId user_id = 2;
 }
 
+message BbFinalizeProject {
+    BbProjectId project_id = 1;
+}
+
 message BbRegisterCommandDispatcher {
     string dispatcher_name = 1;
 }

--- a/testutil-server/src/test/proto/spine/testing/server/blackbox/events.proto
+++ b/testutil-server/src/test/proto/spine/testing/server/blackbox/events.proto
@@ -80,6 +80,10 @@ message BbAssigneeRemoved {
     spine.core.UserId user_id = 2 [(required) = true];
 }
 
+message BbProjectDone {
+    BbProjectId id = 1;
+}
+
 message BbEventDispatcherRegistered {
 
     string dispatcher_name = 1;


### PR DESCRIPTION
This PR fixes #1008.

The `BlackBoxBoundedContext` will now fail on posting unsupported commands, both directly to the `receivesCommand(...)`/`receivesCommands(...)` methods and generated from the commanding entities (`@Command`).

For this, the `BlackBoxBoundedContext` subscribes to the `CommandErrored` event posted by the system.

The `CommandErrored` event unifies various kinds of errors that can happen to a command. Currently, we fail the test only in case of unsupported command, while leaving the rest of error types as some kind of valid test cases.