### PR TITLE
Release only non-empty sessions

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.0.3`
+# Dependencies of `io.spine:spine-client:1.0.6-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -457,12 +457,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 14:39:07 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 04 17:49:29 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.0.3`
+# Dependencies of `io.spine:spine-core:1.0.6-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -865,12 +865,12 @@ This report was generated on **Wed Sep 04 14:39:07 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 14:39:08 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 04 17:49:29 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.0.3`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.0.6-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1321,12 +1321,12 @@ This report was generated on **Wed Sep 04 14:39:08 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 14:39:09 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 04 17:49:30 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.0.3`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.0.6-SNAPSHOT`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -1939,12 +1939,12 @@ This report was generated on **Wed Sep 04 14:39:09 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 14:39:10 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 04 17:49:31 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.0.3`
+# Dependencies of `io.spine:spine-server:1.0.6-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2461,12 +2461,12 @@ This report was generated on **Wed Sep 04 14:39:10 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 14:39:11 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 04 17:49:31 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.0.3`
+# Dependencies of `io.spine:spine-testutil-client:1.0.6-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2993,12 +2993,12 @@ This report was generated on **Wed Sep 04 14:39:11 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 14:39:11 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 04 17:49:32 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.0.3`
+# Dependencies of `io.spine:spine-testutil-core:1.0.6-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3533,12 +3533,12 @@ This report was generated on **Wed Sep 04 14:39:11 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 14:39:12 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 04 17:49:33 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.0.3`
+# Dependencies of `io.spine:spine-testutil-server:1.0.6-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -4119,4 +4119,4 @@ This report was generated on **Wed Sep 04 14:39:12 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 14:39:13 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 04 17:49:34 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.0.3</version>
+<version>1.0.6-SNAPSHOT</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
+++ b/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
@@ -74,13 +74,15 @@ public class InMemoryShardedWorkRegistry implements ShardedWorkRegistry {
         ImmutableSet.Builder<ShardIndex> resultBuilder = ImmutableSet.builder();
 
         for (ShardSessionRecord record : workByNode.values()) {
-            Timestamp whenPicked = record.getWhenLastPicked();
-            Duration elapsed = between(whenPicked, currentTime());
+            if (record.hasPickedBy()) {
+                Timestamp whenPicked = record.getWhenLastPicked();
+                Duration elapsed = between(whenPicked, currentTime());
 
-            int comparison = Durations.compare(elapsed, inactivityPeriod);
-            if (comparison >= 0) {
-                clearNode(record);
-                resultBuilder.add(record.getIndex());
+                int comparison = Durations.compare(elapsed, inactivityPeriod);
+                if (comparison >= 0) {
+                    clearNode(record);
+                    resultBuilder.add(record.getIndex());
+                }
             }
         }
         return resultBuilder.build();

--- a/server/src/test/java/io/spine/server/delivery/ShardedWorkRegistryTest.java
+++ b/server/src/test/java/io/spine/server/delivery/ShardedWorkRegistryTest.java
@@ -21,7 +21,6 @@
 package io.spine.server.delivery;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.truth.Truth8;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.util.Durations;
 import io.spine.server.NodeId;
@@ -32,6 +31,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static io.spine.server.delivery.given.DeliveryTestEnv.generateNodeId;
 import static io.spine.server.delivery.given.DeliveryTestEnv.newShardIndex;
@@ -59,9 +59,9 @@ public abstract class ShardedWorkRegistryTest {
         Optional<ShardProcessingSession> session = registry.pickUp(index, node);
         ShardProcessingSession actualSession = assertSession(session, index);
 
-        Truth8.assertThat(registry.pickUp(index, node))
+        assertThat(registry.pickUp(index, node))
               .isEmpty();
-        Truth8.assertThat(registry.pickUp(index, generateNodeId()))
+        assertThat(registry.pickUp(index, generateNodeId()))
               .isEmpty();
 
         actualSession.complete();
@@ -76,7 +76,6 @@ public abstract class ShardedWorkRegistryTest {
 
         int totalShards = 35;
 
-        ImmutableSet.Builder<NodeId> nodeBuilder = ImmutableSet.builder();
         ImmutableSet.Builder<ShardIndex> indexBuilder = ImmutableSet.builder();
         rangeClosed(1, totalShards)
                 .forEach((i) -> {
@@ -85,10 +84,8 @@ public abstract class ShardedWorkRegistryTest {
 
                     Optional<ShardProcessingSession> session = registry.pickUp(newIndex, newNode);
                     assertSession(session, newIndex);
-                    nodeBuilder.add(newNode);
                     indexBuilder.add(newIndex);
                 });
-        ImmutableSet<NodeId> nodes = nodeBuilder.build();
         ImmutableSet<ShardIndex> indexes = indexBuilder.build();
 
         Iterable<ShardIndex> releasedIndexes =
@@ -108,7 +105,6 @@ public abstract class ShardedWorkRegistryTest {
             NodeId anotherNode = generateNodeId();
             Optional<ShardProcessingSession> newSession = registry.pickUp(shardIndex, anotherNode);
             assertSession(newSession, shardIndex);
-
         }
     }
 
@@ -116,7 +112,7 @@ public abstract class ShardedWorkRegistryTest {
     @CanIgnoreReturnValue
     private static ShardProcessingSession
     assertSession(Optional<ShardProcessingSession> session, ShardIndex index) {
-        Truth8.assertThat(session)
+        assertThat(session)
               .isPresent();
         ShardProcessingSession actualSession = session.get();
         assertThat(actualSession.shardIndex()).isEqualTo(index);

--- a/server/src/test/java/io/spine/server/delivery/ShardedWorkRegistryTest.java
+++ b/server/src/test/java/io/spine/server/delivery/ShardedWorkRegistryTest.java
@@ -22,20 +22,23 @@ package io.spine.server.delivery;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.protobuf.Duration;
 import com.google.protobuf.util.Durations;
 import io.spine.server.NodeId;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static io.spine.server.delivery.given.DeliveryTestEnv.generateNodeId;
 import static io.spine.server.delivery.given.DeliveryTestEnv.newShardIndex;
-import static java.util.stream.IntStream.rangeClosed;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.IntStream.range;
 
 /**
  * An abstract base for {@link ShardedWorkRegistry} tests.
@@ -76,36 +79,56 @@ public abstract class ShardedWorkRegistryTest {
 
         int totalShards = 35;
 
-        ImmutableSet.Builder<ShardIndex> indexBuilder = ImmutableSet.builder();
-        rangeClosed(1, totalShards)
-                .forEach((i) -> {
-                    NodeId newNode = generateNodeId();
-                    ShardIndex newIndex = newShardIndex(i, totalShards);
-
-                    Optional<ShardProcessingSession> session = registry.pickUp(newIndex, newNode);
-                    assertSession(session, newIndex);
-                    indexBuilder.add(newIndex);
-                });
-        ImmutableSet<ShardIndex> indexes = indexBuilder.build();
-
+        ImmutableSet<ShardIndex> indexes = pickUp(registry, totalShards, totalShards);
         Iterable<ShardIndex> releasedIndexes =
                 registry.releaseExpiredSessions(Durations.fromSeconds(100));
         assertThat(releasedIndexes.iterator()
                                   .hasNext()).isFalse();
 
-        sleepUninterruptibly(101, TimeUnit.MILLISECONDS);
+        sleepUninterruptibly(101, MILLISECONDS);
         releasedIndexes = registry.releaseExpiredSessions(Durations.fromMillis(100));
-
-        ImmutableSet<ShardIndex> releasedValues = ImmutableSet.<ShardIndex>builder()
-                .addAll(releasedIndexes)
-                .build();
-        assertThat(releasedValues).isEqualTo(indexes);
+        assertThat(releasedIndexes).containsExactlyElementsIn(indexes);
 
         for (ShardIndex shardIndex : indexes) {
             NodeId anotherNode = generateNodeId();
             Optional<ShardProcessingSession> newSession = registry.pickUp(shardIndex, anotherNode);
             assertSession(newSession, shardIndex);
         }
+    }
+
+    @Test
+    @DisplayName("release a shard only if it's blocked")
+    void testOnlyReleaseBlocked() {
+        ShardedWorkRegistry registry = registry();
+
+        int totalShards = 12;
+
+        Duration expirationPeriod = Durations.fromMillis(1);
+        ImmutableSet<ShardIndex> allIndexes = pickUp(registry, totalShards, totalShards);
+        sleepUninterruptibly(1, SECONDS);
+        registry.releaseExpiredSessions(expirationPeriod);
+
+        // Pick up half of the shards and leave another half empty.
+        ImmutableSet<ShardIndex> newIndexes =
+                pickUp(registry, totalShards, totalShards / 2);
+        sleepUninterruptibly(1, SECONDS);
+        Iterable<ShardIndex> releasedIndexes = registry.releaseExpiredSessions(expirationPeriod);
+        assertThat(releasedIndexes).containsExactlyElementsIn(newIndexes);
+    }
+
+    private static ImmutableSet<ShardIndex>
+    pickUp(ShardedWorkRegistry registry, int outOfTotal, int howMany) {
+        ImmutableSet<ShardIndex> indexes = range(1, howMany)
+                .mapToObj(i -> {
+                    NodeId newNode = generateNodeId();
+                    ShardIndex newIndex = newShardIndex(i, outOfTotal);
+
+                    Optional<ShardProcessingSession> session = registry.pickUp(newIndex, newNode);
+                    assertSession(session, newIndex);
+                    return newIndex;
+                })
+                .collect(toImmutableSet());
+        return indexes;
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")     // asserting the `Optional`.

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '1.0.6-SNAPSHOT'
+def final SPINE_VERSION = '1.0.7-SNAPSHOT'
 
 ext {
     // The version of the modules in this project.


### PR DESCRIPTION
Previously, when force-releasing old shards, we cleaned up all the shards which have been picked last time before a certain timestamp. That set included the shards which had no active sessions, i.e. were not being processed by any node at the time.

Now, we only release the shards which have an active session, as they are the only ones which can possibly be "stuck".

This approach prevents us from race conditions in a distributed/multithreaded environment. Also, this gives the user a clearer picture of which shards were released forcefully.