### PR TITLE
Describe the allowed return types for `@React`

### DIFF
--- a/server/src/main/java/io/spine/server/event/React.java
+++ b/server/src/main/java/io/spine/server/event/React.java
@@ -83,6 +83,7 @@ import java.lang.annotation.Target;
  * {@literal @}React
  * {@literal Pair<ProjectOwnerAssigned, ProjectDueDateChanged>} on(ProjectCreated event) { ... }
  *  </pre>
+ *
  * </ul>
  *
  * <p>If the annotation is applied to a method which does not satisfy either of these requirements,

--- a/server/src/main/java/io/spine/server/event/React.java
+++ b/server/src/main/java/io/spine/server/event/React.java
@@ -28,19 +28,64 @@ import java.lang.annotation.Target;
 
 /**
  * Marks a method of an entity as one that <em>may</em> modify the state of the entity in
- * response to an <em>external</em> event.
+ * response to some domain event.
  *
  * <p>A reacting method <strong>must:</strong>
  * <ul>
  *     <li>be annotated with {@link React @React};
  *     <li>have package-private visibility;
  *     <li>accept an event message (derived from {@link io.spine.base.EventMessage EventMessage})
- *         as the first parameter;
- *     <li>return an event message derived from {@link io.spine.base.EventMessage Message}
- *         <strong>or</strong> several event messages returned as an {@code Iterable}.
+ *         as the first parameter.
  * </ul>
  *
- * <p>If the annotation is applied to a method which does not satisfy any of these requirements,
+ * <h1>Returning Values</h1>
+ *
+ * <p>The essence of a reacting method is an emission of one or several events in a reaction to
+ * the dispatched event. The emitted events must derive from {@link io.spine.base.EventMessage
+ * EventMessage} in order to make the code less error-prone.
+ *
+ * <p>As long as an entity may have a complex logic of determining which event to emit in reaction,
+ * the {@code React}-marked methods allow a variety of options for the returning values.
+ *
+ * <p>A reacting method must return either
+ * <ul>
+ *
+ * <li>an event message:
+ * <pre>
+ * {@literal @}React
+ *  TaskReassigned on(UserDeactivated event) { ... }
+ * </pre>
+ *
+ *  <li>an {@code Optional} event message:
+ *  <pre>
+ * {@literal @}React
+ * {@literal Optional<PersonAllowedToBuyAlcohol>} on(PersonAgeChanged event) { ... }
+ *  </pre>
+ *
+ *  <li>{@linkplain io.spine.server.tuple.Either one of} particular events;
+ *  it also allows to use a special {@link io.spine.server.model.Nothing Nothing} event stating
+ *  that the entity may choose not to react at all:
+ *  <pre>
+ * {@literal @}React
+ * {@literal EitherOf3<ProjectCompleted, ProjectEstimateUpdated, Nothing>} on(TaskCompleted event) { ... }
+ *  </pre>
+ *
+ *
+ *  <li>an {@code Iterable} of event messages:
+ *  <pre>
+ * {@literal @}React
+ * {@literal Iterable<StoryMovedToBacklog>} on(SprintCompleted event) { ... }
+ *  </pre>
+ *
+ *  <li>a {@link io.spine.server.tuple.Tuple tuple} of event messages; being similar
+ *  to {@code Iterable}, tuples allow to declare the exact types of returning values:
+ *  <pre>
+ * {@literal @}React
+ * {@literal Pair<ProjectOwnerAssigned, ProjectDueDateChanged>} on(ProjectCreated event) { ... }
+ *  </pre>
+ * </ul>
+ *
+ * <p>If the annotation is applied to a method which does not satisfy either of these requirements,
  * this method will not be registering for receiving events.
  */
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
This changeset improves the documentation of `@React` annotation by describing the allowed return types.

Special attention was paid to the Javadoc formatting. See #1170 on this matter.

Once this changeset is reviewed, the following PRs will be addressing the same issue by extending and fixing the Javadocs for the rest of Spine annotations.