### PR TITLE
Extend Delivery API

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.1.8`
+# Dependencies of `io.spine:spine-client:1.1.9`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -432,12 +432,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Oct 20 15:46:12 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 21 20:52:15 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.1.8`
+# Dependencies of `io.spine:spine-core:1.1.9`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -815,12 +815,12 @@ This report was generated on **Sun Oct 20 15:46:12 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Oct 20 15:46:13 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 21 20:52:16 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.1.8`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.1.9`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1246,12 +1246,12 @@ This report was generated on **Sun Oct 20 15:46:13 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Oct 20 15:46:14 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 21 20:52:17 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.1.8`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.1.9`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -1839,12 +1839,12 @@ This report was generated on **Sun Oct 20 15:46:14 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Oct 20 15:46:15 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 21 21:01:36 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.1.8`
+# Dependencies of `io.spine:spine-server:1.1.9`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2336,12 +2336,12 @@ This report was generated on **Sun Oct 20 15:46:15 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Oct 20 15:46:16 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 21 21:01:37 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.1.8`
+# Dependencies of `io.spine:spine-testutil-client:1.1.9`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2826,12 +2826,12 @@ This report was generated on **Sun Oct 20 15:46:16 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Oct 20 15:46:16 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 21 21:01:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.1.8`
+# Dependencies of `io.spine:spine-testutil-core:1.1.9`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3324,12 +3324,12 @@ This report was generated on **Sun Oct 20 15:46:16 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Oct 20 15:46:17 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 21 21:01:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.1.8`
+# Dependencies of `io.spine:spine-testutil-server:1.1.9`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3868,4 +3868,4 @@ This report was generated on **Sun Oct 20 15:46:17 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sun Oct 20 15:46:18 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 21 21:01:39 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.1.8</version>
+<version>1.1.9</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/delivery/Delivery.java
+++ b/server/src/main/java/io/spine/server/delivery/Delivery.java
@@ -425,10 +425,12 @@ public final class Delivery {
      *
      * @param entityId
      *         the ID of the entity, to which the message is heading
+     * @param entityStateType
+     *         the state type of the entity, to which the message is heading
      * @return the index of the shard for the message
      */
-    ShardIndex whichShardFor(Object entityId) {
-        return strategy.indexFor(entityId);
+    ShardIndex whichShardFor(Object entityId, TypeUrl entityStateType) {
+        return strategy.indexFor(entityId, entityStateType);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/delivery/Delivery.java
+++ b/server/src/main/java/io/spine/server/delivery/Delivery.java
@@ -266,6 +266,7 @@ public final class Delivery {
             session.complete();
         }
         DeliveryStats stats = new DeliveryStats(index, totalDelivered);
+        monitor.onDeliveryCompleted(stats);
         return Optional.of(stats);
     }
 

--- a/server/src/main/java/io/spine/server/delivery/Delivery.java
+++ b/server/src/main/java/io/spine/server/delivery/Delivery.java
@@ -227,7 +227,8 @@ public final class Delivery {
      * a particular shard. Therefore, in scope of this delivery, an approach based on pessimistic
      * locking per-{@code ShardIndex} is applied.
      *
-     * <p>In case the given shard is already processed by some node, this method does nothing.
+     * <p>In case the given shard is already processed by some node, this method does nothing and
+     * returns {@code Optional.empty()}.
      *
      * <p>The content of the shard is read and delivered on page-by-page basis. The runtime
      * exceptions occurring while a page is being delivered are accumulated and then the first
@@ -242,24 +243,30 @@ public final class Delivery {
      *
      * @param index
      *         the shard index to deliver the messages from.
+     * @return the statistics on the performed delivery, or {@code Optional.empty()} if there
+     *         were no delivery performed
      */
-    public void deliverMessagesFrom(ShardIndex index) {
+    public Optional<DeliveryStats> deliverMessagesFrom(ShardIndex index) {
         NodeId currentNode = ServerEnvironment.instance()
                                               .nodeId();
         Optional<ShardProcessingSession> picked = workRegistry.pickUp(index, currentNode);
         if (!picked.isPresent()) {
-            return;
+            return Optional.empty();
         }
         ShardProcessingSession session = picked.get();
 
+        RunResult runResult;
+        int totalDelivered = 0;
         try {
-            RunResult runResult;
             do {
                 runResult = doDeliver(session);
+                totalDelivered += runResult.deliveredCount();
             } while (runResult.shouldRunAgain());
         } finally {
             session.complete();
         }
+        DeliveryStats stats = new DeliveryStats(index, totalDelivered);
+        return Optional.of(stats);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/delivery/DeliveryMonitor.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryMonitor.java
@@ -68,6 +68,22 @@ public class DeliveryMonitor {
     }
 
     /**
+     * Called once some delivery process has completed and the corresponding shard
+     * has been released.
+     *
+     * <p>The descendants may override this method to understand when it is safe to pick up
+     * the corresponding shard again. Another usage scenario is calculation of the message delivery
+     * throughput.
+     *
+     * @param stats
+     *         the statistics of the performed delivery
+     */
+    @SuppressWarnings("unused")  // This SPI method is designed for descendants.
+    public void onDeliveryCompleted(DeliveryStats stats) {
+        // do nothing.
+    }
+
+    /**
      * Returns an instance of {@code DeliveryMonitor} which always tells to continue.
      */
     static DeliveryMonitor alwaysContinue() {

--- a/server/src/main/java/io/spine/server/delivery/DeliveryStats.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryStats.java
@@ -21,33 +21,30 @@
 package io.spine.server.delivery;
 
 /**
- * How ended the delivery of all messages read from the {@code Inbox} according to a certain
- * {@code ShardIndex}.
+ * The statistics on {@linkplain Delivery#deliverMessagesFrom(ShardIndex) delivering the messages}
+ * from a certain shard.
  */
-class RunResult {
+public final class DeliveryStats {
 
-    private final int deliveredMsgCount;
-    private final boolean stoppedByMonitor;
+    private final ShardIndex index;
+    private final int deliveredCount;
 
-    RunResult(int count, boolean stoppedByMonitor) {
-        deliveredMsgCount = count;
-        this.stoppedByMonitor = stoppedByMonitor;
+    DeliveryStats(ShardIndex index, int deliveredCount) {
+        this.index = index;
+        this.deliveredCount = deliveredCount;
     }
 
     /**
-     * Tells if another run is required.
-     *
-     * <p>The run is not required either if there were no messages delivered or if
-     * the {@code DeliveryMonitor} stopped the execution.
+     * Returns the index of the shard for which this statistics is calculated.
      */
-    boolean shouldRunAgain() {
-        return !stoppedByMonitor && deliveredMsgCount > 0;
+    public ShardIndex shardIndex() {
+        return index;
     }
 
     /**
-     * Returns the number of delivered messages.
+     * Returns the total number of messages delivered.
      */
-    int deliveredCount() {
-        return this.deliveredMsgCount;
+    public int deliveredCount() {
+        return deliveredCount;
     }
 }

--- a/server/src/main/java/io/spine/server/delivery/DeliveryStrategy.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryStrategy.java
@@ -20,6 +20,8 @@
 
 package io.spine.server.delivery;
 
+import io.spine.type.TypeUrl;
+
 /**
  * Determines the {@linkplain ShardIndex index of a shard} for the given identifier of an entity.
  *
@@ -35,9 +37,11 @@ public interface DeliveryStrategy {
      *
      * @param entityId
      *         the identifier of the entity, to which the messages are dispatched
+     * @param entityStateType
+     *         the type URL of the entity, to which the messages are dispatched
      * @return the shard index
      */
-    ShardIndex indexFor(Object entityId);
+    ShardIndex indexFor(Object entityId, TypeUrl entityStateType);
 
     /**
      * Tells how many shards there are according to this strategy.

--- a/server/src/main/java/io/spine/server/delivery/InboxPart.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxPart.java
@@ -92,7 +92,7 @@ abstract class InboxPart<I, M extends SignalEnvelope<?, ?, ?>> {
         InboxId inboxId = InboxIds.wrap(entityId, entityStateType);
         Delivery delivery = ServerEnvironment.instance()
                                              .delivery();
-        ShardIndex shardIndex = delivery.whichShardFor(entityId);
+        ShardIndex shardIndex = delivery.whichShardFor(entityId, entityStateType);
         InboxMessage.Builder builder = InboxMessage
                 .newBuilder()
                 .setId(InboxMessageId.generate())

--- a/server/src/main/java/io/spine/server/delivery/UniformAcrossAllShards.java
+++ b/server/src/main/java/io/spine/server/delivery/UniformAcrossAllShards.java
@@ -24,6 +24,7 @@ import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import com.google.errorprone.annotations.Immutable;
 import com.google.protobuf.Message;
+import io.spine.type.TypeUrl;
 
 import java.io.Serializable;
 import java.nio.charset.Charset;
@@ -80,7 +81,7 @@ public final class UniformAcrossAllShards implements DeliveryStrategy, Serializa
     }
 
     @Override
-    public ShardIndex indexFor(Object entityId) {
+    public ShardIndex indexFor(Object entityId, TypeUrl entityStateType) {
         if (1 == numberOfShards) {
             return newIndex(0);
         }

--- a/server/src/test/java/io/spine/server/delivery/DeliveryTest.java
+++ b/server/src/test/java/io/spine/server/delivery/DeliveryTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
+import com.google.common.truth.Truth8;
 import com.google.protobuf.util.Durations;
 import io.spine.core.TenantId;
 import io.spine.server.ServerEnvironment;
@@ -35,11 +36,14 @@ import io.spine.server.delivery.given.DeliveryTestEnv.ShardIndexMemoizer;
 import io.spine.server.delivery.given.DeliveryTestEnv.SignalMemoizer;
 import io.spine.server.delivery.given.FixedShardStrategy;
 import io.spine.server.delivery.given.MemoizingDeliveryMonitor;
+import io.spine.server.delivery.memory.InMemoryShardedWorkRegistry;
+import io.spine.server.tenant.TenantAwareRunner;
 import io.spine.test.delivery.AddNumber;
 import io.spine.test.delivery.Calc;
 import io.spine.test.delivery.NumberImported;
 import io.spine.test.delivery.NumberReacted;
 import io.spine.testing.SlowTest;
+import io.spine.testing.core.given.GivenTenantId;
 import io.spine.testing.server.blackbox.BlackBoxBoundedContext;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.AfterEach;
@@ -47,10 +51,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -64,8 +70,10 @@ import static com.google.common.collect.Streams.concat;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static io.spine.server.delivery.given.DeliveryTestEnv.manyTargets;
+import static io.spine.server.delivery.given.DeliveryTestEnv.newShardIndex;
 import static io.spine.server.delivery.given.DeliveryTestEnv.singleTarget;
 import static io.spine.server.tenant.TenantAwareRunner.with;
+import static java.util.Collections.synchronizedList;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
@@ -165,7 +173,6 @@ class DeliveryTest {
     @DisplayName("multiple shards to multiple targets " +
             "in a multi-threaded env with the custom strategy")
     void withCustomStrategy() {
-
         FixedShardStrategy strategy = new FixedShardStrategy(13);
         Delivery newDelivery = Delivery.localWithStrategyAndWindow(strategy, Durations.ZERO);
         ShardIndexMemoizer memoizer = new ShardIndexMemoizer();
@@ -181,6 +188,74 @@ class DeliveryTest {
         assertThat(shards.iterator()
                          .next())
                 .isEqualTo(strategy.nonEmptyShard());
+    }
+
+    @Test
+    @DisplayName("multiple shards to multiple targets in a single-threaded env " +
+            "and calculate the statistics properly")
+    void calculateStats() {
+        Delivery delivery = Delivery.newBuilder()
+                                    .setStrategy(UniformAcrossAllShards.forNumber(7))
+                                    .build();
+        ServerEnvironment.instance()
+                         .configureDelivery(delivery);
+        List<DeliveryStats> deliveryStats = synchronizedList(new ArrayList<>());
+        delivery.subscribe(msg -> {
+            Optional<DeliveryStats> stats = delivery.deliverMessagesFrom(msg.getShardIndex());
+            stats.ifPresent(deliveryStats::add);
+        });
+
+        RawMessageMemoizer rawMessageMemoizer = new RawMessageMemoizer();
+        delivery.subscribe(rawMessageMemoizer);
+
+        ImmutableSet<String> targets = manyTargets(7);
+        new ThreadSimulator(1).runWith(targets);
+        int totalMsgsInStats = deliveryStats.stream()
+                               .mapToInt(DeliveryStats::deliveredCount)
+                               .sum();
+        assertThat(totalMsgsInStats).isEqualTo(rawMessageMemoizer.messages().size());
+    }
+
+    @Test
+    @DisplayName("single shard and return stats when picked up the shard " +
+            "and `Optional.empty()` if shard was already picked")
+    void returnOptionalEmptyIfPicked() {
+        int shardCount = 11;
+
+        ShardedWorkRegistry workRegistry = new InMemoryShardedWorkRegistry();
+        Delivery delivery = Delivery.newBuilder()
+                                    .setStrategy(new FixedShardStrategy(shardCount))
+                                    .setWorkRegistry(workRegistry)
+                                    .build();
+        ServerEnvironment serverEnvironment = ServerEnvironment.instance();
+        serverEnvironment.configureDelivery(delivery);
+
+        ShardIndex index = newShardIndex(0, shardCount);
+        TenantId tenantId = GivenTenantId.generate();
+        TenantAwareRunner.with(tenantId)
+                         .run(() -> checkPresentStats(delivery, index));
+
+        Optional<ShardProcessingSession> session =
+                workRegistry.pickUp(index,serverEnvironment.nodeId());
+        Truth8.assertThat(session)
+              .isPresent();
+
+        TenantAwareRunner.with(tenantId)
+                         .run(() -> checkStatsEmpty(delivery, index));
+    }
+
+    private static void checkStatsEmpty(Delivery delivery, ShardIndex index) {
+        Optional<DeliveryStats> emptyStats = delivery.deliverMessagesFrom(index);
+        Truth8.assertThat(emptyStats)
+              .isEmpty();
+    }
+
+    private static void checkPresentStats(Delivery delivery, ShardIndex index) {
+        Optional<DeliveryStats> stats = delivery.deliverMessagesFrom(index);
+        Truth8.assertThat(stats)
+              .isPresent();
+        assertThat(stats.get()
+                        .shardIndex()).isEqualTo(index);
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/delivery/given/FixedShardStrategy.java
+++ b/server/src/test/java/io/spine/server/delivery/given/FixedShardStrategy.java
@@ -22,6 +22,7 @@ package io.spine.server.delivery.given;
 
 import io.spine.server.delivery.DeliveryStrategy;
 import io.spine.server.delivery.ShardIndex;
+import io.spine.type.TypeUrl;
 
 import java.io.Serializable;
 
@@ -51,7 +52,7 @@ public class FixedShardStrategy implements DeliveryStrategy, Serializable {
     }
 
     @Override
-    public ShardIndex indexFor(Object entityId) {
+    public ShardIndex indexFor(Object entityId, TypeUrl entityStateType) {
         return nonEmptyShard;
     }
 

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.1.8'
+final def spineVersion = '1.1.9'
 
 ext {
     // The version of the modules in this project.


### PR DESCRIPTION
Before this changeset, a developer of a Spine-based application had too little evidence of what's going on during the message delivery.  This PR extends the delivery API to help with that.

* `Delivery.deliverMessagesFrom(shardIndex)` now returns an `Optional<DeliveryStats>` instead of `void`. It allows to tell whether the delivery really occurred (or the shard was busy by some other node) and if the delivery was taking place, what the number of delivered messages was.

* `DeliveryMonitor` was appended with ` void onDeliveryCompleted(DeliveryStats)`. This method is called when the delivery has been completed and, most importantly, the previously picked shard has been released — so that another node could pick it up if needed.

* `DeliveryStrategy.indexFor` is now passed not only with an entity identifier as previously but also with the type URL of the target entity. In theory, it should ease grouping the entities by shards.

The library version is set to `1.1.9`.