### PR TITLE
Common repository code and configuring Process Managers

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.1.1-SNAPSHOT+1`
+# Dependencies of `io.spine:spine-client:1.1.1-SNAPSHOT+2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -301,6 +301,14 @@
      * **POM Project URL:** [http://junit.org](http://junit.org)
      * **POM License: Eclipse Public License 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
+1. **Group:** net.bytebuddy **Name:** byte-buddy **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy-agent **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1. **Group:** net.java.dev.javacc **Name:** javacc **Version:** 5.0
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
@@ -394,6 +402,15 @@
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
+1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
+     * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
+     * **POM License: The MIT License** - [https://github.com/mockito/mockito/blob/master/LICENSE](https://github.com/mockito/mockito/blob/master/LICENSE)
+
+1. **Group:** org.objenesis **Name:** objenesis **Version:** 2.6
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://objenesis.org](http://objenesis.org)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1. **Group:** org.opentest4j **Name:** opentest4j **Version:** 1.2.0
      * **Manifest License:** The Apache License, Version 2.0 (Not packaged)
      * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
@@ -432,12 +449,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Sep 13 13:14:35 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 24 20:22:17 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.1.1-SNAPSHOT+1`
+# Dependencies of `io.spine:spine-core:1.1.1-SNAPSHOT+2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -684,6 +701,14 @@ This report was generated on **Fri Sep 13 13:14:35 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://junit.org](http://junit.org)
      * **POM License: Eclipse Public License 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
+1. **Group:** net.bytebuddy **Name:** byte-buddy **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy-agent **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1. **Group:** net.java.dev.javacc **Name:** javacc **Version:** 5.0
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
@@ -777,6 +802,15 @@ This report was generated on **Fri Sep 13 13:14:35 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
+1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
+     * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
+     * **POM License: The MIT License** - [https://github.com/mockito/mockito/blob/master/LICENSE](https://github.com/mockito/mockito/blob/master/LICENSE)
+
+1. **Group:** org.objenesis **Name:** objenesis **Version:** 2.6
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://objenesis.org](http://objenesis.org)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1. **Group:** org.opentest4j **Name:** opentest4j **Version:** 1.2.0
      * **Manifest License:** The Apache License, Version 2.0 (Not packaged)
      * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
@@ -815,12 +849,12 @@ This report was generated on **Fri Sep 13 13:14:35 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Sep 13 13:14:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 24 20:22:17 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.1.1-SNAPSHOT+1`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.1.1-SNAPSHOT+2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1115,6 +1149,14 @@ This report was generated on **Fri Sep 13 13:14:38 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://junit.org](http://junit.org)
      * **POM License: Eclipse Public License 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
+1. **Group:** net.bytebuddy **Name:** byte-buddy **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy-agent **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1. **Group:** net.java.dev.javacc **Name:** javacc **Version:** 5.0
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
@@ -1208,6 +1250,15 @@ This report was generated on **Fri Sep 13 13:14:38 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
+1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
+     * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
+     * **POM License: The MIT License** - [https://github.com/mockito/mockito/blob/master/LICENSE](https://github.com/mockito/mockito/blob/master/LICENSE)
+
+1. **Group:** org.objenesis **Name:** objenesis **Version:** 2.6
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://objenesis.org](http://objenesis.org)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1. **Group:** org.opentest4j **Name:** opentest4j **Version:** 1.2.0
      * **Manifest License:** The Apache License, Version 2.0 (Not packaged)
      * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
@@ -1246,12 +1297,12 @@ This report was generated on **Fri Sep 13 13:14:38 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Sep 13 13:14:41 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 24 20:22:18 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.1.1-SNAPSHOT+1`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.1.1-SNAPSHOT+2`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -1660,6 +1711,14 @@ This report was generated on **Fri Sep 13 13:14:41 EEST 2019** using [Gradle-Lic
 1. **Group:** kr.motd.maven **Name:** os-maven-plugin **Version:** 1.4.0.Final
      * **POM Project URL:** [https://github.com/trustin/os-maven-plugin/](https://github.com/trustin/os-maven-plugin/)
      * **POM License: Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy-agent **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** net.java.dev.javacc **Name:** javacc **Version:** 5.0
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
@@ -1796,6 +1855,15 @@ This report was generated on **Fri Sep 13 13:14:41 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
+1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
+     * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
+     * **POM License: The MIT License** - [https://github.com/mockito/mockito/blob/master/LICENSE](https://github.com/mockito/mockito/blob/master/LICENSE)
+
+1. **Group:** org.objenesis **Name:** objenesis **Version:** 2.6
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://objenesis.org](http://objenesis.org)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1. **Group:** org.opentest4j **Name:** opentest4j **Version:** 1.2.0
      * **Manifest License:** The Apache License, Version 2.0 (Not packaged)
      * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
@@ -1839,12 +1907,12 @@ This report was generated on **Fri Sep 13 13:14:41 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Sep 13 13:14:44 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 24 20:22:19 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.1.1-SNAPSHOT+1`
+# Dependencies of `io.spine:spine-server:1.1.1-SNAPSHOT+2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2205,6 +2273,14 @@ This report was generated on **Fri Sep 13 13:14:44 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://junit.org](http://junit.org)
      * **POM License: Eclipse Public License 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
+1. **Group:** net.bytebuddy **Name:** byte-buddy **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy-agent **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1. **Group:** net.java.dev.javacc **Name:** javacc **Version:** 5.0
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
@@ -2298,6 +2374,15 @@ This report was generated on **Fri Sep 13 13:14:44 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
+1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
+     * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
+     * **POM License: The MIT License** - [https://github.com/mockito/mockito/blob/master/LICENSE](https://github.com/mockito/mockito/blob/master/LICENSE)
+
+1. **Group:** org.objenesis **Name:** objenesis **Version:** 2.6
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://objenesis.org](http://objenesis.org)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1. **Group:** org.opentest4j **Name:** opentest4j **Version:** 1.2.0
      * **Manifest License:** The Apache License, Version 2.0 (Not packaged)
      * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
@@ -2336,12 +2421,12 @@ This report was generated on **Fri Sep 13 13:14:44 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Sep 13 13:14:48 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 24 20:22:20 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.1.1-SNAPSHOT+1`
+# Dependencies of `io.spine:spine-testutil-client:1.1.1-SNAPSHOT+2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2474,6 +2559,14 @@ This report was generated on **Fri Sep 13 13:14:48 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://junit.org](http://junit.org)
      * **POM License: Eclipse Public License 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
+1. **Group:** net.bytebuddy **Name:** byte-buddy **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy-agent **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1. **Group:** org.apiguardian **Name:** apiguardian-api **Version:** 1.0.0
      * **POM Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -2508,6 +2601,15 @@ This report was generated on **Fri Sep 13 13:14:48 EEST 2019** using [Gradle-Lic
 1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
+     * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
+     * **POM License: The MIT License** - [https://github.com/mockito/mockito/blob/master/LICENSE](https://github.com/mockito/mockito/blob/master/LICENSE)
+
+1. **Group:** org.objenesis **Name:** objenesis **Version:** 2.6
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://objenesis.org](http://objenesis.org)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** org.opentest4j **Name:** opentest4j **Version:** 1.2.0
      * **Manifest License:** The Apache License, Version 2.0 (Not packaged)
@@ -2695,6 +2797,14 @@ This report was generated on **Fri Sep 13 13:14:48 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://junit.org](http://junit.org)
      * **POM License: Eclipse Public License 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
+1. **Group:** net.bytebuddy **Name:** byte-buddy **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy-agent **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1. **Group:** net.java.dev.javacc **Name:** javacc **Version:** 5.0
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
@@ -2788,6 +2898,15 @@ This report was generated on **Fri Sep 13 13:14:48 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
+1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
+     * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
+     * **POM License: The MIT License** - [https://github.com/mockito/mockito/blob/master/LICENSE](https://github.com/mockito/mockito/blob/master/LICENSE)
+
+1. **Group:** org.objenesis **Name:** objenesis **Version:** 2.6
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://objenesis.org](http://objenesis.org)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1. **Group:** org.opentest4j **Name:** opentest4j **Version:** 1.2.0
      * **Manifest License:** The Apache License, Version 2.0 (Not packaged)
      * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
@@ -2826,12 +2945,12 @@ This report was generated on **Fri Sep 13 13:14:48 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Sep 13 13:14:51 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 24 20:22:20 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.1.1-SNAPSHOT+1`
+# Dependencies of `io.spine:spine-testutil-core:1.1.1-SNAPSHOT+2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2964,6 +3083,14 @@ This report was generated on **Fri Sep 13 13:14:51 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://junit.org](http://junit.org)
      * **POM License: Eclipse Public License 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
+1. **Group:** net.bytebuddy **Name:** byte-buddy **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy-agent **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1. **Group:** org.apiguardian **Name:** apiguardian-api **Version:** 1.0.0
      * **POM Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -3006,6 +3133,15 @@ This report was generated on **Fri Sep 13 13:14:51 EEST 2019** using [Gradle-Lic
 1. **Group:** org.junit.platform **Name:** junit-platform-engine **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
+     * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
+     * **POM License: The MIT License** - [https://github.com/mockito/mockito/blob/master/LICENSE](https://github.com/mockito/mockito/blob/master/LICENSE)
+
+1. **Group:** org.objenesis **Name:** objenesis **Version:** 2.6
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://objenesis.org](http://objenesis.org)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** org.opentest4j **Name:** opentest4j **Version:** 1.2.0
      * **Manifest License:** The Apache License, Version 2.0 (Not packaged)
@@ -3193,6 +3329,14 @@ This report was generated on **Fri Sep 13 13:14:51 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://junit.org](http://junit.org)
      * **POM License: Eclipse Public License 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
+1. **Group:** net.bytebuddy **Name:** byte-buddy **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy-agent **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1. **Group:** net.java.dev.javacc **Name:** javacc **Version:** 5.0
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
@@ -3286,6 +3430,15 @@ This report was generated on **Fri Sep 13 13:14:51 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
+1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
+     * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
+     * **POM License: The MIT License** - [https://github.com/mockito/mockito/blob/master/LICENSE](https://github.com/mockito/mockito/blob/master/LICENSE)
+
+1. **Group:** org.objenesis **Name:** objenesis **Version:** 2.6
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://objenesis.org](http://objenesis.org)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1. **Group:** org.opentest4j **Name:** opentest4j **Version:** 1.2.0
      * **Manifest License:** The Apache License, Version 2.0 (Not packaged)
      * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
@@ -3324,12 +3477,12 @@ This report was generated on **Fri Sep 13 13:14:51 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Sep 13 13:14:53 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 24 20:22:21 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.1.1-SNAPSHOT+1`
+# Dependencies of `io.spine:spine-testutil-server:1.1.1-SNAPSHOT+2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3462,6 +3615,14 @@ This report was generated on **Fri Sep 13 13:14:53 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://junit.org](http://junit.org)
      * **POM License: Eclipse Public License 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
+1. **Group:** net.bytebuddy **Name:** byte-buddy **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy-agent **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1. **Group:** org.apiguardian **Name:** apiguardian-api **Version:** 1.0.0
      * **POM Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -3496,6 +3657,15 @@ This report was generated on **Fri Sep 13 13:14:53 EEST 2019** using [Gradle-Lic
 1. **Group:** org.junit.platform **Name:** junit-platform-commons **Version:** 1.5.1
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
+
+1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
+     * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
+     * **POM License: The MIT License** - [https://github.com/mockito/mockito/blob/master/LICENSE](https://github.com/mockito/mockito/blob/master/LICENSE)
+
+1. **Group:** org.objenesis **Name:** objenesis **Version:** 2.6
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://objenesis.org](http://objenesis.org)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** org.opentest4j **Name:** opentest4j **Version:** 1.2.0
      * **Manifest License:** The Apache License, Version 2.0 (Not packaged)
@@ -3737,6 +3907,14 @@ This report was generated on **Fri Sep 13 13:14:53 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [http://junit.org](http://junit.org)
      * **POM License: Eclipse Public License 1.0** - [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html)
 
+1. **Group:** net.bytebuddy **Name:** byte-buddy **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1. **Group:** net.bytebuddy **Name:** byte-buddy-agent **Version:** 1.7.9
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1. **Group:** net.java.dev.javacc **Name:** javacc **Version:** 5.0
      * **POM Project URL:** [https://javacc.dev.java.net/](https://javacc.dev.java.net/)
      * **POM License: Berkeley Software Distribution (BSD) License** - [http://www.opensource.org/licenses/bsd-license.html](http://www.opensource.org/licenses/bsd-license.html)
@@ -3830,6 +4008,15 @@ This report was generated on **Fri Sep 13 13:14:53 EEST 2019** using [Gradle-Lic
      * **POM Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **POM License: Eclipse Public License v2.0** - [https://www.eclipse.org/legal/epl-v20.html](https://www.eclipse.org/legal/epl-v20.html)
 
+1. **Group:** org.mockito **Name:** mockito-core **Version:** 2.12.0
+     * **POM Project URL:** [https://github.com/mockito/mockito](https://github.com/mockito/mockito)
+     * **POM License: The MIT License** - [https://github.com/mockito/mockito/blob/master/LICENSE](https://github.com/mockito/mockito/blob/master/LICENSE)
+
+1. **Group:** org.objenesis **Name:** objenesis **Version:** 2.6
+     * **Manifest license URL:** [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **POM Project URL:** [http://objenesis.org](http://objenesis.org)
+     * **POM License: Apache 2** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1. **Group:** org.opentest4j **Name:** opentest4j **Version:** 1.2.0
      * **Manifest License:** The Apache License, Version 2.0 (Not packaged)
      * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
@@ -3868,4 +4055,4 @@ This report was generated on **Fri Sep 13 13:14:53 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Sep 13 13:14:57 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 24 20:22:21 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.1.1-SNAPSHOT+1</version>
+<version>1.1.1-SNAPSHOT+2</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Sets.SetView;
 import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import io.spine.annotation.Internal;
 import io.spine.base.EventMessage;
-import io.spine.base.ThrowableMessage;
 import io.spine.core.CommandId;
 import io.spine.core.Event;
 import io.spine.core.EventContext;
@@ -39,11 +38,11 @@ import io.spine.server.delivery.Delivery;
 import io.spine.server.delivery.Inbox;
 import io.spine.server.delivery.InboxLabel;
 import io.spine.server.entity.EntityLifecycle;
+import io.spine.server.entity.EventProducingRepository;
 import io.spine.server.entity.Repository;
 import io.spine.server.entity.RepositoryCache;
 import io.spine.server.event.EventBus;
 import io.spine.server.event.EventDispatcherDelegate;
-import io.spine.server.event.RejectionEnvelope;
 import io.spine.server.route.CommandRouting;
 import io.spine.server.route.EventRouting;
 import io.spine.server.route.Route;
@@ -57,7 +56,6 @@ import io.spine.system.server.Mirror;
 import io.spine.system.server.MirrorRepository;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
-import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -84,7 +82,7 @@ import static io.spine.util.Exceptions.newIllegalStateException;
 @SuppressWarnings("ClassWithTooManyMethods")
 public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
         extends Repository<I, A>
-        implements CommandDispatcher, EventDispatcherDelegate {
+        implements CommandDispatcher, EventProducingRepository,  EventDispatcherDelegate {
 
     /** The default number of events to be stored before a next snapshot is made. */
     static final int DEFAULT_SNAPSHOT_TRIGGER = 100;
@@ -155,6 +153,11 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
         initCache(context.isMultitenant());
         initInbox();
         initMirror();
+    }
+
+    @Override
+    public EventBus eventBus() {
+        return context().eventBus();
     }
 
     private void initCache(boolean multitenant) {
@@ -340,14 +343,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
     @Override
     protected final void onRoutingFailed(SignalEnvelope<?, ?, ?> envelope, Throwable cause) {
         super.onRoutingFailed(envelope, cause);
-        if (envelope instanceof CommandEnvelope && cause instanceof ThrowableMessage) {
-            // TODO:2019-07-08:dmytro.dashenkov: Extract.
-            //  https://github.com/SpineEventEngine/core-java/issues/1109
-            CommandEnvelope command = (CommandEnvelope) envelope;
-            ThrowableMessage rejection = (ThrowableMessage) cause;
-            RejectionEnvelope rejectionEnvelope = RejectionEnvelope.from(command, rejection);
-            postEvents(ImmutableSet.of(rejectionEnvelope.outerObject()));
-        }
+        postRejectionIfCommand(envelope, cause);
     }
 
     @Override
@@ -458,15 +454,6 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      */
     private EventRouting<I> eventRouting() {
         return eventRouting;
-    }
-
-    /**
-     * Posts passed events to {@link EventBus}.
-     */
-    final void postEvents(Collection<Event> events) {
-        Iterable<Event> filteredEvents = eventFilter().filter(events);
-        EventBus bus = context().eventBus();
-        bus.post(filteredEvents);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -82,7 +82,7 @@ import static io.spine.util.Exceptions.newIllegalStateException;
 @SuppressWarnings("ClassWithTooManyMethods")
 public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
         extends Repository<I, A>
-        implements CommandDispatcher, EventProducingRepository,  EventDispatcherDelegate {
+        implements CommandDispatcher, EventProducingRepository, EventDispatcherDelegate {
 
     /** The default number of events to be stored before a next snapshot is made. */
     static final int DEFAULT_SNAPSHOT_TRIGGER = 100;
@@ -156,7 +156,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
     }
 
     @Override
-    public EventBus eventBus() {
+    public final EventBus eventBus() {
         return context().eventBus();
     }
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -307,7 +307,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
     }
 
     @Override
-    public Set<CommandClass> messageClasses() {
+    public final Set<CommandClass> messageClasses() {
         return aggregateClass().commands();
     }
 
@@ -323,7 +323,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      *         the command to dispatch
      */
     @Override
-    public void dispatch(CommandEnvelope cmd) {
+    public final void dispatch(CommandEnvelope cmd) {
         checkNotNull(cmd);
         Optional<I> target = route(cmd);
         target.ifPresent(id -> inbox().send(cmd)

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -343,7 +343,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
     @Override
     protected final void onRoutingFailed(SignalEnvelope<?, ?, ?> envelope, Throwable cause) {
         super.onRoutingFailed(envelope, cause);
-        postRejectionIfCommand(envelope, cause);
+        postIfCommandRejected(envelope, cause);
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/aggregate/model/AggregateClass.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/AggregateClass.java
@@ -21,6 +21,7 @@
 package io.spine.server.aggregate.model;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.entity.model.CommandHandlingEntityClass;
 import io.spine.server.event.model.EventReactorMethod;
@@ -30,8 +31,6 @@ import io.spine.server.model.HandlerMap;
 import io.spine.server.type.EmptyClass;
 import io.spine.server.type.EventClass;
 import io.spine.type.MessageClass;
-
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Sets.union;
@@ -73,7 +72,7 @@ public class AggregateClass<A extends Aggregate>
      * Obtains the set of event classes on which this aggregate class reacts.
      */
     @Override
-    public final Set<EventClass> events() {
+    public final ImmutableSet<EventClass> events() {
         return delegate.events();
     }
 
@@ -81,16 +80,16 @@ public class AggregateClass<A extends Aggregate>
      * Obtains the set of <em>external</em> event classes on which this aggregate class reacts.
      */
     @Override
-    public final Set<EventClass> externalEvents() {
+    public final ImmutableSet<EventClass> externalEvents() {
         return delegate.externalEvents();
     }
 
     /**
      * Obtains event types produced by this aggregate class.
      */
-    public Set<EventClass> outgoingEvents() {
-        Set<EventClass> result = union(commandOutput(), reactionOutput());
-        return result;
+    public ImmutableSet<EventClass> outgoingEvents() {
+        Sets.SetView<EventClass> result = union(commandOutput(), reactionOutput());
+        return result.immutableCopy();
     }
 
     /**
@@ -98,7 +97,7 @@ public class AggregateClass<A extends Aggregate>
      *
      * @see #importableEvents()
      */
-    public final Set<EventClass> stateEvents() {
+    public final ImmutableSet<EventClass> stateEvents() {
         return stateEvents.messageClasses();
     }
 
@@ -109,7 +108,7 @@ public class AggregateClass<A extends Aggregate>
      *
      * @see #stateEvents()
      */
-    public final Set<EventClass> importableEvents() {
+    public final ImmutableSet<EventClass> importableEvents() {
         return importableEvents;
     }
 
@@ -128,7 +127,7 @@ public class AggregateClass<A extends Aggregate>
     }
 
     @Override
-    public Set<EventClass> reactionOutput() {
+    public ImmutableSet<EventClass> reactionOutput() {
         return delegate.reactionOutput();
     }
 

--- a/server/src/main/java/io/spine/server/command/model/AbstractCommandHandlingClass.java
+++ b/server/src/main/java/io/spine/server/command/model/AbstractCommandHandlingClass.java
@@ -33,7 +33,7 @@ import io.spine.type.MessageClass;
  * @param <C>
  *         the type of a command handling class
  * @param <R>
- *         the type of the produced message classes
+ *         the type of the class of produced messages
  * @param <H>
  *         the type of methods performing the command handle
  */

--- a/server/src/main/java/io/spine/server/command/model/AbstractCommandHandlingClass.java
+++ b/server/src/main/java/io/spine/server/command/model/AbstractCommandHandlingClass.java
@@ -20,34 +20,33 @@
 
 package io.spine.server.command.model;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
 import io.spine.server.model.HandlerMap;
 import io.spine.server.model.ModelClass;
 import io.spine.server.type.CommandClass;
 import io.spine.type.MessageClass;
 
-import java.util.Set;
-
 /**
  * Abstract base for classes providing message handling information of classes that handle commands.
  *
  * @param <C>
  *         the type of a command handling class
- * @param <P>
+ * @param <R>
  *         the type of the produced message classes
  * @param <H>
  *         the type of methods performing the command handle
  */
 @Immutable(containerOf = "H")
 public abstract class AbstractCommandHandlingClass<C,
-                                                   P extends MessageClass<?>,
-                                                   H extends CommandAcceptingMethod<?, P>>
+                                                   R extends MessageClass<?>,
+                                                   H extends CommandAcceptingMethod<?, R>>
         extends ModelClass<C>
         implements CommandHandlingClass {
 
     private static final long serialVersionUID = 0L;
 
-    private final HandlerMap<CommandClass, P, H> commands;
+    private final HandlerMap<CommandClass, R, H> commands;
 
     AbstractCommandHandlingClass(Class<? extends C> cls,
                                  CommandAcceptingSignature<H> signature) {
@@ -56,12 +55,12 @@ public abstract class AbstractCommandHandlingClass<C,
     }
 
     @Override
-    public Set<CommandClass> commands() {
+    public ImmutableSet<CommandClass> commands() {
         return commands.messageClasses();
     }
 
     @Override
-    public Set<P> commandOutput() {
+    public ImmutableSet<R> commandOutput() {
         return commands.producedTypes();
     }
 

--- a/server/src/main/java/io/spine/server/command/model/CommandHandlingClass.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandHandlingClass.java
@@ -20,31 +20,30 @@
 
 package io.spine.server.command.model;
 
+import com.google.common.collect.ImmutableSet;
 import io.spine.server.type.CommandClass;
 import io.spine.type.MessageClass;
-
-import java.util.Set;
 
 /**
  * A common interface for classes that handle commands.
  *
- * @param <P>
+ * @param <R>
  *         the type of message classes produced from the command handling
  * @param <H>
  *         the type of methods which perform command handling
  */
-public interface CommandHandlingClass<P extends MessageClass<?>,
-                                      H extends CommandAcceptingMethod<?, P>> {
+public interface CommandHandlingClass<R extends MessageClass<?>,
+                                      H extends CommandAcceptingMethod<?, R>> {
 
     /**
      * Obtains classes of commands handled by the class.
      */
-    Set<CommandClass> commands();
+    ImmutableSet<CommandClass> commands();
 
     /**
      * Obtains classes of all messages produced as a result of command handling.
      */
-    Set<P> commandOutput();
+    ImmutableSet<R> commandOutput();
 
     /**
      * Obtains the handler method for the passed command class.

--- a/server/src/main/java/io/spine/server/command/model/CommanderClass.java
+++ b/server/src/main/java/io/spine/server/command/model/CommanderClass.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.command.model;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets.SetView;
 import io.spine.server.command.AbstractCommander;
 import io.spine.server.command.Commander;
@@ -71,12 +72,12 @@ public final class CommanderClass<C extends Commander>
     }
 
     @Override
-    public Set<EventClass> events() {
+    public ImmutableSet<EventClass> events() {
         return delegate.events();
     }
 
     @Override
-    public Set<EventClass> externalEvents() {
+    public ImmutableSet<EventClass> externalEvents() {
         return delegate.externalEvents();
     }
 
@@ -96,9 +97,9 @@ public final class CommanderClass<C extends Commander>
     }
 
     @Override
-    public Set<CommandClass> outgoingCommands() {
+    public ImmutableSet<CommandClass> outgoingCommands() {
         SetView<CommandClass> result = union(commandOutput(), delegate.producedTypes());
-        return result;
+        return result.immutableCopy();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/command/model/CommandingClass.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandingClass.java
@@ -20,9 +20,8 @@
 
 package io.spine.server.command.model;
 
+import com.google.common.collect.ImmutableSet;
 import io.spine.server.type.CommandClass;
-
-import java.util.Set;
 
 /**
  * An interface common for model classes of objects that create commands.
@@ -32,5 +31,5 @@ public interface CommandingClass {
     /**
      * Obtains the classes of commands produced by this commanding class.
      */
-    Set<CommandClass> outgoingCommands();
+    ImmutableSet<CommandClass> outgoingCommands();
 }

--- a/server/src/main/java/io/spine/server/entity/EventProducingRepository.java
+++ b/server/src/main/java/io/spine/server/entity/EventProducingRepository.java
@@ -37,7 +37,7 @@ import java.util.Collection;
 public interface EventProducingRepository {
 
     /**
-     * Obtains classes of the events produced by this {@code Repository}.
+     * Obtains classes of the events produced by this repository.
      */
     ImmutableSet<EventClass> outgoingEvents();
 

--- a/server/src/main/java/io/spine/server/entity/EventProducingRepository.java
+++ b/server/src/main/java/io/spine/server/entity/EventProducingRepository.java
@@ -27,6 +27,7 @@ import io.spine.core.Event;
 import io.spine.server.event.EventBus;
 import io.spine.server.event.RejectionEnvelope;
 import io.spine.server.type.CommandEnvelope;
+import io.spine.server.type.EventClass;
 import io.spine.server.type.SignalEnvelope;
 
 import java.util.Collection;
@@ -36,6 +37,11 @@ import java.util.Collection;
  */
 @Internal
 public interface EventProducingRepository {
+
+    /**
+     * Obtains classes of the events produced by this {@code Repository}.
+     */
+    ImmutableSet<EventClass> outgoingEvents();
 
     /**
      * Obtains the {@code EventBus} to which the repository posts.

--- a/server/src/main/java/io/spine/server/entity/EventProducingRepository.java
+++ b/server/src/main/java/io/spine/server/entity/EventProducingRepository.java
@@ -62,10 +62,10 @@ public interface EventProducingRepository {
     }
 
     /**
-     * If the passed signal is command and the error occurred is a rejection, posts
-     * it to the associated {@link #eventBus() EventBus}.
+     * If the passed signal is a command and the thrown cause is a rejection,
+     * posts the rejection to the associated {@link #eventBus() EventBus}.
      */
-    default void postRejectionIfCommand(SignalEnvelope<?, ?, ?> signal, Throwable cause) {
+    default void postIfCommandRejected(SignalEnvelope<?, ?, ?> signal, Throwable cause) {
         if (signal instanceof CommandEnvelope && cause instanceof ThrowableMessage) {
             CommandEnvelope command = (CommandEnvelope) signal;
             ThrowableMessage rejection = (ThrowableMessage) cause;

--- a/server/src/main/java/io/spine/server/entity/EventProducingRepository.java
+++ b/server/src/main/java/io/spine/server/entity/EventProducingRepository.java
@@ -21,7 +21,6 @@
 package io.spine.server.entity;
 
 import com.google.common.collect.ImmutableSet;
-import io.spine.annotation.Internal;
 import io.spine.base.ThrowableMessage;
 import io.spine.core.Event;
 import io.spine.server.event.EventBus;
@@ -35,7 +34,6 @@ import java.util.Collection;
 /**
  * Operations common for repositories that can post to {@link #eventBus() EventBus}.
  */
-@Internal
 public interface EventProducingRepository {
 
     /**
@@ -49,9 +47,17 @@ public interface EventProducingRepository {
     EventBus eventBus();
 
     /**
-     * Filters events before they are posted to the bus.
+     * Declared for mixing-in with {@link Repository#eventFilter()}.
      */
-    Iterable<Event> filter(Collection<Event> events);
+    EventFilter eventFilter();
+
+    /**
+     * Filters passed events using the {@linkplain #eventFilter()} filter} of this repository.
+     */
+    default Iterable<Event> filter(Collection<Event> events) {
+        Iterable<Event> filtered = eventFilter().filter(events);
+        return filtered;
+    }
 
     /**
      * Filters the passed events and posts the result to the EventBus.

--- a/server/src/main/java/io/spine/server/entity/EventProducingRepository.java
+++ b/server/src/main/java/io/spine/server/entity/EventProducingRepository.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.entity;
+
+import com.google.common.collect.ImmutableSet;
+import io.spine.annotation.Internal;
+import io.spine.base.ThrowableMessage;
+import io.spine.core.Event;
+import io.spine.server.event.EventBus;
+import io.spine.server.event.RejectionEnvelope;
+import io.spine.server.type.CommandEnvelope;
+import io.spine.server.type.SignalEnvelope;
+
+import java.util.Collection;
+
+/**
+ * Operations common for repositories that can post to {@link #eventBus() EventBus}.
+ */
+@Internal
+public interface EventProducingRepository {
+
+    /**
+     * Obtains the {@code EventBus} to which the repository posts.
+     */
+    EventBus eventBus();
+
+    /**
+     * Filters events before they are posted to the bus.
+     */
+    Iterable<Event> filter(Collection<Event> events);
+
+    /**
+     * Filters the passed events and posts the result to the EventBus.
+     */
+    default void postEvents(Collection<Event> events) {
+        Iterable<Event> filtered = filter(events);
+        eventBus().post(filtered);
+    }
+
+    /**
+     * If the passed signal is command and the error occurred is a rejection, posts
+     * it to the associated {@link #eventBus() EventBus}.
+     */
+    default void postRejectionIfCommand(SignalEnvelope<?, ?, ?> signal, Throwable cause) {
+        if (signal instanceof CommandEnvelope && cause instanceof ThrowableMessage) {
+            CommandEnvelope command = (CommandEnvelope) signal;
+            ThrowableMessage rejection = (ThrowableMessage) cause;
+            RejectionEnvelope re = RejectionEnvelope.from(command, rejection);
+            postEvents(ImmutableSet.of(re.outerObject()));
+        }
+    }
+}

--- a/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
+++ b/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
@@ -113,6 +113,7 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
         cacheEntityColumns();
     }
 
+    @OverridingMethodsMustInvokeSuper
     @Override
     public E create(I id) {
         E result = entityFactory().create(id);

--- a/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
+++ b/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
@@ -352,7 +352,11 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
         return result;
     }
 
-    private E toEntity(EntityRecord record) {
+    /**
+     * Converts the passed record into an entity.
+     */
+    @OverridingMethodsMustInvokeSuper
+    protected E toEntity(EntityRecord record) {
         E result = storageConverter().reverse()
                                      .convert(record);
         checkNotNull(result);

--- a/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
+++ b/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
@@ -21,6 +21,7 @@
 package io.spine.server.entity;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterators;
 import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import com.google.protobuf.Any;
 import com.google.protobuf.FieldMask;
@@ -51,7 +52,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.Iterators.filter;
 import static com.google.common.collect.Iterators.transform;
 import static com.google.common.collect.Maps.newHashMapWithExpectedSize;
 import static io.spine.protobuf.AnyPacker.unpack;
@@ -130,7 +130,7 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
     @Override
     public Iterator<E> iterator(Predicate<E> filter) {
         Iterator<E> allEntities = loadAll(ResponseFormat.getDefaultInstance());
-        Iterator<E> result = filter(allEntities, filter::test);
+        Iterator<E> result = Iterators.filter(allEntities, filter::test);
         return result;
     }
 
@@ -257,7 +257,7 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
     public Iterator<E> loadAll(Iterable<I> ids, FieldMask fieldMask) {
         RecordStorage<I> storage = recordStorage();
         Iterator<@Nullable EntityRecord> records = storage.readMultiple(ids, fieldMask);
-        Iterator<EntityRecord> presentRecords = filter(records, Objects::nonNull);
+        Iterator<EntityRecord> presentRecords = Iterators.filter(records, Objects::nonNull);
         Function<EntityRecord, E> toEntity = storageConverter().reverse();
         Iterator<E> result = transform(presentRecords, toEntity::apply);
         return result;

--- a/server/src/main/java/io/spine/server/entity/Repository.java
+++ b/server/src/main/java/io/spine/server/entity/Repository.java
@@ -405,7 +405,8 @@ public abstract class Repository<I, E extends Entity<I, ?>>
     @Internal
     public EntityLifecycle lifecycleOf(I id) {
         checkNotNull(id);
-        SystemWriteSide writeSide = context().systemClient().writeSide();
+        SystemWriteSide writeSide = context().systemClient()
+                                             .writeSide();
         EventFilter eventFilter = eventFilter();
         EntityLifecycle lifecycle = EntityLifecycle
                 .newBuilder()

--- a/server/src/main/java/io/spine/server/entity/Repository.java
+++ b/server/src/main/java/io/spine/server/entity/Repository.java
@@ -150,53 +150,6 @@ public abstract class Repository<I, E extends Entity<I, ?>>
     }
 
     /**
-     * Obtains an instance of {@link EntityLifecycle} for the entity with the given ID.
-     *
-     * <p>It is necessary that a tenant ID is set when calling this method in a multitenant
-     * environment.
-     *
-     * @param id the ID of the target entity
-     * @return {@link EntityLifecycle} of the given entity
-     */
-    @Internal
-    public EntityLifecycle lifecycleOf(I id) {
-        checkNotNull(id);
-        SystemWriteSide writeSide = context().systemClient().writeSide();
-        EventFilter eventFilter = eventFilter();
-        EntityLifecycle lifecycle = EntityLifecycle
-                .newBuilder()
-                .setEntityId(id)
-                .setEntityType(entityModelClass())
-                .setSystemWriteSide(writeSide)
-                .setEventFilter(eventFilter)
-                .build();
-        return lifecycle;
-    }
-
-    /**
-     * Creates an {@link EventFilter} for this repository.
-     *
-     * <p>All the events posted by this repository, domain, and system are first passed through this
-     * filter.
-     *
-     * <p>By default, the filter allows all the events to be posted. For entities which do not allow
-     * state subscription, the {@link io.spine.system.server.event.EntityStateChanged} event is
-     * filtered out. Override this method to change this behaviour.
-     *
-     * @return an {@link EventFilter} to apply to all posted events
-     * @implNote This method may be called many times for a single repository. It is reasonable that
-     *           it does not re-initialize the filter each time. Also, it is necessary that
-     *           the filter returned from this method is always (at least effectively) the same.
-     *           See {@link Pure @Pure} for the details on the expected behaviour.
-     */
-    @SPI
-    @Pure
-    public EventFilter eventFilter() {
-        EntityClass<E> entityClass = entityModelClass();
-        return EntityStateChangedFilter.forType(entityClass);
-    }
-
-    /**
      * Obtains a model class for the passed entity class value.
      */
     @Internal
@@ -329,7 +282,7 @@ public abstract class Repository<I, E extends Entity<I, ?>>
      *
      * <p>In order to create a custom storage, please override {@link #createStorage()} providing
      * custom implementation.
-     * 
+     *
      * @see #createStorage()
      */
     @Internal
@@ -438,6 +391,53 @@ public abstract class Repository<I, E extends Entity<I, ?>>
         context().systemClient()
                  .writeSide()
                  .postEvent(systemEvent, envelope.asMessageOrigin());
+    }
+
+    /**
+     * Obtains an instance of {@link EntityLifecycle} for the entity with the given ID.
+     *
+     * <p>It is necessary that a tenant ID is set when calling this method in a multitenant
+     * environment.
+     *
+     * @param id the ID of the target entity
+     * @return {@link EntityLifecycle} of the given entity
+     */
+    @Internal
+    public EntityLifecycle lifecycleOf(I id) {
+        checkNotNull(id);
+        SystemWriteSide writeSide = context().systemClient().writeSide();
+        EventFilter eventFilter = eventFilter();
+        EntityLifecycle lifecycle = EntityLifecycle
+                .newBuilder()
+                .setEntityId(id)
+                .setEntityType(entityModelClass())
+                .setSystemWriteSide(writeSide)
+                .setEventFilter(eventFilter)
+                .build();
+        return lifecycle;
+    }
+
+    /**
+     * Creates an {@link EventFilter} for this repository.
+     *
+     * <p>All the events posted by this repository, domain, and system are first passed through this
+     * filter.
+     *
+     * <p>By default, the filter allows all the events to be posted. For entities which do not allow
+     * state subscription, the {@link io.spine.system.server.event.EntityStateChanged} event is
+     * filtered out. Override this method to change this behaviour.
+     *
+     * @return an {@link EventFilter} to apply to all posted events
+     * @implNote This method may be called many times for a single repository. It is reasonable that
+     *           it does not re-initialize the filter each time. Also, it is necessary that
+     *           the filter returned from this method is always (at least effectively) the same.
+     *           See {@link Pure @Pure} for the details on the expected behaviour.
+     */
+    @SPI
+    @Pure
+    public EventFilter eventFilter() {
+        EntityClass<E> entityClass = entityModelClass();
+        return EntityStateChangedFilter.forType(entityClass);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/entity/Repository.java
+++ b/server/src/main/java/io/spine/server/entity/Repository.java
@@ -21,7 +21,6 @@
 package io.spine.server.entity;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import com.google.protobuf.Message;
@@ -40,7 +39,6 @@ import io.spine.server.entity.model.EntityClass;
 import io.spine.server.route.Route;
 import io.spine.server.storage.Storage;
 import io.spine.server.storage.StorageFactory;
-import io.spine.server.type.EventClass;
 import io.spine.server.type.SignalEnvelope;
 import io.spine.system.server.RoutingFailed;
 import io.spine.system.server.SystemWriteSide;
@@ -178,16 +176,6 @@ public abstract class Repository<I, E extends Entity<I, ?>>
      */
     public final TypeUrl entityStateType() {
         return entityModelClass().stateType();
-    }
-
-    /**
-     * Obtains classes of the events produced by this {@code Repository}.
-     *
-     * <p>For convenience purposes the default version returns an empty set.
-     * This method should be overridden by repositories which actually produce events.
-     */
-    public ImmutableSet<EventClass> outgoingEvents() {
-        return ImmutableSet.of();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/entity/Repository.java
+++ b/server/src/main/java/io/spine/server/entity/Repository.java
@@ -29,6 +29,7 @@ import io.spine.annotation.Internal;
 import io.spine.annotation.SPI;
 import io.spine.base.Identifier;
 import io.spine.base.MessageContext;
+import io.spine.core.Event;
 import io.spine.logging.Logging;
 import io.spine.reflect.GenericTypeIndex;
 import io.spine.server.BoundedContext;
@@ -49,6 +50,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.qual.Pure;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -453,6 +455,14 @@ public abstract class Repository<I, E extends Entity<I, ?>>
         return EntityStateChangedFilter.forType(entityClass);
     }
 
+    /**
+     * Filters passed events using the {@linkplain #eventFilter()} filter} of this repository.
+     */
+    public final Iterable<Event> filter(Collection<Event> events) {
+        Iterable<Event> filtered = eventFilter().filter(events);
+        return filtered;
+    }
+    
     /**
      * Enumeration of generic type parameters of this class.
      */

--- a/server/src/main/java/io/spine/server/entity/model/CommandHandlingEntityClass.java
+++ b/server/src/main/java/io/spine/server/entity/model/CommandHandlingEntityClass.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.entity.model;
 
+import com.google.common.collect.ImmutableSet;
 import io.spine.server.command.model.CommandHandlerMethod;
 import io.spine.server.command.model.CommandHandlerSignature;
 import io.spine.server.command.model.CommandHandlingClass;
@@ -27,8 +28,6 @@ import io.spine.server.entity.Entity;
 import io.spine.server.model.HandlerMap;
 import io.spine.server.type.CommandClass;
 import io.spine.server.type.EventClass;
-
-import java.util.Set;
 
 /**
  * Abstract base for entity classes that handle commands.
@@ -46,12 +45,12 @@ public abstract class CommandHandlingEntityClass<E extends Entity>
     }
 
     @Override
-    public Set<CommandClass> commands() {
+    public ImmutableSet<CommandClass> commands() {
         return commands.messageClasses();
     }
 
     @Override
-    public Set<EventClass> commandOutput() {
+    public ImmutableSet<EventClass> commandOutput() {
         return commands.producedTypes();
     }
 

--- a/server/src/main/java/io/spine/server/entity/model/StateSubscribingClass.java
+++ b/server/src/main/java/io/spine/server/entity/model/StateSubscribingClass.java
@@ -20,7 +20,7 @@
 
 package io.spine.server.entity.model;
 
-import java.util.Set;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * A class which can {@linkplain io.spine.core.Subscribe subscribe} to updates of entity states.
@@ -32,13 +32,15 @@ public interface StateSubscribingClass {
 
     /**
      * Obtains domestic entity states to which the class is subscribed.
+     * @return
      */
-    Set<StateClass> domesticStates();
+    ImmutableSet<StateClass> domesticStates();
 
     /**
      * Obtains external entity states to which the class is subscribed.
+     * @return
      */
-    Set<StateClass> externalStates();
+    ImmutableSet<StateClass> externalStates();
 
     /**
      * Verifies if this class is {@linkplain io.spine.core.Subscribe subscribed} to updates of

--- a/server/src/main/java/io/spine/server/entity/model/StateSubscribingClass.java
+++ b/server/src/main/java/io/spine/server/entity/model/StateSubscribingClass.java
@@ -32,13 +32,11 @@ public interface StateSubscribingClass {
 
     /**
      * Obtains domestic entity states to which the class is subscribed.
-     * @return
      */
     ImmutableSet<StateClass> domesticStates();
 
     /**
      * Obtains external entity states to which the class is subscribed.
-     * @return
      */
     ImmutableSet<StateClass> externalStates();
 

--- a/server/src/main/java/io/spine/server/event/model/EventReactorClass.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReactorClass.java
@@ -28,8 +28,6 @@ import io.spine.server.model.ModelClass;
 import io.spine.server.type.EventClass;
 import io.spine.type.MessageClass;
 
-import java.util.Set;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -69,17 +67,17 @@ public final class EventReactorClass<S extends AbstractEventReactor> extends Mod
     }
 
     @Override
-    public Set<EventClass> reactionOutput() {
+    public ImmutableSet<EventClass> reactionOutput() {
         return reactors.producedTypes();
     }
 
     @Override
-    public Set<EventClass> events() {
+    public ImmutableSet<EventClass> events() {
         return events;
     }
 
     @Override
-    public Set<EventClass> externalEvents() {
+    public ImmutableSet<EventClass> externalEvents() {
         return externalEvents;
     }
 }

--- a/server/src/main/java/io/spine/server/event/model/EventReceiverClass.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReceiverClass.java
@@ -20,10 +20,9 @@
 
 package io.spine.server.event.model;
 
+import com.google.common.collect.ImmutableSet;
 import io.spine.annotation.Internal;
 import io.spine.server.type.EventClass;
-
-import java.util.Set;
 
 /**
  * Describes a class of objects that receive events.
@@ -41,7 +40,7 @@ public interface EventReceiverClass {
      *
      * <p>For only the external events, please see {@link #externalEvents()}.
      */
-    Set<EventClass> events();
+    ImmutableSet<EventClass> events();
 
     /**
      * Obtains a set of external events which this class receives.
@@ -49,5 +48,5 @@ public interface EventReceiverClass {
      * <p>External events are those that are delivered to the {@code BoundedContext}
      * to which this class belongs from outside.
      */
-    Set<EventClass> externalEvents();
+    ImmutableSet<EventClass> externalEvents();
 }

--- a/server/src/main/java/io/spine/server/event/model/EventReceivingClassDelegate.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReceivingClassDelegate.java
@@ -31,8 +31,6 @@ import io.spine.server.model.ModelClass;
 import io.spine.server.type.EventClass;
 import io.spine.type.MessageClass;
 
-import java.util.Set;
-
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 /**
@@ -79,35 +77,35 @@ public class EventReceivingClassDelegate<T extends EventReceiver,
     /**
      * Obtains domestic event classes handled by the delegating class.
      */
-    public Set<EventClass> events() {
+    public ImmutableSet<EventClass> events() {
         return events;
     }
 
     /**
      * Obtains external event classes handled by the delegating class.
      */
-    public Set<EventClass> externalEvents() {
+    public ImmutableSet<EventClass> externalEvents() {
         return externalEvents;
     }
 
     /**
      * Obtains domestic entity states to which the delegating class is subscribed.
      */
-    public Set<StateClass> domesticStates() {
+    public ImmutableSet<StateClass> domesticStates() {
         return domesticStates;
     }
 
     /**
      * Obtains external entity states to which the delegating class is subscribed.
      */
-    public Set<StateClass> externalStates() {
+    public ImmutableSet<StateClass> externalStates() {
         return externalStates;
     }
 
     /**
      * Obtains the classes of messages produced by handler methods of this class.
      */
-    public Set<P> producedTypes() {
+    public ImmutableSet<P> producedTypes() {
         return handlers.producedTypes();
     }
 

--- a/server/src/main/java/io/spine/server/event/model/EventSubscriberClass.java
+++ b/server/src/main/java/io/spine/server/event/model/EventSubscriberClass.java
@@ -27,8 +27,6 @@ import io.spine.server.type.EmptyClass;
 import io.spine.server.type.EventClass;
 import io.spine.type.MessageClass;
 
-import java.util.Set;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -61,12 +59,12 @@ public final class EventSubscriberClass<S extends AbstractEventSubscriber> exten
     }
 
     @Override
-    public Set<EventClass> events() {
+    public ImmutableSet<EventClass> events() {
         return delegate.events();
     }
 
     @Override
-    public Set<EventClass> externalEvents() {
+    public ImmutableSet<EventClass> externalEvents() {
         return delegate.externalEvents();
     }
 

--- a/server/src/main/java/io/spine/server/event/model/ReactingClass.java
+++ b/server/src/main/java/io/spine/server/event/model/ReactingClass.java
@@ -20,10 +20,9 @@
 
 package io.spine.server.event.model;
 
+import com.google.common.collect.ImmutableSet;
 import io.spine.server.type.EventClass;
 import io.spine.type.MessageClass;
-
-import java.util.Set;
 
 /**
  * Provides message handling information on a class that reacts on messages.
@@ -38,5 +37,5 @@ public interface ReactingClass extends EventReceiverClass {
     /**
      * Obtains the classes of events produced from the event reaction.
      */
-    Set<EventClass> reactionOutput();
+    ImmutableSet<EventClass> reactionOutput();
 }

--- a/server/src/main/java/io/spine/server/event/model/ReactorClassDelegate.java
+++ b/server/src/main/java/io/spine/server/event/model/ReactorClassDelegate.java
@@ -20,11 +20,10 @@
 
 package io.spine.server.event.model;
 
+import com.google.common.collect.ImmutableSet;
 import io.spine.server.event.EventReceiver;
 import io.spine.server.type.EventClass;
 import io.spine.type.MessageClass;
-
-import java.util.Set;
 
 /**
  * The helper class for holding messaging information on behalf of another model class.
@@ -48,7 +47,7 @@ public final class ReactorClassDelegate<T extends EventReceiver>
     }
 
     @Override
-    public Set<EventClass> reactionOutput() {
+    public ImmutableSet<EventClass> reactionOutput() {
         return producedTypes();
     }
 }

--- a/server/src/main/java/io/spine/server/procman/PmEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmEndpoint.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.procman;
 
+import com.google.common.collect.ImmutableList;
 import io.spine.base.Error;
 import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.dispatch.Success;
@@ -90,7 +91,7 @@ abstract class PmEndpoint<I,
                                                          .getEventList());
                 break;
             case REJECTION:
-                repository().postEvent(successfulOutcome.getRejection());
+                repository().postEvents(ImmutableList.of(successfulOutcome.getRejection()));
                 break;
             case PRODUCED_COMMANDS:
                 repository().postCommands(successfulOutcome.getProducedCommands()

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
@@ -414,6 +414,7 @@ public abstract class ProcessManagerRepository<I,
         super.store(entity);
     }
 
+    @OverridingMethodsMustInvokeSuper
     @Override
     public P create(I id) {
         P procman = super.create(id);

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
@@ -339,7 +339,7 @@ public abstract class ProcessManagerRepository<I,
     @Override
     protected final void onRoutingFailed(SignalEnvelope<?, ?, ?> envelope, Throwable cause) {
         super.onRoutingFailed(envelope, cause);
-        postRejectionIfCommand(envelope, cause);
+        postIfCommandRejected(envelope, cause);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
@@ -21,7 +21,6 @@
 package io.spine.server.procman;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import com.google.protobuf.Message;
@@ -165,7 +164,7 @@ public abstract class ProcessManagerRepository<I,
     }
 
     @Override
-    public EventBus eventBus() {
+    public final EventBus eventBus() {
         return context().eventBus();
     }
 
@@ -250,7 +249,7 @@ public abstract class ProcessManagerRepository<I,
      *         domestic events
      */
     @Override
-    public Set<EventClass> messageClasses() {
+    public final Set<EventClass> messageClasses() {
         return processManagerClass().events();
     }
 
@@ -262,7 +261,7 @@ public abstract class ProcessManagerRepository<I,
      *         external events
      */
     @Override
-    public Set<EventClass> externalEventClasses() {
+    public final Set<EventClass> externalEventClasses() {
         return processManagerClass().externalEvents();
     }
 
@@ -272,8 +271,7 @@ public abstract class ProcessManagerRepository<I,
      * @return a set of command classes or empty set if process managers do not handle commands
      */
     @Override
-    @SuppressWarnings("ReturnOfCollectionOrArrayField") // it is immutable
-    public Set<CommandClass> commandClasses() {
+    public final Set<CommandClass> commandClasses() {
         return processManagerClass().commands();
     }
 
@@ -333,7 +331,8 @@ public abstract class ProcessManagerRepository<I,
     private void onCommandTargetSet(I id, CommandEnvelope cmd) {
         EntityLifecycle lifecycle = lifecycleOf(id);
         CommandId commandId = cmd.id();
-        with(cmd.tenantId()).run(() -> lifecycle.onTargetAssignedToCommand(commandId));
+        with(cmd.tenantId())
+                .run(() -> lifecycle.onTargetAssignedToCommand(commandId));
     }
 
     @Internal
@@ -365,16 +364,9 @@ public abstract class ProcessManagerRepository<I,
     }
 
     /**
-     * Posts the passed event to {@link EventBus}.
-     */
-    void postEvent(Event event) {
-        postEvents(ImmutableList.of(event));
-    }
-
-    /**
      * Posts passed commands to {@link CommandBus}.
      */
-    void postCommands(Collection<Command> commands) {
+    final void postCommands(Collection<Command> commands) {
         CommandBus bus = context().commandBus();
         bus.post(commands, noOpObserver());
     }
@@ -394,7 +386,7 @@ public abstract class ProcessManagerRepository<I,
     }
 
     @Override
-    public void store(P entity) {
+    public final void store(P entity) {
         cache.store(entity);
     }
 

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
@@ -373,8 +373,8 @@ public abstract class ProcessManagerRepository<I,
     }
 
     /**
-     * Creates {@linkplain #configure(ProcessManager) configures} an instance of the process manager
-     * by the passed record.
+     * Creates and {@linkplain #configure(ProcessManager) configures} an instance of
+     * the process manager by the passed record.
      */
     @Override
     protected final P toEntity(EntityRecord record) {

--- a/server/src/main/java/io/spine/server/procman/model/ProcessManagerClass.java
+++ b/server/src/main/java/io/spine/server/procman/model/ProcessManagerClass.java
@@ -124,7 +124,7 @@ public final class ProcessManagerClass<P extends ProcessManager>
     }
 
     /**
-     * Obtains a method which generates one or more commands in response to incoming
+     * Obtains a method which may generate one or more commands in response to incoming
      * event with the passed class.
      */
     public CommandReactionMethod commanderOf(EventClass eventClass) {

--- a/server/src/main/java/io/spine/server/procman/model/ProcessManagerClass.java
+++ b/server/src/main/java/io/spine/server/procman/model/ProcessManagerClass.java
@@ -20,6 +20,7 @@
 
 package io.spine.server.procman.model;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets.SetView;
 import io.spine.server.command.model.CommandReactionMethod;
 import io.spine.server.command.model.CommandSubstituteMethod;
@@ -33,8 +34,6 @@ import io.spine.server.procman.ProcessManager;
 import io.spine.server.type.CommandClass;
 import io.spine.server.type.EventClass;
 import io.spine.type.MessageClass;
-
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Sets.union;
@@ -72,33 +71,33 @@ public final class ProcessManagerClass<P extends ProcessManager>
     }
 
     @Override
-    public Set<CommandClass> commands() {
+    public ImmutableSet<CommandClass> commands() {
         SetView<CommandClass> result =
                 union(super.commands(), commanderDelegate.commands());
-        return result;
+        return result.immutableCopy();
     }
 
     @Override
-    public Set<EventClass> events() {
+    public ImmutableSet<EventClass> events() {
         SetView<EventClass> result =
                 union(reactorDelegate.events(), commanderDelegate.events());
-        return result;
+        return result.immutableCopy();
     }
 
     @Override
-    public Set<EventClass> externalEvents() {
+    public ImmutableSet<EventClass> externalEvents() {
         SetView<EventClass> result =
                 union(reactorDelegate.externalEvents(),
                       commanderDelegate.externalEvents());
-        return result;
+        return result.immutableCopy();
     }
 
     /**
      * Obtains event classes produced by this process manager class.
      */
-    public Set<EventClass> outgoingEvents() {
+    public ImmutableSet<EventClass> outgoingEvents() {
         SetView<EventClass> result = union(commandOutput(), reactionOutput());
-        return result;
+        return result.immutableCopy();
     }
 
     @Override
@@ -107,31 +106,50 @@ public final class ProcessManagerClass<P extends ProcessManager>
     }
 
     @Override
-    public Set<EventClass> reactionOutput() {
+    public ImmutableSet<EventClass> reactionOutput() {
         return reactorDelegate.reactionOutput();
     }
 
     @Override
-    public Set<CommandClass> outgoingCommands() {
+    public ImmutableSet<CommandClass> outgoingCommands() {
         return commanderDelegate.outgoingCommands();
     }
 
+    /**
+     * Obtains a method which handles the passed class of commands by producing
+     * one or more other commands.
+     */
     public CommandSubstituteMethod commanderOf(CommandClass commandClass) {
         return commanderDelegate.handlerOf(commandClass);
     }
 
+    /**
+     * Obtains a method which generates one or more commands in response to incoming
+     * event with the passed class.
+     */
     public CommandReactionMethod commanderOf(EventClass eventClass) {
         return commanderDelegate.getCommander(eventClass);
     }
 
+    /**
+     * Verifies if the process manager class has a method which generates one or more
+     * commands in response to a command of the passed class.
+     */
     public boolean substitutesCommand(CommandClass commandClass) {
         return commanderDelegate.substitutesCommand(commandClass);
     }
 
+    /**
+     * Verifies if the class of process managers react on an event of the passed class.
+     */
     public boolean reactsOnEvent(EventClass eventClass) {
         return reactorDelegate.contains(eventClass);
     }
 
+    /**
+     * Verifies if the process manager class generates a command in response to
+     * an event of the passed class.
+     */
     public boolean producesCommandsOn(EventClass eventClass) {
         return commanderDelegate.producesCommandsOn(eventClass);
     }

--- a/server/src/main/java/io/spine/server/projection/ProjectionRepository.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionRepository.java
@@ -214,7 +214,7 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S, ?>, S e
     }
 
     /** Obtains {@link EventStore} from which to get events during catch-up. */
-    EventStore eventStore() {
+    final EventStore eventStore() {
         return context()
                 .eventBus()
                 .eventStore();
@@ -269,14 +269,14 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S, ?>, S e
      * @throws IllegalStateException if the storage is null
      */
     @Override
-    protected RecordStorage<I> recordStorage() {
+    protected final RecordStorage<I> recordStorage() {
         @SuppressWarnings("unchecked") // ensured by the type returned by `createdStorage()`.
         RecordStorage<I> recordStorage = ((ProjectionStorage<I>) storage()).recordStorage();
         return checkStorage(recordStorage);
     }
 
     @Override
-    protected ProjectionStorage<I> createStorage() {
+    protected final ProjectionStorage<I> createStorage() {
         StorageFactory sf = defaultStorageFactory();
         Class<P> projectionClass = entityClass();
         ProjectionStorage<I> projectionStorage =
@@ -290,7 +290,7 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S, ?>, S e
      * <p>Overrides to perform finding using the cache.
      */
     @Override
-    protected P findOrCreate(I id) {
+    protected final P findOrCreate(I id) {
         return cache.load(id);
     }
 
@@ -299,7 +299,7 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S, ?>, S e
     }
 
     @Override
-    public void store(P entity) {
+    public final void store(P entity) {
         cache.store(entity);
     }
 
@@ -320,18 +320,18 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S, ?>, S e
     }
 
     @Override
-    public Set<EventClass> messageClasses() {
+    public final Set<EventClass> messageClasses() {
         return projectionClass().events();
     }
 
     @Override
-    public Set<EventClass> externalEventClasses() {
+    public final Set<EventClass> externalEventClasses() {
         return projectionClass().externalEvents();
     }
 
     @OverridingMethodsMustInvokeSuper
     @Override
-    public boolean canDispatch(EventEnvelope event) {
+    public final boolean canDispatch(EventEnvelope event) {
         Optional<SubscriberMethod> subscriber = projectionClass().subscriberOf(event);
         return subscriber.isPresent();
     }
@@ -342,7 +342,7 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S, ?>, S e
      * <p>Sends a system command to dispatch the given event to a subscriber.
      */
     @Override
-    protected void dispatchTo(I id, Event event) {
+    protected final void dispatchTo(I id, Event event) {
         inbox().send(EventEnvelope.of(event))
                .toSubscriber(id);
     }
@@ -360,7 +360,7 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S, ?>, S e
     }
 
     @VisibleForTesting
-    EventStreamQuery createStreamQuery() {
+    final EventStreamQuery createStreamQuery() {
         Set<EventFilter> eventFilters = createEventFilters();
 
         // Gets the timestamp of the last event. This also ensures we have the storage.

--- a/server/src/main/java/io/spine/server/projection/ProjectionRepository.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionRepository.java
@@ -231,6 +231,7 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S, ?>, S e
         return asProjectionClass(cls);
     }
 
+    @OverridingMethodsMustInvokeSuper
     @Override
     public P create(I id) {
         P projection = super.create(id);
@@ -286,7 +287,7 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S, ?>, S e
     /**
      * {@inheritDoc}
      *
-     * //TODO:2019-08-25:alex.tymchenko: document.
+     * <p>Overrides to perform finding using the cache.
      */
     @Override
     protected P findOrCreate(I id) {

--- a/server/src/main/java/io/spine/server/projection/model/ProjectionClass.java
+++ b/server/src/main/java/io/spine/server/projection/model/ProjectionClass.java
@@ -34,8 +34,6 @@ import io.spine.server.type.EmptyClass;
 import io.spine.server.type.EventClass;
 import io.spine.type.MessageClass;
 
-import java.util.Set;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -67,22 +65,22 @@ public final class ProjectionClass<P extends Projection>
     }
 
     @Override
-    public final Set<EventClass> events() {
+    public final ImmutableSet<EventClass> events() {
         return delegate.events();
     }
 
     @Override
-    public final Set<StateClass> domesticStates() {
+    public final ImmutableSet<StateClass> domesticStates() {
         return delegate.domesticStates();
     }
 
     @Override
-    public final Set<EventClass> externalEvents() {
+    public final ImmutableSet<EventClass> externalEvents() {
         return delegate.externalEvents();
     }
 
     @Override
-    public final Set<StateClass> externalStates() {
+    public final ImmutableSet<StateClass> externalStates() {
         return delegate.externalStates();
     }
 

--- a/server/src/main/java/io/spine/server/stand/InMemoryEventRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/InMemoryEventRegistry.java
@@ -21,6 +21,7 @@
 package io.spine.server.stand;
 
 import com.google.common.collect.ImmutableSet;
+import io.spine.server.entity.EventProducingRepository;
 import io.spine.server.entity.Repository;
 import io.spine.server.type.EventClass;
 import io.spine.type.TypeUrl;
@@ -45,8 +46,11 @@ final class InMemoryEventRegistry implements EventRegistry {
 
     @Override
     public void register(Repository<?, ?> repository) {
-        repository.outgoingEvents()
-                  .forEach(this::putIntoMap);
+        if (repository instanceof EventProducingRepository) {
+            EventProducingRepository repo = (EventProducingRepository) repository;
+            repo.outgoingEvents()
+                .forEach(this::putIntoMap);
+        }
     }
 
     @Override

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/EventDiscardingAggregateRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/EventDiscardingAggregateRepository.java
@@ -34,7 +34,7 @@ public class EventDiscardingAggregateRepository
     private static final EventFilter discardAll = anyEvent -> empty();
 
     @Override
-    protected EventFilter eventFilter() {
+    public EventFilter eventFilter() {
         return discardAll;
     }
 }

--- a/server/src/test/java/io/spine/server/commandbus/given/DirectScheduledExecutor.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/DirectScheduledExecutor.java
@@ -71,7 +71,7 @@ public final class DirectScheduledExecutor implements ScheduledExecutorService {
      * <p>Returns {@code null} as the result of {@code schedule} for command bus is always
      * ignored.
      */
-    @SuppressWarnings({"CheckReturnValue", "ResultOfMethodCallIgnored"})
+    @SuppressWarnings({"CheckReturnValue", "ResultOfMethodCallIgnored", "FutureReturnValueIgnored"})
     // In these tests, we do not really care about the schedule result.
     @Override
     public <V> @Nullable ScheduledFuture<V>

--- a/server/src/test/java/io/spine/server/procman/given/repo/EventDiscardingProcManRepository.java
+++ b/server/src/test/java/io/spine/server/procman/given/repo/EventDiscardingProcManRepository.java
@@ -41,7 +41,7 @@ public final class EventDiscardingProcManRepository
     private static final EventFilter eventFilter = anyEvent -> Optional.empty();
 
     @Override
-    protected EventFilter eventFilter() {
+    public EventFilter eventFilter() {
         return eventFilter;
     }
 }

--- a/server/src/test/java/io/spine/server/procman/given/repo/TestProcessManagerRepository.java
+++ b/server/src/test/java/io/spine/server/procman/given/repo/TestProcessManagerRepository.java
@@ -32,6 +32,8 @@ import static io.spine.server.route.EventRoute.withId;
 public final class TestProcessManagerRepository
         extends ProcessManagerRepository<ProjectId, TestProcessManager, Project> {
 
+    private boolean configureCalled;
+
     @Override
     protected void setupEventRouting(EventRouting<ProjectId> routing) {
         super.setupEventRouting(routing);
@@ -42,5 +44,19 @@ public final class TestProcessManagerRepository
     @Override
     public EventFilter eventFilter() {
         return super.eventFilter();
+    }
+
+    @Override
+    protected void configure(TestProcessManager processManager) {
+        super.configure(processManager);
+        configureCalled = true;
+    }
+
+    public boolean configureCalled() {
+        return configureCalled;
+    }
+
+    public void clearConfigureCalledFlag() {
+        configureCalled = false;
     }
 }

--- a/server/src/test/java/io/spine/system/server/given/entity/PersonProcmanRepository.java
+++ b/server/src/test/java/io/spine/system/server/given/entity/PersonProcmanRepository.java
@@ -33,7 +33,7 @@ public class PersonProcmanRepository
 
     // Allow all events for the test purposes.
     @Override
-    protected EventFilter eventFilter() {
+    public EventFilter eventFilter() {
         return EventFilter.allowAll();
     }
 }

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.1.1-SNAPSHOT+1'
+final def spineVersion = '1.1.1-SNAPSHOT+2'
 
 ext {
     // The version of the modules in this project.


### PR DESCRIPTION
This PR:
  * Extracts the code common to `ProcessManagerRepository` and `AggregateRepository` (because of their event-generation abilities) into a mix-in interface `EventProducingRepository` (addressing #1109).
  * Makes methods of repository classes that are not intended for overriding `final`.
  * Makes model classes to return `ImmutableSet` (rather than just `Set`).
  * Introduces the ability to configure `ProcessManager` before it's returned to the calling code when finding or creating.