### PR TITLE
Add method to clear enrichments from all parent contexts of the event

### DIFF
--- a/core/src/main/java/io/spine/core/Enrichments.java
+++ b/core/src/main/java/io/spine/core/Enrichments.java
@@ -120,7 +120,7 @@ final class Enrichments {
         EventContext.Builder eventContext = event.getContext()
                                             .toBuilder()
                                             .clearEnrichment();
-        Deque<EventContext.Builder> contexts = eventContextHierarchy(eventContext);
+        Deque<EventContext.Builder> contexts = eventOriginHierarchy(eventContext);
 
         EventContext.Builder context = contexts.pollLast();
         EventContext.Builder next = contexts.pollLast();
@@ -137,11 +137,12 @@ final class Enrichments {
     /**
      * Traverses the event origin hierarchy until non-{@link EventContext} origin is found.
      *
-     * @return gathered origins in the form of {@code Deque<EventContext.Builder>}
+     * <p>All of the {@link EventContext}-kind origins are collected and returned as
+     * {@code Deque<EventContext.Builder>}.
      */
     @SuppressWarnings("deprecation") // Uses the deprecated field to be sure to clean up old data.
     private static Deque<EventContext.Builder>
-    eventContextHierarchy(EventContext.Builder eventContext) {
+    eventOriginHierarchy(EventContext.Builder eventContext) {
 
         EventContext.Builder child = eventContext;
         EventContext.OriginCase originCase = child.getOriginCase();

--- a/core/src/main/java/io/spine/core/Enrichments.java
+++ b/core/src/main/java/io/spine/core/Enrichments.java
@@ -111,7 +111,7 @@ final class Enrichments {
     }
 
     /**
-     * Clears the enrichments from the {@code event} and all of its origin hierarchy.
+     * Clears the enrichments from the {@code event} and all of its parent contexts.
      */
     @SuppressWarnings({
             "deprecation" /* Uses the deprecated field to be sure to clean up old data. */,
@@ -135,7 +135,7 @@ final class Enrichments {
     }
 
     /**
-     * Traverses the event origin hierarchy until non-{@link EventContext} origin is found.
+     * Traverses the event parent context hierarchy until non-{@link EventContext} origin is found.
      *
      * <p>All of the {@link EventContext}-kind origins are collected and returned as
      * {@code Deque<EventContext.Builder>}, where the deepest origin resides last.

--- a/core/src/main/java/io/spine/core/Enrichments.java
+++ b/core/src/main/java/io/spine/core/Enrichments.java
@@ -26,8 +26,10 @@ import io.spine.core.Enrichment.Container;
 import io.spine.core.Enrichment.ModeCase;
 import io.spine.type.TypeName;
 
+import java.util.Deque;
 import java.util.Optional;
 
+import static com.google.common.collect.Queues.newArrayDeque;
 import static io.spine.protobuf.AnyPacker.unpack;
 import static io.spine.util.Exceptions.newIllegalStateException;
 
@@ -85,5 +87,76 @@ final class Enrichments {
         Optional<E> result = Optional.ofNullable(any)
                                      .map(packed -> unpack(packed, enrichmentClass));
         return result;
+    }
+
+    /**
+     * Clears the enrichments from the {@code event} and its origin.
+     */
+    @SuppressWarnings("deprecation")
+    // Uses the `event_context` field to be sure to clean up old data.
+    static Event clear(Event event) {
+        EventContext context = event.getContext();
+        EventContext.OriginCase originCase = context.getOriginCase();
+        EventContext.Builder resultContext = context.toBuilder()
+                                                    .clearEnrichment();
+        if (originCase == EventContext.OriginCase.EVENT_CONTEXT) {
+            resultContext.setEventContext(context.getEventContext()
+                                                 .toBuilder()
+                                                 .clearEnrichment()
+                                                 .build());
+        }
+        Event result = event.toBuilder()
+                            .setContext(resultContext.build())
+                            .build();
+        return result;
+    }
+
+    /**
+     * Clears the enrichments from the {@code event} and all of its origin hierarchy.
+     */
+    @SuppressWarnings({
+            "deprecation" /* Uses the `event_context` field to be sure to clean up old data. */,
+            "ConstantConditions" /* Checked logically. */})
+    static Event clearAll(Event event) {
+        EventContext.Builder eventContext = event.getContext()
+                                            .toBuilder()
+                                            .clearEnrichment();
+        Deque<EventContext.Builder> contexts = eventContextHierarchy(eventContext);
+
+        EventContext.Builder context = contexts.pollLast();
+        EventContext.Builder next = contexts.pollLast();
+        while (next != null) {
+            context = next.setEventContext(context);
+            next = contexts.pollLast();
+        }
+        Event result = event.toBuilder()
+                            .setContext(context.build())
+                            .build();
+        return result;
+    }
+
+    /**
+     * Traverses the event origin hierarchy until non-{@link EventContext} origin is found.
+     *
+     * @return gathered origins in the form of {@code Deque<EventContext.Builder>}
+     */
+    @SuppressWarnings("deprecation")
+    // Uses the `event_context` field to be sure to clean up old data.
+    private static Deque<EventContext.Builder>
+    eventContextHierarchy(EventContext.Builder eventContext) {
+
+        EventContext.Builder child = eventContext;
+        EventContext.OriginCase originCase = child.getOriginCase();
+        Deque<EventContext.Builder> contexts = newArrayDeque();
+        contexts.add(child);
+        while (originCase == EventContext.OriginCase.EVENT_CONTEXT) {
+            EventContext.Builder origin = child.getEventContext()
+                                               .toBuilder()
+                                               .clearEnrichment();
+            contexts.add(origin);
+            child = origin;
+            originCase = child.getOriginCase();
+        }
+        return contexts;
     }
 }

--- a/core/src/main/java/io/spine/core/Enrichments.java
+++ b/core/src/main/java/io/spine/core/Enrichments.java
@@ -92,8 +92,7 @@ final class Enrichments {
     /**
      * Clears the enrichments from the {@code event} and its origin.
      */
-    @SuppressWarnings("deprecation")
-    // Uses the `event_context` field to be sure to clean up old data.
+    @SuppressWarnings("deprecation") // Uses the deprecated field to be sure to clean up old data.
     static Event clear(Event event) {
         EventContext context = event.getContext();
         EventContext.OriginCase originCase = context.getOriginCase();
@@ -115,7 +114,7 @@ final class Enrichments {
      * Clears the enrichments from the {@code event} and all of its origin hierarchy.
      */
     @SuppressWarnings({
-            "deprecation" /* Uses the `event_context` field to be sure to clean up old data. */,
+            "deprecation" /* Uses the deprecated field to be sure to clean up old data. */,
             "ConstantConditions" /* Checked logically. */})
     static Event clearAll(Event event) {
         EventContext.Builder eventContext = event.getContext()
@@ -140,8 +139,7 @@ final class Enrichments {
      *
      * @return gathered origins in the form of {@code Deque<EventContext.Builder>}
      */
-    @SuppressWarnings("deprecation")
-    // Uses the `event_context` field to be sure to clean up old data.
+    @SuppressWarnings("deprecation") // Uses the deprecated field to be sure to clean up old data.
     private static Deque<EventContext.Builder>
     eventContextHierarchy(EventContext.Builder eventContext) {
 

--- a/core/src/main/java/io/spine/core/Enrichments.java
+++ b/core/src/main/java/io/spine/core/Enrichments.java
@@ -138,7 +138,7 @@ final class Enrichments {
      * Traverses the event origin hierarchy until non-{@link EventContext} origin is found.
      *
      * <p>All of the {@link EventContext}-kind origins are collected and returned as
-     * {@code Deque<EventContext.Builder>}.
+     * {@code Deque<EventContext.Builder>}, where the deepest origin resides last.
      */
     @SuppressWarnings("deprecation") // Uses the deprecated field to be sure to clean up old data.
     private static Deque<EventContext.Builder>

--- a/core/src/main/java/io/spine/core/Enrichments.java
+++ b/core/src/main/java/io/spine/core/Enrichments.java
@@ -118,9 +118,9 @@ final class Enrichments {
             "ConstantConditions" /* Checked logically. */})
     static Event clearAll(Event event) {
         EventContext.Builder eventContext = event.getContext()
-                                            .toBuilder()
-                                            .clearEnrichment();
-        Deque<EventContext.Builder> contexts = eventOriginHierarchy(eventContext);
+                                                 .toBuilder()
+                                                 .clearEnrichment();
+        Deque<EventContext.Builder> contexts = eventContextHierarchy(eventContext);
 
         EventContext.Builder context = contexts.pollLast();
         EventContext.Builder next = contexts.pollLast();
@@ -142,7 +142,7 @@ final class Enrichments {
      */
     @SuppressWarnings("deprecation") // Uses the deprecated field to be sure to clean up old data.
     private static Deque<EventContext.Builder>
-    eventOriginHierarchy(EventContext.Builder eventContext) {
+    eventContextHierarchy(EventContext.Builder eventContext) {
 
         EventContext.Builder child = eventContext;
         EventContext.OriginCase originCase = child.getOriginCase();

--- a/core/src/main/java/io/spine/core/EventMixin.java
+++ b/core/src/main/java/io/spine/core/EventMixin.java
@@ -106,7 +106,8 @@ public interface EventMixin extends Signal<EventId, EventMessage, EventContext>,
      * <p>This method does not remove enrichments from second-level and deeper origins to avoid a
      * heavy performance operation.
      *
-     * <p>To remove enrichments from the whole origin hierarchy, use {@link #clearAllEnrichments()}.
+     * <p>To remove enrichments from the whole parent context hierarchy, use
+     * {@link #clearAllEnrichments()}.
      *
      * @return the event without enrichments
      */
@@ -117,7 +118,7 @@ public interface EventMixin extends Signal<EventId, EventMessage, EventContext>,
     }
 
     /**
-     * Creates a copy of this instance with enrichments cleared from self and origin hierarchy.
+     * Creates a copy of this instance with enrichments cleared from self and all parent contexts.
      *
      * <p>Use this method to decrease a size of an event, if enrichments aren't important.
      *

--- a/server/src/test/java/io/spine/core/EventTest.java
+++ b/server/src/test/java/io/spine/core/EventTest.java
@@ -204,11 +204,6 @@ public class EventTest extends UtilityClassTest<Events> {
             assertThat(event.tenant())
                     .isEqualTo(targetTenantId);
         }
-
-        private EventContext.Builder contextWithoutOrigin() {
-            return context.toBuilder()
-                          .clearOrigin();
-        }
     }
 
     @Test
@@ -233,5 +228,43 @@ public class EventTest extends UtilityClassTest<Events> {
     void tellWhenNotRejection() {
         assertThat(event.isRejection())
                 .isFalse();
+    }
+
+    @Test
+    @DisplayName("clear enrichments")
+    void clearEnrichments() {
+
+    }
+
+    @SuppressWarnings("deprecation") // Required for backward compatibility.
+    @Test
+    @DisplayName("clear enrichment hierarchy")
+    void clearEnrichmentHierarchy() {
+        Enrichment someEnrichment = Enrichment
+                .newBuilder()
+                .setDoNotEnrich(true)
+                .build();
+
+        EventContext.Builder grandOriginContext =
+                context.toBuilder()
+                       .setEnrichment(someEnrichment);
+        EventContext.Builder originContext = contextWithoutOrigin()
+                .setEventContext(grandOriginContext);
+        EventContext context =
+                contextWithoutOrigin()
+                        .setEventContext(originContext)
+                        .build();
+        Event event = event(context);
+
+        Event eventWithoutEnrichments = event.clearEnrichmentHierarchy();
+        EventContext grandOrigin = eventWithoutEnrichments.getContext()
+                                                          .getEventContext()
+                                                          .getEventContext();
+        assertThat(grandOrigin.hasEnrichment()).isFalse();
+    }
+
+    private EventContext.Builder contextWithoutOrigin() {
+        return context.toBuilder()
+                      .clearOrigin();
     }
 }

--- a/server/src/test/java/io/spine/core/EventTest.java
+++ b/server/src/test/java/io/spine/core/EventTest.java
@@ -56,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * <p>This test suite is placed under the {@code server} module to avoid dependency on the event
  * generation code which belongs to server-side.
  */
-@DisplayName("Event should")
+@DisplayName("`Event` should")
 public class EventTest extends UtilityClassTest<Events> {
 
     private static final TestActorRequestFactory requestFactory =

--- a/server/src/test/java/io/spine/core/EventTest.java
+++ b/server/src/test/java/io/spine/core/EventTest.java
@@ -230,10 +230,37 @@ public class EventTest extends UtilityClassTest<Events> {
                 .isFalse();
     }
 
+    @SuppressWarnings("deprecation") // Required for backward compatibility.
     @Test
-    @DisplayName("clear enrichments")
+    @DisplayName("clear enrichments from the event and its origin")
     void clearEnrichments() {
+        Enrichment someEnrichment = Enrichment
+                .newBuilder()
+                .setDoNotEnrich(true)
+                .build();
+        EventContext.Builder grandOriginContext =
+                context.toBuilder()
+                       .setEnrichment(someEnrichment);
+        EventContext.Builder originContext =
+                contextWithoutOrigin()
+                        .setEventContext(grandOriginContext)
+                        .setEnrichment(someEnrichment);
+        EventContext eventContext =
+                contextWithoutOrigin()
+                        .setEventContext(originContext)
+                        .setEnrichment(someEnrichment)
+                        .build();
+        Event event = event(eventContext);
 
+        Event eventWithoutEnrichments = event.clearEnrichments();
+
+        EventContext context = eventWithoutEnrichments.getContext();
+        EventContext origin = context.getEventContext();
+        EventContext grandOrigin = origin.getEventContext();
+
+        assertThat(context.hasEnrichment()).isFalse();
+        assertThat(origin.hasEnrichment()).isFalse();
+        assertThat(grandOrigin.hasEnrichment()).isTrue();
     }
 
     @SuppressWarnings("deprecation") // Required for backward compatibility.
@@ -247,8 +274,9 @@ public class EventTest extends UtilityClassTest<Events> {
         EventContext.Builder grandOriginContext =
                 context.toBuilder()
                        .setEnrichment(someEnrichment);
-        EventContext.Builder originContext = contextWithoutOrigin()
-                .setEventContext(grandOriginContext);
+        EventContext.Builder originContext =
+                contextWithoutOrigin()
+                        .setEventContext(grandOriginContext);
         EventContext context =
                 contextWithoutOrigin()
                         .setEventContext(originContext)

--- a/server/src/test/java/io/spine/core/EventTest.java
+++ b/server/src/test/java/io/spine/core/EventTest.java
@@ -244,7 +244,6 @@ public class EventTest extends UtilityClassTest<Events> {
                 .newBuilder()
                 .setDoNotEnrich(true)
                 .build();
-
         EventContext.Builder grandOriginContext =
                 context.toBuilder()
                        .setEnrichment(someEnrichment);
@@ -256,7 +255,8 @@ public class EventTest extends UtilityClassTest<Events> {
                         .build();
         Event event = event(context);
 
-        Event eventWithoutEnrichments = event.clearEnrichmentHierarchy();
+        Event eventWithoutEnrichments = event.clearAllEnrichments();
+
         EventContext grandOrigin = eventWithoutEnrichments.getContext()
                                                           .getEventContext()
                                                           .getEventContext();


### PR DESCRIPTION
This PR resolves #1000.

Now, `EventMixin` contains a `clearAllEnrichments()` method, which removes enrichments from the event itself and also from all of its parent contexts.

The old `clearEnrichments()` method works the same as previously.
