### PR TITLE
Avoid using real gRPC server in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Gradle is used as a build and dependency management system.
 ## Releases
 The project is under active ongoing development. You are welcome to experiment and [provide your feedback][email-developers].
 
-The latest stable version is [1.1.0][latest-release].  
+The latest stable version is [1.1.2][latest-release].  
 
 ## Quickstart and Examples
 
@@ -51,7 +51,7 @@ or provide custom storage implementations.
 If you need to use API with one of these annotations, please [contact us][email-developers].
 
 [email-developers]: mailto:spine-developers@teamdev.com
-[latest-release]: https://github.com/SpineEventEngine/core-java/releases/tag/v1.1.0
+[latest-release]: https://github.com/SpineEventEngine/core-java/releases/tag/v1.1.2
 [spine-site]: https://spine.io/
 [wiki-home]: https://github.com/SpineEventEngine/core-java/wiki
 [java-code-style]: https://github.com/SpineEventEngine/core-java/wiki/Java-Code-Style 

--- a/license-report.md
+++ b/license-report.md
@@ -432,7 +432,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 25 18:00:29 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 26 21:08:01 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -815,7 +815,7 @@ This report was generated on **Wed Sep 25 18:00:29 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 25 18:00:32 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 26 21:08:08 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1246,7 +1246,7 @@ This report was generated on **Wed Sep 25 18:00:32 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 25 18:00:35 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 26 21:08:14 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1839,7 +1839,7 @@ This report was generated on **Wed Sep 25 18:00:35 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 25 18:00:39 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 26 21:08:22 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2336,7 +2336,7 @@ This report was generated on **Wed Sep 25 18:00:39 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 25 18:00:43 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 26 21:08:29 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2826,7 +2826,7 @@ This report was generated on **Wed Sep 25 18:00:43 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 25 18:00:46 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 26 21:08:35 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3324,7 +3324,7 @@ This report was generated on **Wed Sep 25 18:00:46 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 25 18:00:51 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 26 21:08:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3868,4 +3868,4 @@ This report was generated on **Wed Sep 25 18:00:51 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Sep 25 18:00:57 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 26 21:08:49 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/server/src/main/java/io/spine/server/entity/storage/ColumnReader.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ColumnReader.java
@@ -109,7 +109,8 @@ final class ColumnReader {
      * <p>If the check for correctness fails, throws {@link IllegalStateException}.
      *
      * @return a {@code Collection} of {@link EntityColumn} corresponded to entity class
-     * @throws IllegalStateException if entity column definitions are incorrect
+     * @throws IllegalStateException
+     *         if entity column definitions are incorrect
      */
     Collection<EntityColumn> readColumns() {
         ImmutableSet<EntityColumn> columns = scanColumns();

--- a/server/src/main/java/io/spine/server/entity/storage/EntityColumnCache.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityColumnCache.java
@@ -79,8 +79,9 @@ public final class EntityColumnCache {
      * Instead, the cache instance will wait for the first access to it to cache
      * {@linkplain EntityColumn entity columns}.
      *
-     * @param entityClass the class for which {@linkplain EntityColumn entity columns} should
-     *                    be obtained and cached
+     * @param entityClass
+     *         the class for which {@linkplain EntityColumn entity columns} should be obtained and
+     *         cached
      * @return new instance
      */
     public static EntityColumnCache initializeFor(Class<? extends Entity<?, ?>> entityClass) {
@@ -97,9 +98,11 @@ public final class EntityColumnCache {
      * <p>If there is no {@link EntityColumn column} with the given name in the {@link Entity}
      * class managed by this cache, the method will throw {@link IllegalArgumentException}.
      *
-     * @param columnName the {@linkplain EntityColumn#name() name} of the searched column
+     * @param columnName
+     *         the {@linkplain EntityColumn#name() name} of the searched column
      * @return {@linkplain EntityColumn found entity column}
-     * @throws IllegalArgumentException if the {@link EntityColumn} is not found
+     * @throws IllegalArgumentException
+     *         if the {@link EntityColumn} is not found
      */
     public EntityColumn findColumn(String columnName) {
         checkColumnName(columnName);
@@ -160,8 +163,8 @@ public final class EntityColumnCache {
      * <p>If {@link Column} definitions are incorrect for the given {@link Entity} class this method
      * will throw {@link IllegalStateException}.
      *
-     * @throws IllegalStateException if entity column definitions for the managed {@link Entity}
-     * class are incorrect
+     * @throws IllegalStateException
+     *         if entity column definitions for the managed {@link Entity} class are incorrect
      */
     private void obtainAndCacheColumns() {
         Collection<EntityColumn> columns = Columns.getAllColumns(entityClass);
@@ -172,7 +175,8 @@ public final class EntityColumnCache {
      * Stores {@linkplain EntityColumn entity columns} from the {@link Iterable} to the inner
      * {@link EntityColumnCache#entityColumnData cache}.
      *
-     * @param columns {@linkplain EntityColumn columns} to store
+     * @param columns
+     *         {@linkplain EntityColumn columns} to store
      */
     private void cacheEntityColumns(Iterable<EntityColumn> columns) {
         for (EntityColumn column : columns) {

--- a/server/src/main/java/io/spine/server/transport/GrpcContainer.java
+++ b/server/src/main/java/io/spine/server/transport/GrpcContainer.java
@@ -67,7 +67,8 @@ public final class GrpcContainer {
     /**
      * Starts the service.
      *
-     * @throws IOException if unable to bind
+     * @throws IOException
+     *         if unable to bind
      */
     public void start() throws IOException {
         checkState(grpcServer == null, "gRPC server is started already.");
@@ -129,7 +130,8 @@ public final class GrpcContainer {
      * <p>To find out whether the service is already available for calls,
      * use {@link #isLive(BindableService)} method.
      *
-     * @param service the gRPC service to check
+     * @param service
+     *         the gRPC service to check
      * @return {@code true}, if the given gRPC service for deployment and {@code false} otherwise
      */
     public boolean isScheduledForDeployment(BindableService service) {
@@ -153,7 +155,8 @@ public final class GrpcContainer {
      * <p>  a. the service has been previously scheduled for the deployment,
      * <p>  b. the container has been started.
      *
-     * @param service the gRPC service
+     * @param service
+     *         the gRPC service
      * @return {@code true}, if the service is available for interaction within this container and
      *         {@code false} otherwise
      */

--- a/server/src/main/java/io/spine/server/transport/GrpcContainer.java
+++ b/server/src/main/java/io/spine/server/transport/GrpcContainer.java
@@ -52,6 +52,9 @@ public final class GrpcContainer {
 
     private @Nullable Server grpcServer;
 
+    @VisibleForTesting
+    private @Nullable Server injectedServer;
+
     public static Builder newBuilder() {
         return new Builder();
     }
@@ -171,8 +174,10 @@ public final class GrpcContainer {
                .addShutdownHook(new Thread(getOnShutdownCallback()));
     }
 
-    @VisibleForTesting
-    Server createGrpcServer() {
+    private Server createGrpcServer() {
+        if (injectedServer != null) {
+            return injectedServer;
+        }
         ServerBuilder builder = ServerBuilder.forPort(port);
         for (ServerServiceDefinition service : services) {
             builder.addService(service);
@@ -203,6 +208,18 @@ public final class GrpcContainer {
     @VisibleForTesting
     Server grpcServer() {
         return grpcServer;
+    }
+
+    /**
+     * Injects a server to this container.
+     *
+     * <p>All calls to {@link #createGrpcServer()} will resolve to the given server instance.
+     *
+     * <p>A test-only method.
+     */
+    @VisibleForTesting
+    public void injectServer(Server server) {
+        this.injectedServer = server;
     }
 
     public static class Builder {

--- a/server/src/test/java/io/spine/server/CommandServiceTest.java
+++ b/server/src/test/java/io/spine/server/CommandServiceTest.java
@@ -29,6 +29,7 @@ import io.spine.core.Command;
 import io.spine.core.CommandValidationError;
 import io.spine.core.Status;
 import io.spine.grpc.MemoizingObserver;
+import io.spine.server.given.transport.TestGrpcServer;
 import io.spine.server.transport.GrpcContainer;
 import io.spine.test.commandservice.CmdServDontHandle;
 import io.spine.testing.client.TestActorRequestFactory;
@@ -153,18 +154,13 @@ class CommandServiceTest {
         GrpcContainer grpcContainer = GrpcContainer.newBuilder()
                                                    .addService(service)
                                                    .build();
-        try {
-            assertTrue(grpcContainer.isScheduledForDeployment(service));
+        grpcContainer.injectServer(new TestGrpcServer());
+        assertTrue(grpcContainer.isScheduledForDeployment(service));
 
-            grpcContainer.start();
-            assertTrue(grpcContainer.isLive(service));
+        grpcContainer.start();
+        assertTrue(grpcContainer.isLive(service));
 
-            grpcContainer.shutdown();
-            assertFalse(grpcContainer.isLive(service));
-        } finally {
-            if (!grpcContainer.isShutdown()) {
-                grpcContainer.shutdown();
-            }
-        }
+        grpcContainer.shutdown();
+        assertFalse(grpcContainer.isLive(service));
     }
 }

--- a/server/src/test/java/io/spine/server/given/transport/TestGrpcServer.java
+++ b/server/src/test/java/io/spine/server/given/transport/TestGrpcServer.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.given.transport;
+
+import io.grpc.Server;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A test implementation of the gRPC server.
+ *
+ * <p>Does nothing except recording own "up"/"down" state.
+ *
+ * <p>As this server doesn't acquire any resources, nor does it process any calls, being
+ * {@linkplain #isShutdown() shutdown} for it is the same as being
+ * {@linkplain #isTerminated() terminated}.
+ *
+ * <p>For the same reasons all {@code awaitTermination(...)} calls are NO-OP.
+ */
+public final class TestGrpcServer extends Server {
+
+    private boolean isShutdownAndTerminated;
+
+    @Override
+    public Server start() {
+        return this;
+    }
+
+    @Override
+    public Server shutdown() {
+        isShutdownAndTerminated = true;
+        return this;
+    }
+
+    @Override
+    public Server shutdownNow() {
+        isShutdownAndTerminated = true;
+        return this;
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return isShutdownAndTerminated;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return isShutdownAndTerminated;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+        return true;
+    }
+
+    @Override
+    public void awaitTermination() {
+        // NO-OP as it's not necessary to await anything.
+    }
+}

--- a/server/src/test/java/io/spine/server/given/transport/package-info.java
+++ b/server/src/test/java/io/spine/server/given/transport/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * The test environment for tests that rely on Spine transport.
+ */
+
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.server.given.transport;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/test/java/io/spine/server/transport/GrpcContainerTest.java
+++ b/server/src/test/java/io/spine/server/transport/GrpcContainerTest.java
@@ -45,11 +45,15 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @DisplayName("GrpcContainer should")
 class GrpcContainerTest {
+
+    private static final int PORT = 50052;
+
     private GrpcContainer grpcContainer;
 
     @BeforeEach
     void setUp() {
         grpcContainer = GrpcContainer.newBuilder()
+                                     .setPort(PORT)
                                      .build();
     }
 

--- a/server/src/test/java/io/spine/server/transport/GrpcContainerTest.java
+++ b/server/src/test/java/io/spine/server/transport/GrpcContainerTest.java
@@ -24,8 +24,8 @@ import io.grpc.BindableService;
 import io.grpc.Server;
 import io.grpc.ServerServiceDefinition;
 import io.spine.server.CommandService;
+import io.spine.server.given.transport.TestGrpcServer;
 import io.spine.testing.logging.MuteLogging;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -46,22 +46,13 @@ import static org.junit.jupiter.api.Assertions.fail;
 @DisplayName("GrpcContainer should")
 class GrpcContainerTest {
 
-    private static final int PORT = 50052;
-
     private GrpcContainer grpcContainer;
 
     @BeforeEach
     void setUp() {
         grpcContainer = GrpcContainer.newBuilder()
-                                     .setPort(PORT)
                                      .build();
-    }
-
-    @AfterEach
-    void tearDown() {
-        if (!grpcContainer.isShutdown()) {
-            grpcContainer.shutdownNowAndWait();
-        }
+        grpcContainer.injectServer(new TestGrpcServer());
     }
 
     @SuppressWarnings("MagicNumber")


### PR DESCRIPTION
This PR rewrites the gRPC-related tests that were failing from time to time locally and on CI.

Now they will use a stub instead of the real server and the failures should stop occurring.

This PR also mentions version [1.1.2](https://github.com/SpineEventEngine/core-java/releases/tag/v1.1.2) as the latest stable Spine version in the project-level README.