### PR TITLE
Filter event subscription by parameter annotation

### DIFF
--- a/.idea/dictionaries/common.xml
+++ b/.idea/dictionaries/common.xml
@@ -38,7 +38,6 @@
       <w>oneof</w>
       <w>onmessage</w>
       <w>onopen</w>
-      <w>overriden</w>
       <w>parameterizing</w>
       <w>plugable</w>
       <w>processmanager</w>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -474,6 +474,7 @@
       <option name="ignoreForLoopDeclarations" value="true" />
     </inspection_tool>
     <inspection_tool class="MultipleTopLevelClassesInFile" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="MultipleVariablesInDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NakedNotify" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NativeMethods" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NestedAssignment" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -494,6 +495,7 @@
         <extension name="JUnit4MethodNamingConvention" enabled="true">
           <option name="m_regex" value="[a-z][A-Za-z\d]*" />
           <option name="m_minLength" value="2" />
+          <option name="m_maxLength" value="64" />
         </extension>
       </scope>
       <scope name="Production" level="WARNING" enabled="true">
@@ -643,7 +645,6 @@
       <option name="ignoreCloneable" value="false" />
     </inspection_tool>
     <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="RedundantSuppression" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
@@ -713,9 +714,6 @@
     <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SwitchStatementWithTooFewBranches" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="m_limit" value="2" />
-    </inspection_tool>
     <inspection_tool class="SwitchStatementsWithoutDefault" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreFullyCoveredEnums" value="true" />
     </inspection_tool>
@@ -732,13 +730,11 @@
     <inspection_tool class="SystemSetSecurityManager" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TailRecursion" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TestOnlyProblems" enabled="true" level="TYPO" enabled_by_default="true" />
-    <inspection_tool class="TextLabelInSwitchStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThisEscapedInConstructor" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadDeathRethrown" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadDumpStack" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadLocalNotStaticFinal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadPriority" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ThreadRun" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadStartInConstruction" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadStopSuspendResume" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadWithDefaultRunMethod" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -822,9 +818,6 @@
       <option name="ignoreReferences" value="true" />
       <option name="ignoreComplexLiterals" value="false" />
     </inspection_tool>
-    <inspection_tool class="UnqualifiedInnerClassAccess" enabled="false" level="WARNING" enabled_by_default="false">
-      <option name="ignoreReferencesToLocalInnerClasses" value="true" />
-    </inspection_tool>
     <inspection_tool class="UnsecureRandomNumberGeneration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnstableApiUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="Tests" level="WEAK WARNING" enabled="false" />
@@ -855,7 +848,7 @@
       </option>
       <option name="ignoreClassesWithOnlyMain" value="false" />
     </inspection_tool>
-    <inspection_tool class="VariableNotUsedInsideIf" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="VariableNotUsedInsideIf" enabled="true" level="TYPO" enabled_by_default="true" />
     <inspection_tool class="VolatileArrayField" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="VolatileLongOrDoubleField" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="WaitCalledOnCondition" enabled="true" level="WARNING" enabled_by_default="true" />

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -474,7 +474,6 @@
       <option name="ignoreForLoopDeclarations" value="true" />
     </inspection_tool>
     <inspection_tool class="MultipleTopLevelClassesInFile" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MultipleVariablesInDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NakedNotify" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NativeMethods" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NestedAssignment" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -495,7 +494,6 @@
         <extension name="JUnit4MethodNamingConvention" enabled="true">
           <option name="m_regex" value="[a-z][A-Za-z\d]*" />
           <option name="m_minLength" value="2" />
-          <option name="m_maxLength" value="64" />
         </extension>
       </scope>
       <scope name="Production" level="WARNING" enabled="true">
@@ -645,6 +643,7 @@
       <option name="ignoreCloneable" value="false" />
     </inspection_tool>
     <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="RedundantSuppression" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
@@ -714,6 +713,9 @@
     <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SwitchStatementWithTooFewBranches" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="m_limit" value="2" />
+    </inspection_tool>
     <inspection_tool class="SwitchStatementsWithoutDefault" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreFullyCoveredEnums" value="true" />
     </inspection_tool>
@@ -730,11 +732,13 @@
     <inspection_tool class="SystemSetSecurityManager" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TailRecursion" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TestOnlyProblems" enabled="true" level="TYPO" enabled_by_default="true" />
+    <inspection_tool class="TextLabelInSwitchStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThisEscapedInConstructor" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadDeathRethrown" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadDumpStack" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadLocalNotStaticFinal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadPriority" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ThreadRun" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadStartInConstruction" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadStopSuspendResume" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadWithDefaultRunMethod" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -817,6 +821,9 @@
     <inspection_tool class="UnpredictableBigDecimalConstructorCall" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreReferences" value="true" />
       <option name="ignoreComplexLiterals" value="false" />
+    </inspection_tool>
+    <inspection_tool class="UnqualifiedInnerClassAccess" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreReferencesToLocalInnerClasses" value="true" />
     </inspection_tool>
     <inspection_tool class="UnsecureRandomNumberGeneration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnstableApiUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">

--- a/client/src/main/java/io/spine/client/Filters.java
+++ b/client/src/main/java/io/spine/client/Filters.java
@@ -23,8 +23,8 @@ package io.spine.client;
 import com.google.common.primitives.Primitives;
 import com.google.protobuf.Any;
 import com.google.protobuf.Timestamp;
+import io.spine.base.Field;
 import io.spine.base.FieldPath;
-import io.spine.base.FieldPaths;
 import io.spine.client.CompositeFilter.CompositeOperator;
 
 import java.util.Collection;
@@ -222,7 +222,7 @@ public final class Filters {
     }
 
     private static Filter createFilter(String fieldPath, Object value, Operator operator) {
-        FieldPath path = FieldPaths.parse(fieldPath);
+        FieldPath path = Field.parse(fieldPath).path();
         Any wrappedValue = toAny(value);
         Filter filter = Filter
                 .newBuilder()

--- a/core/src/main/java/io/spine/core/Subscribe.java
+++ b/core/src/main/java/io/spine/core/Subscribe.java
@@ -151,6 +151,9 @@ public @interface Subscribe {
      *
      * <p>If the {@link ByField#path() @ByField.path} if empty, the filter is not
      * applied.
+     *
+     * @deprecated please use {@link Where @Where} annotation for the first method parameter.
      */
+    @Deprecated
     ByField filter() default @ByField(path = "", value = "");
 }

--- a/core/src/main/java/io/spine/core/Where.java
+++ b/core/src/main/java/io/spine/core/Where.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.core;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Filters events delivered to the {@linkplain Subscribe subscriber method} the first
+ * parameter of which has this annotation.
+ *
+ * <p>For example, the following method would be invoked only if the owner of the created
+ * project is {@code mary@ackme.net}:
+ * <pre>{@code
+ * \@Subscribe
+ * void on(@Where(field = "owner.email" equals = "mary@ackme.net") ProjectCreated e) { ... }
+ * }</pre>
+ *
+ * <p><em>NOTE:</em> This syntax applies only to events. Filtering state subscriptions
+ * is not supported.
+ */
+@Retention(RUNTIME)
+@Target(PARAMETER)
+@Documented
+public @interface Where {
+
+    /**
+     * The {@linkplain io.spine.base.FieldPath path to the field} of the event message to filter by.
+     */
+    String field();
+
+    /**
+     * The expected value of the field.
+     *
+     * <p>The value converted with help of {@link io.spine.string.Stringifier Stringifier}s into
+     * the type of the actual value of the message field.
+     */
+    String equals();
+}

--- a/license-report.md
+++ b/license-report.md
@@ -457,7 +457,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 19:35:36 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 19:48:15 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -865,7 +865,7 @@ This report was generated on **Wed Sep 04 19:35:36 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 19:35:37 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 19:48:15 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1321,7 +1321,7 @@ This report was generated on **Wed Sep 04 19:35:37 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 19:35:37 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 19:48:16 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1939,7 +1939,7 @@ This report was generated on **Wed Sep 04 19:35:37 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 19:35:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 19:48:16 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2461,7 +2461,7 @@ This report was generated on **Wed Sep 04 19:35:38 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 19:35:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 19:48:17 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2993,7 +2993,7 @@ This report was generated on **Wed Sep 04 19:35:38 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 19:35:39 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 19:48:17 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3533,7 +3533,7 @@ This report was generated on **Wed Sep 04 19:35:39 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 19:35:39 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 19:48:18 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4119,4 +4119,4 @@ This report was generated on **Wed Sep 04 19:35:39 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 04 19:35:39 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 05 19:48:18 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.0.3`
+# Dependencies of `io.spine:spine-client:1.0.8-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -457,12 +457,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Sep 01 13:04:20 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 04 19:35:36 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.0.3`
+# Dependencies of `io.spine:spine-core:1.0.8-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -865,12 +865,12 @@ This report was generated on **Sun Sep 01 13:04:20 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Sep 01 13:04:20 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 04 19:35:37 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.0.3`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.0.8-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1321,12 +1321,12 @@ This report was generated on **Sun Sep 01 13:04:20 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Sep 01 13:04:21 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 04 19:35:37 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.0.3`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.0.8-SNAPSHOT`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -1939,12 +1939,12 @@ This report was generated on **Sun Sep 01 13:04:21 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Sep 01 13:04:22 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 04 19:35:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.0.3`
+# Dependencies of `io.spine:spine-server:1.0.8-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2461,12 +2461,12 @@ This report was generated on **Sun Sep 01 13:04:22 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Sep 01 13:04:23 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 04 19:35:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.0.3`
+# Dependencies of `io.spine:spine-testutil-client:1.0.8-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2993,12 +2993,12 @@ This report was generated on **Sun Sep 01 13:04:23 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Sep 01 13:04:23 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 04 19:35:39 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.0.3`
+# Dependencies of `io.spine:spine-testutil-core:1.0.8-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3533,12 +3533,12 @@ This report was generated on **Sun Sep 01 13:04:23 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Sep 01 13:04:24 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 04 19:35:39 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.0.3`
+# Dependencies of `io.spine:spine-testutil-server:1.0.8-SNAPSHOT`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -4119,4 +4119,4 @@ This report was generated on **Sun Sep 01 13:04:24 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Sep 01 13:04:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 04 19:35:39 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -457,7 +457,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 19:48:15 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 06 00:35:36 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -865,7 +865,7 @@ This report was generated on **Thu Sep 05 19:48:15 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 19:48:15 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 06 00:35:37 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1321,7 +1321,7 @@ This report was generated on **Thu Sep 05 19:48:15 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 19:48:16 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 06 00:35:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1939,7 +1939,7 @@ This report was generated on **Thu Sep 05 19:48:16 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 19:48:16 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 06 00:35:39 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2461,7 +2461,7 @@ This report was generated on **Thu Sep 05 19:48:16 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 19:48:17 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 06 00:35:39 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2993,7 +2993,7 @@ This report was generated on **Thu Sep 05 19:48:17 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 19:48:17 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 06 00:35:39 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3533,7 +3533,7 @@ This report was generated on **Thu Sep 05 19:48:17 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 19:48:18 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 06 00:35:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4119,4 +4119,4 @@ This report was generated on **Thu Sep 05 19:48:18 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 05 19:48:18 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 06 00:35:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.guava</groupId>
     <artifactId>guava</artifactId>
-    <version>28.0-jre</version>
+    <version>28.1-jre</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -112,7 +112,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-testlib</artifactId>
-    <version>28.0-jre</version>
+    <version>28.1-jre</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.0.3</version>
+<version>1.0.8-SNAPSHOT</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -70,7 +70,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -82,13 +82,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -124,7 +124,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -136,13 +136,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -210,12 +210,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-time</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -130,7 +130,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-time</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.8-SNAPSHOT</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/server/src/main/java/io/spine/server/event/model/EventSubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/EventSubscriberMethod.java
@@ -40,7 +40,7 @@ public final class EventSubscriberMethod extends SubscriberMethod {
 
     @Override
     public ArgumentFilter createFilter() {
-        ArgumentFilter result = createFilter(rawMethod());
+        ArgumentFilter result = ArgumentFilter.createFilter(rawMethod());
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/event/model/EventSubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/EventSubscriberMethod.java
@@ -21,18 +21,11 @@
 package io.spine.server.event.model;
 
 import com.google.errorprone.annotations.Immutable;
-import io.spine.base.FieldPath;
-import io.spine.base.FieldPaths;
-import io.spine.core.ByField;
-import io.spine.core.Subscribe;
 import io.spine.server.model.ArgumentFilter;
 import io.spine.server.model.ParameterSpec;
 import io.spine.server.type.EventEnvelope;
 
 import java.lang.reflect.Method;
-
-import static io.spine.base.FieldPaths.typeOfFieldAt;
-import static io.spine.string.Stringifiers.fromString;
 
 /**
  * A wrapper for an event subscriber method.
@@ -47,16 +40,8 @@ public final class EventSubscriberMethod extends SubscriberMethod {
 
     @Override
     public ArgumentFilter createFilter() {
-        Subscribe annotation = rawMethod().getAnnotation(Subscribe.class);
-        ByField byFieldFilter = annotation.filter();
-        String rawFieldPath = byFieldFilter.path();
-        if (rawFieldPath.isEmpty()) {
-            return ArgumentFilter.acceptingAll();
-        }
-        FieldPath fieldPath = FieldPaths.parse(rawFieldPath);
-        Class<?> fieldType = typeOfFieldAt(rawMessageClass(), fieldPath);
-        Object expectedValue = fromString(byFieldFilter.value(), fieldType);
-        return ArgumentFilter.acceptingOnly(fieldPath, expectedValue);
+        ArgumentFilter result = createFilter(rawMethod());
+        return result;
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/event/model/StateSubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/StateSubscriberMethod.java
@@ -28,8 +28,6 @@ import io.spine.base.FieldPath;
 import io.spine.base.FieldPaths;
 import io.spine.core.BoundedContext;
 import io.spine.core.BoundedContextName;
-import io.spine.core.ByField;
-import io.spine.core.Subscribe;
 import io.spine.logging.Logging;
 import io.spine.server.model.ArgumentFilter;
 import io.spine.server.model.Model;
@@ -62,9 +60,8 @@ public final class StateSubscriberMethod extends SubscriberMethod implements Log
     }
 
     private static Method checkNotFiltered(Method method) {
-        Subscribe subscribe = method.getAnnotation(Subscribe.class);
-        ByField filter = subscribe.filter();
-        checkState(filter.path().isEmpty() && filter.value().isEmpty(),
+        ArgumentFilter filter = createFilter(method);
+        checkState(filter.acceptsAll(),
                    "A state subscriber method cannot declare filters but the method `%s` does.",
                    method);
         return method;

--- a/server/src/main/java/io/spine/server/event/model/StateSubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/StateSubscriberMethod.java
@@ -24,8 +24,8 @@ import com.google.errorprone.annotations.Immutable;
 import com.google.protobuf.Message;
 import io.spine.base.Environment;
 import io.spine.base.EventMessage;
+import io.spine.base.Field;
 import io.spine.base.FieldPath;
-import io.spine.base.FieldPaths;
 import io.spine.core.BoundedContext;
 import io.spine.core.BoundedContextName;
 import io.spine.logging.Logging;
@@ -47,7 +47,7 @@ import static io.spine.core.BoundedContextNames.assumingTests;
 @Immutable
 public final class StateSubscriberMethod extends SubscriberMethod implements Logging {
 
-    private static final FieldPath ENTITY_TYPE_URL = FieldPaths.parse("entity.type_url");
+    private static final FieldPath ENTITY_TYPE_URL = Field.parse("entity.type_url").path();
 
     private final BoundedContextName contextOfSubscriber;
     private final Class<? extends Message> stateType;

--- a/server/src/main/java/io/spine/server/event/model/StateSubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/StateSubscriberMethod.java
@@ -60,7 +60,7 @@ public final class StateSubscriberMethod extends SubscriberMethod implements Log
     }
 
     private static Method checkNotFiltered(Method method) {
-        ArgumentFilter filter = createFilter(method);
+        ArgumentFilter filter = ArgumentFilter.createFilter(method);
         checkState(filter.acceptsAll(),
                    "A state subscriber method cannot declare filters but the method `%s` does.",
                    method);

--- a/server/src/main/java/io/spine/server/event/model/SubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/SubscriberMethod.java
@@ -21,12 +21,7 @@
 package io.spine.server.event.model;
 
 import com.google.errorprone.annotations.Immutable;
-import com.google.protobuf.Message;
 import io.spine.base.EventMessage;
-import io.spine.base.FieldPath;
-import io.spine.base.FieldPaths;
-import io.spine.core.ByField;
-import io.spine.core.Subscribe;
 import io.spine.server.event.EventSubscriber;
 import io.spine.server.model.AbstractHandlerMethod;
 import io.spine.server.model.ArgumentFilter;
@@ -43,8 +38,6 @@ import java.lang.reflect.Method;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Suppliers.memoize;
-import static io.spine.base.FieldPaths.typeOfFieldAt;
-import static io.spine.string.Stringifiers.fromString;
 
 /**
  * A method annotated with the {@link io.spine.core.Subscribe @Subscribe} annotation.
@@ -68,26 +61,6 @@ public abstract class SubscriberMethod
 
     protected SubscriberMethod(Method method, ParameterSpec<EventEnvelope> parameterSpec) {
         super(method, parameterSpec);
-    }
-
-    /**
-     * Creates a new filter by the passed method.
-     *
-     * <p>If the method is not annotated for filtering, the returned instance
-     * {@linkplain ArgumentFilter#acceptsAll() accepts all} arguments.
-     */
-    static ArgumentFilter createFilter(Method method) {
-        Subscribe annotation = method.getAnnotation(Subscribe.class);
-        ByField byFieldFilter = annotation.filter();
-        String rawFieldPath = byFieldFilter.path();
-        if (rawFieldPath.isEmpty()) {
-            return ArgumentFilter.acceptingAll();
-        }
-        FieldPath fieldPath = FieldPaths.parse(rawFieldPath);
-        Class<Message> firstParam = firstParamType(method);
-        Class<?> fieldType = typeOfFieldAt(firstParam, fieldPath);
-        Object expectedValue = fromString(byFieldFilter.value(), fieldType);
-        return ArgumentFilter.acceptingOnly(fieldPath, expectedValue);
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/event/model/SubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/SubscriberMethod.java
@@ -21,7 +21,12 @@
 package io.spine.server.event.model;
 
 import com.google.errorprone.annotations.Immutable;
+import com.google.protobuf.Message;
 import io.spine.base.EventMessage;
+import io.spine.base.FieldPath;
+import io.spine.base.FieldPaths;
+import io.spine.core.ByField;
+import io.spine.core.Subscribe;
 import io.spine.server.event.EventSubscriber;
 import io.spine.server.model.AbstractHandlerMethod;
 import io.spine.server.model.ArgumentFilter;
@@ -38,6 +43,8 @@ import java.lang.reflect.Method;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Suppliers.memoize;
+import static io.spine.base.FieldPaths.typeOfFieldAt;
+import static io.spine.string.Stringifiers.fromString;
 
 /**
  * A method annotated with the {@link io.spine.core.Subscribe @Subscribe} annotation.
@@ -61,6 +68,26 @@ public abstract class SubscriberMethod
 
     protected SubscriberMethod(Method method, ParameterSpec<EventEnvelope> parameterSpec) {
         super(method, parameterSpec);
+    }
+
+    /**
+     * Creates a new filter by the passed method.
+     *
+     * <p>If the method is not annotated for filtering, the returned instance
+     * {@linkplain ArgumentFilter#acceptsAll() accepts all} arguments.
+     */
+    static ArgumentFilter createFilter(Method method) {
+        Subscribe annotation = method.getAnnotation(Subscribe.class);
+        ByField byFieldFilter = annotation.filter();
+        String rawFieldPath = byFieldFilter.path();
+        if (rawFieldPath.isEmpty()) {
+            return ArgumentFilter.acceptingAll();
+        }
+        FieldPath fieldPath = FieldPaths.parse(rawFieldPath);
+        Class<Message> firstParam = firstParamType(method);
+        Class<?> fieldType = typeOfFieldAt(firstParam, fieldPath);
+        Object expectedValue = fromString(byFieldFilter.value(), fieldType);
+        return ArgumentFilter.acceptingOnly(fieldPath, expectedValue);
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/model/ArgumentFilter.java
+++ b/server/src/main/java/io/spine/server/model/ArgumentFilter.java
@@ -143,11 +143,7 @@ public final class ArgumentFilter implements Predicate<EventMessage> {
      * Tells if the passed filter works on the same field as this one.
      */
     boolean sameField(ArgumentFilter another) {
-        if (field == null) {
-            return another.field == null;
-        }
-        boolean result = field.equals(another.field);
-        return result;
+        return Objects.equals(field, another.field);
     }
 
     /** Obtains the depth of the filtered field. */

--- a/server/src/main/java/io/spine/server/model/ArgumentFilter.java
+++ b/server/src/main/java/io/spine/server/model/ArgumentFilter.java
@@ -55,6 +55,15 @@ public final class ArgumentFilter implements Predicate<EventMessage> {
     @SuppressWarnings("Immutable") // Values are primitives.
     private final @Nullable Object expectedValue;
 
+    private ArgumentFilter(FieldPath path, Object expectedValue) {
+        this.field = path.getFieldNameCount() > 0
+                     ? Field.withPath(path)
+                     : null;
+        this.expectedValue = field != null
+                             ? expectedValue
+                             : null;
+    }
+
     /**
      * Creates a new filter which accepts only the passed value of the specified field.
      */
@@ -168,15 +177,6 @@ public final class ArgumentFilter implements Predicate<EventMessage> {
             return 0;
         }
         return field.path().getFieldNameCount();
-    }
-
-    private ArgumentFilter(FieldPath path, Object expectedValue) {
-        this.field = path.getFieldNameCount() > 0
-            ? Field.withPath(path)
-            : null;
-        this.expectedValue = field != null
-            ? expectedValue
-            : null;
     }
 
     /** Tells if this filter accepts all the events. */

--- a/server/src/main/java/io/spine/server/model/ArgumentFilter.java
+++ b/server/src/main/java/io/spine/server/model/ArgumentFilter.java
@@ -74,6 +74,7 @@ public final class ArgumentFilter implements Predicate<EventMessage> {
      * <p>If the method is not annotated for filtering, the returned instance
      * {@linkplain ArgumentFilter#acceptsAll() accepts all} arguments.
      */
+    @SuppressWarnings("deprecation") // still need to support `ByField` when building older models.
     public static ArgumentFilter createFilter(Method method) {
         Subscribe annotation = method.getAnnotation(Subscribe.class);
         checkAnnotated(method, annotation);

--- a/server/src/main/java/io/spine/server/model/MethodScan.java
+++ b/server/src/main/java/io/spine/server/model/MethodScan.java
@@ -123,7 +123,8 @@ final class MethodScan<H extends HandlerMethod<?, ?, ?, ?>> {
         }
         MessageClass handledClass = handler.messageClass();
         SelectiveHandler existingHandler = selectiveHandlers.put(handledClass, handler);
-        if (existingHandler != null) {
+        if (existingHandler != null
+                && !filter.sameField(existingHandler.filter())) {
             // There is already a handler for this message class.
             // See that the field which is used as the condition for filtering is the same.
             // It is not allowed to have filtered handlers by various fields because it
@@ -134,11 +135,9 @@ final class MethodScan<H extends HandlerMethod<?, ?, ?, ?>> {
             // different values. It allows to split logic into smaller methods instead of having
             // if-else chains (that branch by different values) inside a bigger handler method.
             //
-            if (!filter.sameField(existingHandler.filter())) {
-                throw new HandlerFieldFilterClashError(
-                        declaringClass, handler.rawMethod(), existingHandler.rawMethod()
-                );
-            }
+            throw new HandlerFieldFilterClashError(
+                    declaringClass, handler.rawMethod(), existingHandler.rawMethod()
+            );
             // It is OK to keep only the last filtering handler in the map (and not all of them)
             // because filtered fields are required to be the same.
         }

--- a/server/src/main/java/io/spine/server/stand/UpdateHandler.java
+++ b/server/src/main/java/io/spine/server/stand/UpdateHandler.java
@@ -22,8 +22,7 @@ package io.spine.server.stand;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
-import io.spine.base.FieldPath;
-import io.spine.base.FieldPaths;
+import io.spine.base.Field;
 import io.spine.client.CompositeFilter;
 import io.spine.client.Filter;
 import io.spine.client.IdFilter;
@@ -43,7 +42,6 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkState;
-import static io.spine.base.FieldPaths.getValue;
 import static io.spine.server.storage.OperatorEvaluator.eval;
 import static io.spine.util.Exceptions.newIllegalArgumentException;
 
@@ -197,8 +195,8 @@ abstract class UpdateHandler implements Logging {
     }
 
     private static boolean checkPasses(Message state, Filter filter) {
-        FieldPath fieldPath = filter.getFieldPath();
-        Object actual = getValue(fieldPath, state);
+        Field field = Field.withPath(filter.getFieldPath());
+        Object actual = field.valueIn(state);
         Any requiredAsAny = filter.getValue();
         Object required = TypeConverter.toObject(requiredAsAny, actual.getClass());
         try {
@@ -208,8 +206,7 @@ abstract class UpdateHandler implements Logging {
                     e,
                     "Filter value `%s` cannot be properly compared to" +
                             " the message field `%s` of the class `%s`.",
-                    required, FieldPaths.toString(fieldPath), actual.getClass()
-                                                                    .getName()
+                    required, field, actual.getClass().getName()
             );
         }
     }

--- a/server/src/main/java/io/spine/system/server/CommandLogProjection.java
+++ b/server/src/main/java/io/spine/system/server/CommandLogProjection.java
@@ -20,7 +20,6 @@
 
 package io.spine.system.server;
 
-import io.spine.core.ByField;
 import io.spine.core.Command;
 import io.spine.core.CommandContext;
 import io.spine.core.CommandContext.Schedule;
@@ -28,6 +27,7 @@ import io.spine.core.CommandId;
 import io.spine.core.Responses;
 import io.spine.core.Status;
 import io.spine.core.Subscribe;
+import io.spine.core.Where;
 import io.spine.server.projection.Projection;
 import io.spine.system.server.Substituted.Sequence;
 import io.spine.system.server.event.CommandAcknowledged;
@@ -88,11 +88,10 @@ final class CommandLogProjection
         setStatus(Responses.statusOk());
     }
 
-    @Subscribe(filter = @ByField(
-            path = "handled_signal.id.type_url",
-            value = "type.spine.io/spine.core.Command"
-    ))
-    void on(HandlerFailedUnexpectedly event) {
+    @Subscribe
+    void on(@Where(field = "handled_signal.id.type_url",
+                   equals = "type.spine.io/spine.core.Command")
+            HandlerFailedUnexpectedly event) {
         Status status = Status
                 .newBuilder()
                 .setError(event.getError())

--- a/server/src/test/java/io/spine/server/entity/AbstractEventSubscriberTest.java
+++ b/server/src/test/java/io/spine/server/entity/AbstractEventSubscriberTest.java
@@ -30,6 +30,7 @@ import io.spine.core.UserId;
 import io.spine.server.BoundedContext;
 import io.spine.server.event.model.InsufficientVisibilityError;
 import io.spine.server.given.groups.FilteredStateSubscriber;
+import io.spine.server.given.groups.FilteredStateSubscriberWhere;
 import io.spine.server.given.groups.Group;
 import io.spine.server.given.groups.GroupId;
 import io.spine.server.given.groups.HiddenEntitySubscriber;
@@ -151,9 +152,15 @@ class AbstractEventSubscriberTest {
     }
 
     @Test
-    @DisplayName("fail to subscribe to entity states with filters")
+    @DisplayName("fail to subscribe to entity states with filters (@ByField)")
     void failToSubscribeToStateWithFilters() {
         assertThrows(IllegalStateException.class, FilteredStateSubscriber::new);
+    }
+
+    @Test
+    @DisplayName("fail to subscribe to entity states with filters (@Where)")
+    void failToSubscribeToStateWithFiltersWhere() {
+        assertThrows(IllegalStateException.class, FilteredStateSubscriberWhere::new);
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/entity/storage/EntityQueryTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/EntityQueryTest.java
@@ -27,8 +27,8 @@ import com.google.common.collect.Multimap;
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
 import com.google.common.truth.StringSubject;
+import io.spine.base.Field;
 import io.spine.base.FieldPath;
-import io.spine.base.FieldPaths;
 import io.spine.client.Filter;
 import io.spine.client.Filters;
 import io.spine.client.IdFilter;
@@ -204,7 +204,7 @@ class EntityQueryTest {
         Multimap<EntityColumn, Filter> filters = HashMultimap.create(values.size(), 1);
         for (Map.Entry<EntityColumn, Object> param : values.entrySet()) {
             EntityColumn column = param.getKey();
-            FieldPath fieldPath = FieldPaths.parse(column.name());
+            FieldPath fieldPath = Field.parse(column.name()).path();
             Filter filter = Filter
                     .newBuilder()
                     .setOperator(EQUAL)

--- a/server/src/test/java/io/spine/server/given/groups/FilteredStateSubscriber.java
+++ b/server/src/test/java/io/spine/server/given/groups/FilteredStateSubscriber.java
@@ -27,7 +27,15 @@ import io.spine.server.given.organizations.Organization;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
-@SuppressWarnings("deprecation")
+/**
+ * This class declares invalid subscriber because filtering of states is not allowed.
+ *
+ * <p>{@code ByField}, which is deprecated, is still used to cover the negative case using
+ * this annotation.
+ *
+ * @see FilteredStateSubscriberWhere
+ */
+@SuppressWarnings("deprecation") // see Javadoc
 public class FilteredStateSubscriber extends AbstractEventSubscriber {
 
     @Subscribe(

--- a/server/src/test/java/io/spine/server/given/groups/FilteredStateSubscriber.java
+++ b/server/src/test/java/io/spine/server/given/groups/FilteredStateSubscriber.java
@@ -25,7 +25,7 @@ import io.spine.core.Subscribe;
 import io.spine.server.event.AbstractEventSubscriber;
 import io.spine.server.given.organizations.Organization;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static io.spine.testing.Tests.halt;
 
 /**
  * This class declares invalid subscriber because filtering of states is not allowed.
@@ -42,7 +42,6 @@ public class FilteredStateSubscriber extends AbstractEventSubscriber {
             filter = @ByField(path = "head.value", value = "42") // <-- Error here. Shouldn't have a filter.
     )
     void on(Organization organization) {
-        fail(FilteredStateSubscriber.class.getSimpleName() +
-                     " should not be able to receive any updates.");
+        halt();
     }
 }

--- a/server/src/test/java/io/spine/server/given/groups/FilteredStateSubscriber.java
+++ b/server/src/test/java/io/spine/server/given/groups/FilteredStateSubscriber.java
@@ -27,6 +27,7 @@ import io.spine.server.given.organizations.Organization;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+@SuppressWarnings("deprecation")
 public class FilteredStateSubscriber extends AbstractEventSubscriber {
 
     @Subscribe(

--- a/server/src/test/java/io/spine/server/given/groups/FilteredStateSubscriberWhere.java
+++ b/server/src/test/java/io/spine/server/given/groups/FilteredStateSubscriberWhere.java
@@ -18,35 +18,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.server.model.given.map;
+package io.spine.server.given.groups;
 
 import io.spine.core.Subscribe;
 import io.spine.core.Where;
-import io.spine.server.projection.Projection;
-import io.spine.server.projection.given.SavedString;
-import io.spine.test.projection.event.Int32Imported;
+import io.spine.server.event.AbstractEventSubscriber;
+import io.spine.server.given.organizations.Organization;
 
-import static io.spine.testing.Tests.halt;
+import static org.junit.jupiter.api.Assertions.fail;
 
-/**
- * Valid projection class which filters events by values.
- */
-public final class FilteredSubscription
-        extends Projection<String, SavedString, SavedString.Builder> {
-
-    private static final String VALUE_FIELD_PATH = "value";
-
-    private FilteredSubscription(String id) {
-        super(id);
-    }
+public class FilteredStateSubscriberWhere extends AbstractEventSubscriber {
 
     @Subscribe
-    void only100(@Where(field = VALUE_FIELD_PATH, equals = "100") Int32Imported event) {
-        halt();
-    }
-
-    @Subscribe
-    void only500(@Where(field = VALUE_FIELD_PATH, equals = "500") Int32Imported event) {
-        halt();
+    void on(@Where(field = "head.value", equals = "42") // <-- Error here. Shouldn't have a filter.
+                    Organization organization) {
+        fail(FilteredStateSubscriberWhere.class.getSimpleName() +
+                     " should not be able to receive any updates.");
     }
 }

--- a/server/src/test/java/io/spine/server/given/groups/FilteredStateSubscriberWhere.java
+++ b/server/src/test/java/io/spine/server/given/groups/FilteredStateSubscriberWhere.java
@@ -27,6 +27,11 @@ import io.spine.server.given.organizations.Organization;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+/**
+ * This class declares invalid subscriber because filtering of states is not allowed.
+ *
+ * @see FilteredStateSubscriber
+ */
 public class FilteredStateSubscriberWhere extends AbstractEventSubscriber {
 
     @Subscribe

--- a/server/src/test/java/io/spine/server/given/groups/FilteredStateSubscriberWhere.java
+++ b/server/src/test/java/io/spine/server/given/groups/FilteredStateSubscriberWhere.java
@@ -25,7 +25,7 @@ import io.spine.core.Where;
 import io.spine.server.event.AbstractEventSubscriber;
 import io.spine.server.given.organizations.Organization;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static io.spine.testing.Tests.halt;
 
 /**
  * This class declares invalid subscriber because filtering of states is not allowed.
@@ -35,9 +35,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class FilteredStateSubscriberWhere extends AbstractEventSubscriber {
 
     @Subscribe
-    void on(@Where(field = "head.value", equals = "42") // <-- Error here. Shouldn't have a filter.
-                    Organization organization) {
-        fail(FilteredStateSubscriberWhere.class.getSimpleName() +
-                     " should not be able to receive any updates.");
+    void on(
+            @Where(field = "head.value", equals = "42") // <-- Error here. Shouldn't have a filter.
+            Organization organization) {
+        halt();
     }
 }

--- a/server/src/test/java/io/spine/server/model/ArgumentFilterTest.java
+++ b/server/src/test/java/io/spine/server/model/ArgumentFilterTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.model;
+
+import com.google.common.testing.NullPointerTester;
+import io.spine.base.EventMessage;
+import io.spine.base.FieldPath;
+import io.spine.server.model.given.filter.BeanAdded;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.spine.server.model.ArgumentFilter.createFilter;
+import static io.spine.server.model.given.filter.Bucket.everythingElse;
+import static io.spine.server.model.given.filter.Bucket.onlyBeans;
+import static io.spine.server.model.given.filter.Bucket.onlyPeas;
+import static io.spine.server.model.given.filter.Legume.BEAN;
+import static io.spine.server.model.given.filter.Legume.PEA;
+
+@DisplayName("`ArgumentFilter` should")
+class ArgumentFilterTest {
+
+    @Test
+    @DisplayName("pass null-tolerance check")
+    void nullTolerance() {
+        new NullPointerTester()
+                .setDefault(FieldPath.class, FieldPath.getDefaultInstance())
+                .testAllPublicStaticMethods(ArgumentFilter.class);
+    }
+
+    @Test
+    @DisplayName("create instance for `@Where` annotation")
+    void onWhere() {
+        ArgumentFilter filter = createFilter(onlyPeas());
+        assertThat(filter.acceptsAll())
+                .isFalse();
+        assertThat(filter.pathLength())
+                .isEqualTo(1);
+        assertThat(filter.expectedValue())
+                .isEqualTo(PEA);
+        assertThat(filter.test(peasAdded()))
+                .isTrue();
+        assertThat(filter.test(beansAdded()))
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("create instance for `@ByField` annotation")
+    void onByField() {
+        ArgumentFilter filter = createFilter(onlyBeans());
+        assertThat(filter.acceptsAll())
+                .isFalse();
+        assertThat(filter.pathLength())
+                .isEqualTo(1);
+        assertThat(filter.expectedValue())
+                .isEqualTo(BEAN);
+        assertThat(filter.test(beansAdded()))
+                .isTrue();
+        assertThat(filter.test(peasAdded()))
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("create empty filter if not annotated")
+    void emptyFilter() {
+        ArgumentFilter filter = createFilter(everythingElse());
+        assertThat(filter.acceptsAll())
+                .isTrue();
+        assertThat(filter.pathLength())
+                .isEqualTo(0);
+    }
+
+    private static EventMessage peasAdded() {
+        return BeanAdded
+                .newBuilder()
+                .setKind(PEA)
+                .build();
+    }
+
+    private static EventMessage beansAdded() {
+        return BeanAdded
+                .newBuilder()
+                .setKind(BEAN)
+                .build();
+    }
+}

--- a/server/src/test/java/io/spine/server/model/HandlerMapTest.java
+++ b/server/src/test/java/io/spine/server/model/HandlerMapTest.java
@@ -22,6 +22,7 @@ package io.spine.server.model;
 
 import io.spine.server.command.model.CommandHandlerSignature;
 import io.spine.server.model.given.map.DupEventFilterValue;
+import io.spine.server.model.given.map.DupEventFilterValueWhere;
 import io.spine.server.model.given.map.DuplicatingCommandHandlers;
 import io.spine.server.model.given.map.TwoFieldsInSubscription;
 import io.spine.string.StringifierRegistry;
@@ -60,9 +61,15 @@ class HandlerMapTest {
         }
 
         @Test
-        @DisplayName("the same value of the filtered event field")
+        @DisplayName("the same value of the filtered event field (ByField)")
         void rejectFilterFieldDuplication() {
             assertDuplication(() -> asProjectionClass(DupEventFilterValue.class));
+        }
+
+        @Test
+        @DisplayName("the same value of the filtered event field (Where)")
+        void rejectFilterFieldDuplicationWhere() {
+            assertDuplication(() -> asProjectionClass(DupEventFilterValueWhere.class));
         }
 
         @Test

--- a/server/src/test/java/io/spine/server/model/HandlerMapTest.java
+++ b/server/src/test/java/io/spine/server/model/HandlerMapTest.java
@@ -23,7 +23,7 @@ package io.spine.server.model;
 import io.spine.server.command.model.CommandHandlerSignature;
 import io.spine.server.model.given.map.DupEventFilterValue;
 import io.spine.server.model.given.map.DupEventFilterValueWhere;
-import io.spine.server.model.given.map.DuplicatingCommandHandlers;
+import io.spine.server.model.given.map.DuplicateCommandHandlers;
 import io.spine.server.model.given.map.TwoFieldsInSubscription;
 import io.spine.server.model.given.method.OneParamSignature;
 import io.spine.server.model.given.method.StubHandler;
@@ -60,7 +60,7 @@ class HandlerMapTest {
         @DisplayName("duplicate message classes in handlers")
         void rejectDuplicateHandlers() {
             assertDuplicate(
-                    () -> create(DuplicatingCommandHandlers.class, new CommandHandlerSignature())
+                    () -> create(DuplicateCommandHandlers.class, new CommandHandlerSignature())
             );
         }
 

--- a/server/src/test/java/io/spine/server/model/given/filter/Bucket.java
+++ b/server/src/test/java/io/spine/server/model/given/filter/Bucket.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.model.given.filter;
+
+import io.spine.core.ByField;
+import io.spine.core.Subscribe;
+import io.spine.core.Where;
+
+import java.lang.reflect.Method;
+
+import static io.spine.util.Exceptions.illegalStateWithCauseOf;
+
+/**
+ * Test environment class which declares filtering and non-filtering subscriber methods.
+ *
+ * @see io.spine.server.model.ArgumentFilterTest
+ */
+public class Bucket {
+
+    private long peas;
+    private long beans;
+    private long other;
+
+    public static Method onlyPeas() {
+        return method("onlyPeas");
+    }
+
+    public static Method onlyBeans() {
+        return method("onlyBeans");
+    }
+
+    public static Method everythingElse() {
+        return method("everythingElse");
+    }
+
+    @Subscribe
+    void onlyPeas(@Where(field = "kind", equals = "PEA") BeanAdded e) {
+        peas = peas + e.getNumber();
+    }
+
+    @Subscribe(filter = @ByField(path = "kind", value = "BEAN"))
+    void onlyBeans(BeanAdded e) {
+        beans = beans + e.getNumber();
+    }
+
+    @Subscribe
+    void everythingElse(BeanAdded e) {
+        other = other + e.getNumber();
+    }
+
+    private static Method method(String name) {
+        try {
+            return Bucket.class.getDeclaredMethod(name, BeanAdded.class);
+        } catch (NoSuchMethodException e) {
+            throw illegalStateWithCauseOf(e);
+        }
+    }
+}

--- a/server/src/test/java/io/spine/server/model/given/filter/Bucket.java
+++ b/server/src/test/java/io/spine/server/model/given/filter/Bucket.java
@@ -56,6 +56,7 @@ public class Bucket {
         peas = peas + e.getNumber();
     }
 
+    @SuppressWarnings("deprecation") // to be migrated during removal of `@ByField`.
     @Subscribe(filter = @ByField(path = "kind", value = "BEAN"))
     void onlyBeans(BeanAdded e) {
         beans = beans + e.getNumber();

--- a/server/src/test/java/io/spine/server/model/given/filter/package-info.java
+++ b/server/src/test/java/io/spine/server/model/given/filter/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test environment classes for {@link io.spine.server.model.ArgumentFilterTest}.
+ */
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.server.model.given.filter;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/test/java/io/spine/server/model/given/map/DupEventFilterValue.java
+++ b/server/src/test/java/io/spine/server/model/given/map/DupEventFilterValue.java
@@ -32,6 +32,7 @@ import static io.spine.testing.Tests.halt;
  * This projection class is not valid because values used in the filtering subscriber
  * annotations evaluate to the same field value (even though that the string values are different).
  */
+@SuppressWarnings("deprecation")
 public final class DupEventFilterValue
         extends Projection<String, SavedString, SavedString.Builder> {
 

--- a/server/src/test/java/io/spine/server/model/given/map/DupEventFilterValueWhere.java
+++ b/server/src/test/java/io/spine/server/model/given/map/DupEventFilterValueWhere.java
@@ -29,24 +29,25 @@ import io.spine.test.projection.event.Int32Imported;
 import static io.spine.testing.Tests.halt;
 
 /**
- * Valid projection class which filters events by values.
+ * This projection class is not valid because values used in the filtering subscriber
+ * annotations evaluate to the same field value (even though that the string values are different).
  */
-public final class FilteredSubscription
+public final class DupEventFilterValueWhere
         extends Projection<String, SavedString, SavedString.Builder> {
 
     private static final String VALUE_FIELD_PATH = "value";
 
-    private FilteredSubscription(String id) {
+    private DupEventFilterValueWhere(String id) {
         super(id);
     }
 
     @Subscribe
-    void only100(@Where(field = VALUE_FIELD_PATH, equals = "100") Int32Imported event) {
+    void onString1(@Where(field = VALUE_FIELD_PATH, equals = "1") Int32Imported event) {
         halt();
     }
 
     @Subscribe
-    void only500(@Where(field = VALUE_FIELD_PATH, equals = "500") Int32Imported event) {
+    void onStringOne(@Where(field = VALUE_FIELD_PATH, equals = "+1") Int32Imported event) {
         halt();
     }
 }

--- a/server/src/test/java/io/spine/server/model/given/map/TwoFieldsInSubscription.java
+++ b/server/src/test/java/io/spine/server/model/given/map/TwoFieldsInSubscription.java
@@ -20,8 +20,8 @@
 
 package io.spine.server.model.given.map;
 
-import io.spine.core.ByField;
 import io.spine.core.Subscribe;
+import io.spine.core.Where;
 import io.spine.server.projection.Projection;
 import io.spine.server.projection.given.SavedString;
 import io.spine.test.projection.event.PairImported;
@@ -39,13 +39,13 @@ public final class TwoFieldsInSubscription
         super(id);
     }
 
-    @Subscribe(filter = @ByField(path = "integer", value = "42"))
-    void onInt(PairImported event) {
+    @Subscribe
+    void onInt(@Where(field = "integer", equals = "42") PairImported event) {
         halt();
     }
 
-    @Subscribe(filter = @ByField(path = "str", value = "42"))
-    void onString(PairImported event) {
+    @Subscribe
+    void onString(@Where(field = "str", equals = "42") PairImported event) {
         halt();
     }
 }

--- a/server/src/test/java/io/spine/server/projection/given/NoDefaultOptionProjection.java
+++ b/server/src/test/java/io/spine/server/projection/given/NoDefaultOptionProjection.java
@@ -20,8 +20,8 @@
 
 package io.spine.server.projection.given;
 
-import io.spine.core.ByField;
 import io.spine.core.Subscribe;
+import io.spine.core.Where;
 import io.spine.server.projection.Projection;
 import io.spine.test.projection.event.StringImported;
 
@@ -36,8 +36,8 @@ public final class NoDefaultOptionProjection
         super(id);
     }
 
-    @Subscribe(filter = @ByField(path = VALUE_FIELD_PATH, value = ACCEPTED_VALUE))
-    void on(StringImported event) {
+    @Subscribe
+    void on(@Where(field = VALUE_FIELD_PATH, equals = ACCEPTED_VALUE) StringImported event) {
         builder().setValue(event.getValue());
     }
 }

--- a/server/src/test/java/io/spine/server/projection/given/cls/DifferentFieldSubscription.java
+++ b/server/src/test/java/io/spine/server/projection/given/cls/DifferentFieldSubscription.java
@@ -20,8 +20,8 @@
 
 package io.spine.server.projection.given.cls;
 
-import io.spine.core.ByField;
 import io.spine.core.Subscribe;
+import io.spine.core.Where;
 import io.spine.server.projection.Projection;
 import io.spine.server.projection.given.SavedString;
 import io.spine.test.projection.event.PairImported;
@@ -39,13 +39,13 @@ public final class DifferentFieldSubscription
         super(id);
     }
 
-    @Subscribe(filter = @ByField(path = "integer", value = "42"))
-    void onInt(PairImported event) {
+    @Subscribe
+    void onInt(@Where(field = "integer", equals = "42") PairImported event) {
         halt();
     }
 
-    @Subscribe(filter = @ByField(path = "str", value = "42"))
-    void onString(PairImported event) {
+    @Subscribe
+    void onString(@Where(field = "str", equals = "42") PairImported event) {
         halt();
     }
 }

--- a/server/src/test/java/io/spine/server/projection/given/cls/DuplicateValueSubscription.java
+++ b/server/src/test/java/io/spine/server/projection/given/cls/DuplicateValueSubscription.java
@@ -20,8 +20,8 @@
 
 package io.spine.server.projection.given.cls;
 
-import io.spine.core.ByField;
 import io.spine.core.Subscribe;
+import io.spine.core.Where;
 import io.spine.server.projection.Projection;
 import io.spine.server.projection.given.SavedString;
 import io.spine.test.projection.event.Int32Imported;
@@ -41,13 +41,13 @@ public final class DuplicateValueSubscription
         super(id);
     }
 
-    @Subscribe(filter = @ByField(path = VALUE_FIELD_PATH, value = "1"))
-    void onString1(Int32Imported event) {
+    @Subscribe
+    void onString1(@Where(field = VALUE_FIELD_PATH, equals = "1") Int32Imported event) {
         halt();
     }
 
-    @Subscribe(filter = @ByField(path = VALUE_FIELD_PATH, value = "+1"))
-    void onStringOne(Int32Imported event) {
+    @Subscribe
+    void onStringOne(@Where(field = VALUE_FIELD_PATH, equals = "+1") Int32Imported event) {
         halt();
     }
 }

--- a/server/src/test/java/io/spine/server/projection/given/cls/DuplicateValueSubscription.java
+++ b/server/src/test/java/io/spine/server/projection/given/cls/DuplicateValueSubscription.java
@@ -29,8 +29,8 @@ import io.spine.test.projection.event.Int32Imported;
 import static io.spine.testing.Tests.halt;
 
 /**
- * This projection class is not valid because values used in the filtering subscribes
- * evaluate to the same field value (even though that the string values are different).
+ * This projection class is not valid because values used in the filtering subscriber
+ * annotations evaluate to the same field value (even though that the string values are different).
  */
 public final class DuplicateValueSubscription
         extends Projection<String, SavedString, SavedString.Builder> {

--- a/server/src/test/java/io/spine/server/projection/given/cls/FilteringProjection.java
+++ b/server/src/test/java/io/spine/server/projection/given/cls/FilteringProjection.java
@@ -20,8 +20,8 @@
 
 package io.spine.server.projection.given.cls;
 
-import io.spine.core.ByField;
 import io.spine.core.Subscribe;
+import io.spine.core.Where;
 import io.spine.server.projection.Projection;
 import io.spine.server.projection.given.SavedString;
 import io.spine.test.projection.event.StringImported;
@@ -47,14 +47,14 @@ public final class FilteringProjection
     }
 
     /** This method does not use the value passed in the event. */
-    @Subscribe(filter = @ByField(path = VALUE_FIELD_PATH, value = SET_A))
-    void onReserved(StringImported event) {
+    @Subscribe
+    void onReserved(@Where(field = VALUE_FIELD_PATH, equals = SET_A)StringImported event) {
         builder().setValue(VALUE_A);
     }
 
     /** This method does not use the value passed in the event either. */
-    @Subscribe(filter = @ByField(path = VALUE_FIELD_PATH, value = SET_B))
-    void onSecret(StringImported event) {
+    @Subscribe
+    void onSecret(@Where(field = VALUE_FIELD_PATH, equals = SET_B) StringImported event) {
         builder().setValue(VALUE_B);
     }
 

--- a/server/src/test/java/io/spine/system/server/given/diagnostics/ViolationsWatch.java
+++ b/server/src/test/java/io/spine/system/server/given/diagnostics/ViolationsWatch.java
@@ -23,8 +23,8 @@ package io.spine.system.server.given.diagnostics;
 import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
-import io.spine.core.ByField;
 import io.spine.core.Subscribe;
+import io.spine.core.Where;
 import io.spine.server.projection.Projection;
 import io.spine.server.projection.ProjectionRepository;
 import io.spine.server.route.EventRouting;
@@ -47,11 +47,10 @@ public final class ViolationsWatch extends Projection<WatchId, InvalidText, Inva
     public static final WatchId DEFAULT = WatchId.generate();
     private static final String LAST_MESSAGE_TYPE_PATH = "last_message.type_url";
 
-    @Subscribe(filter = @ByField(
-            path = LAST_MESSAGE_TYPE_PATH,
-            value = "type.spine.io/spine.system.server.test.TextValidated"
-    ))
-    void onInvalidText(ConstraintViolated event) {
+    @Subscribe
+    void onInvalidText(@Where(field = LAST_MESSAGE_TYPE_PATH,
+                              equals = "type.spine.io/spine.system.server.test.TextValidated")
+                       ConstraintViolated event) {
         List<ConstraintViolation> violations = event.getViolationList();
         checkArgument(violations.size() == 1);
         ConstraintViolation violation = violations.get(0);
@@ -62,11 +61,11 @@ public final class ViolationsWatch extends Projection<WatchId, InvalidText, Inva
         builder().setInvalidText(stringValue);
     }
 
-    @Subscribe(filter = @ByField(
-            path = LAST_MESSAGE_TYPE_PATH,
-            value = "type.spine.io/spine.system.server.test.StartVerification"
-    ))
-    void onInvalidVerification(ConstraintViolated event) {
+    @Subscribe
+    void onInvalidVerification(
+            @Where(field = LAST_MESSAGE_TYPE_PATH,
+                    equals = "type.spine.io/spine.system.server.test.StartVerification")
+            ConstraintViolated event) {
         List<ConstraintViolation> violations = event.getViolationList();
         checkArgument(violations.size() == 1);
         ConstraintViolation violation = violations.get(0);

--- a/server/src/test/java/io/spine/system/server/given/diagnostics/ViolationsWatch.java
+++ b/server/src/test/java/io/spine/system/server/given/diagnostics/ViolationsWatch.java
@@ -48,9 +48,10 @@ public final class ViolationsWatch extends Projection<WatchId, InvalidText, Inva
     private static final String LAST_MESSAGE_TYPE_PATH = "last_message.type_url";
 
     @Subscribe
-    void onInvalidText(@Where(field = LAST_MESSAGE_TYPE_PATH,
-                              equals = "type.spine.io/spine.system.server.test.TextValidated")
-                       ConstraintViolated event) {
+    void onInvalidText(
+            @Where(field = LAST_MESSAGE_TYPE_PATH,
+                   equals = "type.spine.io/spine.system.server.test.TextValidated")
+            ConstraintViolated event) {
         List<ConstraintViolation> violations = event.getViolationList();
         checkArgument(violations.size() == 1);
         ConstraintViolation violation = violations.get(0);
@@ -64,7 +65,7 @@ public final class ViolationsWatch extends Projection<WatchId, InvalidText, Inva
     @Subscribe
     void onInvalidVerification(
             @Where(field = LAST_MESSAGE_TYPE_PATH,
-                    equals = "type.spine.io/spine.system.server.test.StartVerification")
+                   equals = "type.spine.io/spine.system.server.test.StartVerification")
             ConstraintViolated event) {
         List<ConstraintViolation> violations = event.getViolationList();
         checkArgument(violations.size() == 1);

--- a/server/src/test/proto/spine/test/model/filter/argument_filter_test_events.proto
+++ b/server/src/test/proto/spine/test/model/filter/argument_filter_test_events.proto
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+syntax = "proto3";
+
+package spine.test.model;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package="io.spine.server.model.given.filter";
+option java_multiple_files = true;
+option java_outer_classname = "EventsProto";
+
+enum Legume {
+    BEAN_UNKNOWN = 0;
+    PEA = 1;
+    BEAN = 2;
+}
+
+message BeanAdded {
+    int32 bucket = 1;
+    Legume kind = 2 [(required) = true];
+    int64 number = 3 [(min).value = "1"];
+}

--- a/version.gradle
+++ b/version.gradle
@@ -25,8 +25,6 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '1.0.3'
-
 ext {
     // The version of the modules in this project.
     versionToPublish = '1.0.8-SNAPSHOT'
@@ -35,5 +33,5 @@ ext {
     spineBaseVersion = '1.0.8-SNAPSHOT'
 
     // Depend on `time` for `ZoneId`, `ZoneOffset` and other date/time types and utilities.
-    spineTimeVersion = '1.0.3'
+    spineTimeVersion = '1.0.8-SNAPSHOT'
 }

--- a/version.gradle
+++ b/version.gradle
@@ -29,11 +29,11 @@ def final SPINE_VERSION = '1.0.3'
 
 ext {
     // The version of the modules in this project.
-    versionToPublish = SPINE_VERSION
+    versionToPublish = '1.0.8-SNAPSHOT'
 
     // Depend on `base` for the general definitions and a model compiler.
-    spineBaseVersion = SPINE_VERSION
+    spineBaseVersion = '1.0.8-SNAPSHOT'
 
     // Depend on `time` for `ZoneId`, `ZoneOffset` and other date/time types and utilities.
-    spineTimeVersion = SPINE_VERSION
+    spineTimeVersion = '1.0.3'
 }


### PR DESCRIPTION
This PR introduces `@Where` annotation for the first parameter of an event subscriber method.

`@Subscribe.filter()` was deprecated. The annotation interface `ByField` was not marked as deprecated to avoid numerous warnings on import statements in the code which still uses this interface (for backward compatibility).

This PR depends on [this one from `base`](https://github.com/SpineEventEngine/base/pull/468).
