### PR TITLE
`AggregateStorage.index()` using `MirrorRepository`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.0.0`
+# Dependencies of `io.spine:spine-client:1.0.1-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -457,12 +457,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 07 13:49:10 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 08 17:09:04 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.0.0`
+# Dependencies of `io.spine:spine-core:1.0.1-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -865,12 +865,12 @@ This report was generated on **Wed Aug 07 13:49:10 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 07 13:49:14 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 08 17:09:05 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.0.0`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.0.1-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1321,12 +1321,12 @@ This report was generated on **Wed Aug 07 13:49:14 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 07 13:49:19 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 08 17:09:05 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.0.0`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.0.1-SNAPSHOT`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -1939,12 +1939,12 @@ This report was generated on **Wed Aug 07 13:49:19 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 07 13:49:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 08 17:09:06 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.0.0`
+# Dependencies of `io.spine:spine-server:1.0.1-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2461,12 +2461,12 @@ This report was generated on **Wed Aug 07 13:49:25 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 07 13:49:31 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 08 17:09:07 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.0.0`
+# Dependencies of `io.spine:spine-testutil-client:1.0.1-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2993,12 +2993,12 @@ This report was generated on **Wed Aug 07 13:49:31 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 07 13:49:37 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 08 17:09:07 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.0.0`
+# Dependencies of `io.spine:spine-testutil-core:1.0.1-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3533,12 +3533,12 @@ This report was generated on **Wed Aug 07 13:49:37 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 07 13:49:43 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 08 17:09:08 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.0.0`
+# Dependencies of `io.spine:spine-testutil-server:1.0.1-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -4119,4 +4119,4 @@ This report was generated on **Wed Aug 07 13:49:43 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 07 13:49:50 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 08 17:09:08 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -457,7 +457,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 06 16:53:00 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 07 13:49:10 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -865,7 +865,7 @@ This report was generated on **Tue Aug 06 16:53:00 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 06 16:53:03 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 07 13:49:14 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1321,7 +1321,7 @@ This report was generated on **Tue Aug 06 16:53:03 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 06 16:53:06 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 07 13:49:19 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1939,7 +1939,7 @@ This report was generated on **Tue Aug 06 16:53:06 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 06 16:53:10 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 07 13:49:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2461,7 +2461,7 @@ This report was generated on **Tue Aug 06 16:53:10 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 06 16:53:14 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 07 13:49:31 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2993,7 +2993,7 @@ This report was generated on **Tue Aug 06 16:53:14 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 06 16:53:18 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 07 13:49:37 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3533,7 +3533,7 @@ This report was generated on **Tue Aug 06 16:53:18 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 06 16:53:21 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 07 13:49:43 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4119,4 +4119,4 @@ This report was generated on **Tue Aug 06 16:53:21 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 06 16:53:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 07 13:49:50 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -457,7 +457,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Aug 04 18:40:51 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 06 16:53:00 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -865,7 +865,7 @@ This report was generated on **Sun Aug 04 18:40:51 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Aug 04 18:40:51 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 06 16:53:03 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1321,7 +1321,7 @@ This report was generated on **Sun Aug 04 18:40:51 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Aug 04 18:40:52 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 06 16:53:06 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1939,7 +1939,7 @@ This report was generated on **Sun Aug 04 18:40:52 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Aug 04 18:40:52 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 06 16:53:10 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2461,7 +2461,7 @@ This report was generated on **Sun Aug 04 18:40:52 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Aug 04 18:40:53 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 06 16:53:14 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2993,7 +2993,7 @@ This report was generated on **Sun Aug 04 18:40:53 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Aug 04 18:40:53 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 06 16:53:18 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3533,7 +3533,7 @@ This report was generated on **Sun Aug 04 18:40:53 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Aug 04 18:40:54 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 06 16:53:21 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4119,4 +4119,4 @@ This report was generated on **Sun Aug 04 18:40:54 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Aug 04 18:40:54 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 06 16:53:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.0.0</version>
+<version>1.0.1-SNAPSHOT</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -70,25 +70,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-time</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -124,25 +124,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-time</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -210,12 +210,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -50,6 +50,8 @@ import io.spine.server.type.CommandEnvelope;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
 import io.spine.server.type.SignalEnvelope;
+import io.spine.system.server.Mirror;
+import io.spine.system.server.MirrorRepository;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import java.util.Collection;
@@ -274,6 +276,10 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
     protected AggregateStorage<I> createStorage() {
         StorageFactory sf = defaultStorageFactory();
         AggregateStorage<I> result = sf.createAggregateStorage(context().spec(), entityClass());
+        Optional<MirrorRepository> mirrorRepository = context().systemClient()
+                                                               .systemRepositoryFor(Mirror.class)
+                                                               .map(MirrorRepository.class::cast);
+        mirrorRepository.ifPresent(repo -> result.configureMirror(repo, aggregateClass()));
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
@@ -86,7 +86,7 @@ public abstract class AggregateStorage<I>
     }
 
     /**
-     * Configures an aggregate {@code Mirror} to optimize the certain kinds of aggregate reads.
+     * Configures an aggregate {@code Mirror} to optimize certain kinds of aggregate reads.
      *
      * @param mirrorRepository
      *         the repository storing mirror {@linkplain MirrorProjection projections}

--- a/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
@@ -69,10 +69,10 @@ public abstract class AggregateStorage<I>
             "The specified snapshot index is incorrect";
 
     /**
-     * Executes certain kinds of aggregate reads using aggregate
-     * {@linkplain MirrorProjection mirrors}.
+     * Executes certain kinds of aggregate reads using the
+     * {@linkplain MirrorProjection mirror projections} of aggregates.
      *
-     * <p>Can be used to optimize performance-heavy storage operations.
+     * <p>Used to optimize performance-heavy storage operations.
      *
      * <p>Is {@code null} either if not yet configured or if the corresponding aggregate type
      * is not mirrored.
@@ -315,7 +315,7 @@ public abstract class AggregateStorage<I>
     protected abstract void truncate(int snapshotIndex, Timestamp date);
 
     /**
-     * Executes certain kinds of aggregate reads through {@link MirrorRepository}.
+     * Executes certain kinds of aggregate reads through the {@link MirrorRepository}.
      *
      * <p>Used to optimize performance-heavy operations on the storage.
      *

--- a/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
@@ -69,11 +69,13 @@ public abstract class AggregateStorage<I>
             "The specified snapshot index is incorrect";
 
     /**
-     * Executes certain kinds of aggregate reads through aggregate
-     * {@linkplain MirrorProjection mirror}.
+     * Executes certain kinds of aggregate reads using aggregate
+     * {@linkplain MirrorProjection mirrors}.
+     *
+     * <p>Can be used to optimize performance-heavy storage operations.
      *
      * <p>Is {@code null} either if not yet configured or if the corresponding aggregate type
-     * doesn't have a mirror.
+     * is not mirrored.
      *
      * @see MirrorRepository
      */

--- a/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
@@ -115,8 +115,9 @@ public abstract class AggregateStorage<I>
      * <p>Attempts to read aggregate IDs from the {@link MirrorRepository}, as they are already
      * stored there in a convenient form.
      *
-     * <p>If an aggregate {@link Mirror} is not configured, falls back to the default method of
-     * getting distinct aggregate IDs from the event records.
+     * <p>If an aggregate {@link MirrorRepository} is not configured to use for reads with this
+     * repository, falls back to the default method of getting distinct aggregate IDs
+     * from the event records.
      */
     @Override
     public Iterator<I> index() {
@@ -125,11 +126,6 @@ public abstract class AggregateStorage<I>
         }
         return distinctAggregateIds();
     }
-
-    /**
-     * Obtains distinct aggregate IDs from the stored event records.
-     */
-    protected abstract Iterator<I> distinctAggregateIds();
 
     /**
      * Forms and returns an {@link AggregateHistory} based on the
@@ -313,6 +309,11 @@ public abstract class AggregateStorage<I>
      * entity.
      */
     protected abstract void truncate(int snapshotIndex, Timestamp date);
+
+    /**
+     * Obtains distinct aggregate IDs from the stored event records.
+     */
+    protected abstract Iterator<I> distinctAggregateIds();
 
     /**
      * Executes certain kinds of aggregate reads through the {@link MirrorRepository}.

--- a/server/src/main/java/io/spine/server/storage/memory/InMemoryAggregateStorage.java
+++ b/server/src/main/java/io/spine/server/storage/memory/InMemoryAggregateStorage.java
@@ -62,7 +62,7 @@ class InMemoryAggregateStorage<I> extends AggregateStorage<I> {
     }
 
     @Override
-    public Iterator<I> index() {
+    protected Iterator<I> distinctAggregateIds() {
         return getStorage().index();
     }
 

--- a/server/src/main/java/io/spine/server/tenant/TenantAwareRunner.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantAwareRunner.java
@@ -52,6 +52,14 @@ public final class TenantAwareRunner {
         return new TenantAwareRunner(tenant);
     }
 
+    /**
+     * Creates a new {@code TenantAwareRunner}, which runs all the given operations for the current
+     * {@code tenant}.
+     *
+     * @param multitenant
+     *         if the current environment is multitenant
+     * @return new instance of {@code TenantAwareRunner}
+     */
     public static TenantAwareRunner withCurrentTenant(boolean multitenant) {
         return with(TenantAware.getCurrentTenant(multitenant));
     }

--- a/server/src/main/java/io/spine/server/tenant/TenantAwareRunner.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantAwareRunner.java
@@ -52,6 +52,10 @@ public final class TenantAwareRunner {
         return new TenantAwareRunner(tenant);
     }
 
+    public static TenantAwareRunner withCurrentTenant(boolean multitenant) {
+        return with(TenantAware.getCurrentTenant(multitenant));
+    }
+
     /**
      * Runs the given {@code operation} for the given tenant and returns the result of
      * the operation.

--- a/server/src/main/java/io/spine/system/server/DefaultSystemClient.java
+++ b/server/src/main/java/io/spine/system/server/DefaultSystemClient.java
@@ -21,7 +21,11 @@
 package io.spine.system.server;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.Message;
 import io.spine.server.BoundedContext;
+import io.spine.server.entity.Repository;
+
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -54,6 +58,11 @@ final class DefaultSystemClient implements SystemClient {
     @Override
     public SystemReadSide readSide() {
         return readSide;
+    }
+
+    @Override
+    public Optional<Repository> systemRepositoryFor(Class<? extends Message> stateClass) {
+        return context.findRepository(stateClass);
     }
 
     @Override

--- a/server/src/main/java/io/spine/system/server/MirrorProjection.java
+++ b/server/src/main/java/io/spine/system/server/MirrorProjection.java
@@ -23,6 +23,7 @@ package io.spine.system.server;
 import com.google.protobuf.Any;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.Message;
+import io.spine.annotation.Internal;
 import io.spine.client.CompositeFilter;
 import io.spine.client.IdFilter;
 import io.spine.client.Target;
@@ -63,9 +64,10 @@ import static java.util.stream.Collectors.toList;
  *         subscriber method is an event used by the framework to bind the method to the event type.
  *         The content of the event, in those cases, is irrelevant.
  */
-final class MirrorProjection extends Projection<MirrorId, Mirror, Mirror.Builder> {
+@Internal
+public final class MirrorProjection extends Projection<MirrorId, Mirror, Mirror.Builder> {
 
-    private static final String TYPE_COLUMN_NAME = "aggregate_type";
+    public static final String TYPE_COLUMN_NAME = "aggregate_type";
 
     MirrorProjection(MirrorId id) {
         super(id);

--- a/server/src/main/java/io/spine/system/server/MirrorRepository.java
+++ b/server/src/main/java/io/spine/system/server/MirrorRepository.java
@@ -97,9 +97,6 @@ public final class MirrorRepository
 
     /**
      * Tells if the entity type should be mirrored.
-     *
-     * <p>Currently, all {@code Aggregate} types with a
-     * non-{@linkplain EntityOption.Visibility#NONE private} visibility are mirrored.
      */
     public static boolean shouldMirror(TypeUrl type) {
         Kind kind = entityKind(type);

--- a/server/src/main/java/io/spine/system/server/MirrorRepository.java
+++ b/server/src/main/java/io/spine/system/server/MirrorRepository.java
@@ -65,7 +65,7 @@ import static io.spine.system.server.MirrorProjection.buildFilters;
  * <p>An entity has a mirror if all of the following conditions are met:
  * <ul>
  *     <li>the entity repository is registered in a domain bounded context;
- *     <li>the entity state is marked as an {@link EntityOption.Kind#AGGREGATE AGGREGATE};
+ *     <li>the entity state is marked as an {@link Kind#AGGREGATE AGGREGATE};
  *     <li>the aggregate is visible for querying or subscribing.
  * </ul>
  *

--- a/server/src/main/java/io/spine/system/server/MirrorRepository.java
+++ b/server/src/main/java/io/spine/system/server/MirrorRepository.java
@@ -26,6 +26,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.Message;
+import io.spine.annotation.Internal;
 import io.spine.client.EntityStateWithVersion;
 import io.spine.client.Query;
 import io.spine.client.ResponseFormat;
@@ -70,7 +71,9 @@ import static io.spine.system.server.MirrorProjection.buildFilters;
  *
  * <p>In other cases, an entity won't have a {@link Mirror}.
  */
-final class MirrorRepository extends ProjectionRepository<MirrorId, MirrorProjection, Mirror> {
+@Internal
+public final class MirrorRepository
+        extends ProjectionRepository<MirrorId, MirrorProjection, Mirror> {
 
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
     private static final FieldMask AGGREGATE_STATE_WITH_VERSION = fromFieldNumbers(
@@ -92,19 +95,19 @@ final class MirrorRepository extends ProjectionRepository<MirrorId, MirrorProjec
                       (message, context) -> targetsFrom(message.getEntity()));
     }
 
+    public static boolean shouldMirror(TypeUrl type) {
+        Kind kind = entityKind(type);
+        EntityVisibility visibility = entityVisibility(type);
+        boolean aggregate = kind == AGGREGATE && visibility.isNotNone();
+        return aggregate;
+    }
+
     private static Set<MirrorId> targetsFrom(MessageId entityId) {
         TypeUrl type = TypeUrl.parse(entityId.getTypeUrl());
         boolean shouldMirror = shouldMirror(type);
         return shouldMirror
                ? ImmutableSet.of(idFrom(entityId))
                : ImmutableSet.of();
-    }
-
-    private static boolean shouldMirror(TypeUrl type) {
-        Kind kind = entityKind(type);
-        EntityVisibility visibility = entityVisibility(type);
-        boolean aggregate = kind == AGGREGATE && visibility.isNotNone();
-        return aggregate;
     }
 
     private static EntityOption.Kind entityKind(TypeUrl type) {

--- a/server/src/main/java/io/spine/system/server/MirrorRepository.java
+++ b/server/src/main/java/io/spine/system/server/MirrorRepository.java
@@ -95,6 +95,12 @@ public final class MirrorRepository
                       (message, context) -> targetsFrom(message.getEntity()));
     }
 
+    /**
+     * Tells if the entity type should be mirrored.
+     *
+     * <p>Currently, all {@code Aggregate} types with a
+     * non-{@linkplain EntityOption.Visibility#NONE private} visibility are mirrored.
+     */
     public static boolean shouldMirror(TypeUrl type) {
         Kind kind = entityKind(type);
         EntityVisibility visibility = entityVisibility(type);

--- a/server/src/main/java/io/spine/system/server/NoOpSystemClient.java
+++ b/server/src/main/java/io/spine/system/server/NoOpSystemClient.java
@@ -20,6 +20,11 @@
 
 package io.spine.system.server;
 
+import com.google.protobuf.Message;
+import io.spine.server.entity.Repository;
+
+import java.util.Optional;
+
 /**
  * An implementation of {@link SystemClient} which never performs an action.
  *
@@ -40,6 +45,11 @@ public enum NoOpSystemClient implements SystemClient {
     @Override
     public NoOpSystemReadSide readSide() {
         return NoOpSystemReadSide.INSTANCE;
+    }
+
+    @Override
+    public Optional<Repository> systemRepositoryFor(Class<? extends Message> stateClass) {
+        return Optional.empty();
     }
 
     @Override

--- a/server/src/main/java/io/spine/system/server/SystemClient.java
+++ b/server/src/main/java/io/spine/system/server/SystemClient.java
@@ -42,6 +42,9 @@ public interface SystemClient {
      */
     SystemReadSide readSide();
 
+    /**
+     * Finds a system repository by the state class of entities.
+     */
     Optional<Repository> systemRepositoryFor(Class<? extends Message> stateClass);
 
     /**

--- a/server/src/main/java/io/spine/system/server/SystemClient.java
+++ b/server/src/main/java/io/spine/system/server/SystemClient.java
@@ -20,7 +20,11 @@
 
 package io.spine.system.server;
 
+import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
+import io.spine.server.entity.Repository;
+
+import java.util.Optional;
 
 /**
  * The entry point of a system context API exposed to its domain counterpart.
@@ -37,6 +41,8 @@ public interface SystemClient {
      * Obtains the system context read side.
      */
     SystemReadSide readSide();
+
+    Optional<Repository> systemRepositoryFor(Class<? extends Message> stateClass);
 
     /**
      * Closes the underlying system context.

--- a/server/src/test/proto/spine/test/delivery/calc.proto
+++ b/server/src/test/proto/spine/test/delivery/calc.proto
@@ -11,6 +11,8 @@ option java_multiple_files = true;
 
 message Calc {
 
+    option (entity).kind = AGGREGATE;
+
     string id = 1;
 
     int32 sum = 2;

--- a/server/src/test/proto/spine/test/model/contexts/orders/order.proto
+++ b/server/src/test/proto/spine/test/model/contexts/orders/order.proto
@@ -32,6 +32,9 @@ message OrderId {
 }
 
 message Order {
+
+    option (entity).kind = AGGREGATE;
+
     OrderId id = 1;
     string name = 2 [(required) = true];
     repeated Item item = 3;

--- a/version.gradle
+++ b/version.gradle
@@ -25,15 +25,15 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '1.0.0'
+def final SPINE_VERSION = '1.0.1-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.
     versionToPublish = SPINE_VERSION
 
     // Depend on `base` for the general definitions and a model compiler.
-    spineBaseVersion = SPINE_VERSION
+    spineBaseVersion = '1.0.1'
 
     // Depend on `time` for `ZoneId`, `ZoneOffset` and other date/time types and utilities.
-    spineTimeVersion = SPINE_VERSION
+    spineTimeVersion = '1.0.1'
 }


### PR DESCRIPTION
This PR optimizes the work of `AggregateStorage.index()` method.

From now on it will try to get aggregate IDs from the `MirrorRepository`, where they are already stored in a convenient form for reading.

If, for some reason, the aggregate mirror is inaccessible, the `index()` method will fall back to the old implementation, where the distinct aggregate IDs are extracted from the huge amount of event records.

The version is now `1.0.1-SNAPSHOT`. The `base` and `time` versions used are `1.0.1`.