### PR TITLE
Proper `external` event dispatching

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.1.7`
+# Dependencies of `io.spine:spine-client:1.1.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -432,12 +432,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 15 18:14:27 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 20 15:46:12 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.1.7`
+# Dependencies of `io.spine:spine-core:1.1.8`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -815,12 +815,12 @@ This report was generated on **Tue Oct 15 18:14:27 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 15 18:14:27 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 20 15:46:13 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.1.7`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.1.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1246,12 +1246,12 @@ This report was generated on **Tue Oct 15 18:14:27 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 15 18:14:28 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 20 15:46:14 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.1.7`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.1.8`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -1839,12 +1839,12 @@ This report was generated on **Tue Oct 15 18:14:28 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 15 18:14:29 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 20 15:46:15 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.1.7`
+# Dependencies of `io.spine:spine-server:1.1.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2336,12 +2336,12 @@ This report was generated on **Tue Oct 15 18:14:29 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 15 18:14:29 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 20 15:46:16 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.1.7`
+# Dependencies of `io.spine:spine-testutil-client:1.1.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2826,12 +2826,12 @@ This report was generated on **Tue Oct 15 18:14:29 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 15 18:14:30 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 20 15:46:16 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.1.7`
+# Dependencies of `io.spine:spine-testutil-core:1.1.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3324,12 +3324,12 @@ This report was generated on **Tue Oct 15 18:14:30 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 15 18:14:30 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 20 15:46:17 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.1.7`
+# Dependencies of `io.spine:spine-testutil-server:1.1.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3868,4 +3868,4 @@ This report was generated on **Tue Oct 15 18:14:30 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 15 18:14:31 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Oct 20 15:46:18 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.1.7</version>
+<version>1.1.8</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -201,7 +201,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      */
     private void checkNotVoid() {
         boolean handlesCommands = dispatchesCommands();
-        boolean reactsOnEvents = dispatchesEvents() || dispatchesExternalEvents();
+        boolean reactsOnEvents = dispatchesEvents();
 
         if (!handlesCommands && !reactsOnEvents) {
             throw newIllegalStateException(
@@ -349,6 +349,11 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
     @Override
     public Set<EventClass> events() {
         return aggregateClass().events();
+    }
+
+    @Override
+    public Set<EventClass> domesticEvents() {
+        return aggregateClass().domesticEvents();
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/aggregate/EventImportDispatcher.java
+++ b/server/src/main/java/io/spine/server/aggregate/EventImportDispatcher.java
@@ -65,6 +65,11 @@ public final class EventImportDispatcher<I> implements EventDispatcher, Logging 
         return repository.importableEvents();
     }
 
+    @Override
+    public Set<EventClass> domesticEventClasses() {
+        return eventClasses();
+    }
+
     /**
      * Always returns empty set because external events cannot be imported.
      */

--- a/server/src/main/java/io/spine/server/aggregate/model/AggregateClass.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/AggregateClass.java
@@ -85,6 +85,14 @@ public class AggregateClass<A extends Aggregate>
     }
 
     /**
+     * Obtains the set of <em>domestic</em> event classes on which this aggregate class reacts.
+     */
+    @Override
+    public final ImmutableSet<EventClass> domesticEvents() {
+        return delegate.domesticEvents();
+    }
+
+    /**
      * Obtains event types produced by this aggregate class.
      */
     public ImmutableSet<EventClass> outgoingEvents() {

--- a/server/src/main/java/io/spine/server/bus/DispatcherRegistry.java
+++ b/server/src/main/java/io/spine/server/bus/DispatcherRegistry.java
@@ -30,6 +30,7 @@ import io.spine.type.MessageClass;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiPredicate;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -102,8 +103,17 @@ public abstract class DispatcherRegistry<C extends MessageClass<? extends Messag
                 .get(messageClass)
                 .stream()
                 .filter(dispatcher -> dispatcher.canDispatch(envelope))
+                .filter(dispatcher -> attributeFilter().test(envelope, dispatcher))
                 .collect(toImmutableSet());
         return dispatchers;
+    }
+
+    /**
+     * Returns a filter allowing to tell whether the attributes of the envelope match
+     * the dispatcher requirements.
+     */
+    protected BiPredicate<E, D> attributeFilter() {
+        return (e, d) -> true;
     }
 
     /**

--- a/server/src/main/java/io/spine/server/bus/MulticastBus.java
+++ b/server/src/main/java/io/spine/server/bus/MulticastBus.java
@@ -46,8 +46,8 @@ public abstract class MulticastBus<M extends Message,
     /**
      * Call the dispatchers for the {@code messageEnvelope}.
      *
-     * @param messageEnvelope the message envelope to pass to the dispatchers.
-     * @return the number of the dispatchers called or {@code 0} if there weren't any.
+     * @param messageEnvelope the message envelope to pass to the dispatchers
+     * @return the number of the dispatchers called or {@code 0} if there weren't any
      */
     protected int callDispatchers(E messageEnvelope) {
         Collection<D> dispatchers = registry().dispatchersOf(messageEnvelope);

--- a/server/src/main/java/io/spine/server/command/AbstractCommander.java
+++ b/server/src/main/java/io/spine/server/command/AbstractCommander.java
@@ -95,6 +95,11 @@ public abstract class AbstractCommander
     }
 
     @Override
+    public Set<EventClass> domesticEvents() {
+        return thisClass.domesticEvents();
+    }
+
+    @Override
     public void dispatchEvent(EventEnvelope event) {
         CommandReactionMethod method = thisClass.getCommander(event.messageClass());
         DispatchOutcome outcome = method.invoke(this, event);

--- a/server/src/main/java/io/spine/server/command/model/CommandReactionMethod.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandReactionMethod.java
@@ -60,4 +60,18 @@ public final class CommandReactionMethod
         return Success.newBuilder()
                       .build();
     }
+
+    /**
+     * Ensures that the domestic events are dispatched to the domestic-event handlers
+     * and the external events are dispatched to the external-event handlers.
+     *
+     * @see io.spine.server.command.Command#external()
+     */
+    @Override
+    protected void checkAttributesMatch(EventEnvelope envelope) {
+        super.checkAttributesMatch(envelope);
+        boolean expected = envelope.context()
+                                   .getExternal();
+        ensureExternalMatch(expected);
+    }
 }

--- a/server/src/main/java/io/spine/server/command/model/CommanderClass.java
+++ b/server/src/main/java/io/spine/server/command/model/CommanderClass.java
@@ -77,6 +77,11 @@ public final class CommanderClass<C extends Commander>
     }
 
     @Override
+    public ImmutableSet<EventClass> domesticEvents() {
+        return delegate.domesticEvents();
+    }
+
+    @Override
     public ImmutableSet<EventClass> externalEvents() {
         return delegate.externalEvents();
     }

--- a/server/src/main/java/io/spine/server/event/AbstractEventReactor.java
+++ b/server/src/main/java/io/spine/server/event/AbstractEventReactor.java
@@ -140,4 +140,9 @@ public abstract class AbstractEventReactor
     public Set<EventClass> externalEventClasses() {
         return thisClass.externalEvents();
     }
+
+    @Override
+    public Set<EventClass> domesticEventClasses() {
+        return thisClass.domesticEvents();
+    }
 }

--- a/server/src/main/java/io/spine/server/event/AbstractEventSubscriber.java
+++ b/server/src/main/java/io/spine/server/event/AbstractEventSubscriber.java
@@ -151,4 +151,9 @@ public abstract class AbstractEventSubscriber
     public Set<EventClass> externalEventClasses() {
         return thisClass.externalEvents();
     }
+
+    @Override
+    public Set<EventClass> domesticEventClasses() {
+        return thisClass.domesticEvents();
+    }
 }

--- a/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
+++ b/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
@@ -65,6 +65,11 @@ public final class DelegatingEventDispatcher implements EventDispatcher {
     }
 
     @Override
+    public Set<EventClass> domesticEventClasses() {
+        return delegate.domesticEvents();
+    }
+
+    @Override
     public Set<EventClass> externalEventClasses() {
         return delegate.externalEvents();
     }

--- a/server/src/main/java/io/spine/server/event/EventBus.java
+++ b/server/src/main/java/io/spine/server/event/EventBus.java
@@ -226,7 +226,7 @@ public final class EventBus
         return Optional.ofNullable(enricher);
     }
 
-    protected EventEnvelope enrich(EventEnvelope event) {
+    private EventEnvelope enrich(EventEnvelope event) {
         if (enricher == null) {
             return event;
         }

--- a/server/src/main/java/io/spine/server/event/EventDispatcher.java
+++ b/server/src/main/java/io/spine/server/event/EventDispatcher.java
@@ -33,7 +33,7 @@ public interface EventDispatcher
         extends MulticastDispatcher<EventClass, EventEnvelope> {
 
     /**
-     * Obtains classes of domestic events processed by this dispatcher.
+     * Obtains classes of all events processed by this dispatcher.
      */
     default Set<EventClass> eventClasses() {
         return messageClasses();
@@ -45,7 +45,12 @@ public interface EventDispatcher
     Set<EventClass> externalEventClasses();
 
     /**
-     * Verifies if this instance dispatches at least one domestic event.
+     * Obtains classes of domestic events processed by this dispatcher.
+     */
+    Set<EventClass> domesticEventClasses();
+
+    /**
+     * Verifies if this instance dispatches at least one event.
      */
     default boolean dispatchesEvents() {
         return !eventClasses().isEmpty();

--- a/server/src/main/java/io/spine/server/event/EventDispatcherDelegate.java
+++ b/server/src/main/java/io/spine/server/event/EventDispatcherDelegate.java
@@ -42,9 +42,14 @@ import java.util.Set;
 public interface EventDispatcherDelegate {
 
     /**
-     * Obtains event classes dispatched by this delegate.
+     * Obtains all event classes dispatched by this delegate.
      */
     Set<EventClass> events();
+
+    /**
+     * Obtains domestic event classes dispatched by this delegate.
+     */
+    Set<EventClass> domesticEvents();
 
     /**
      * Obtains external event classes dispatched by this delegate.
@@ -70,7 +75,7 @@ public interface EventDispatcherDelegate {
     }
 
     /**
-     * Verifies if this instance dispatches at least one domestic event.
+     * Verifies if this instance dispatches at least one event.
      */
     default boolean dispatchesEvents() {
         return !events().isEmpty();

--- a/server/src/main/java/io/spine/server/event/EventDispatcherRegistry.java
+++ b/server/src/main/java/io/spine/server/event/EventDispatcherRegistry.java
@@ -34,7 +34,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * <p>There can be multiple dispatchers per event class.
  */
-class EventDispatcherRegistry
+final class EventDispatcherRegistry
         extends DispatcherRegistry<EventClass, EventEnvelope, EventDispatcher> {
 
     @Override

--- a/server/src/main/java/io/spine/server/event/model/EventReactorClass.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReactorClass.java
@@ -43,12 +43,14 @@ public final class EventReactorClass<S extends AbstractEventReactor> extends Mod
 
     private final HandlerMap<EventClass, EventClass, EventReactorMethod> reactors;
     private final ImmutableSet<EventClass> events;
+    private final ImmutableSet<EventClass> domesticEvents;
     private final ImmutableSet<EventClass> externalEvents;
 
     private EventReactorClass(Class<? extends S> cls) {
         super(cls);
         this.reactors = HandlerMap.create(cls, new EventReactorSignature());
         this.events = reactors.messageClasses();
+        this.domesticEvents = reactors.messageClasses((h) -> !h.isExternal());
         this.externalEvents = reactors.messageClasses(HandlerMethod::isExternal);
     }
 
@@ -79,5 +81,10 @@ public final class EventReactorClass<S extends AbstractEventReactor> extends Mod
     @Override
     public ImmutableSet<EventClass> externalEvents() {
         return externalEvents;
+    }
+
+    @Override
+    public ImmutableSet<EventClass> domesticEvents() {
+        return domesticEvents;
     }
 }

--- a/server/src/main/java/io/spine/server/event/model/EventReceiverClass.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReceiverClass.java
@@ -38,9 +38,16 @@ public interface EventReceiverClass {
      *
      * <p>The returned set contains both domestic and external event classes.
      *
+     * <p>For only the domestic events, please see {@link #domesticEvents()}.
+     *
      * <p>For only the external events, please see {@link #externalEvents()}.
      */
     ImmutableSet<EventClass> events();
+
+    /**
+     * Obtains a set of domestic events which this class receives.
+     */
+    ImmutableSet<EventClass> domesticEvents();
 
     /**
      * Obtains a set of external events which this class receives.

--- a/server/src/main/java/io/spine/server/event/model/EventReceivingClassDelegate.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReceivingClassDelegate.java
@@ -53,6 +53,7 @@ public class EventReceivingClassDelegate<T extends EventReceiver,
     private static final long serialVersionUID = 0L;
     private final HandlerMap<EventClass, P, M> handlers;
     private final ImmutableSet<EventClass> events;
+    private final ImmutableSet<EventClass> domesticEvents;
     private final ImmutableSet<EventClass> externalEvents;
     private final ImmutableSet<StateClass> domesticStates;
     private final ImmutableSet<StateClass> externalStates;
@@ -65,6 +66,7 @@ public class EventReceivingClassDelegate<T extends EventReceiver,
         super(delegatingClass);
         this.handlers = HandlerMap.create(delegatingClass, signature);
         this.events = handlers.messageClasses();
+        this.domesticEvents = handlers.messageClasses((h) -> !h.isExternal());
         this.externalEvents = handlers.messageClasses(HandlerMethod::isExternal);
         this.domesticStates = extractStates(false);
         this.externalStates = extractStates(true);
@@ -75,10 +77,17 @@ public class EventReceivingClassDelegate<T extends EventReceiver,
     }
 
     /**
-     * Obtains domestic event classes handled by the delegating class.
+     * Obtains all event classes handled by the delegating class.
      */
     public ImmutableSet<EventClass> events() {
         return events;
+    }
+
+    /**
+     * Obtains domestic event classes handled by the delegating class.
+     */
+    public ImmutableSet<EventClass> domesticEvents() {
+        return domesticEvents;
     }
 
     /**

--- a/server/src/main/java/io/spine/server/event/model/EventSubscriberClass.java
+++ b/server/src/main/java/io/spine/server/event/model/EventSubscriberClass.java
@@ -64,6 +64,11 @@ public final class EventSubscriberClass<S extends AbstractEventSubscriber> exten
     }
 
     @Override
+    public ImmutableSet<EventClass> domesticEvents() {
+        return delegate.domesticEvents();
+    }
+
+    @Override
     public ImmutableSet<EventClass> externalEvents() {
         return delegate.externalEvents();
     }

--- a/server/src/main/java/io/spine/server/integration/DomesticEventPublisher.java
+++ b/server/src/main/java/io/spine/server/integration/DomesticEventPublisher.java
@@ -60,6 +60,11 @@ final class DomesticEventPublisher implements EventDispatcher, Logging {
     }
 
     @Override
+    public Set<EventClass> domesticEventClasses() {
+        return eventClasses();
+    }
+
+    @Override
     public Set<EventClass> externalEventClasses() {
         return ImmutableSet.of();
     }

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
@@ -234,9 +234,7 @@ public abstract class ProcessManagerRepository<I,
      * Ensures the process manager class handles at least one type of messages.
      */
     private void checkNotDeaf() {
-        boolean dispatchesEvents = dispatchesEvents() || dispatchesExternalEvents();
-
-        if (!dispatchesCommands() && !dispatchesEvents) {
+        if (!dispatchesCommands() && !dispatchesEvents()) {
             throw newIllegalStateException(
                     "Process managers of the repository %s have no command handlers, " +
                             "and do not react to any events.", this);
@@ -252,6 +250,18 @@ public abstract class ProcessManagerRepository<I,
     @Override
     public final Set<EventClass> messageClasses() {
         return processManagerClass().events();
+    }
+
+    /**
+     * Obtains classes of domestic events to which the process managers managed by this repository
+     * react.
+     *
+     * @return a set of event classes or an empty set if process managers do not react to
+     *         domestic events
+     */
+    @Override
+    public final Set<EventClass> domesticEventClasses() {
+        return processManagerClass().domesticEvents();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/procman/model/ProcessManagerClass.java
+++ b/server/src/main/java/io/spine/server/procman/model/ProcessManagerClass.java
@@ -85,10 +85,16 @@ public final class ProcessManagerClass<P extends ProcessManager>
     }
 
     @Override
+    public ImmutableSet<EventClass> domesticEvents() {
+        SetView<EventClass> result =
+                union(reactorDelegate.domesticEvents(), commanderDelegate.domesticEvents());
+        return result.immutableCopy();
+    }
+
+    @Override
     public ImmutableSet<EventClass> externalEvents() {
         SetView<EventClass> result =
-                union(reactorDelegate.externalEvents(),
-                      commanderDelegate.externalEvents());
+                union(reactorDelegate.externalEvents(), commanderDelegate.externalEvents());
         return result.immutableCopy();
     }
 

--- a/server/src/main/java/io/spine/server/projection/ProjectionRepository.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionRepository.java
@@ -149,12 +149,9 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S, ?>, S e
     private void ensureDispatchesEvents() {
         boolean noEventSubscriptions = !dispatchesEvents();
         if (noEventSubscriptions) {
-            boolean noExternalSubscriptions = !dispatchesExternalEvents();
-            if (noExternalSubscriptions) {
-                throw newIllegalStateException(
-                        "Projections of the repository `%s` have neither domestic nor external" +
-                                " event subscriptions.", this);
-            }
+            throw newIllegalStateException(
+                    "Projections of the repository `%s` have neither domestic nor external" +
+                            " event subscriptions.", this);
         }
     }
 
@@ -322,6 +319,11 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S, ?>, S e
     @Override
     public final Set<EventClass> messageClasses() {
         return projectionClass().events();
+    }
+
+    @Override
+    public final Set<EventClass> domesticEventClasses() {
+        return projectionClass().domesticEvents();
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/projection/model/ProjectionClass.java
+++ b/server/src/main/java/io/spine/server/projection/model/ProjectionClass.java
@@ -70,13 +70,18 @@ public final class ProjectionClass<P extends Projection>
     }
 
     @Override
-    public final ImmutableSet<StateClass> domesticStates() {
-        return delegate.domesticStates();
+    public final ImmutableSet<EventClass> domesticEvents() {
+        return delegate.domesticEvents();
     }
 
     @Override
     public final ImmutableSet<EventClass> externalEvents() {
         return delegate.externalEvents();
+    }
+
+    @Override
+    public final ImmutableSet<StateClass> domesticStates() {
+        return delegate.domesticStates();
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/stand/Stand.java
+++ b/server/src/main/java/io/spine/server/stand/Stand.java
@@ -222,6 +222,16 @@ public class Stand extends AbstractEventSubscriber implements AutoCloseable {
         return ImmutableSet.of();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Stand only consumes the domestic events.
+     */
+    @Override
+    public Set<EventClass> domesticEventClasses() {
+        return eventClasses();
+    }
+
     @Internal
     @VisibleForTesting
     public boolean isMultitenant() {

--- a/server/src/test/java/com/example/ForeignContextConfig.java
+++ b/server/src/test/java/com/example/ForeignContextConfig.java
@@ -84,6 +84,11 @@ public final class ForeignContextConfig {
             }
 
             @Override
+            public Set<EventClass> domesticEventClasses() {
+                return eventClasses();
+            }
+
+            @Override
             public Set<EventClass> messageClasses() {
                 return ImmutableSet.of();
             }

--- a/server/src/test/java/io/spine/server/bc/given/Given.java
+++ b/server/src/test/java/io/spine/server/bc/given/Given.java
@@ -36,6 +36,8 @@ import io.spine.test.bc.event.BcTaskAdded;
 
 import java.util.Set;
 
+import static com.google.common.collect.Sets.union;
+
 public class Given {
 
     private Given() {
@@ -91,8 +93,13 @@ public class Given {
         }
 
         @Override
-        public Set<EventClass> messageClasses() {
+        public Set<EventClass> domesticEventClasses() {
             return ImmutableSet.of();
+        }
+
+        @Override
+        public Set<EventClass> messageClasses() {
+            return union(externalEventClasses(), domesticEventClasses());
         }
 
         @CanIgnoreReturnValue

--- a/server/src/test/java/io/spine/server/commandbus/given/CommandHandlerTestEnv.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/CommandHandlerTestEnv.java
@@ -72,6 +72,11 @@ public class CommandHandlerTestEnv {
         }
 
         @Override
+        public Set<EventClass> domesticEventClasses() {
+            return eventClasses();
+        }
+
+        @Override
         public Set<EventClass> externalEventClasses() {
             return ImmutableSet.of();
         }

--- a/server/src/test/java/io/spine/server/event/EventBusTest.java
+++ b/server/src/test/java/io/spine/server/event/EventBusTest.java
@@ -39,7 +39,6 @@ import io.spine.server.event.given.bus.GivenEvent;
 import io.spine.server.event.given.bus.ProjectAggregate;
 import io.spine.server.event.given.bus.RememberingSubscriber;
 import io.spine.server.event.given.bus.TaskCreatedFilter;
-import io.spine.server.model.SignalOriginMismatchError;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
 import io.spine.test.event.EBTaskAdded;
@@ -440,8 +439,8 @@ public class EventBusTest {
                 .setTask(task)
                 .build();
         Event event = eventFactory.createEvent(eventMessage);
-        assertThrows(SignalOriginMismatchError.class,
-                     () -> eventBus.post(event, StreamObservers.noOpObserver()));
+        eventBus.post(event, StreamObservers.noOpObserver());
+        assertThat(EBExternalTaskAddedSubscriber.taskAddedEvent).isNull();
     }
 
     /**

--- a/server/src/test/java/io/spine/server/event/given/DelegatingEventDispatcherTestEnv.java
+++ b/server/src/test/java/io/spine/server/event/given/DelegatingEventDispatcherTestEnv.java
@@ -28,6 +28,8 @@ import io.spine.test.event.EvTeamCreated;
 
 import java.util.Set;
 
+import static com.google.common.collect.Sets.union;
+
 public class DelegatingEventDispatcherTestEnv {
 
     /** Prevents instantiation of this utility class. */
@@ -39,6 +41,11 @@ public class DelegatingEventDispatcherTestEnv {
 
         @Override
         public Set<EventClass> events() {
+            return union(domesticEvents(), externalEvents());
+        }
+
+        @Override
+        public Set<EventClass> domesticEvents() {
             return ImmutableSet.of();
         }
 
@@ -60,6 +67,11 @@ public class DelegatingEventDispatcherTestEnv {
         @Override
         public Set<EventClass> events() {
             return EventClass.setOf(EvTeamCreated.class);
+        }
+
+        @Override
+        public Set<EventClass> domesticEvents() {
+            return events();
         }
 
         @Override

--- a/server/src/test/java/io/spine/server/event/given/bus/BareDispatcher.java
+++ b/server/src/test/java/io/spine/server/event/given/bus/BareDispatcher.java
@@ -42,6 +42,11 @@ public class BareDispatcher implements EventDispatcher {
     }
 
     @Override
+    public Set<EventClass> domesticEventClasses() {
+        return eventClasses();
+    }
+
+    @Override
     public Set<EventClass> externalEventClasses() {
         return ImmutableSet.of();
     }

--- a/server/src/test/java/io/spine/server/event/given/bus/EBExternalTaskAddedSubscriber.java
+++ b/server/src/test/java/io/spine/server/event/given/bus/EBExternalTaskAddedSubscriber.java
@@ -32,9 +32,13 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class EBExternalTaskAddedSubscriber extends AbstractEventSubscriber {
 
+    @SuppressWarnings({"PublicField", "StaticNonFinalField"}) // making it available for inspection.
+    public static EBTaskAdded taskAddedEvent = null;
 
+    @SuppressWarnings("AssignmentToStaticFieldFromInstanceMethod")
     @Subscribe(external = true)
     void on(EBTaskAdded message, EventContext context) {
+        taskAddedEvent = message;
         if (!context.getExternal()) {
             fail(format(
                     "Domestic event `%s` was delivered to an external subscriber.",

--- a/server/src/test/java/io/spine/server/integration/IntegrationBrokerTest.java
+++ b/server/src/test/java/io/spine/server/integration/IntegrationBrokerTest.java
@@ -42,7 +42,6 @@ import io.spine.server.integration.given.ProjectDetails;
 import io.spine.server.integration.given.ProjectEventsSubscriber;
 import io.spine.server.integration.given.ProjectStartedExtSubscriber;
 import io.spine.server.integration.given.ProjectWizard;
-import io.spine.server.model.SignalOriginMismatchError;
 import io.spine.testing.logging.MuteLogging;
 import io.spine.testing.server.blackbox.BlackBoxBoundedContext;
 import io.spine.testing.server.model.ModelTests;
@@ -66,7 +65,6 @@ import static io.spine.server.integration.given.IntegrationBrokerTestEnv.project
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("IntegrationBroker should")
@@ -297,7 +295,7 @@ class IntegrationBrokerTest {
         assertNull(ProjectCountAggregate.externalEvent());
 
         Event projectCreated = projectCreated();
-        assertThrows(SignalOriginMismatchError.class, () -> eventBus.post(projectCreated));
+        eventBus.post(projectCreated);
 
         assertNull(ProjectEventsSubscriber.externalEvent());
         assertNull(ProjectDetails.externalEvent());

--- a/server/src/test/java/io/spine/server/integration/IntegrationBrokerTest.java
+++ b/server/src/test/java/io/spine/server/integration/IntegrationBrokerTest.java
@@ -36,6 +36,7 @@ import io.spine.server.integration.given.MemoizingProjectDetails1Repository;
 import io.spine.server.integration.given.MemoizingProjectDetails2Repository;
 import io.spine.server.integration.given.MemoizingProjection;
 import io.spine.server.integration.given.PhotosProcMan;
+import io.spine.server.integration.given.ProjectCommander;
 import io.spine.server.integration.given.ProjectCountAggregate;
 import io.spine.server.integration.given.ProjectDetails;
 import io.spine.server.integration.given.ProjectEventsSubscriber;
@@ -64,7 +65,6 @@ import static io.spine.server.integration.given.IntegrationBrokerTestEnv.project
 import static io.spine.server.integration.given.IntegrationBrokerTestEnv.projectStarted;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -125,12 +125,15 @@ class IntegrationBrokerTest {
             contextWithExternalSubscribers();
 
             assertNull(ProjectEventsSubscriber.externalEvent());
+            assertNull(ProjectCommander.externalEvent());
 
             Event event = projectCreated();
+            Message expectedMsg = unpack(event.getMessage());
+
             sourceContext.eventBus()
                          .post(event);
-            assertEquals(unpack(event.getMessage()),
-                         ProjectEventsSubscriber.externalEvent());
+            assertThat(ProjectEventsSubscriber.externalEvent()).isEqualTo(expectedMsg);
+            assertThat(ProjectCommander.externalEvent()).isEqualTo(expectedMsg);
 
             sourceContext.close();
         }
@@ -183,11 +186,11 @@ class IntegrationBrokerTest {
     }
 
     @Nested
-    @DisplayName("avoid dispatching events from one BC")
+    @DisplayName("avoid dispatching events from a BC")
     class AvoidDispatching {
 
         @Test
-        @DisplayName("to domestic entity subscribers of another BC")
+        @DisplayName("to domestic entities subscribers of another BC")
         void toDomesticEntitySubscribers() throws Exception {
             BoundedContext sourceContext = newContext();
             BoundedContext destContext = contextWithExtEntitySubscribers();
@@ -214,21 +217,42 @@ class IntegrationBrokerTest {
             BoundedContext destContext = contextWithExternalSubscribers();
 
             assertNull(ProjectEventsSubscriber.domesticEvent());
+            assertNull(ProjectCommander.domesticEvent());
 
-            Event event = projectStarted();
+            Event projectStarted = projectStarted();
             sourceContext.eventBus()
-                         .post(event);
+                         .post(projectStarted);
 
-            assertNotEquals(unpack(event.getMessage()),
-                            ProjectEventsSubscriber.domesticEvent());
-            assertNull(ProjectEventsSubscriber.domesticEvent());
+            Message expectedEventMsg = unpack(projectStarted.getMessage());
+
+            assertThat(ProjectEventsSubscriber.domesticEvent()).isNull();
+            assertThat(ProjectCommander.domesticEvent()).isNull();
 
             destContext.eventBus()
-                       .post(event);
-            assertEquals(unpack(event.getMessage()),
-                         ProjectEventsSubscriber.domesticEvent());
+                       .post(projectStarted);
+
+            assertThat(ProjectEventsSubscriber.domesticEvent()).isEqualTo(expectedEventMsg);
+            assertThat(ProjectCommander.domesticEvent()).isEqualTo(expectedEventMsg);
 
             sourceContext.close();
+            destContext.close();
+        }
+
+        @Test
+        @DisplayName("to own standalone subscribers if they expect external events")
+        void toOwnExternalStandaloneSubscribers() throws Exception {
+            BoundedContext destContext = contextWithExternalSubscribers();
+
+            assertThat(ProjectEventsSubscriber.externalEvent()).isNull();
+            assertThat(ProjectCommander.externalEvent()).isNull();
+
+            Event projectCreated = projectCreated();
+            destContext.eventBus()
+                       .post(projectCreated);
+
+            assertThat(ProjectEventsSubscriber.externalEvent()).isNull();
+            assertThat(ProjectCommander.externalEvent()).isNull();
+
             destContext.close();
         }
     }

--- a/server/src/test/java/io/spine/server/integration/given/IntegrationBrokerTestEnv.java
+++ b/server/src/test/java/io/spine/server/integration/given/IntegrationBrokerTestEnv.java
@@ -58,6 +58,7 @@ public class IntegrationBrokerTestEnv {
         boundedContext.registerEventDispatcher(new ProjectEventsSubscriber());
         boundedContext.register(DefaultRepository.of(ProjectCountAggregate.class));
         boundedContext.register(DefaultRepository.of(ProjectWizard.class));
+        boundedContext.registerCommandDispatcher(new ProjectCommander());
         return boundedContext;
     }
 
@@ -85,10 +86,13 @@ public class IntegrationBrokerTestEnv {
     }
 
     public static Event projectCreated() {
-        ProjectId projectId = ProjectId.newBuilder()
-                                       .setId(Throwables.getStackTraceAsString(new RuntimeException()))
-                                       .build();
-        TestEventFactory eventFactory = newInstance(pack(projectId), IntegrationBrokerTestEnv.class);
+        ProjectId projectId =
+                ProjectId.newBuilder()
+                         .setId(Throwables.getStackTraceAsString(
+                                 new RuntimeException("Project ID")))
+                         .build();
+        TestEventFactory eventFactory = newInstance(pack(projectId),
+                                                    IntegrationBrokerTestEnv.class);
         return eventFactory.createEvent(
                 ItgProjectCreated.newBuilder()
                                  .setProjectId(projectId)

--- a/server/src/test/java/io/spine/server/integration/given/ProjectCommander.java
+++ b/server/src/test/java/io/spine/server/integration/given/ProjectCommander.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.integration.given;
+
+import io.spine.server.command.AbstractCommander;
+import io.spine.server.command.Command;
+import io.spine.test.integration.command.ItgAddTask;
+import io.spine.test.integration.command.ItgStartProject;
+import io.spine.test.integration.event.ItgProjectCreated;
+import io.spine.test.integration.event.ItgProjectStarted;
+
+import java.util.Optional;
+
+@SuppressWarnings("AssignmentToStaticFieldFromInstanceMethod")  // OK to preserve the state.
+public final class ProjectCommander extends AbstractCommander {
+
+    private static ItgProjectCreated externalEvent = null;
+    private static ItgProjectStarted domesticEvent = null;
+
+
+    @Command(external = true)
+    Optional<ItgStartProject> on(ItgProjectCreated event) {
+        externalEvent = event;
+        return Optional.empty();
+    }
+
+    @Command
+    Optional<ItgAddTask> on(ItgProjectStarted event) {
+        domesticEvent = event;
+        return Optional.empty();
+    }
+
+    public static ItgProjectCreated externalEvent() {
+        return externalEvent;
+    }
+
+    public static ItgProjectStarted domesticEvent() {
+        return domesticEvent;
+    }
+
+    public static void clear() {
+        externalEvent = null;
+        domesticEvent = null;
+    }
+}

--- a/server/src/test/java/io/spine/system/server/given/AbstractEventAccumulator.java
+++ b/server/src/test/java/io/spine/system/server/given/AbstractEventAccumulator.java
@@ -67,6 +67,11 @@ public abstract class AbstractEventAccumulator implements EventDispatcher {
     }
 
     @Override
+    public final Set<EventClass> domesticEventClasses() {
+        return eventClasses();
+    }
+
+    @Override
     public Set<EventClass> externalEventClasses() {
         return ImmutableSet.of();
     }

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxBoundedContext.java
@@ -299,6 +299,16 @@ public abstract class BlackBoxBoundedContext<T extends BlackBoxBoundedContext>
     /**
      * {@inheritDoc}
      *
+     * <p>The {@code BlackBoxBoundedContext} only consumes domestic events.
+     */
+    @Override
+    public Set<EventClass> domesticEventClasses() {
+        return eventClasses();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * <p>The {@code BlackBoxBoundedContext} does not consume external events.
      */
     @Override

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.1.7'
+final def spineVersion = '1.1.8'
 
 ext {
     // The version of the modules in this project.


### PR DESCRIPTION
Before this changeset the `external` events were delivered to their destinations up until the call
of the handler method. Only then we have checked whether the `external` attribute value matched its counterpart in the handler's annotation.

While this behavior was working fine, it caused a lot of extra work in case the external event was being delivered to a domestic handler and vice versa. We proceeded all the way through the delivery and loading the instance just to unwind all that stuff back.

This changeset moves the attribute checks onto the `EventDispatcherRegistry` level.

In addition, we had a number of `Set<EventClass> events()` and `Set<EventClass> eventClasses()` methods of dispatchers and dispatcher classes. These methods were calling one another, but at the same time had different meanings. I.e. there were clashes in whether _all_ the event classes of a dispatcher were returned or just the domestic events. 

This changeset addresses this issue by introducing an explicit `domesticEvents()` and `domesticEventClasses()` API, making `events()` to return _all_ event classes.

As a result, the `@Command`-ing methods now work properly when dispatching external and domestic events. 

The library version is now `1.1.8`.