### PR TITLE
Identity utils

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.1.13`
+# Dependencies of `io.spine:spine-client:1.1.14`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -429,12 +429,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 31 19:02:50 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 06 21:57:47 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.1.13`
+# Dependencies of `io.spine:spine-core:1.1.14`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -809,12 +809,12 @@ This report was generated on **Thu Oct 31 19:02:50 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 31 19:02:53 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 06 21:57:48 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.1.13`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.1.14`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1237,12 +1237,12 @@ This report was generated on **Thu Oct 31 19:02:53 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 31 19:02:56 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 06 21:57:49 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.1.13`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.1.14`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -1827,12 +1827,12 @@ This report was generated on **Thu Oct 31 19:02:56 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 31 19:02:59 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 06 21:57:49 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.1.13`
+# Dependencies of `io.spine:spine-server:1.1.14`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2321,12 +2321,12 @@ This report was generated on **Thu Oct 31 19:02:59 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 31 19:03:03 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 06 21:57:50 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.1.13`
+# Dependencies of `io.spine:spine-testutil-client:1.1.14`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2808,12 +2808,12 @@ This report was generated on **Thu Oct 31 19:03:03 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 31 19:03:06 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 06 21:57:51 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.1.13`
+# Dependencies of `io.spine:spine-testutil-core:1.1.14`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3303,12 +3303,12 @@ This report was generated on **Thu Oct 31 19:03:06 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 31 19:03:09 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 06 21:57:52 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.1.13`
+# Dependencies of `io.spine:spine-testutil-server:1.1.14`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3844,4 +3844,4 @@ This report was generated on **Thu Oct 31 19:03:09 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 31 19:03:13 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 06 21:57:52 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.1.13</version>
+<version>1.1.14</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/Identity.java
+++ b/server/src/main/java/io/spine/server/Identity.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.Empty;
+import io.spine.annotation.Internal;
+import io.spine.base.Identifier;
+import io.spine.core.MessageId;
+import io.spine.type.TypeUrl;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.util.Preconditions2.checkNotEmptyOrBlank;
+
+/**
+ * Utilities for exposing identity of a server-side object as {@link io.spine.core.MessageId}s.
+ */
+@Internal
+public final class Identity {
+
+    private static final TypeUrl EMPTY_URL = TypeUrl.of(Empty.class);
+
+    /** Prevents instantiation of this utility class. */
+    private Identity() {
+    }
+
+    /**
+     * Creates the ID which has only the passed value.
+     *
+     * <p>The returned ID does not contain the type information.
+     */
+    public static MessageId byString(String value) {
+        checkNotEmptyOrBlank(value);
+        Any producer = Identifier.pack(value);
+        return ofProducer(producer);
+    }
+
+    /**
+     * Creates the ID which has only fully qualified name of the passed class.
+     *
+     * <p>The returned ID does not contain the type information.
+     */
+    public static MessageId ofSingleton(Class<?> singletonClass) {
+        checkNotNull(singletonClass);
+        return byString(singletonClass.getName());
+    }
+
+    /**
+     * Creates the identity by the passed producer ID.
+     *
+     * <p>The returned ID does not contain the type information.
+     */
+    public static MessageId ofProducer(Any producerId) {
+        checkNotNull(producerId);
+        return MessageId
+                .newBuilder()
+                .setId(producerId)
+                .setTypeUrl(EMPTY_URL.value())
+                .vBuild();
+    }
+}

--- a/server/src/main/java/io/spine/server/command/AbstractCommandDispatcher.java
+++ b/server/src/main/java/io/spine/server/command/AbstractCommandDispatcher.java
@@ -22,19 +22,18 @@ package io.spine.server.command;
 
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import com.google.protobuf.Any;
-import com.google.protobuf.Empty;
 import io.spine.base.Error;
 import io.spine.core.Event;
 import io.spine.core.MessageId;
 import io.spine.protobuf.TypeConverter;
 import io.spine.server.BoundedContext;
 import io.spine.server.ContextAware;
+import io.spine.server.Identity;
 import io.spine.server.commandbus.CommandDispatcher;
 import io.spine.server.event.EventBus;
 import io.spine.server.type.SignalEnvelope;
 import io.spine.system.server.HandlerFailedUnexpectedly;
 import io.spine.system.server.SystemWriteSide;
-import io.spine.type.TypeUrl;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import java.util.function.Supplier;
@@ -57,11 +56,8 @@ public abstract class AbstractCommandDispatcher implements CommandDispatcher, Co
     /** Supplier for a packed version of the dispatcher ID. */
     private final Supplier<Any> producerId =
             memoize(() -> pack(TypeConverter.toMessage(id())));
-    private final Supplier<MessageId> eventAnchor = memoize(() -> MessageId
-            .newBuilder()
-            .setId(producerId())
-            .setTypeUrl(TypeUrl.of(Empty.class).value())
-            .vBuild());
+    private final Supplier<MessageId> eventAnchor =
+            memoize(() -> Identity.ofProducer(producerId()));
 
     @Override
     public void registerWith(BoundedContext context) {

--- a/server/src/main/java/io/spine/server/stand/Stand.java
+++ b/server/src/main/java/io/spine/server/stand/Stand.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.CheckReturnValue;
 import com.google.protobuf.Any;
-import com.google.protobuf.Empty;
 import io.grpc.stub.StreamObserver;
 import io.spine.annotation.Internal;
 import io.spine.base.Identifier;
@@ -40,6 +39,7 @@ import io.spine.core.Response;
 import io.spine.core.Responses;
 import io.spine.core.TenantId;
 import io.spine.protobuf.AnyPacker;
+import io.spine.server.Identity;
 import io.spine.server.aggregate.AggregateRepository;
 import io.spine.server.entity.Entity;
 import io.spine.server.entity.EntityLifecycle;
@@ -161,12 +161,7 @@ public class Stand extends AbstractEventSubscriber implements AutoCloseable {
                 .newBuilder()
                 .setNewValue(record)
                 .vBuild();
-        MessageId origin = MessageId
-                .newBuilder()
-                .setId(Identifier.pack("Stand-received-entity-update"))
-                .setTypeUrl(TypeUrl.of(Empty.class)
-                                   .value())
-                .vBuild();
+        MessageId origin = Identity.byString("Stand-received-entity-update");
         lifecycle.onStateChanged(change,
                                  ImmutableSet.of(origin),
                                  Origin.getDefaultInstance());

--- a/server/src/test/java/io/spine/server/IdentityTest.java
+++ b/server/src/test/java/io/spine/server/IdentityTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server;
+
+import io.spine.testing.UtilityClassTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("`Identity` utility class should")
+class IdentityTest extends UtilityClassTest<Identity> {
+
+    IdentityTest() {
+        super(Identity.class);
+    }
+
+    @Test
+    @DisplayName("not allow empty or blank identity")
+    void stringIdentity() {
+        assertRejects("");
+        assertRejects(" ");
+    }
+
+    void assertRejects(String value) {
+        assertThrows(IllegalArgumentException.class, () -> Identity.byString(value));
+    }
+}

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/ProjectAggregateRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/ProjectAggregateRepository.java
@@ -22,11 +22,11 @@ package io.spine.server.aggregate.given.repo;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Any;
-import com.google.protobuf.Empty;
 import io.spine.base.Identifier;
 import io.spine.core.EventContext;
 import io.spine.core.MessageId;
 import io.spine.core.Origin;
+import io.spine.server.Identity;
 import io.spine.server.aggregate.AggregateRepository;
 import io.spine.server.aggregate.AggregateStorage;
 import io.spine.server.entity.EntityRecord;
@@ -36,7 +36,6 @@ import io.spine.server.route.EventRouting;
 import io.spine.test.aggregate.ProjectId;
 import io.spine.test.aggregate.event.AggProjectArchived;
 import io.spine.test.aggregate.event.AggProjectDeleted;
-import io.spine.type.TypeUrl;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Optional;
@@ -139,12 +138,7 @@ public class ProjectAggregateRepository
                 .setPreviousValue(previousRecord)
                 .setNewValue(newRecord)
                 .build();
-        MessageId origin = MessageId
-                .newBuilder()
-                .setId(Identifier.pack("some-random-origin"))
-                .setTypeUrl(TypeUrl.of(Empty.class)
-                                   .value())
-                .vBuild();
+        MessageId origin = Identity.byString("some-random-origin");
         lifecycleOf(aggregate.id())
                 .onStateChanged(change, ImmutableSet.of(origin), Origin.getDefaultInstance());
     }

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.1.13'
+final def spineVersion = '1.1.14'
 
 ext {
     // The version of the modules in this project.


### PR DESCRIPTION
This PR encapsulates creation of identity based on `MessageId` into a utility class so that finding such cases is easier, and returned values can be documented.

It does not address the “mystery” of having `Empty` type URL in the returned values. And that should be discussed and addressed separately.
