### PR TITLE
Abstract base for `ShardedWorkRegistry`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -457,7 +457,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 14:34:21 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 15:40:01 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -865,7 +865,7 @@ This report was generated on **Thu Sep 05 14:34:21 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 14:34:21 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 15:40:01 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1321,7 +1321,7 @@ This report was generated on **Thu Sep 05 14:34:21 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 14:34:22 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 15:40:02 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1939,7 +1939,7 @@ This report was generated on **Thu Sep 05 14:34:22 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 14:34:23 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 15:40:03 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2461,7 +2461,7 @@ This report was generated on **Thu Sep 05 14:34:23 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 14:34:23 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 15:40:04 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2993,7 +2993,7 @@ This report was generated on **Thu Sep 05 14:34:23 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 14:34:24 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 15:40:04 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3533,7 +3533,7 @@ This report was generated on **Thu Sep 05 14:34:24 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 14:34:24 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 15:40:05 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4119,4 +4119,4 @@ This report was generated on **Thu Sep 05 14:34:24 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 14:34:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 15:40:05 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.0.6-SNAPSHOT`
+# Dependencies of `io.spine:spine-client:1.0.7-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -457,12 +457,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 17:49:29 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 14:34:21 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.0.6-SNAPSHOT`
+# Dependencies of `io.spine:spine-core:1.0.7-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -865,12 +865,12 @@ This report was generated on **Wed Sep 04 17:49:29 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 17:49:29 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 14:34:21 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.0.6-SNAPSHOT`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.0.7-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1321,12 +1321,12 @@ This report was generated on **Wed Sep 04 17:49:29 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 17:49:30 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 14:34:22 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.0.6-SNAPSHOT`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.0.7-SNAPSHOT`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -1939,12 +1939,12 @@ This report was generated on **Wed Sep 04 17:49:30 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 17:49:31 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 14:34:23 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.0.6-SNAPSHOT`
+# Dependencies of `io.spine:spine-server:1.0.7-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2461,12 +2461,12 @@ This report was generated on **Wed Sep 04 17:49:31 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 17:49:31 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 14:34:23 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.0.6-SNAPSHOT`
+# Dependencies of `io.spine:spine-testutil-client:1.0.7-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2993,12 +2993,12 @@ This report was generated on **Wed Sep 04 17:49:31 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 17:49:32 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 14:34:24 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.0.6-SNAPSHOT`
+# Dependencies of `io.spine:spine-testutil-core:1.0.7-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3533,12 +3533,12 @@ This report was generated on **Wed Sep 04 17:49:32 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 17:49:33 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 14:34:24 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.0.6-SNAPSHOT`
+# Dependencies of `io.spine:spine-testutil-server:1.0.7-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -4119,4 +4119,4 @@ This report was generated on **Wed Sep 04 17:49:33 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 17:49:34 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 14:34:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.0.6-SNAPSHOT</version>
+<version>1.0.7-SNAPSHOT</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/delivery/AbstractWorkRegistry.java
+++ b/server/src/main/java/io/spine/server/delivery/AbstractWorkRegistry.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.delivery;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Durations;
+import io.spine.annotation.SPI;
+import io.spine.server.NodeId;
+
+import java.util.Optional;
+
+import static com.google.protobuf.util.Timestamps.between;
+import static io.spine.base.Time.currentTime;
+
+/**
+ * An implementation base for {@link ShardedWorkRegistry ShardedWorkRegistries} based on a specific
+ * persistence mechanism.
+ *
+ * @implNote This class is NOT thread safe. Synchronize the atomic persistence operations as well as
+ *         the methods implemented in this class make an implementation thread safe.
+ */
+@SPI
+public abstract class AbstractWorkRegistry implements ShardedWorkRegistry {
+
+    @Override
+    public Optional<ShardProcessingSession> pickUp(ShardIndex index, NodeId nodeId) {
+        Optional<ShardSessionRecord> record = find(index);
+        if (record.isPresent()) {
+            ShardSessionRecord existingRecord = record.get();
+            if (existingRecord.hasPickedBy()) {
+                return Optional.empty();
+            } else {
+                ShardSessionRecord updatedRecord = updateNode(existingRecord, nodeId);
+                return Optional.of(asSession(updatedRecord));
+            }
+        } else {
+            ShardSessionRecord newRecord = createRecord(index, nodeId);
+            return Optional.of(asSession(newRecord));
+        }
+    }
+
+    private ShardSessionRecord createRecord(ShardIndex index, NodeId nodeId) {
+        ShardSessionRecord newRecord = ShardSessionRecord
+                .newBuilder()
+                .setIndex(index)
+                .setPickedBy(nodeId)
+                .setWhenLastPicked(currentTime())
+                .vBuild();
+        write(newRecord);
+        return newRecord;
+    }
+
+    private ShardSessionRecord updateNode(ShardSessionRecord record, NodeId nodeId) {
+        ShardSessionRecord updatedRecord = record
+                .toBuilder()
+                .setPickedBy(nodeId)
+                .build();
+        write(updatedRecord);
+        return updatedRecord;
+    }
+
+    @Override
+    public Iterable<ShardIndex> releaseExpiredSessions(Duration inactivityPeriod) {
+        ImmutableSet.Builder<ShardIndex> resultBuilder = ImmutableSet.builder();
+        for (ShardSessionRecord record : allRecords()) {
+            if (record.hasPickedBy()) {
+                Timestamp whenPicked = record.getWhenLastPicked();
+                Duration elapsed = between(whenPicked, currentTime());
+
+                int comparison = Durations.compare(elapsed, inactivityPeriod);
+                if (comparison >= 0) {
+                    clearNode(record);
+                    resultBuilder.add(record.getIndex());
+                }
+            }
+        }
+        return resultBuilder.build();
+    }
+
+    /**
+     * Clears the value of {@code ShardSessionRecord.when_last_picked} and stores the session.
+     */
+    protected void clearNode(ShardSessionRecord session) {
+        ShardSessionRecord record = session.toBuilder()
+                                           .clearPickedBy()
+                                           .build();
+        write(record);
+    }
+
+    /**
+     * Obtains all the session records associated with this registry.
+     */
+    protected abstract Iterable<ShardSessionRecord> allRecords();
+
+    /**
+     * Stores the given session.
+     *
+     * <p>The session may or may be not present in the registry already. After calling this method,
+     * the given session must be reachable via {@link #find(ShardIndex)} and {@link #allRecords()}.
+     */
+    protected abstract void write(ShardSessionRecord session);
+
+    /**
+     * Looks for the session record by the given shard index.
+     *
+     * @param index
+     *         shard index to find a session for
+     * @return a session record or {@code Optional.empty()} if the record is not present in
+     *         the registry
+     */
+    protected abstract Optional<ShardSessionRecord> find(ShardIndex index);
+
+    /**
+     * Restores a {@link ShardProcessingSession} from the given session record.
+     */
+    protected abstract ShardProcessingSession asSession(ShardSessionRecord record);
+}

--- a/server/src/main/java/io/spine/server/delivery/AbstractWorkRegistry.java
+++ b/server/src/main/java/io/spine/server/delivery/AbstractWorkRegistry.java
@@ -79,6 +79,7 @@ public abstract class AbstractWorkRegistry implements ShardedWorkRegistry {
         ShardSessionRecord updatedRecord = record
                 .toBuilder()
                 .setPickedBy(nodeId)
+                .setWhenLastPicked(currentTime())
                 .build();
         write(updatedRecord);
         return updatedRecord;

--- a/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
+++ b/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
@@ -20,101 +20,61 @@
 
 package io.spine.server.delivery.memory;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Duration;
-import com.google.protobuf.Timestamp;
-import com.google.protobuf.util.Durations;
 import io.spine.server.NodeId;
+import io.spine.server.delivery.AbstractWorkRegistry;
 import io.spine.server.delivery.ShardIndex;
 import io.spine.server.delivery.ShardProcessingSession;
 import io.spine.server.delivery.ShardSessionRecord;
 import io.spine.server.delivery.ShardedWorkRegistry;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Map;
 import java.util.Optional;
 
-import static com.google.protobuf.util.Timestamps.between;
-import static io.spine.base.Time.currentTime;
+import static com.google.common.collect.Maps.newConcurrentMap;
 
 /**
  * An in-memory implementation of {@link ShardedWorkRegistry ShardedWorkRegistry}.
+ *
+ * @implNote This implementation synchronizes methods of {@code AbstractWorkRegistry} and
+ *         uses a concurrent collection in order to guarantee thread safety.
  */
-public class InMemoryShardedWorkRegistry implements ShardedWorkRegistry {
+public final class InMemoryShardedWorkRegistry extends AbstractWorkRegistry {
 
-    private final Map<ShardIndex, ShardSessionRecord> workByNode =
-            Maps.newConcurrentMap();
+    private final Map<ShardIndex, ShardSessionRecord> workByNode = newConcurrentMap();
 
     @Override
     public synchronized Optional<ShardProcessingSession> pickUp(ShardIndex index, NodeId nodeId) {
-        if (workByNode.containsKey(index)) {
-            ShardSessionRecord existingRecord = workByNode.get(index);
-            if (existingRecord.hasPickedBy()) {
-                return Optional.empty();
-            } else {
-                ShardSessionRecord updatedRecord = updatePickedBy(existingRecord, nodeId);
-                return Optional.of(asSession(updatedRecord));
-            }
-        }
-        ShardSessionRecord record =
-                ShardSessionRecord
-                        .newBuilder()
-                        .setIndex(index)
-                        .setPickedBy(nodeId)
-                        .setWhenLastPicked(currentTime())
-                        .vBuild();
-        workByNode.put(index, record);
-        return Optional.of(asSession(record));
+        return super.pickUp(index, nodeId);
     }
 
     @Override
     public synchronized Iterable<ShardIndex> releaseExpiredSessions(Duration inactivityPeriod) {
-        ImmutableSet.Builder<ShardIndex> resultBuilder = ImmutableSet.builder();
-
-        for (ShardSessionRecord record : workByNode.values()) {
-            if (record.hasPickedBy()) {
-                Timestamp whenPicked = record.getWhenLastPicked();
-                Duration elapsed = between(whenPicked, currentTime());
-
-                int comparison = Durations.compare(elapsed, inactivityPeriod);
-                if (comparison >= 0) {
-                    clearNode(record);
-                    resultBuilder.add(record.getIndex());
-                }
-            }
-        }
-        return resultBuilder.build();
+        return super.releaseExpiredSessions(inactivityPeriod);
     }
 
-    private void clearNode(ShardSessionRecord record) {
-        updatePickedBy(record, null);
+    @Override
+    protected synchronized void clearNode(ShardSessionRecord session) {
+        super.clearNode(session);
     }
 
-    /**
-     * Updates the {@code picked_by} field or clears it if {@code null} is passed.
-     *
-     * @return the updated record value.
-     * @implNote As the field is only updated, the record message isn't validated. It allows
-     *         to save some CPU cycles.
-     */
-    @SuppressWarnings("ResultOfMethodCallIgnored")      // `Builder` methods called in `if-else`.
-    @CanIgnoreReturnValue
-    private ShardSessionRecord updatePickedBy(ShardSessionRecord record,
-                                              @Nullable NodeId nodeId) {
-        ShardSessionRecord.Builder builder = record.toBuilder();
-        if (nodeId == null) {
-            builder.clearPickedBy();
-        } else {
-            builder.setPickedBy(nodeId);
-        }
-        ShardSessionRecord updatedRecord = builder.build();
-        workByNode.put(record.getIndex(), updatedRecord);
-        return updatedRecord;
+    @Override
+    protected Iterable<ShardSessionRecord> allRecords() {
+        return workByNode.values();
     }
 
-    private ShardProcessingSession asSession(ShardSessionRecord record) {
+    @Override
+    protected void write(ShardSessionRecord session) {
+        workByNode.put(session.getIndex(), session);
+    }
+
+    @Override
+    protected Optional<ShardSessionRecord> find(ShardIndex index) {
+        return Optional.ofNullable(workByNode.get(index));
+    }
+
+    @Override
+    protected ShardProcessingSession asSession(ShardSessionRecord record) {
         return new InMemoryShardSession(record);
     }
 

--- a/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
+++ b/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
@@ -28,9 +28,11 @@ import io.spine.server.delivery.ShardProcessingSession;
 import io.spine.server.delivery.ShardSessionRecord;
 import io.spine.server.delivery.ShardedWorkRegistry;
 
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.collect.Iterators.unmodifiableIterator;
 import static com.google.common.collect.Maps.newConcurrentMap;
 
 /**
@@ -59,8 +61,8 @@ public final class InMemoryShardedWorkRegistry extends AbstractWorkRegistry {
     }
 
     @Override
-    protected Iterable<ShardSessionRecord> allRecords() {
-        return workByNode.values();
+    protected Iterator<ShardSessionRecord> allRecords() {
+        return unmodifiableIterator(workByNode.values().iterator());
     }
 
     @Override


### PR DESCRIPTION
In this PR we extract common implementation parts from `SessionWorkRegistry` implementations into an abstract class. The in-mem implementation now does, and other implementations should, extend `AbstractWorkRegistry` in order to avoid duplicate code.