### PR TITLE
Better parameters

### DIFF
--- a/.idea/dictionaries/common.xml
+++ b/.idea/dictionaries/common.xml
@@ -38,6 +38,7 @@
       <w>oneof</w>
       <w>onmessage</w>
       <w>onopen</w>
+      <w>overriden</w>
       <w>parameterizing</w>
       <w>plugable</w>
       <w>processmanager</w>

--- a/license-report.md
+++ b/license-report.md
@@ -457,7 +457,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 18:39:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 29 15:53:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -865,7 +865,7 @@ This report was generated on **Wed Aug 28 18:39:38 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 18:39:39 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 29 15:53:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1321,7 +1321,7 @@ This report was generated on **Wed Aug 28 18:39:39 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 18:39:39 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 29 15:53:26 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1939,7 +1939,7 @@ This report was generated on **Wed Aug 28 18:39:39 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 18:39:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 29 15:53:27 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2461,7 +2461,7 @@ This report was generated on **Wed Aug 28 18:39:40 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 18:39:41 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 29 15:53:28 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2993,7 +2993,7 @@ This report was generated on **Wed Aug 28 18:39:41 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 18:39:41 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 29 15:53:29 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3533,7 +3533,7 @@ This report was generated on **Wed Aug 28 18:39:41 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 18:39:41 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 29 15:53:29 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4119,4 +4119,4 @@ This report was generated on **Wed Aug 28 18:39:41 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 18:39:42 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Aug 29 15:53:30 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/server/src/main/java/io/spine/server/aggregate/model/AllowImportAttribute.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/AllowImportAttribute.java
@@ -22,7 +22,7 @@ package io.spine.server.aggregate.model;
 
 import com.google.errorprone.annotations.Immutable;
 import io.spine.server.aggregate.Apply;
-import io.spine.server.model.MethodAttribute;
+import io.spine.server.model.Attribute;
 
 import java.lang.reflect.Method;
 
@@ -37,7 +37,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @see io.spine.server.aggregate.Apply#allowImport()
  */
 @Immutable
-public enum AllowImportAttribute implements MethodAttribute<Boolean> {
+public enum AllowImportAttribute implements Attribute<Boolean> {
 
     ALLOW(true),
 
@@ -50,12 +50,12 @@ public enum AllowImportAttribute implements MethodAttribute<Boolean> {
     }
 
     @Override
-    public String getName() {
+    public String parameter() {
         return "allowImport";
     }
 
     @Override
-    public Boolean getValue() {
+    public Boolean value() {
         return value;
     }
 
@@ -64,14 +64,17 @@ public enum AllowImportAttribute implements MethodAttribute<Boolean> {
      *
      * <p>The passed method must be an {@linkplain Apply event applier}.
      *
-     * @param method the method to inspect
+     * @param method
+     *         the method to inspect
      * @return the value of {@code AllowImportAttribute} for the given {@code Method}
-     * @throws IllegalArgumentException if the passed method is not properly annotated
+     * @throws IllegalArgumentException
+     *         if the passed method is not properly annotated
      */
     public static AllowImportAttribute of(Method method) {
         checkNotNull(method);
         Apply annotation = method.getAnnotation(Apply.class);
-        checkArgument(annotation != null, "The method `%s` is not annotated with `@Apply`", method);
+        checkArgument(annotation != null, "The method `%s` is not annotated with `@Apply`.",
+                      method);
         AllowImportAttribute result = annotation.allowImport() ? ALLOW : DO_NOT_ALLOW;
         return result;
     }

--- a/server/src/main/java/io/spine/server/aggregate/model/AllowImportAttribute.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/AllowImportAttribute.java
@@ -73,7 +73,8 @@ public enum AllowImportAttribute implements Attribute<Boolean> {
     public static AllowImportAttribute of(Method method) {
         checkNotNull(method);
         Apply annotation = method.getAnnotation(Apply.class);
-        checkArgument(annotation != null, "The method `%s` is not annotated with `@Apply`.",
+        checkArgument(annotation != null,
+                      "The method `%s` is not annotated with `@Apply`.",
                       method);
         AllowImportAttribute result = annotation.allowImport() ? ALLOW : DO_NOT_ALLOW;
         return result;

--- a/server/src/main/java/io/spine/server/aggregate/model/Applier.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/Applier.java
@@ -25,7 +25,7 @@ import com.google.common.collect.Sets;
 import io.spine.base.EventMessage;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.model.AbstractHandlerMethod;
-import io.spine.server.model.MethodAttribute;
+import io.spine.server.model.Attribute;
 import io.spine.server.model.ParameterSpec;
 import io.spine.server.model.VoidMethod;
 import io.spine.server.type.EmptyClass;
@@ -63,7 +63,7 @@ public final class Applier
      * Adds {@link AllowImportAttribute} to the set of method attributes.
      */
     @Override
-    protected Set<Function<Method, MethodAttribute<?>>> attributeSuppliers() {
+    protected Set<Function<Method, Attribute<?>>> attributeSuppliers() {
         return Sets.union(super.attributeSuppliers(), ImmutableSet.of(AllowImportAttribute::of));
     }
 

--- a/server/src/main/java/io/spine/server/aggregate/model/EventApplierSignature.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/EventApplierSignature.java
@@ -33,8 +33,6 @@ import io.spine.server.type.EventEnvelope;
 
 import java.lang.reflect.Method;
 
-import static io.spine.server.model.MethodParams.consistsOfSingle;
-
 /**
  * The signature of the {@link Applier} method.
  */
@@ -79,11 +77,6 @@ final class EventApplierSignature extends MethodSignature<Applier, EventEnvelope
     enum EventApplierParams implements ParameterSpec<EventEnvelope> {
 
         MESSAGE {
-            @Override
-            public boolean matches(Class<?>[] methodParams) {
-                return consistsOfSingle(methodParams, EventMessage.class);
-            }
-
             @Override
             public boolean matches(MethodParams params) {
                 return params.is(EventMessage.class);

--- a/server/src/main/java/io/spine/server/aggregate/model/EventApplierSignature.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/EventApplierSignature.java
@@ -53,8 +53,8 @@ final class EventApplierSignature extends MethodSignature<Applier, EventEnvelope
     }
 
     @Override
-    public Applier doCreate(Method method, ParameterSpec<EventEnvelope> parameterSpec) {
-        return new Applier(method, parameterSpec);
+    public Applier create(Method method, ParameterSpec<EventEnvelope> params) {
+        return new Applier(method, params);
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/aggregate/model/EventApplierSignature.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/EventApplierSignature.java
@@ -39,13 +39,17 @@ import static io.spine.server.model.MethodParams.consistsOfSingle;
  */
 final class EventApplierSignature extends MethodSignature<Applier, EventEnvelope> {
 
+    private static final ImmutableSet<Class<?>> RETURN_TYPES = ImmutableSet.of(void.class);
+    private static final ImmutableSet<AccessModifier> MODIFIERS =
+            ImmutableSet.of(AccessModifier.PRIVATE);
+
     EventApplierSignature() {
         super(Apply.class);
     }
 
     @Override
     protected ImmutableSet<Class<?>> returnTypes() {
-        return ImmutableSet.of(void.class);
+        return RETURN_TYPES;
     }
 
     @Override
@@ -55,7 +59,7 @@ final class EventApplierSignature extends MethodSignature<Applier, EventEnvelope
 
     @Override
     protected ImmutableSet<AccessModifier> modifiers() {
-        return ImmutableSet.of(AccessModifier.PRIVATE);
+        return MODIFIERS;
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/aggregate/model/EventApplierSignature.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/EventApplierSignature.java
@@ -39,9 +39,12 @@ import static io.spine.server.model.MethodParams.consistsOfSingle;
  */
 final class EventApplierSignature extends MethodSignature<Applier, EventEnvelope> {
 
-    private static final ImmutableSet<Class<?>> RETURN_TYPES = ImmutableSet.of(void.class);
-    private static final ImmutableSet<AccessModifier> MODIFIERS =
-            ImmutableSet.of(AccessModifier.PRIVATE);
+    private static final ImmutableSet<Class<?>>
+            RETURN_TYPES = ImmutableSet.of(void.class);
+    private static final ImmutableSet<AccessModifier>
+            MODIFIERS = ImmutableSet.of(AccessModifier.PRIVATE);
+    private static final ImmutableSet<EventApplierParams>
+            PARAM_SPEC = ImmutableSet.copyOf(EventApplierParams.values());
 
     EventApplierSignature() {
         super(Apply.class);
@@ -64,7 +67,7 @@ final class EventApplierSignature extends MethodSignature<Applier, EventEnvelope
 
     @Override
     public ImmutableSet<? extends ParameterSpec<EventEnvelope>> paramSpecs() {
-        return ImmutableSet.copyOf(EventApplierParams.values());
+        return PARAM_SPEC;
     }
 
     /**

--- a/server/src/main/java/io/spine/server/aggregate/model/EventApplierSignature.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/EventApplierSignature.java
@@ -26,6 +26,7 @@ import com.google.errorprone.annotations.Immutable;
 import io.spine.base.EventMessage;
 import io.spine.server.aggregate.Apply;
 import io.spine.server.model.AccessModifier;
+import io.spine.server.model.MethodParams;
 import io.spine.server.model.MethodSignature;
 import io.spine.server.model.ParameterSpec;
 import io.spine.server.type.EventEnvelope;
@@ -81,6 +82,11 @@ final class EventApplierSignature extends MethodSignature<Applier, EventEnvelope
             @Override
             public boolean matches(Class<?>[] methodParams) {
                 return consistsOfSingle(methodParams, EventMessage.class);
+            }
+
+            @Override
+            public boolean matches(MethodParams params) {
+                return params.is(EventMessage.class);
             }
 
             @Override

--- a/server/src/main/java/io/spine/server/command/model/CommandAcceptingSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandAcceptingSignature.java
@@ -46,13 +46,16 @@ abstract class CommandAcceptingSignature
         <H extends HandlerMethod<?, CommandClass, CommandEnvelope, ?>>
         extends MethodSignature<H, CommandEnvelope> {
 
+    private static final ImmutableSet<CommandAcceptingMethodParams> PARAM_SPECS =
+            ImmutableSet.copyOf(CommandAcceptingMethodParams.values());
+
     CommandAcceptingSignature(Class<? extends Annotation> annotation) {
         super(annotation);
     }
 
     @Override
     public ImmutableSet<? extends ParameterSpec<CommandEnvelope>> paramSpecs() {
-        return ImmutableSet.copyOf(CommandAcceptingMethodParams.values());
+        return PARAM_SPECS;
     }
 
     /**

--- a/server/src/main/java/io/spine/server/command/model/CommandAcceptingSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandAcceptingSignature.java
@@ -35,9 +35,6 @@ import io.spine.server.type.CommandEnvelope;
 import java.lang.annotation.Annotation;
 import java.util.Optional;
 
-import static io.spine.server.model.MethodParams.consistsOfSingle;
-import static io.spine.server.model.MethodParams.consistsOfTwo;
-
 /**
  * The signature of a method, that accepts {@code Command} envelopes as parameter values.
  *
@@ -81,11 +78,6 @@ abstract class CommandAcceptingSignature
 
         MESSAGE {
             @Override
-            public boolean matches(Class<?>[] methodParams) {
-                return consistsOfSingle(methodParams, CommandMessage.class);
-            }
-
-            @Override
             public boolean matches(MethodParams params) {
                 return params.is(CommandMessage.class);
             }
@@ -97,11 +89,6 @@ abstract class CommandAcceptingSignature
         },
 
         MESSAGE_AND_CONTEXT {
-            @Override
-            public boolean matches(Class<?>[] methodParams) {
-                return consistsOfTwo(methodParams, CommandMessage.class, CommandContext.class);
-            }
-
             @Override
             public boolean matches(MethodParams params) {
                 return params.are(CommandMessage.class, CommandContext.class);

--- a/server/src/main/java/io/spine/server/command/model/CommandAcceptingSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandAcceptingSignature.java
@@ -46,8 +46,11 @@ abstract class CommandAcceptingSignature
         <H extends HandlerMethod<?, CommandClass, CommandEnvelope, ?>>
         extends MethodSignature<H, CommandEnvelope> {
 
-    private static final ImmutableSet<CommandAcceptingMethodParams> PARAM_SPECS =
-            ImmutableSet.copyOf(CommandAcceptingMethodParams.values());
+    private static final ImmutableSet<CommandAcceptingMethodParams>
+            PARAM_SPECS = ImmutableSet.copyOf(CommandAcceptingMethodParams.values());
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType") // to save on allocations.
+    private static final Optional<Class<? extends Throwable>>
+            ALLOWED_THROWABLE = Optional.of(ThrowableMessage.class);
 
     CommandAcceptingSignature(Class<? extends Annotation> annotation) {
         super(annotation);
@@ -66,7 +69,7 @@ abstract class CommandAcceptingSignature
      */
     @Override
     protected Optional<Class<? extends Throwable>> allowedThrowable() {
-        return Optional.of(ThrowableMessage.class);
+        return ALLOWED_THROWABLE;
     }
 
     /**

--- a/server/src/main/java/io/spine/server/command/model/CommandAcceptingSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandAcceptingSignature.java
@@ -26,6 +26,7 @@ import io.spine.base.CommandMessage;
 import io.spine.base.ThrowableMessage;
 import io.spine.core.CommandContext;
 import io.spine.server.model.HandlerMethod;
+import io.spine.server.model.MethodParams;
 import io.spine.server.model.MethodSignature;
 import io.spine.server.model.ParameterSpec;
 import io.spine.server.type.CommandClass;
@@ -85,6 +86,11 @@ abstract class CommandAcceptingSignature
             }
 
             @Override
+            public boolean matches(MethodParams params) {
+                return params.is(CommandMessage.class);
+            }
+
+            @Override
             public Object[] extractArguments(CommandEnvelope envelope) {
                 return new Object[]{envelope.message()};
             }
@@ -94,6 +100,11 @@ abstract class CommandAcceptingSignature
             @Override
             public boolean matches(Class<?>[] methodParams) {
                 return consistsOfTwo(methodParams, CommandMessage.class, CommandContext.class);
+            }
+
+            @Override
+            public boolean matches(MethodParams params) {
+                return params.are(CommandMessage.class, CommandContext.class);
             }
 
             @Override

--- a/server/src/main/java/io/spine/server/command/model/CommandHandlerSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandHandlerSignature.java
@@ -47,7 +47,7 @@ public final class CommandHandlerSignature
     }
 
     @Override
-    public CommandHandlerMethod doCreate(Method method, ParameterSpec<CommandEnvelope> paramSpec) {
-        return new CommandHandlerMethod(method, paramSpec);
+    public CommandHandlerMethod create(Method method, ParameterSpec<CommandEnvelope> params) {
+        return new CommandHandlerMethod(method, params);
     }
 }

--- a/server/src/main/java/io/spine/server/command/model/CommandHandlerSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandHandlerSignature.java
@@ -34,8 +34,8 @@ import java.lang.reflect.Method;
 public final class CommandHandlerSignature
         extends CommandAcceptingSignature<CommandHandlerMethod> {
 
-    private static final ImmutableSet<Class<?>> RETURN_TYPES =
-            ImmutableSet.of(EventMessage.class, Iterable.class);
+    private static final ImmutableSet<Class<?>>
+            RETURN_TYPES = ImmutableSet.of(EventMessage.class, Iterable.class);
 
     public CommandHandlerSignature() {
         super(Assign.class);

--- a/server/src/main/java/io/spine/server/command/model/CommandHandlerSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandHandlerSignature.java
@@ -34,18 +34,20 @@ import java.lang.reflect.Method;
 public final class CommandHandlerSignature
         extends CommandAcceptingSignature<CommandHandlerMethod> {
 
+    private static final ImmutableSet<Class<?>> RETURN_TYPES =
+            ImmutableSet.of(EventMessage.class, Iterable.class);
+
     public CommandHandlerSignature() {
         super(Assign.class);
     }
 
     @Override
     protected ImmutableSet<Class<?>> returnTypes() {
-        return ImmutableSet.of(EventMessage.class, Iterable.class);
+        return RETURN_TYPES;
     }
 
     @Override
-    public CommandHandlerMethod doCreate(Method method,
-                                         ParameterSpec<CommandEnvelope> parameterSpec) {
-        return new CommandHandlerMethod(method, parameterSpec);
+    public CommandHandlerMethod doCreate(Method method, ParameterSpec<CommandEnvelope> paramSpec) {
+        return new CommandHandlerMethod(method, paramSpec);
     }
 }

--- a/server/src/main/java/io/spine/server/command/model/CommandReactionSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandReactionSignature.java
@@ -101,6 +101,11 @@ public class CommandReactionSignature
             }
 
             @Override
+            public boolean matches(MethodParams params) {
+                return params.is(EventMessage.class);
+            }
+
+            @Override
             public Object[] extractArguments(EventEnvelope event) {
                 return new Object[]{event.message()};
             }
@@ -113,6 +118,11 @@ public class CommandReactionSignature
             }
 
             @Override
+            public boolean matches(MethodParams params) {
+                return params.are(EventMessage.class, EventContext.class);
+            }
+
+            @Override
             public Object[] extractArguments(EventEnvelope event) {
                 return new Object[]{event.message(), event.context()};
             }
@@ -122,6 +132,11 @@ public class CommandReactionSignature
             @Override
             public boolean matches(Class<?>[] methodParams) {
                 return consistsOfTwo(methodParams, RejectionMessage.class, CommandContext.class);
+            }
+
+            @Override
+            public boolean matches(MethodParams params) {
+                return params.are(RejectionMessage.class, CommandContext.class);
             }
 
             @Override

--- a/server/src/main/java/io/spine/server/command/model/CommandReactionSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandReactionSignature.java
@@ -45,24 +45,28 @@ import static io.spine.server.model.MethodParams.consistsOfTwo;
 public class CommandReactionSignature
         extends MethodSignature<CommandReactionMethod, EventEnvelope> {
 
+    private static final ImmutableSet<CommandReactionParams> PARAM_SPECS =
+            ImmutableSet.copyOf(CommandReactionParams.values());
+    private static final ImmutableSet<Class<?>> RETURN_TYPES =
+            ImmutableSet.of(CommandMessage.class, Iterable.class, Optional.class);
+
     CommandReactionSignature() {
         super(Command.class);
     }
 
     @Override
     public ImmutableSet<? extends ParameterSpec<EventEnvelope>> paramSpecs() {
-        return ImmutableSet.copyOf(CommandReactionParams.values());
+        return PARAM_SPECS;
     }
 
     @Override
     protected ImmutableSet<Class<?>> returnTypes() {
-        return ImmutableSet.of(CommandMessage.class, Iterable.class, Optional.class);
+        return RETURN_TYPES;
     }
 
     @Override
-    public CommandReactionMethod doCreate(Method method,
-                                          ParameterSpec<EventEnvelope> parameterSpec) {
-        return new CommandReactionMethod(method, parameterSpec);
+    public CommandReactionMethod doCreate(Method method, ParameterSpec<EventEnvelope> paramSpec) {
+        return new CommandReactionMethod(method, paramSpec);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/command/model/CommandReactionSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandReactionSignature.java
@@ -45,10 +45,10 @@ import static io.spine.server.model.MethodParams.consistsOfTwo;
 public class CommandReactionSignature
         extends MethodSignature<CommandReactionMethod, EventEnvelope> {
 
-    private static final ImmutableSet<CommandReactionParams> PARAM_SPECS =
-            ImmutableSet.copyOf(CommandReactionParams.values());
-    private static final ImmutableSet<Class<?>> RETURN_TYPES =
-            ImmutableSet.of(CommandMessage.class, Iterable.class, Optional.class);
+    private static final ImmutableSet<CommandReactionParams>
+            PARAM_SPECS = ImmutableSet.copyOf(CommandReactionParams.values());
+    private static final ImmutableSet<Class<?>>
+            RETURN_TYPES = ImmutableSet.of(CommandMessage.class, Iterable.class, Optional.class);
 
     CommandReactionSignature() {
         super(Command.class);

--- a/server/src/main/java/io/spine/server/command/model/CommandReactionSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandReactionSignature.java
@@ -65,8 +65,8 @@ public class CommandReactionSignature
     }
 
     @Override
-    public CommandReactionMethod doCreate(Method method, ParameterSpec<EventEnvelope> paramSpec) {
-        return new CommandReactionMethod(method, paramSpec);
+    public CommandReactionMethod create(Method method, ParameterSpec<EventEnvelope> params) {
+        return new CommandReactionMethod(method, params);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/command/model/CommandReactionSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandReactionSignature.java
@@ -36,9 +36,6 @@ import io.spine.server.type.EventEnvelope;
 import java.lang.reflect.Method;
 import java.util.Optional;
 
-import static io.spine.server.model.MethodParams.consistsOfSingle;
-import static io.spine.server.model.MethodParams.consistsOfTwo;
-
 /**
  * A signature of {@link CommandReactionMethod}.
  */
@@ -74,15 +71,14 @@ public class CommandReactionSignature
      * <p>
      * @implNote This method distinguishes {@linkplain Command Commander} methods one from another,
      * as they use the same annotation, but have different parameter list. It skips the methods
-     * which first parameter {@linkplain MethodParams#isFirstParamCommand(Method) is }
+     * which first parameter {@linkplain MethodParams#firstIsCommand(Method) is }
      * a {@code Command} message.
      */
     @Override
     protected boolean skipMethod(Method method) {
         boolean parentResult = !super.skipMethod(method);
-
-        if(parentResult) {
-            return MethodParams.isFirstParamCommand(method);
+        if (parentResult) {
+            return MethodParams.firstIsCommand(method);
         }
         return true;
     }
@@ -96,11 +92,6 @@ public class CommandReactionSignature
 
         MESSAGE {
             @Override
-            public boolean matches(Class<?>[] methodParams) {
-                return consistsOfSingle(methodParams, EventMessage.class);
-            }
-
-            @Override
             public boolean matches(MethodParams params) {
                 return params.is(EventMessage.class);
             }
@@ -112,11 +103,6 @@ public class CommandReactionSignature
         },
 
         EVENT_AND_EVENT_CONTEXT {
-            @Override
-            public boolean matches(Class<?>[] methodParams) {
-                return consistsOfTwo(methodParams, EventMessage.class, EventContext.class);
-            }
-
             @Override
             public boolean matches(MethodParams params) {
                 return params.are(EventMessage.class, EventContext.class);
@@ -130,21 +116,17 @@ public class CommandReactionSignature
 
         REJECTION_AND_COMMAND_CONTEXT {
             @Override
-            public boolean matches(Class<?>[] methodParams) {
-                return consistsOfTwo(methodParams, RejectionMessage.class, CommandContext.class);
-            }
-
-            @Override
             public boolean matches(MethodParams params) {
                 return params.are(RejectionMessage.class, CommandContext.class);
             }
 
             @Override
             public Object[] extractArguments(EventEnvelope event) {
-                CommandContext originContext = event.context()
-                                                    .getRejection()
-                                                    .getCommand()
-                                                    .getContext();
+                CommandContext originContext =
+                        event.context()
+                             .getRejection()
+                             .getCommand()
+                             .getContext();
                 return new Object[]{event.message(), originContext};
             }
         }

--- a/server/src/main/java/io/spine/server/command/model/CommandSubstituteSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandSubstituteSignature.java
@@ -58,16 +58,15 @@ public class CommandSubstituteSignature
      *
      * @implNote This method distinguishes {@linkplain Command Commander} methods one from
      * another, as they use the same annotation, but have different parameter list. It skips
-     * the methods which first parameter {@linkplain MethodParams#isFirstParamCommand(Method)
+     * the methods which first parameter {@linkplain MethodParams#firstIsCommand(Method)
      * is NOT} a {@code Command} message.
      */
     @SuppressWarnings("UnnecessaryInheritDoc") // IDEA bug.
     @Override
     protected boolean skipMethod(Method method) {
         boolean parentResult = !super.skipMethod(method);
-
         if (parentResult) {
-            return !MethodParams.isFirstParamCommand(method);
+            return !MethodParams.firstIsCommand(method);
         }
         return true;
     }

--- a/server/src/main/java/io/spine/server/command/model/CommandSubstituteSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandSubstituteSignature.java
@@ -44,9 +44,8 @@ public class CommandSubstituteSignature
     }
 
     @Override
-    public CommandSubstituteMethod doCreate(Method method,
-                                            ParameterSpec<CommandEnvelope> paramSpec) {
-        return new CommandSubstituteMethod(method, paramSpec);
+    public CommandSubstituteMethod create(Method method, ParameterSpec<CommandEnvelope> params) {
+        return new CommandSubstituteMethod(method, params);
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/command/model/CommandSubstituteSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandSubstituteSignature.java
@@ -36,19 +36,22 @@ import java.lang.reflect.Method;
 public class CommandSubstituteSignature
         extends CommandAcceptingSignature<CommandSubstituteMethod> {
 
+    private static final ImmutableSet<Class<?>> RETURN_TYPES =
+            ImmutableSet.of(CommandMessage.class, Iterable.class);
+
     CommandSubstituteSignature() {
         super(Command.class);
     }
 
     @Override
     public CommandSubstituteMethod doCreate(Method method,
-                                            ParameterSpec<CommandEnvelope> parameterSpec) {
-        return new CommandSubstituteMethod(method, parameterSpec);
+                                            ParameterSpec<CommandEnvelope> paramSpec) {
+        return new CommandSubstituteMethod(method, paramSpec);
     }
 
     @Override
     protected ImmutableSet<Class<?>> returnTypes() {
-        return ImmutableSet.of(CommandMessage.class, Iterable.class);
+        return RETURN_TYPES;
     }
 
     /**

--- a/server/src/main/java/io/spine/server/command/model/CommandSubstituteSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandSubstituteSignature.java
@@ -36,8 +36,8 @@ import java.lang.reflect.Method;
 public class CommandSubstituteSignature
         extends CommandAcceptingSignature<CommandSubstituteMethod> {
 
-    private static final ImmutableSet<Class<?>> RETURN_TYPES =
-            ImmutableSet.of(CommandMessage.class, Iterable.class);
+    private static final ImmutableSet<Class<?>>
+            RETURN_TYPES = ImmutableSet.of(CommandMessage.class, Iterable.class);
 
     CommandSubstituteSignature() {
         super(Command.class);

--- a/server/src/main/java/io/spine/server/event/model/EventAcceptingMethodParams.java
+++ b/server/src/main/java/io/spine/server/event/model/EventAcceptingMethodParams.java
@@ -34,8 +34,6 @@ import io.spine.server.model.MethodParams;
 import io.spine.server.model.ParameterSpec;
 import io.spine.server.type.EventEnvelope;
 
-import static io.spine.server.model.MethodParams.consistsOfTypes;
-
 /**
  * Allowed combinations of parameters for the methods, that accept {@code Event}s.
  */
@@ -97,11 +95,6 @@ enum EventAcceptingMethodParams implements ParameterSpec<EventEnvelope> {
     EventAcceptingMethodParams(boolean awareOfCommandType, Class<?>... parameters) {
         this.expectedParameters = ImmutableList.copyOf(parameters);
         this.awareOfCommandType = awareOfCommandType;
-    }
-
-    @Override
-    public boolean matches(Class<?>[] methodParams) {
-        return consistsOfTypes(methodParams, expectedParameters);
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/event/model/EventAcceptingMethodParams.java
+++ b/server/src/main/java/io/spine/server/event/model/EventAcceptingMethodParams.java
@@ -40,21 +40,21 @@ import io.spine.server.type.EventEnvelope;
 @Immutable
 enum EventAcceptingMethodParams implements ParameterSpec<EventEnvelope> {
 
-    MESSAGE(false, EventMessage.class) {
+    MESSAGE(EventMessage.class) {
         @Override
         public Object[] extractArguments(EventEnvelope event) {
             return new Object[]{event.message()};
         }
     },
 
-    MESSAGE_EVENT_CTX(false, EventMessage.class, EventContext.class) {
+    MESSAGE_EVENT_CTX(EventMessage.class, EventContext.class) {
         @Override
         public Object[] extractArguments(EventEnvelope event) {
             return new Object[] {event.message(), event.context()};
         }
     },
 
-    MESSAGE_COMMAND_CTX(false, RejectionMessage.class, CommandContext.class) {
+    MESSAGE_COMMAND_CTX(RejectionMessage.class, CommandContext.class) {
         @Override
         public Object[] extractArguments(EventEnvelope event) {
             Message message = event.message();
@@ -65,7 +65,7 @@ enum EventAcceptingMethodParams implements ParameterSpec<EventEnvelope> {
         }
     },
 
-    MESSAGE_COMMAND_MSG(true, RejectionMessage.class, CommandMessage.class) {
+    MESSAGE_COMMAND_MSG(RejectionMessage.class, CommandMessage.class) {
         @Override
         public Object[] extractArguments(EventEnvelope event) {
             Message message = event.message();
@@ -76,7 +76,7 @@ enum EventAcceptingMethodParams implements ParameterSpec<EventEnvelope> {
     },
 
     MESSAGE_COMMAND_MSG_COMMAND_CTX(
-            true, RejectionMessage.class, CommandMessage.class, CommandContext.class) {
+            RejectionMessage.class, CommandMessage.class, CommandContext.class) {
         @Override
         public Object[] extractArguments(EventEnvelope event) {
             Message message = event.message();
@@ -90,11 +90,9 @@ enum EventAcceptingMethodParams implements ParameterSpec<EventEnvelope> {
     };
 
     private final ImmutableList<Class<?>> expectedParameters;
-    private final boolean awareOfCommandType;
 
-    EventAcceptingMethodParams(boolean awareOfCommandType, Class<?>... parameters) {
+    EventAcceptingMethodParams(Class<?>... parameters) {
         this.expectedParameters = ImmutableList.copyOf(parameters);
-        this.awareOfCommandType = awareOfCommandType;
     }
 
     @Override
@@ -102,7 +100,7 @@ enum EventAcceptingMethodParams implements ParameterSpec<EventEnvelope> {
         return params.match(expectedParameters);
     }
 
-    public boolean isAwareOfCommandType() {
-        return awareOfCommandType;
+    public boolean acceptsCommand() {
+        return expectedParameters.contains(CommandMessage.class);
     }
 }

--- a/server/src/main/java/io/spine/server/event/model/EventAcceptingMethodParams.java
+++ b/server/src/main/java/io/spine/server/event/model/EventAcceptingMethodParams.java
@@ -59,8 +59,9 @@ enum EventAcceptingMethodParams implements ParameterSpec<EventEnvelope> {
         public Object[] extractArguments(EventEnvelope event) {
             Message message = event.message();
             RejectionEnvelope rejection = RejectionEnvelope.from(event);
-            CommandContext context = rejection.getOrigin()
-                                              .getContext();
+            CommandContext context =
+                    rejection.getOrigin()
+                             .getContext();
             return new Object[] {message, context};
         }
     },
@@ -84,7 +85,6 @@ enum EventAcceptingMethodParams implements ParameterSpec<EventEnvelope> {
             Command origin = rejection.getOrigin();
             CommandMessage commandMessage = origin.enclosedMessage();
             CommandContext context = origin.context();
-
             return new Object[] {message, commandMessage, context};
         }
     };

--- a/server/src/main/java/io/spine/server/event/model/EventAcceptingSignature.java
+++ b/server/src/main/java/io/spine/server/event/model/EventAcceptingSignature.java
@@ -36,12 +36,15 @@ import java.lang.annotation.Annotation;
 abstract class EventAcceptingSignature<H extends HandlerMethod<?, ?, EventEnvelope, ?>>
         extends MethodSignature<H, EventEnvelope> {
 
+    static final ImmutableSet<EventAcceptingMethodParams> PARAM_SPEC =
+            ImmutableSet.copyOf(EventAcceptingMethodParams.values());
+
     EventAcceptingSignature(Class<? extends Annotation> annotation) {
         super(annotation);
     }
 
     @Override
     public ImmutableSet<? extends ParameterSpec<EventEnvelope>> paramSpecs() {
-        return ImmutableSet.copyOf(EventAcceptingMethodParams.values());
+        return PARAM_SPEC;
     }
 }

--- a/server/src/main/java/io/spine/server/event/model/EventAcceptingSignature.java
+++ b/server/src/main/java/io/spine/server/event/model/EventAcceptingSignature.java
@@ -36,8 +36,12 @@ import java.lang.annotation.Annotation;
 abstract class EventAcceptingSignature<H extends HandlerMethod<?, ?, EventEnvelope, ?>>
         extends MethodSignature<H, EventEnvelope> {
 
-    static final ImmutableSet<EventAcceptingMethodParams> PARAM_SPEC =
-            ImmutableSet.copyOf(EventAcceptingMethodParams.values());
+    /**
+     * This field is also is used by {@link SubscriberSignature} to avoid repeated scanning in
+     * the overriden {@link #paramSpecs()}.
+     */
+    static final ImmutableSet<EventAcceptingMethodParams>
+            PARAM_SPEC = ImmutableSet.copyOf(EventAcceptingMethodParams.values());
 
     EventAcceptingSignature(Class<? extends Annotation> annotation) {
         super(annotation);

--- a/server/src/main/java/io/spine/server/event/model/EventHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/EventHandlerMethod.java
@@ -63,14 +63,14 @@ public abstract class EventHandlerMethod<T, P extends MessageClass<?>>
     @Override
     public HandlerId id() {
         EventClass eventClass = messageClass();
-        if (!parameterSpec().isAwareOfCommandType()) {
-            return createId(eventClass);
-        } else {
+        if (parameterSpec().acceptsCommand()) {
             Class<?>[] parameters = rawMethod().getParameterTypes();
             Class<? extends CommandMessage> commandMessageClass =
                     castClass(parameters[1], CommandMessage.class);
             CommandClass commandClass = CommandClass.from(commandMessageClass);
             return createId(eventClass, commandClass);
+        } else {
+            return createId(eventClass);
         }
     }
 

--- a/server/src/main/java/io/spine/server/event/model/EventReactorSignature.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReactorSignature.java
@@ -47,7 +47,7 @@ final class EventReactorSignature extends EventAcceptingSignature<EventReactorMe
     }
 
     @Override
-    public EventReactorMethod doCreate(Method method, ParameterSpec<EventEnvelope> parameterSpec) {
-        return new EventReactorMethod(method, parameterSpec);
+    public EventReactorMethod create(Method method, ParameterSpec<EventEnvelope> params) {
+        return new EventReactorMethod(method, params);
     }
 }

--- a/server/src/main/java/io/spine/server/event/model/EventReactorSignature.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReactorSignature.java
@@ -32,7 +32,10 @@ import java.util.Optional;
 /**
  * The signature of {@link EventReactorMethod}.
  */
-class EventReactorSignature extends EventAcceptingSignature<EventReactorMethod> {
+final class EventReactorSignature extends EventAcceptingSignature<EventReactorMethod> {
+
+    private static final ImmutableSet<Class<?>> RETURN_TYPES =
+            ImmutableSet.of(EventMessage.class, Iterable.class, Optional.class);
 
     EventReactorSignature() {
         super(React.class);
@@ -40,7 +43,7 @@ class EventReactorSignature extends EventAcceptingSignature<EventReactorMethod> 
 
     @Override
     protected ImmutableSet<Class<?>> returnTypes() {
-        return ImmutableSet.of(EventMessage.class, Iterable.class, Optional.class);
+        return RETURN_TYPES;
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/event/model/EventReactorSignature.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReactorSignature.java
@@ -34,8 +34,8 @@ import java.util.Optional;
  */
 final class EventReactorSignature extends EventAcceptingSignature<EventReactorMethod> {
 
-    private static final ImmutableSet<Class<?>> RETURN_TYPES =
-            ImmutableSet.of(EventMessage.class, Iterable.class, Optional.class);
+    private static final ImmutableSet<Class<?>>
+            RETURN_TYPES = ImmutableSet.of(EventMessage.class, Iterable.class, Optional.class);
 
     EventReactorSignature() {
         super(React.class);

--- a/server/src/main/java/io/spine/server/event/model/StateSubscriberSpec.java
+++ b/server/src/main/java/io/spine/server/event/model/StateSubscriberSpec.java
@@ -26,6 +26,7 @@ import com.google.protobuf.Message;
 import io.spine.base.EventMessage;
 import io.spine.core.EventContext;
 import io.spine.server.entity.EntityVisibility;
+import io.spine.server.model.MethodParams;
 import io.spine.server.model.ParameterSpec;
 import io.spine.server.type.EventEnvelope;
 import io.spine.system.server.event.EntityStateChanged;
@@ -69,6 +70,21 @@ enum StateSubscriberSpec implements ParameterSpec<EventEnvelope> {
         }
         @SuppressWarnings("unchecked") // Checked above.
         Class<? extends Message> firstParameter = (Class<? extends Message>) methodParams[0];
+        EntityVisibility visibility = EntityVisibility.of(firstParameter);
+        if (visibility.canSubscribe()) {
+            return true;
+        } else {
+            throw new InsufficientVisibilityError(TypeName.of(firstParameter), visibility);
+        }
+    }
+
+    @Override
+    public boolean matches(MethodParams params) {
+        if (!params.match(parameters)) {
+            return false;
+        }
+        @SuppressWarnings("unchecked") // Checked above.
+        Class<? extends Message> firstParameter = (Class<? extends Message>) params.type(0);
         EntityVisibility visibility = EntityVisibility.of(firstParameter);
         if (visibility.canSubscribe()) {
             return true;

--- a/server/src/main/java/io/spine/server/event/model/StateSubscriberSpec.java
+++ b/server/src/main/java/io/spine/server/event/model/StateSubscriberSpec.java
@@ -34,7 +34,6 @@ import io.spine.type.TypeName;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.spine.protobuf.AnyPacker.unpack;
-import static io.spine.server.model.MethodParams.consistsOfTypes;
 
 /**
  * A {@link ParameterSpec} of an entity state subscriber method.
@@ -60,22 +59,6 @@ enum StateSubscriberSpec implements ParameterSpec<EventEnvelope> {
 
     StateSubscriberSpec(ImmutableList<Class<?>> parameters) {
         this.parameters = parameters;
-    }
-
-    @Override
-    public boolean matches(Class<?>[] methodParams) {
-        boolean typesMatch = consistsOfTypes(methodParams, parameters);
-        if (!typesMatch) {
-            return false;
-        }
-        @SuppressWarnings("unchecked") // Checked above.
-        Class<? extends Message> firstParameter = (Class<? extends Message>) methodParams[0];
-        EntityVisibility visibility = EntityVisibility.of(firstParameter);
-        if (visibility.canSubscribe()) {
-            return true;
-        } else {
-            throw new InsufficientVisibilityError(TypeName.of(firstParameter), visibility);
-        }
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/event/model/SubscriberSignature.java
+++ b/server/src/main/java/io/spine/server/event/model/SubscriberSignature.java
@@ -34,6 +34,12 @@ import java.lang.reflect.Method;
  */
 public class SubscriberSignature extends EventAcceptingSignature<SubscriberMethod> {
 
+    private static final ImmutableSet<ParameterSpec<EventEnvelope>> PARAM_SPEC = ImmutableSet
+            .<ParameterSpec<EventEnvelope>>builder()
+            .addAll(EventAcceptingSignature.PARAM_SPEC)
+            .addAll(ImmutableList.copyOf(StateSubscriberSpec.values()))
+            .build();
+
     public SubscriberSignature() {
         super(Subscribe.class);
     }
@@ -45,12 +51,7 @@ public class SubscriberSignature extends EventAcceptingSignature<SubscriberMetho
 
     @Override
     public ImmutableSet<? extends ParameterSpec<EventEnvelope>> paramSpecs() {
-        ImmutableSet<? extends ParameterSpec<EventEnvelope>> result = ImmutableSet
-                .<ParameterSpec<EventEnvelope>>builder()
-                .addAll(super.paramSpecs())
-                .addAll(ImmutableList.copyOf(StateSubscriberSpec.values()))
-                .build();
-        return result;
+        return PARAM_SPEC;
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/event/model/SubscriberSignature.java
+++ b/server/src/main/java/io/spine/server/event/model/SubscriberSignature.java
@@ -34,11 +34,14 @@ import java.lang.reflect.Method;
  */
 public class SubscriberSignature extends EventAcceptingSignature<SubscriberMethod> {
 
-    private static final ImmutableSet<ParameterSpec<EventEnvelope>> PARAM_SPEC = ImmutableSet
+    private static final ImmutableSet<ParameterSpec<EventEnvelope>>
+            PARAM_SPEC = ImmutableSet
             .<ParameterSpec<EventEnvelope>>builder()
             .addAll(EventAcceptingSignature.PARAM_SPEC)
             .addAll(ImmutableList.copyOf(StateSubscriberSpec.values()))
             .build();
+    private static final ImmutableSet<Class<?>>
+            RETURN_TYPE = ImmutableSet.of(void.class);
 
     public SubscriberSignature() {
         super(Subscribe.class);
@@ -46,7 +49,7 @@ public class SubscriberSignature extends EventAcceptingSignature<SubscriberMetho
 
     @Override
     protected ImmutableSet<Class<?>> returnTypes() {
-        return ImmutableSet.of(void.class);
+        return RETURN_TYPE;
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/event/model/SubscriberSignature.java
+++ b/server/src/main/java/io/spine/server/event/model/SubscriberSignature.java
@@ -55,10 +55,10 @@ public class SubscriberSignature extends EventAcceptingSignature<SubscriberMetho
     }
 
     @Override
-    public SubscriberMethod doCreate(Method method, ParameterSpec<EventEnvelope> parameterSpec) {
+    public SubscriberMethod create(Method method, ParameterSpec<EventEnvelope> params) {
         return isEntitySubscriber(method)
-               ? new StateSubscriberMethod(method, parameterSpec)
-               : new EventSubscriberMethod(method, parameterSpec);
+               ? new StateSubscriberMethod(method, params)
+               : new EventSubscriberMethod(method, params);
     }
 
     private static boolean isEntitySubscriber(Method method) {

--- a/server/src/main/java/io/spine/server/model/AbstractHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/model/AbstractHandlerMethod.java
@@ -96,7 +96,7 @@ public abstract class AbstractHandlerMethod<T,
      * {@linkplain #attributeSuppliers() customize} the set of supported method attributes.
      */
     @SuppressWarnings("Immutable")
-    private ImmutableSet<MethodAttribute<?>> attributes;
+    private ImmutableSet<Attribute<?>> attributes;
 
     /**
      * The specification of parameters for this method.
@@ -142,16 +142,16 @@ public abstract class AbstractHandlerMethod<T,
     @Override
     @PostConstruct
     public final void discoverAttributes() {
-        ImmutableSet.Builder<MethodAttribute<?>> builder = ImmutableSet.builder();
-        for (Function<Method, MethodAttribute<?>> fn : attributeSuppliers()) {
-            MethodAttribute<?> attr = fn.apply(method);
+        ImmutableSet.Builder<Attribute<?>> builder = ImmutableSet.builder();
+        for (Function<Method, Attribute<?>> fn : attributeSuppliers()) {
+            Attribute<?> attr = fn.apply(method);
             builder.add(attr);
         }
         attributes = builder.build();
     }
 
     /**
-     * Obtains a set of functions for getting {@linkplain MethodAttribute method attributes}
+     * Obtains a set of functions for getting {@linkplain Attribute method attributes}
      * by a {@linkplain Method raw method} value.
      *
      * <p>Default implementation returns a one-element set for obtaining {@link ExternalAttribute}.
@@ -161,7 +161,7 @@ public abstract class AbstractHandlerMethod<T,
      * set provided by this method and the one needed by the overriding class.
      */
     @OverridingMethodsMustInvokeSuper
-    protected Set<Function<Method, MethodAttribute<?>>> attributeSuppliers() {
+    protected Set<Function<Method, Attribute<?>>> attributeSuppliers() {
         return ImmutableSet.of(ExternalAttribute::of);
     }
 
@@ -226,11 +226,11 @@ public abstract class AbstractHandlerMethod<T,
     }
 
     @Override
-    public final Set<MethodAttribute<?>> attributes() {
+    public final Set<Attribute<?>> attributes() {
         return attributes;
     }
 
-    private static ImmutableSet<MethodAttribute<?>> discoverAttributes(Method method) {
+    private static ImmutableSet<Attribute<?>> discoverAttributes(Method method) {
         checkNotNull(method);
         ExternalAttribute externalAttribute = ExternalAttribute.of(method);
         return ImmutableSet.of(externalAttribute);

--- a/server/src/main/java/io/spine/server/model/Attribute.java
+++ b/server/src/main/java/io/spine/server/model/Attribute.java
@@ -20,32 +20,24 @@
 package io.spine.server.model;
 
 import com.google.errorprone.annotations.Immutable;
-import io.spine.annotation.Internal;
 
 /**
- * Meta-data set to a {@link HandlerMethod#attributes()} HandlerMethod} attributes.
+ * Contains a value of an annotation parameter.
  *
  * <p>Typical way to add more semantics to a method is via a parameterized annotation,
  * such as {@link io.spine.core.Subscribe Subscribe}.
+ *
+ * @param <V>
+ *         the type of the value of the attribute. As it would typically be an annotation field
+ *         value, its type cannot be restricted to anything except for {@link Object}.
+ * @see HandlerMethod#attributes()
  */
-@Internal
 @Immutable(containerOf = "V")
-public interface MethodAttribute<V> {
+public interface Attribute<V> {
 
-    /**
-     * An attribute name.
-     *
-     * @return a name of the attribute as {@code String}
-     */
-    String getName();
+    /** The name of the parameter. */
+    String parameter();
 
-    /**
-     * A value of the attribute.
-     *
-     * <p>As it'd typically be an annotation field value, its type cannot be restricted
-     * to anything except for {@link Object}.
-     *
-     * @return the value of the attribute
-     */
-    V getValue();
+    /** The value of the attribute. */
+    V value();
 }

--- a/server/src/main/java/io/spine/server/model/Attribute.java
+++ b/server/src/main/java/io/spine/server/model/Attribute.java
@@ -22,7 +22,7 @@ package io.spine.server.model;
 import com.google.errorprone.annotations.Immutable;
 
 /**
- * Contains a value of an annotation parameter.
+ * Contains a value of an annotation attribute.
  *
  * <p>Typical way to add more semantics to a method is via a parameterized annotation,
  * such as {@link io.spine.core.Subscribe Subscribe}.
@@ -35,7 +35,13 @@ import com.google.errorprone.annotations.Immutable;
 @Immutable(containerOf = "V")
 public interface Attribute<V> {
 
-    /** The name of the parameter. */
+    /**
+     * The name of the parameter.
+     *
+     * @apiNote This is mostly a diagnostics method. We do not use it directly.
+     *  This method cannot be called {@code name()} because it would clash with the built-in method
+     *  {@code name()} of enums that implement this interface.
+     */
     String parameter();
 
     /** The value of the attribute. */

--- a/server/src/main/java/io/spine/server/model/ExternalAttribute.java
+++ b/server/src/main/java/io/spine/server/model/ExternalAttribute.java
@@ -37,7 +37,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @see Command#external()
  */
 @Immutable
-enum ExternalAttribute implements MethodAttribute<Boolean> {
+enum ExternalAttribute implements Attribute<Boolean> {
 
     /** An attribute value for the methods, designed to handle external objects only. */
     EXTERNAL(true),
@@ -52,12 +52,12 @@ enum ExternalAttribute implements MethodAttribute<Boolean> {
     }
 
     @Override
-    public String getName() {
+    public String parameter() {
         return "external";
     }
 
     @Override
-    public Boolean getValue() {
+    public Boolean value() {
         return value;
     }
 

--- a/server/src/main/java/io/spine/server/model/HandlerMethod.java
+++ b/server/src/main/java/io/spine/server/model/HandlerMethod.java
@@ -70,7 +70,7 @@ public interface HandlerMethod<T,
     /**
      * Obtains the set of method attributes configured for this method.
      */
-    Set<MethodAttribute<?>> attributes();
+    Set<Attribute<?>> attributes();
 
     /**
      * Obtains the handling method.

--- a/server/src/main/java/io/spine/server/model/MethodParams.java
+++ b/server/src/main/java/io/spine/server/model/MethodParams.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.Arrays.asList;
 
 /**
  * Provides information about parameters of a method.
@@ -41,8 +40,12 @@ public final class MethodParams {
     private final ImmutableList<Parameter> params;
 
     /** Obtains parameters from the passed method. */
-    private MethodParams(Method method) {
+    static MethodParams of(Method method) {
         checkNotNull(method);
+        return new MethodParams(method);
+    }
+
+    private MethodParams(Method method) {
         this.params = ImmutableList.copyOf(method.getParameters());
     }
 
@@ -87,6 +90,13 @@ public final class MethodParams {
     /**
      * Verifies if these parameters match the passed types.
      */
+    public boolean match(Class<?>... types) {
+        return match(ImmutableList.copyOf(types));
+    }
+
+    /**
+     * Verifies if these parameters match the passed types.
+     */
     public boolean match(List<Class<?>> types) {
         if (size() != types.size()) {
             return false;
@@ -94,78 +104,6 @@ public final class MethodParams {
         for (int i = 0; i < size(); i++) {
             Class<?> actual = type(i);
             Class<?> expected = types.get(i);
-            if (!expected.isAssignableFrom(actual)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * Checks whether the given method parameters have exactly one parameter of an expected type.
-     *
-     * <p>This is a convenience shortcut for {@link #consistsOfTypes(Class[], List)
-     * consistsOfTypes(Class[], List)}.
-     *
-     * @param methodParams
-     *         the method parameters to check
-     * @param type
-     *         the type of expected single parameter
-     * @return {@code true} if the method has exactly one parameter of the expected type,
-     *         {@code false} otherwise
-     */
-    public static boolean consistsOfSingle(Class<?>[] methodParams, Class<?> type) {
-        checkNotNull(methodParams);
-        checkNotNull(type);
-
-        if (1 != methodParams.length) {
-            return false;
-        }
-        Class<?> firstParam = methodParams[0];
-        return type.isAssignableFrom(firstParam);
-    }
-
-    /**
-     * Checks whether the given method parameters are two parameters of expected types.
-     *
-     * <p>This is a convenience shortcut for {@link #consistsOfTypes(Class[], List)
-     * consistsOfTypes(Class[], List)}.
-     *
-     * @param methodParams
-     *         the method parameters to check
-     * @param firstType
-     *         the expected type of the first parameter
-     * @param secondType
-     *         the expected type of the second parameter
-     * @return {@code true} if the method parameters are of expected types, {@code false} otherwise
-     */
-    public static boolean consistsOfTwo(Class<?>[] methodParams,
-                                        Class<?> firstType,
-                                        Class<?> secondType) {
-        checkNotNull(methodParams);
-        checkNotNull(firstType);
-        checkNotNull(secondType);
-
-        return consistsOfTypes(methodParams, asList(firstType, secondType));
-    }
-
-    /**
-     * Checks whether the given method parameters are of expected types.
-     *
-     * @param methodParams
-     *         the method params to check
-     * @param expectedTypes
-     *         the expected types
-     * @return {@code true} if the method parameters are of expected types, {@code false} otherwise
-     */
-    public static boolean consistsOfTypes(Class<?>[] methodParams,
-                                          List<Class<?>> expectedTypes) {
-        if (methodParams.length != expectedTypes.size()) {
-            return false;
-        }
-        for (int i = 0; i < methodParams.length; i++) {
-            Class<?> actual = methodParams[i];
-            Class<?> expected = expectedTypes.get(i);
             if (!expected.isAssignableFrom(actual)) {
                 return false;
             }
@@ -190,10 +128,11 @@ public final class MethodParams {
      */
     static <E extends MessageEnvelope<?, ?, ?>, S extends ParameterSpec<E>>
     Optional<S> findMatching(Method method, Collection<S> paramSpecs) {
-        MethodParams params = new MethodParams(method);
-        Optional<S> result = paramSpecs.stream()
-                                       .filter(spec -> spec.matches(params))
-                                       .findFirst();
+        MethodParams params = of(method);
+        Optional<S> result =
+                paramSpecs.stream()
+                          .filter(spec -> spec.matches(params))
+                          .findFirst();
         return result;
     }
 
@@ -205,15 +144,13 @@ public final class MethodParams {
      * @return {@code true} if the first parameter is a {@code Command} message,
      *         {@code false} otherwise
      */
-    public static boolean isFirstParamCommand(Method method) {
+    public static boolean firstIsCommand(Method method) {
         checkNotNull(method);
-
-        Class<?>[] parameterTypes = method.getParameterTypes();
-        if (parameterTypes.length > 0) {
-            Class<?> firstParameter = parameterTypes[0];
-            boolean result = CommandMessage.class.isAssignableFrom(firstParameter);
-            return result;
+        MethodParams params = of(method);
+        if (params.size() == 0) {
+            return false;
         }
-        return false;
+        boolean result = CommandMessage.class.isAssignableFrom(params.type(0));
+        return result;
     }
 }

--- a/server/src/main/java/io/spine/server/model/MethodParams.java
+++ b/server/src/main/java/io/spine/server/model/MethodParams.java
@@ -137,8 +137,7 @@ public final class MethodParams {
     }
 
     /**
-     * Finds out if the first method parameter is a {@linkplain io.spine.core.Command Command}
-     * message.
+     * Finds out if the first method parameter is a {@linkplain CommandMessage}.
      *
      * @param method
      *         the method to inspect

--- a/server/src/main/java/io/spine/server/model/MethodParams.java
+++ b/server/src/main/java/io/spine/server/model/MethodParams.java
@@ -20,24 +20,48 @@
 
 package io.spine.server.model;
 
+import com.google.common.collect.ImmutableList;
 import io.spine.base.CommandMessage;
 import io.spine.server.type.MessageEnvelope;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Arrays.asList;
 
 /**
  * The utility class for working with {@link Method} parameters.
+ *
+ * //TODO:2019-08-28:alexander.yevsyukov: Update the doc.
  */
 public final class MethodParams {
 
-    /** Prevents instantiation of this utility class. */
-    private MethodParams() {
+    private final Method method;
+    private final ImmutableList<Parameter> params;
+
+    /** Obtains parameters from the passed method. */
+    private MethodParams(Method method) {
+        this.method = checkNotNull(method);
+        this.params = ImmutableList.copyOf(method.getParameters());
+    }
+
+    /** Obtains the number of parameters passed to the method. */
+    public int size() {
+        return params.size();
+    }
+
+    public boolean is(Class<?> type) {
+        int size = size();
+        checkState(
+                size == 1, "The method `%s` accepts more than one parameter (%d).", method, size
+        );
+        Class<?> firstParam = params.get(0).getType();
+        return type.isAssignableFrom(firstParam);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/model/MethodParams.java
+++ b/server/src/main/java/io/spine/server/model/MethodParams.java
@@ -90,7 +90,7 @@ public final class MethodParams {
     /**
      * Verifies if these parameters match the passed types.
      */
-    public boolean match(Class<?>... types) {
+    public boolean are(Class<?>... types) {
         return match(ImmutableList.copyOf(types));
     }
 

--- a/server/src/main/java/io/spine/server/model/MethodResults.java
+++ b/server/src/main/java/io/spine/server/model/MethodResults.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import com.google.common.graph.Traverser;
 import com.google.common.reflect.TypeToken;
-import com.google.errorprone.annotations.Immutable;
 import io.spine.base.CommandMessage;
 import io.spine.base.EventMessage;
 import io.spine.reflect.Types;
@@ -48,7 +47,6 @@ import static io.spine.util.Exceptions.newIllegalArgumentException;
  * interface is not added to the set. Thus, if a method returns {@code List<EventMessage>},
  * the set would be empty.
  */
-@Immutable
 final class MethodResults {
 
     /**

--- a/server/src/main/java/io/spine/server/model/MethodSignature.java
+++ b/server/src/main/java/io/spine/server/model/MethodSignature.java
@@ -60,6 +60,8 @@ import static java.util.stream.Collectors.toList;
 public abstract class MethodSignature<H extends HandlerMethod<?, ?, E, ?>,
                                       E extends MessageEnvelope<?, ?, ?>> implements Logging {
 
+    private static final ImmutableSet<AccessModifier> MODIFIERS = ImmutableSet.of(PACKAGE_PRIVATE);
+
     private final Class<? extends Annotation> annotation;
 
     /**
@@ -83,7 +85,7 @@ public abstract class MethodSignature<H extends HandlerMethod<?, ?, E, ?>,
      * the allowed access modifiers.
      */
     protected ImmutableSet<AccessModifier> modifiers() {
-        return ImmutableSet.of(PACKAGE_PRIVATE);
+        return MODIFIERS;
     }
 
     /**

--- a/server/src/main/java/io/spine/server/model/MethodSignature.java
+++ b/server/src/main/java/io/spine/server/model/MethodSignature.java
@@ -60,7 +60,8 @@ import static java.util.stream.Collectors.toList;
 public abstract class MethodSignature<H extends HandlerMethod<?, ?, E, ?>,
                                       E extends MessageEnvelope<?, ?, ?>> implements Logging {
 
-    private static final ImmutableSet<AccessModifier> MODIFIERS = ImmutableSet.of(PACKAGE_PRIVATE);
+    private static final ImmutableSet<AccessModifier>
+            MODIFIER = ImmutableSet.of(PACKAGE_PRIVATE);
 
     private final Class<? extends Annotation> annotation;
 
@@ -85,7 +86,7 @@ public abstract class MethodSignature<H extends HandlerMethod<?, ?, E, ?>,
      * the allowed access modifiers.
      */
     protected ImmutableSet<AccessModifier> modifiers() {
-        return MODIFIERS;
+        return MODIFIER;
     }
 
     /**

--- a/server/src/main/java/io/spine/server/model/MethodSignature.java
+++ b/server/src/main/java/io/spine/server/model/MethodSignature.java
@@ -172,11 +172,13 @@ public abstract class MethodSignature<H extends HandlerMethod<?, ?, E, ?>,
      * <p>This method is designed to NOT perform any matching, but rather create a specific
      * instance of {@code HandlerMethod}.
      *
-     * @param method the raw method to wrap into a {@code HandlerMethod} instance being created
-     * @param parameterSpec the specification of method parameters
+     * @param method
+     *         the raw method to wrap into a {@code HandlerMethod} instance being created
+     * @param params
+     *         the specification of method parameters
      * @return new instance of {@code HandlerMethod}
      */
-    public abstract H doCreate(Method method, ParameterSpec<E> parameterSpec);
+    public abstract H create(Method method, ParameterSpec<E> params);
 
     /**
      * Obtains the annotation, which is required to be declared for the matched raw method.
@@ -204,7 +206,7 @@ public abstract class MethodSignature<H extends HandlerMethod<?, ?, E, ?>,
         }
         Optional<? extends ParameterSpec<E>> matchingSpec = findMatching(method, paramSpecs());
         return matchingSpec.map(spec -> {
-            H handler = doCreate(method, spec);
+            H handler = create(method, spec);
             handler.discoverAttributes();
             return handler;
         });

--- a/server/src/main/java/io/spine/server/model/ParameterSpec.java
+++ b/server/src/main/java/io/spine/server/model/ParameterSpec.java
@@ -50,6 +50,11 @@ public interface ParameterSpec<E extends MessageEnvelope<?, ?, ?>> {
     boolean matches(Class<?>[] methodParams);
 
     /**
+     * Tells if this specification of parameters matches the passed parameters.
+     */
+    boolean matches(MethodParams params);
+
+    /**
      * Extracts the values to be used during the invocation of the method with this parameter
      * specification.
      *

--- a/server/src/main/java/io/spine/server/model/ParameterSpec.java
+++ b/server/src/main/java/io/spine/server/model/ParameterSpec.java
@@ -40,16 +40,6 @@ import io.spine.server.type.MessageEnvelope;
 public interface ParameterSpec<E extends MessageEnvelope<?, ?, ?>> {
 
     /**
-     * Tells if the given {@code methodParams} are matched against this instance of
-     * {@code ParameterSpec}.
-     *
-     * @param methodParams
-     *         the method parameters to match
-     * @return {@code true} if the parameters match, {@code false} otherwise
-     */
-    boolean matches(Class<?>[] methodParams);
-
-    /**
      * Tells if this specification of parameters matches the passed parameters.
      */
     boolean matches(MethodParams params);

--- a/server/src/main/java/io/spine/server/model/VoidMethod.java
+++ b/server/src/main/java/io/spine/server/model/VoidMethod.java
@@ -49,7 +49,7 @@ public interface VoidMethod<T,
     default Success toSuccessfulOutcome(@Nullable Object result, T target, E handledSignal) {
         if (result != null) {
             String errorMessage = format(
-                    "Method `%s` should NOT produce any result. Produced: %s",
+                    "Method `%s` should NOT produce any result. Produced: `%s`.",
                     this,
                     result
             );

--- a/server/src/test/java/io/spine/server/aggregate/model/ApplierTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/model/ApplierTest.java
@@ -153,7 +153,9 @@ class ApplierTest {
                              () -> applier.toSuccessfulOutcome(result,
                                                                applierObject,
                                                                envelope));
-        assertThat(exception).hasMessageThat().endsWith(result);
+        assertThat(exception)
+                .hasMessageThat()
+                .contains(result);
     }
 
     @Nested

--- a/server/src/test/java/io/spine/server/model/MethodParamsTest.java
+++ b/server/src/test/java/io/spine/server/model/MethodParamsTest.java
@@ -21,6 +21,7 @@
 package io.spine.server.model;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Any;
 import com.google.protobuf.Empty;
 import com.google.protobuf.Int32Value;
@@ -38,12 +39,20 @@ import static io.spine.server.model.MethodParams.firstIsCommand;
 import static io.spine.server.model.given.MethodParamsTestEnv.fiveParamMethodStringAnyEmptyInt32UserId;
 import static io.spine.server.model.given.MethodParamsTestEnv.singleParamCommand;
 import static io.spine.server.model.given.MethodParamsTestEnv.twoParamCommandAndCtx;
+import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("`MethodParams` utility should ")
 class MethodParamsTest {
+
+    @Test
+    @DisplayName(NOT_ACCEPT_NULLS)
+    void passNullToleranceCheck() {
+        new NullPointerTester()
+            .testAllPublicStaticMethods(MethodParams.class);
+    }
 
     @Test
     @DisplayName("detect that a method has exactly one parameter of an expected type")

--- a/server/src/test/java/io/spine/server/model/MethodParamsTest.java
+++ b/server/src/test/java/io/spine/server/model/MethodParamsTest.java
@@ -33,11 +33,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-import static io.spine.server.model.MethodParams.consistsOfSingle;
-import static io.spine.server.model.MethodParams.consistsOfTwo;
-import static io.spine.server.model.MethodParams.consistsOfTypes;
 import static io.spine.server.model.MethodParams.findMatching;
-import static io.spine.server.model.MethodParams.isFirstParamCommand;
+import static io.spine.server.model.MethodParams.firstIsCommand;
 import static io.spine.server.model.given.MethodParamsTestEnv.fiveParamMethodStringAnyEmptyInt32UserId;
 import static io.spine.server.model.given.MethodParamsTestEnv.singleParamCommand;
 import static io.spine.server.model.given.MethodParamsTestEnv.twoParamCommandAndCtx;
@@ -51,40 +48,36 @@ class MethodParamsTest {
     @Test
     @DisplayName("detect that a method has exactly one parameter of an expected type")
     void detectSingleParam() {
-        assertTrue(consistsOfSingle(singleParamCommand().getParameterTypes(),
-                                    ModCreateProject.class));
-        assertFalse(consistsOfSingle(twoParamCommandAndCtx().getParameterTypes(),
-                                     ModCreateProject.class));
-        assertFalse(consistsOfSingle(fiveParamMethodStringAnyEmptyInt32UserId().getParameterTypes(),
-                                     ModCreateProject.class));
-
+        assertTrue(MethodParams.of(singleParamCommand())
+                               .is(ModCreateProject.class));
+        assertFalse(MethodParams.of(twoParamCommandAndCtx())
+                                .is(ModCreateProject.class));
+        assertFalse(MethodParams.of(fiveParamMethodStringAnyEmptyInt32UserId())
+                                .is(ModCreateProject.class));
     }
 
     @Test
     @DisplayName("detect that a method has exactly two parameters of expected types")
     void detectTwoParams() {
-        assertTrue(consistsOfTwo(twoParamCommandAndCtx().getParameterTypes(),
-                                 ModCreateProject.class, CommandContext.class));
-        assertFalse(consistsOfTwo(singleParamCommand().getParameterTypes(),
-                                  ModCreateProject.class, CommandContext.class));
-        assertFalse(consistsOfTwo(fiveParamMethodStringAnyEmptyInt32UserId().getParameterTypes(),
-                                  ModCreateProject.class, CommandContext.class));
-
+        assertTrue(MethodParams.of(twoParamCommandAndCtx())
+                               .are(ModCreateProject.class, CommandContext.class));
+        assertFalse(MethodParams.of(singleParamCommand())
+                                .are(ModCreateProject.class, CommandContext.class));
+        assertFalse(MethodParams.of(fiveParamMethodStringAnyEmptyInt32UserId())
+                                .are(ModCreateProject.class, CommandContext.class));
     }
 
     @Test
     @DisplayName("detect that a method has lots of parameters of expected types")
     void detectLotsOfParams() {
-        assertTrue(consistsOfTypes(fiveParamMethodStringAnyEmptyInt32UserId().getParameterTypes(),
-                                   ImmutableList.of(String.class, Any.class,
-                                                    Empty.class, Int32Value.class, UserId.class)));
-        assertFalse(consistsOfTypes(singleParamCommand().getParameterTypes(),
-                                    ImmutableList.of(String.class, Any.class,
-                                       Empty.class, Int32Value.class, UserId.class)));
-        assertFalse(consistsOfTypes(twoParamCommandAndCtx().getParameterTypes(),
-                                    ImmutableList.of(String.class, Any.class,
-                                       Empty.class, Int32Value.class, UserId.class)));
-
+        assertTrue(MethodParams.of(fiveParamMethodStringAnyEmptyInt32UserId())
+                               .match(String.class, Any.class, Empty.class,
+                                      Int32Value.class, UserId.class)
+        );
+        assertFalse(MethodParams.of(singleParamCommand())
+                                .match(String.class, Any.class, Empty.class));
+        assertFalse(MethodParams.of(twoParamCommandAndCtx())
+                                .match(String.class, Any.class, Empty.class));
     }
 
     @Test
@@ -109,8 +102,8 @@ class MethodParamsTest {
     @Test
     @DisplayName("detect if the first method parameter is a Command message")
     void detectFirstCommandParameter() {
-        assertTrue(isFirstParamCommand(singleParamCommand()));
-        assertTrue(isFirstParamCommand(twoParamCommandAndCtx()));
-        assertFalse(isFirstParamCommand(fiveParamMethodStringAnyEmptyInt32UserId()));
+        assertTrue(firstIsCommand(singleParamCommand()));
+        assertTrue(firstIsCommand(twoParamCommandAndCtx()));
+        assertFalse(firstIsCommand(fiveParamMethodStringAnyEmptyInt32UserId()));
     }
 }

--- a/server/src/test/java/io/spine/server/model/MethodParamsTest.java
+++ b/server/src/test/java/io/spine/server/model/MethodParamsTest.java
@@ -71,13 +71,13 @@ class MethodParamsTest {
     @DisplayName("detect that a method has lots of parameters of expected types")
     void detectLotsOfParams() {
         assertTrue(MethodParams.of(fiveParamMethodStringAnyEmptyInt32UserId())
-                               .match(String.class, Any.class, Empty.class,
-                                      Int32Value.class, UserId.class)
+                               .are(String.class, Any.class, Empty.class,
+                                    Int32Value.class, UserId.class)
         );
         assertFalse(MethodParams.of(singleParamCommand())
-                                .match(String.class, Any.class, Empty.class));
+                                .are(String.class, Any.class, Empty.class));
         assertFalse(MethodParams.of(twoParamCommandAndCtx())
-                                .match(String.class, Any.class, Empty.class));
+                                .are(String.class, Any.class, Empty.class));
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/model/MethodParamsTest.java
+++ b/server/src/test/java/io/spine/server/model/MethodParamsTest.java
@@ -28,7 +28,6 @@ import io.spine.core.CommandContext;
 import io.spine.core.UserId;
 import io.spine.server.model.given.MethodParamsTestEnv.ScheduleCommandParamSpec;
 import io.spine.test.model.ModCreateProject;
-import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -47,11 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("`MethodParams` utility should ")
-class MethodParamsTest extends UtilityClassTest<MethodParams> {
-
-    private MethodParamsTest() {
-        super(MethodParams.class);
-    }
+class MethodParamsTest {
 
     @Test
     @DisplayName("detect that a method has exactly one parameter of an expected type")

--- a/server/src/test/java/io/spine/server/model/given/MethodParamsTestEnv.java
+++ b/server/src/test/java/io/spine/server/model/given/MethodParamsTestEnv.java
@@ -27,6 +27,7 @@ import com.google.protobuf.Int32Value;
 import io.spine.base.CommandMessage;
 import io.spine.core.CommandContext;
 import io.spine.core.UserId;
+import io.spine.server.model.MethodParams;
 import io.spine.server.model.ParameterSpec;
 import io.spine.server.type.CommandEnvelope;
 import io.spine.test.model.ModCreateProject;
@@ -89,6 +90,11 @@ public class MethodParamsTestEnv {
             @Override
             public boolean matches(Class<?>[] methodParams) {
                 return consistsOfTwo(methodParams, CommandMessage.class, CommandContext.class);
+            }
+
+            @Override
+            public boolean matches(MethodParams params) {
+                return params.are(CommandMessage.class, CommandContext.class);
             }
 
             @Override

--- a/server/src/test/java/io/spine/server/model/given/MethodParamsTestEnv.java
+++ b/server/src/test/java/io/spine/server/model/given/MethodParamsTestEnv.java
@@ -36,7 +36,6 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Optional;
 
-import static io.spine.server.model.MethodParams.consistsOfTwo;
 import static io.spine.util.Exceptions.newIllegalStateException;
 
 /**
@@ -87,11 +86,6 @@ public class MethodParamsTestEnv {
     public enum ScheduleCommandParamSpec implements ParameterSpec<CommandEnvelope> {
 
         MESSAGE_AND_CONTEXT {
-            @Override
-            public boolean matches(Class<?>[] methodParams) {
-                return consistsOfTwo(methodParams, CommandMessage.class, CommandContext.class);
-            }
-
             @Override
             public boolean matches(MethodParams params) {
                 return params.are(CommandMessage.class, CommandContext.class);

--- a/server/src/test/java/io/spine/server/model/given/method/OneParamSignature.java
+++ b/server/src/test/java/io/spine/server/model/given/method/OneParamSignature.java
@@ -56,8 +56,8 @@ public class OneParamSignature extends MethodSignature<OneParamMethod, EventEnve
     }
 
     @Override
-    public OneParamMethod doCreate(Method method, ParameterSpec<EventEnvelope> parameterSpec) {
-        return new OneParamMethod(method, parameterSpec);
+    public OneParamMethod create(Method method, ParameterSpec<EventEnvelope> params) {
+        return new OneParamMethod(method, params);
     }
 
     private static ImmutableSet<AccessModifier> allModifiers() {

--- a/server/src/test/java/io/spine/server/model/given/method/OneParamSpec.java
+++ b/server/src/test/java/io/spine/server/model/given/method/OneParamSpec.java
@@ -22,6 +22,7 @@ package io.spine.server.model.given.method;
 
 import com.google.errorprone.annotations.Immutable;
 import io.spine.base.EventMessage;
+import io.spine.server.model.MethodParams;
 import io.spine.server.model.ParameterSpec;
 import io.spine.server.type.EventEnvelope;
 
@@ -35,6 +36,11 @@ public enum OneParamSpec implements ParameterSpec<EventEnvelope> {
     @Override
     public boolean matches(Class<?>[] methodParams) {
         return consistsOfSingle(methodParams, EventMessage.class);
+    }
+
+    @Override
+    public boolean matches(MethodParams params) {
+        return params.is(EventMessage.class);
     }
 
     @Override

--- a/server/src/test/java/io/spine/server/model/given/method/OneParamSpec.java
+++ b/server/src/test/java/io/spine/server/model/given/method/OneParamSpec.java
@@ -26,17 +26,10 @@ import io.spine.server.model.MethodParams;
 import io.spine.server.model.ParameterSpec;
 import io.spine.server.type.EventEnvelope;
 
-import static io.spine.server.model.MethodParams.consistsOfSingle;
-
 @Immutable
 public enum OneParamSpec implements ParameterSpec<EventEnvelope> {
 
     INSTANCE;
-
-    @Override
-    public boolean matches(Class<?>[] methodParams) {
-        return consistsOfSingle(methodParams, EventMessage.class);
-    }
 
     @Override
     public boolean matches(MethodParams params) {

--- a/server/src/test/java/io/spine/server/model/given/method/TwoParamSpec.java
+++ b/server/src/test/java/io/spine/server/model/given/method/TwoParamSpec.java
@@ -27,17 +27,10 @@ import io.spine.server.model.MethodParams;
 import io.spine.server.model.ParameterSpec;
 import io.spine.server.type.EventEnvelope;
 
-import static io.spine.server.model.MethodParams.consistsOfTwo;
-
 @Immutable
 public enum TwoParamSpec implements ParameterSpec<EventEnvelope> {
 
     INSTANCE;
-
-    @Override
-    public boolean matches(Class<?>[] methodParams) {
-        return consistsOfTwo(methodParams, Message.class, EventContext.class);
-    }
 
     @Override
     public boolean matches(MethodParams params) {

--- a/server/src/test/java/io/spine/server/model/given/method/TwoParamSpec.java
+++ b/server/src/test/java/io/spine/server/model/given/method/TwoParamSpec.java
@@ -23,6 +23,7 @@ package io.spine.server.model.given.method;
 import com.google.errorprone.annotations.Immutable;
 import com.google.protobuf.Message;
 import io.spine.core.EventContext;
+import io.spine.server.model.MethodParams;
 import io.spine.server.model.ParameterSpec;
 import io.spine.server.type.EventEnvelope;
 
@@ -36,6 +37,11 @@ public enum TwoParamSpec implements ParameterSpec<EventEnvelope> {
     @Override
     public boolean matches(Class<?>[] methodParams) {
         return consistsOfTwo(methodParams, Message.class, EventContext.class);
+    }
+
+    @Override
+    public boolean matches(MethodParams params) {
+        return params.are(Message.class, EventContext.class);
     }
 
     @Override


### PR DESCRIPTION
This PR improves work with method parameters.
  * `MethodAttribute` was renamed to `Attribute`, preparing to use this interface not only for methods, but for parameters as well (for supporting `@Where` parameter filter).
  * `MethodParams` which used to be a utility, now is the first-class Java class.
  * Some method names were also improved.