### PR TITLE
Obtain zone ID and offset from `Time.Provider`

### DIFF
--- a/client/src/main/java/io/spine/client/ActorRequestFactory.java
+++ b/client/src/main/java/io/spine/client/ActorRequestFactory.java
@@ -103,7 +103,10 @@ public class ActorRequestFactory {
      * @param tenant
      *         the ID of the tenant in a multi-tenant application, {@code null} for single-tenant
      * @return new instance of the factory
+     * @deprecated please always use factories on behalf of the current user,
+     *         or with a guest user ID, if the user is not logged in
      */
+    @Deprecated
     public static
     ActorRequestFactory forSystemRequests(Class<?> cls, @Nullable TenantId tenant) {
         checkNotNull(cls);
@@ -122,7 +125,10 @@ public class ActorRequestFactory {
      * @param tenant
      *         the ID of the tenant in a multi-tenant application, {@code null} for single-tenant
      * @return new instance of the factory
+     * @deprecated please always use factories on behalf of the current user,
+     *         or with a guest user ID, if the user is not logged in
      */
+    @Deprecated
     public static
     ActorRequestFactory forSystemRequests(UserId systemUser, @Nullable TenantId tenant) {
         checkNotNull(systemUser);

--- a/client/src/main/java/io/spine/client/ActorRequestFactory.java
+++ b/client/src/main/java/io/spine/client/ActorRequestFactory.java
@@ -22,6 +22,7 @@ package io.spine.client;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.spine.annotation.Internal;
+import io.spine.base.Time;
 import io.spine.core.ActorContext;
 import io.spine.core.CommandContext;
 import io.spine.core.TenantId;
@@ -31,6 +32,8 @@ import io.spine.time.ZoneIds;
 import io.spine.time.ZoneOffset;
 import io.spine.time.ZoneOffsets;
 import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.time.Instant;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -366,12 +369,17 @@ public class ActorRequestFactory {
         public ActorRequestFactory build() {
             checkNotNull(actor, "`actor` must be defined");
 
+            java.time.ZoneId currentZone = Time.currentTimeZone();
+
             if (zoneOffset == null) {
-                setZoneOffset(ZoneOffsets.getDefault());
+                ZoneOffset currentOffset = ZoneOffsets.of(
+                        currentZone.getRules().getOffset(Instant.now())
+                );
+                setZoneOffset(currentOffset);
             }
 
             if (zoneId == null) {
-                setZoneId(ZoneIds.systemDefault());
+                setZoneId(ZoneIds.of(currentZone));
             }
 
             return new ActorRequestFactory(this);

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.1.6`
+# Dependencies of `io.spine:spine-client:1.1.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -432,12 +432,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 10 15:33:21 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 18:14:27 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.1.6`
+# Dependencies of `io.spine:spine-core:1.1.7`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -815,12 +815,12 @@ This report was generated on **Thu Oct 10 15:33:21 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 10 15:33:22 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 18:14:27 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.1.6`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.1.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1246,12 +1246,12 @@ This report was generated on **Thu Oct 10 15:33:22 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 10 15:33:22 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 18:14:28 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.1.6`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.1.7`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -1839,12 +1839,12 @@ This report was generated on **Thu Oct 10 15:33:22 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 10 15:33:23 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 18:14:29 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.1.6`
+# Dependencies of `io.spine:spine-server:1.1.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2336,12 +2336,12 @@ This report was generated on **Thu Oct 10 15:33:23 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 10 15:33:25 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 18:14:29 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.1.6`
+# Dependencies of `io.spine:spine-testutil-client:1.1.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2826,12 +2826,12 @@ This report was generated on **Thu Oct 10 15:33:25 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 10 15:33:27 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 18:14:30 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.1.6`
+# Dependencies of `io.spine:spine-testutil-core:1.1.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3324,12 +3324,12 @@ This report was generated on **Thu Oct 10 15:33:27 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 10 15:33:27 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 18:14:30 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.1.6`
+# Dependencies of `io.spine:spine-testutil-server:1.1.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3868,4 +3868,4 @@ This report was generated on **Thu Oct 10 15:33:27 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 10 15:33:28 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Oct 15 18:14:31 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.1.6</version>
+<version>1.1.7</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.1.6'
+final def spineVersion = '1.1.7'
 
 ext {
     // The version of the modules in this project.


### PR DESCRIPTION
This PR fixes creation of `ActorRequestFactory` to obtain `ZoneId` from `Time.Provider` and calculate current zone offset from it. Previously system default values were taken.

Also, factory methods for creating “system” instances were deprecated.

The version advances to `1.1.7`.