### PR TITLE
Validate the subscription topic on client

### DIFF
--- a/client/src/main/java/io/spine/client/FilterMixin.java
+++ b/client/src/main/java/io/spine/client/FilterMixin.java
@@ -97,7 +97,7 @@ public interface FilterMixin extends FilterOrBuilder {
      */
     default void checkFieldIsColumnIn(Descriptor message) {
         checkNotNull(message);
-        checkFieldIsTopLevel();
+        checkFieldAtTopLevel();
         if (!fieldIsColumnIn(message)) {
             throw newIllegalArgumentException(
                     "The entity column `%s` is not found in entity state type `%s`. " +
@@ -109,7 +109,7 @@ public interface FilterMixin extends FilterOrBuilder {
     /**
      * Checks if the target field is a top-level field.
      */
-    default boolean fieldIsTopLevel() {
+    default boolean fieldAtTopLevel() {
         return !field().isNested();
     }
 
@@ -119,8 +119,8 @@ public interface FilterMixin extends FilterOrBuilder {
      * @throws IllegalArgumentException
      *         if the field is not a top-level field
      */
-    default void checkFieldIsTopLevel() {
-        if (!fieldIsTopLevel()) {
+    default void checkFieldAtTopLevel() {
+        if (!fieldAtTopLevel()) {
             throw newIllegalArgumentException(
                     "The entity filter contains a nested entity column `%s`. " +
                             "Nested entity columns are currently not supported.",

--- a/client/src/main/java/io/spine/client/FilterMixin.java
+++ b/client/src/main/java/io/spine/client/FilterMixin.java
@@ -40,7 +40,7 @@ import static io.spine.util.Exceptions.newIllegalArgumentException;
  * Extends the {@link Filter} with validation routines.
  */
 @GeneratedMixin
-public interface FilterMixin extends FilterOrBuilder {
+interface FilterMixin extends FilterOrBuilder {
 
     /**
      * Obtains the target field.

--- a/client/src/main/java/io/spine/client/FilterMixin.java
+++ b/client/src/main/java/io/spine/client/FilterMixin.java
@@ -62,6 +62,9 @@ public interface FilterMixin extends FilterOrBuilder {
 
     /**
      * Verifies that the target field is present in the passed message type.
+     *
+     * @throws IllegalArgumentException
+     *         if the field is not present in the passed message type
      */
     default void checkFieldPresentIn(Descriptor message) {
         checkNotNull(message);
@@ -88,6 +91,9 @@ public interface FilterMixin extends FilterOrBuilder {
 
     /**
      * Verifies that the target field is an entity column in the passed message type.
+     *
+     * @throws IllegalArgumentException
+     *         if the field is not an entity column in the passed message type
      */
     default void checkFieldIsColumnIn(Descriptor message) {
         checkNotNull(message);
@@ -109,6 +115,9 @@ public interface FilterMixin extends FilterOrBuilder {
 
     /**
      * Verifies that the target field is a top-level field.
+     *
+     * @throws IllegalArgumentException
+     *         if the field is not a top-level field
      */
     default void checkFieldIsTopLevel() {
         if (!fieldIsTopLevel()) {

--- a/client/src/main/java/io/spine/client/FilterMixin.java
+++ b/client/src/main/java/io/spine/client/FilterMixin.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.client;
+
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Message;
+import io.spine.base.EntityState;
+import io.spine.base.Field;
+import io.spine.base.FieldPath;
+import io.spine.type.TypeUrl;
+
+import static io.spine.util.Exceptions.newIllegalArgumentException;
+
+public interface FilterMixin {
+
+    @SuppressWarnings("override") // Implemented in the generated code.
+    FieldPath getFieldPath();
+
+    default Field field() {
+        FieldPath fieldPath = getFieldPath();
+        return Field.withPath(fieldPath);
+    }
+
+    default boolean fieldPresentIn(Descriptor message) {
+        Field field = field();
+        boolean result = field.presentIn(message);
+        return result;
+    }
+
+    default void checkFieldPresentIn(Descriptor message) {
+        if (!fieldPresentIn(message)) {
+            throw newIllegalArgumentException(
+                    "The field with path `%s` is not present in message type `%s`.",
+                    field(), message.getFullName());
+        }
+    }
+
+    default boolean fieldIsTopLevel() {
+        return !field().isNested();
+    }
+
+    default void checkFieldIsTopLevel() {
+        if (!fieldIsTopLevel()) {
+            throw newIllegalArgumentException(
+                    "The entity filter contains a nested entity column `%s`. " +
+                            "The nested entity columns are currently not supported.",
+                    field()
+            );
+        }
+    }
+
+    default void validateAgainst(TypeUrl targetType) {
+        Class<Message> javaClass = targetType.getMessageClass();
+        if (EntityState.class.isAssignableFrom(javaClass)) {
+            checkFieldIsTopLevel();
+        }
+        Descriptor descriptor = targetType.toTypeName()
+                                          .messageDescriptor();
+        checkFieldPresentIn(descriptor);
+    }
+}

--- a/client/src/main/java/io/spine/client/FilterMixin.java
+++ b/client/src/main/java/io/spine/client/FilterMixin.java
@@ -70,7 +70,7 @@ public interface FilterMixin {
         checkNotNull(message);
         if (!fieldPresentIn(message)) {
             throw newIllegalArgumentException(
-                    "The field with path `%s` is not present in message type `%s`.",
+                    "The field with path `%s` is not present in the message type `%s`.",
                     field(), message.getFullName());
         }
     }
@@ -104,7 +104,7 @@ public interface FilterMixin {
     }
 
     /**
-     * Checks that the target field is a top-level field.
+     * Checks if the target field is a top-level field.
      */
     default boolean fieldIsTopLevel() {
         return !field().isNested();
@@ -117,7 +117,7 @@ public interface FilterMixin {
         if (!fieldIsTopLevel()) {
             throw newIllegalArgumentException(
                     "The entity filter contains a nested entity column `%s`. " +
-                            "The nested entity columns are currently not supported.",
+                            "Nested entity columns are currently not supported.",
                     field()
             );
         }

--- a/client/src/main/java/io/spine/client/FilterMixin.java
+++ b/client/src/main/java/io/spine/client/FilterMixin.java
@@ -27,12 +27,13 @@ import io.spine.annotation.GeneratedMixin;
 import io.spine.base.EntityState;
 import io.spine.base.Field;
 import io.spine.base.FieldPath;
-import io.spine.code.proto.ColumnOption;
 import io.spine.code.proto.FieldDeclaration;
 import io.spine.type.TypeUrl;
 
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.code.proto.ColumnOption.isColumn;
 import static io.spine.util.Exceptions.newIllegalArgumentException;
 
 @GeneratedMixin
@@ -47,12 +48,14 @@ public interface FilterMixin {
     }
 
     default boolean fieldPresentIn(Descriptor message) {
+        checkNotNull(message);
         Field field = field();
         boolean result = field.presentIn(message);
         return result;
     }
 
     default void checkFieldPresentIn(Descriptor message) {
+        checkNotNull(message);
         if (!fieldPresentIn(message)) {
             throw newIllegalArgumentException(
                     "The field with path `%s` is not present in message type `%s`.",
@@ -61,20 +64,22 @@ public interface FilterMixin {
     }
 
     default boolean fieldIsColumnIn(Descriptor message) {
+        checkNotNull(message);
         Optional<FieldDescriptor> fieldDescriptor = field().findDescriptor(message);
         if (!fieldDescriptor.isPresent()) {
             return false;
         }
         FieldDeclaration declaration = new FieldDeclaration(fieldDescriptor.get());
-        boolean result = ColumnOption.isColumn(declaration);
+        boolean result = isColumn(declaration);
         return result;
     }
 
     default void checkFieldIsColumnIn(Descriptor message) {
+        checkNotNull(message);
         if (!fieldIsColumnIn(message)) {
             throw newIllegalArgumentException(
                     "The entity column `%s` is not found in entity state type `%s`. " +
-                            "Check the proto field exists and is marked with `(column)` option.",
+                            "Please check the field exists and is marked with `(column)` option.",
                     field(), message.getFullName());
         }
     }
@@ -94,6 +99,8 @@ public interface FilterMixin {
     }
 
     default void validateAgainst(TypeUrl targetType) {
+        checkNotNull(targetType);
+
         Class<Message> javaClass = targetType.getMessageClass();
         Descriptor descriptor = targetType.toTypeName()
                                           .messageDescriptor();

--- a/client/src/main/java/io/spine/client/FilterMixin.java
+++ b/client/src/main/java/io/spine/client/FilterMixin.java
@@ -130,16 +130,18 @@ public interface FilterMixin extends FilterOrBuilder {
     }
 
     /**
-     * Validates a filter against the queried type.
+     * Verifies that the filter can be applied to the given {@code target}.
      *
-     * <p>Makes sure the target field is a valid entity column in case the {@link EntityState} is
-     * queried and is a valid message field in all other cases.
+     * <p>Makes sure the field specified in the filter is a valid entity column or a message field
+     * in the type enclosed by the {@code target}.
      *
      * @throws IllegalArgumentException
-     *         if the target field is not present in the type or doesn't satisfy the constraints
+     *         if the field is not present in the target type or doesn't satisfy the constraints
      */
-    default void validateAgainst(TypeUrl targetType) {
-        checkNotNull(targetType);
+    default void checkCanApplyTo(Target target) {
+        checkNotNull(target);
+
+        TypeUrl targetType = target.typeUrl();
 
         Class<Message> javaClass = targetType.getMessageClass();
         Descriptor descriptor = targetType.toTypeName()

--- a/client/src/main/java/io/spine/client/FilterMixin.java
+++ b/client/src/main/java/io/spine/client/FilterMixin.java
@@ -36,17 +36,26 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.code.proto.ColumnOption.isColumn;
 import static io.spine.util.Exceptions.newIllegalArgumentException;
 
+/**
+ * Extends the {@link Filter} with validation routines.
+ */
 @GeneratedMixin
 public interface FilterMixin {
 
     @SuppressWarnings("override") // Implemented in the generated code.
     FieldPath getFieldPath();
 
+    /**
+     * Obtains the target field.
+     */
     default Field field() {
         FieldPath fieldPath = getFieldPath();
         return Field.withPath(fieldPath);
     }
 
+    /**
+     * Checks if the target field is present in the specified message type.
+     */
     default boolean fieldPresentIn(Descriptor message) {
         checkNotNull(message);
         Field field = field();
@@ -54,6 +63,9 @@ public interface FilterMixin {
         return result;
     }
 
+    /**
+     * Verifies that the target field is present in the passed message type.
+     */
     default void checkFieldPresentIn(Descriptor message) {
         checkNotNull(message);
         if (!fieldPresentIn(message)) {
@@ -63,6 +75,9 @@ public interface FilterMixin {
         }
     }
 
+    /**
+     * Checks if the target field is an entity column in the passed message type.
+     */
     default boolean fieldIsColumnIn(Descriptor message) {
         checkNotNull(message);
         Optional<FieldDescriptor> fieldDescriptor = field().findDescriptor(message);
@@ -74,6 +89,9 @@ public interface FilterMixin {
         return result;
     }
 
+    /**
+     * Verifies that the target field is an entity column in the passed message type.
+     */
     default void checkFieldIsColumnIn(Descriptor message) {
         checkNotNull(message);
         if (!fieldIsColumnIn(message)) {
@@ -84,10 +102,16 @@ public interface FilterMixin {
         }
     }
 
+    /**
+     * Checks that the target field is a top-level field.
+     */
     default boolean fieldIsTopLevel() {
         return !field().isNested();
     }
 
+    /**
+     * Verifies that the target field is a top-level field.
+     */
     default void checkFieldIsTopLevel() {
         if (!fieldIsTopLevel()) {
             throw newIllegalArgumentException(
@@ -98,6 +122,15 @@ public interface FilterMixin {
         }
     }
 
+    /**
+     * Validates a filter against the queried type.
+     *
+     * <p>Makes sure the target field is a valid entity column in case the {@link EntityState} is
+     * queried and is a valid message field in all other cases.
+     *
+     * @throws IllegalArgumentException
+     *         if the target field is not present in the type or doesn't satisfy the constraints
+     */
     default void validateAgainst(TypeUrl targetType) {
         checkNotNull(targetType);
 

--- a/client/src/main/java/io/spine/client/FilterMixin.java
+++ b/client/src/main/java/io/spine/client/FilterMixin.java
@@ -40,10 +40,7 @@ import static io.spine.util.Exceptions.newIllegalArgumentException;
  * Extends the {@link Filter} with validation routines.
  */
 @GeneratedMixin
-public interface FilterMixin {
-
-    @SuppressWarnings("override") // Implemented in the generated code.
-    FieldPath getFieldPath();
+public interface FilterMixin extends FilterOrBuilder {
 
     /**
      * Obtains the target field.

--- a/client/src/main/java/io/spine/client/FilterMixin.java
+++ b/client/src/main/java/io/spine/client/FilterMixin.java
@@ -94,6 +94,7 @@ public interface FilterMixin {
      */
     default void checkFieldIsColumnIn(Descriptor message) {
         checkNotNull(message);
+        checkFieldIsTopLevel();
         if (!fieldIsColumnIn(message)) {
             throw newIllegalArgumentException(
                     "The entity column `%s` is not found in entity state type `%s`. " +
@@ -138,7 +139,6 @@ public interface FilterMixin {
         Descriptor descriptor = targetType.toTypeName()
                                           .messageDescriptor();
         if (EntityState.class.isAssignableFrom(javaClass)) {
-            checkFieldIsTopLevel();
             checkFieldIsColumnIn(descriptor);
         } else {
             checkFieldPresentIn(descriptor);

--- a/client/src/main/java/io/spine/client/TargetMixin.java
+++ b/client/src/main/java/io/spine/client/TargetMixin.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.client;
+
+import com.google.protobuf.Message;
+import io.spine.annotation.GeneratedMixin;
+import io.spine.base.EntityState;
+import io.spine.base.EventMessage;
+import io.spine.type.TypeUrl;
+
+import java.util.Collection;
+
+import static io.spine.util.Exceptions.newIllegalArgumentException;
+
+@GeneratedMixin
+@SuppressWarnings("override") // Methods are implemented in the generated code.
+public interface TargetMixin {
+
+    String getType();
+
+    TargetFilters getFilters();
+
+    default void checkTypeValid() {
+        String type = getType();
+        Class<Message> targetClass = TypeUrl.parse(type)
+                                            .getMessageClass();
+        boolean isEntityState = EntityState.class.isAssignableFrom(targetClass);
+        boolean isEventMessage = EventMessage.class.isAssignableFrom(targetClass);
+        if (!isEntityState && !isEventMessage) {
+            throw newIllegalArgumentException(
+                    "The queried type should represent either an entity state or an event " +
+                            "message. Got type `%s` instead.", targetClass.getCanonicalName());
+        }
+    }
+
+    default void checkValid() {
+        checkTypeValid();
+
+        String type = getType();
+        TypeUrl typeUrl = TypeUrl.parse(type);
+        getFilters()
+                .getFilterList()
+                .stream()
+                .map(CompositeFilter::getFilterList)
+                .flatMap(Collection::stream)
+                .forEach(filter -> filter.validateAgainst(typeUrl));
+    }
+}

--- a/client/src/main/java/io/spine/client/TargetMixin.java
+++ b/client/src/main/java/io/spine/client/TargetMixin.java
@@ -46,7 +46,6 @@ public interface TargetMixin {
      *
      * @throws IllegalArgumentException
      *         if the target type is not a valid type for querying
-     *
      */
     default void checkTypeValid() {
         String type = getType();

--- a/client/src/main/java/io/spine/client/TargetMixin.java
+++ b/client/src/main/java/io/spine/client/TargetMixin.java
@@ -34,7 +34,7 @@ import static io.spine.util.Exceptions.newIllegalArgumentException;
  * Extends the {@link Target} with validation routines.
  */
 @GeneratedMixin
-public interface TargetMixin extends TargetOrBuilder {
+interface TargetMixin extends TargetOrBuilder {
 
     /**
      * Returns the URL of the target type.

--- a/client/src/main/java/io/spine/client/TargetMixin.java
+++ b/client/src/main/java/io/spine/client/TargetMixin.java
@@ -37,6 +37,14 @@ import static io.spine.util.Exceptions.newIllegalArgumentException;
 public interface TargetMixin extends TargetOrBuilder {
 
     /**
+     * Returns the URL of the target type.
+     */
+    default TypeUrl typeUrl() {
+        String type = getType();
+        return TypeUrl.parse(type);
+    }
+
+    /**
      * Verifies that the target type is a valid type for querying.
      *
      * @throws IllegalArgumentException
@@ -61,16 +69,17 @@ public interface TargetMixin extends TargetOrBuilder {
      * @throws IllegalArgumentException
      *         if either the target type is not a valid type for querying or the filters are
      *         invalid
-     * @see FilterMixin#validateAgainst(TypeUrl)
+     * @see FilterMixin#checkCanApplyTo(Target)
      */
+    @SuppressWarnings("ClassReferencesSubclass") // OK for a proto mixin.
     default void checkValid() {
         checkTypeValid();
-        TypeUrl typeUrl = TypeUrl.parse(getType());
+        Target thisAsTarget = (Target) this;
         getFilters()
                 .getFilterList()
                 .stream()
                 .map(CompositeFilter::getFilterList)
                 .flatMap(Collection::stream)
-                .forEach(filter -> filter.validateAgainst(typeUrl));
+                .forEach(filter -> filter.checkCanApplyTo(thisAsTarget));
     }
 }

--- a/client/src/main/java/io/spine/client/TargetMixin.java
+++ b/client/src/main/java/io/spine/client/TargetMixin.java
@@ -30,6 +30,9 @@ import java.util.Collection;
 
 import static io.spine.util.Exceptions.newIllegalArgumentException;
 
+/**
+ * Extends the {@link Target} with validation routines.
+ */
 @GeneratedMixin
 @SuppressWarnings("override") // Methods are implemented in the generated code.
 public interface TargetMixin {
@@ -38,6 +41,13 @@ public interface TargetMixin {
 
     TargetFilters getFilters();
 
+    /**
+     * Verifies that the target type is a valid type for querying.
+     *
+     * @throws IllegalArgumentException
+     *         if the target type is not a valid type for querying
+     *
+     */
     default void checkTypeValid() {
         String type = getType();
         Class<Message> targetClass = TypeUrl.parse(type)
@@ -51,11 +61,17 @@ public interface TargetMixin {
         }
     }
 
+    /**
+     * Verifies that the target has valid type and filters.
+     *
+     * @throws IllegalArgumentException
+     *         if either the target type is not a valid type for querying or the filters are
+     *         invalid
+     * @see FilterMixin#validateAgainst(TypeUrl)
+     */
     default void checkValid() {
         checkTypeValid();
-
-        String type = getType();
-        TypeUrl typeUrl = TypeUrl.parse(type);
+        TypeUrl typeUrl = TypeUrl.parse(getType());
         getFilters()
                 .getFilterList()
                 .stream()

--- a/client/src/main/java/io/spine/client/TargetMixin.java
+++ b/client/src/main/java/io/spine/client/TargetMixin.java
@@ -34,12 +34,7 @@ import static io.spine.util.Exceptions.newIllegalArgumentException;
  * Extends the {@link Target} with validation routines.
  */
 @GeneratedMixin
-@SuppressWarnings("override") // Methods are implemented in the generated code.
-public interface TargetMixin {
-
-    String getType();
-
-    TargetFilters getFilters();
+public interface TargetMixin extends TargetOrBuilder {
 
     /**
      * Verifies that the target type is a valid type for querying.

--- a/client/src/main/java/io/spine/client/TopicBuilder.java
+++ b/client/src/main/java/io/spine/client/TopicBuilder.java
@@ -67,6 +67,7 @@ public final class TopicBuilder extends TargetBuilder<Topic, TopicBuilder> {
     @Override
     public Topic build() {
         Target target = buildTarget();
+        target.checkValid();
         FieldMask mask = composeMask();
         Topic topic = topicFactory.composeTopic(target, mask);
         return topic;

--- a/client/src/main/java/io/spine/client/TopicBuilder.java
+++ b/client/src/main/java/io/spine/client/TopicBuilder.java
@@ -63,6 +63,9 @@ public final class TopicBuilder extends TargetBuilder<Topic, TopicBuilder> {
      * configuration.
      *
      * @return a new {@link io.spine.client.Topic Topic}
+     * @throws IllegalArgumentException
+     *         if the built {@link Target} instance is invalid, e.g. contains filters with
+     *         non-existent fields
      */
     @Override
     public Topic build() {

--- a/client/src/main/java/io/spine/client/TopicFactory.java
+++ b/client/src/main/java/io/spine/client/TopicFactory.java
@@ -28,7 +28,6 @@ import io.spine.core.ActorContext;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.client.Targets.composeTarget;
 import static java.lang.String.format;
 
 /**
@@ -77,8 +76,8 @@ public final class TopicFactory {
     public Topic allOf(Class<? extends Message> targetType) {
         checkNotNull(targetType);
 
-        Target target = composeTarget(targetType, null, null);
-        Topic result = forTarget(target);
+        TopicBuilder builder = new TopicBuilder(targetType, this);
+        Topic result = builder.build();
         return result;
     }
 
@@ -112,6 +111,8 @@ public final class TopicFactory {
      * @param target
      *         a {@code Target} to create a topic for
      * @return an instance of {@code Topic}
+     * @apiNote Assumes the passed target is {@linkplain TargetMixin#checkValid() valid} and
+     *        doesn't do any additional checks.
      */
     @Internal
     public Topic forTarget(Target target) {

--- a/client/src/main/proto/spine/client/filters.proto
+++ b/client/src/main/proto/spine/client/filters.proto
@@ -37,6 +37,7 @@ import "spine/base/field_path.proto";
 // Use Target to specify and narrow down the source for Topic and Query by the target type and
 // various criteria.
 message Target {
+    option (is).java_type = "io.spine.client.TargetMixin";
 
     // The type of the entity or event of interest.
     //
@@ -96,6 +97,7 @@ message CompositeFilter {
 
 // A filter matching some value in the event message/entity state.
 message Filter {
+    option (is).java_type = "io.spine.client.FilterMixin";
 
     // The path to the field to be matched.
     //

--- a/client/src/test/java/io/spine/client/FilterMixinTest.java
+++ b/client/src/test/java/io/spine/client/FilterMixinTest.java
@@ -47,21 +47,21 @@ class FilterMixinTest {
     }
 
     @Test
-    @DisplayName("validate the filter against a target type")
+    @DisplayName("check the filter can be applied to the given target")
     void validateFilter() {
         Filter filter = Filters.eq("first_field", "some entity column value");
-        filter.validateAgainst(TEST_ENTITY_TYPE);
+        filter.checkCanApplyTo(testEntityTarget());
     }
 
     @Test
     @DisplayName("consider the filter targeting a nested field of an event message valid")
     void validateFilterWithNested() {
         Filter filter = Filters.eq("name.value", "a project name");
-        filter.validateAgainst(CREATE_PROJECT_TYPE);
+        filter.checkCanApplyTo(createProjectTarget());
     }
 
     @Nested
-    @DisplayName("deem filter invalid and throw `IllegalArgumentException`")
+    @DisplayName("deem the filter non-applicable to the given target")
     class CheckInvalid {
 
         @Test
@@ -69,7 +69,7 @@ class FilterMixinTest {
         void whenFieldNotPresent() {
             Filter filter = Filters.eq("non_existing_field", "some entity column value");
             assertThrows(IllegalArgumentException.class,
-                         () -> filter.validateAgainst(TEST_ENTITY_TYPE));
+                         () -> filter.checkCanApplyTo(testEntityTarget()));
         }
 
         @Nested
@@ -81,7 +81,7 @@ class FilterMixinTest {
             void whenFieldNotTopLevel() {
                 Filter filter = Filters.eq("name.value", "a test entity name");
                 assertThrows(IllegalArgumentException.class,
-                             () -> filter.validateAgainst(TEST_ENTITY_TYPE));
+                             () -> filter.checkCanApplyTo(testEntityTarget()));
             }
 
             @Test
@@ -93,8 +93,30 @@ class FilterMixinTest {
                         .build();
                 Filter filter = Filters.eq("name", name);
                 assertThrows(IllegalArgumentException.class,
-                             () -> filter.validateAgainst(TEST_ENTITY_TYPE));
+                             () -> filter.checkCanApplyTo(testEntityTarget()));
             }
         }
+    }
+
+    /**
+     * Returns a target enclosing the {@link TestEntity} type.
+     */
+    private static Target testEntityTarget() {
+        Target target = Target
+                .newBuilder()
+                .setType(TEST_ENTITY_TYPE.value())
+                .build();
+        return target;
+    }
+
+    /**
+     * Returns a target enclosing the {@link ClCreateProject} type.
+     */
+    private static Target createProjectTarget() {
+        Target target = Target
+                .newBuilder()
+                .setType(CREATE_PROJECT_TYPE.value())
+                .build();
+        return target;
     }
 }

--- a/client/src/test/java/io/spine/client/FilterMixinTest.java
+++ b/client/src/test/java/io/spine/client/FilterMixinTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.client;
+
+import com.google.common.testing.NullPointerTester;
+import io.spine.test.client.ClCreateProject;
+import io.spine.test.client.TestEntity;
+import io.spine.test.client.TestEntityName;
+import io.spine.type.TypeUrl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("`FilterMixin` should")
+class FilterMixinTest {
+
+    private static final TypeUrl TEST_ENTITY_TYPE = TypeUrl.of(TestEntity.class);
+    private static final TypeUrl CREATE_PROJECT_TYPE = TypeUrl.of(ClCreateProject.class);
+
+    @Test
+    @DisplayName(NOT_ACCEPT_NULLS)
+    void passNullToleranceCheck() {
+        Filter filter = Filters.eq("first_field", "column value");
+        new NullPointerTester()
+                .testAllPublicInstanceMethods(filter);
+    }
+
+    @Test
+    @DisplayName("validate the filter against a target type")
+    void validateFilter() {
+        Filter filter = Filters.eq("first_field", "some entity column value");
+        filter.validateAgainst(TEST_ENTITY_TYPE);
+    }
+
+    @Test
+    @DisplayName("consider the filter targeting a nested field of an event message valid")
+    void validateFilterWithNested() {
+        Filter filter = Filters.eq("name.value", "a project name");
+        filter.validateAgainst(CREATE_PROJECT_TYPE);
+    }
+
+    @Nested
+    @DisplayName("deem filter invalid and throw `IllegalArgumentException`")
+    class CheckInvalid {
+
+        @Test
+        @DisplayName("when the field is not present in the target type")
+        void whenFieldNotPresent() {
+            Filter filter = Filters.eq("non_existing_field", "some entity column value");
+            assertThrows(IllegalArgumentException.class,
+                         () -> filter.validateAgainst(TEST_ENTITY_TYPE));
+        }
+
+        @Nested
+        @DisplayName("when the filter is targeting entity state")
+        class TargetingEntityState {
+
+            @Test
+            @DisplayName("and the target field is not top-level")
+            void whenFieldNotTopLevel() {
+                Filter filter = Filters.eq("name.value", "a test entity name");
+                assertThrows(IllegalArgumentException.class,
+                             () -> filter.validateAgainst(TEST_ENTITY_TYPE));
+            }
+
+            @Test
+            @DisplayName("and the target field is not an entity column")
+            void whenFieldIsNotColumn() {
+                TestEntityName name = TestEntityName
+                        .newBuilder()
+                        .setValue("the entity name")
+                        .build();
+                Filter filter = Filters.eq("name", name);
+                assertThrows(IllegalArgumentException.class,
+                             () -> filter.validateAgainst(TEST_ENTITY_TYPE));
+            }
+        }
+    }
+}

--- a/client/src/test/java/io/spine/client/FilterMixinTest.java
+++ b/client/src/test/java/io/spine/client/FilterMixinTest.java
@@ -21,7 +21,7 @@
 package io.spine.client;
 
 import com.google.common.testing.NullPointerTester;
-import io.spine.test.client.ClCreateProject;
+import io.spine.test.client.ClProjectCreated;
 import io.spine.test.client.TestEntity;
 import io.spine.test.client.TestEntityName;
 import io.spine.type.TypeUrl;
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class FilterMixinTest {
 
     private static final TypeUrl TEST_ENTITY_TYPE = TypeUrl.of(TestEntity.class);
-    private static final TypeUrl CREATE_PROJECT_TYPE = TypeUrl.of(ClCreateProject.class);
+    private static final TypeUrl PROJECT_CREATED_TYPE = TypeUrl.of(ClProjectCreated.class);
 
     @Test
     @DisplayName(NOT_ACCEPT_NULLS)
@@ -115,7 +115,7 @@ class FilterMixinTest {
     private static Target createProjectTarget() {
         Target target = Target
                 .newBuilder()
-                .setType(CREATE_PROJECT_TYPE.value())
+                .setType(PROJECT_CREATED_TYPE.value())
                 .build();
         return target;
     }

--- a/client/src/test/java/io/spine/client/TargetMixinTest.java
+++ b/client/src/test/java/io/spine/client/TargetMixinTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.client;
+
+import io.spine.test.client.TestEntity;
+import io.spine.test.queries.ProjectId;
+import io.spine.type.TypeUrl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static io.spine.client.CompositeFilter.CompositeOperator.ALL;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("`TargetMixin` should")
+class TargetMixinTest {
+
+    private static final TypeUrl TEST_ENTITY_TYPE = TypeUrl.of(TestEntity.class);
+    private static final TypeUrl PROJECT_ID_TYPE = TypeUrl.of(ProjectId.class);
+
+    @Nested
+    @DisplayName("validate the target")
+    class ValidateTarget {
+
+        @Test
+        @DisplayName("which is valid")
+        void valid() {
+            Filter filter = Filters.eq("first_field", "some str");
+            Target target = target(TEST_ENTITY_TYPE, filter);
+            target.checkValid();
+        }
+
+        @Test
+        @DisplayName("which has invalid type")
+        void withInvalidType() {
+            Filter filter = Filters.eq("second_field", false);
+            Target target = target(PROJECT_ID_TYPE, filter);
+            assertThrows(IllegalArgumentException.class, target::checkValid);
+        }
+
+        @Test
+        @DisplayName("which has invalid filters")
+        void withInvalidFilters() {
+            Filter filter = Filters.eq("non_existent_field", false);
+            Target target = target(TEST_ENTITY_TYPE, filter);
+            assertThrows(IllegalArgumentException.class, target::checkValid);
+        }
+    }
+
+    private static Target target(TypeUrl type, Filter... filters) {
+        Set<CompositeFilter> compositeFilters = stream(filters)
+                .map(TargetMixinTest::compositeFilter)
+                .collect(toSet());
+        TargetFilters targetFilters = TargetFilters
+                .newBuilder()
+                .addAllFilter(compositeFilters)
+                .build();
+        Target result = Target
+                .newBuilder()
+                .setType(type.value())
+                .setFilters(targetFilters)
+                .build();
+        return result;
+    }
+
+    private static CompositeFilter compositeFilter(Filter filter) {
+        CompositeFilter result = CompositeFilter
+                .newBuilder()
+                .setOperator(ALL)
+                .addFilter(filter)
+                .build();
+        return result;
+    }
+}

--- a/client/src/test/java/io/spine/client/TopicBuilderTest.java
+++ b/client/src/test/java/io/spine/client/TopicBuilderTest.java
@@ -33,6 +33,7 @@ import io.spine.test.client.TestEntityId;
 import io.spine.test.queries.ProjectId;
 import io.spine.type.TypeUrl;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -78,6 +79,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("Topic builder should")
 @SuppressWarnings("DuplicateStringLiteralInspection")
+@Disabled
 class TopicBuilderTest {
 
     private static final Class<? extends Message> TEST_ENTITY_TYPE = TestEntity.class;

--- a/client/src/test/proto/spine/test/events/events.proto
+++ b/client/src/test/proto/spine/test/events/events.proto
@@ -9,7 +9,7 @@ option java_package = "io.spine.test.client";
 option java_outer_classname = "EventsProto";
 option java_multiple_files = true;
 
-message ClCreateProject {
+message ClProjectCreated {
 
     string id = 1;
     ClProjectName name = 2;

--- a/client/src/test/proto/spine/test/events/events.proto
+++ b/client/src/test/proto/spine/test/events/events.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package spine.test.events;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.test.client";
+option java_outer_classname = "EventsProto";
+option java_multiple_files = true;
+
+message ClCreateProject {
+
+    string id = 1;
+    ClProjectName name = 2;
+}
+
+message ClProjectName {
+    string value = 1;
+}

--- a/client/src/test/proto/spine/test/queries/client_requests.proto
+++ b/client/src/test/proto/spine/test/queries/client_requests.proto
@@ -44,7 +44,21 @@ message TestEntity {
     // Entity ID.
     TestEntityId id = 1;
 
-    string first_field = 2;
+    string first_field = 2 [(column) = true];
 
-    bool second_field = 3;
+    bool second_field = 3  [(column) = true];
+
+    int32 third_field = 4 [(column) = true];
+
+    TestEntityName name = 5;
+}
+
+// A simple value holder.
+//
+// Is an `ENTITY` so it's possible to declare an entity column, which is needed by test.
+//
+message TestEntityName {
+    option (entity).kind = ENTITY;
+
+    string value = 1 [(column) = true];
 }

--- a/client/src/test/proto/spine/test/queries/client_requests.proto
+++ b/client/src/test/proto/spine/test/queries/client_requests.proto
@@ -55,7 +55,7 @@ message TestEntity {
 
 // A simple value holder.
 //
-// Is an `ENTITY` so it's possible to declare an entity column, which is needed by test.
+// Is an `ENTITY` so it's possible to declare an entity column, which is needed by the test.
 //
 message TestEntityName {
     option (entity).kind = ENTITY;

--- a/core/src/main/java/io/spine/core/Signal.java
+++ b/core/src/main/java/io/spine/core/Signal.java
@@ -121,7 +121,7 @@ public interface Signal<I extends SignalId,
     /**
      * Obtains the type URL of the enclosed message.
      */
-    default TypeUrl typeUrl() {
+    default TypeUrl enclosedTypeUrl() {
         return TypeUrl.ofEnclosed(getMessage());
     }
 
@@ -181,7 +181,7 @@ public interface Signal<I extends SignalId,
         return MessageId
                 .newBuilder()
                 .setId(pack(id()))
-                .setTypeUrl(typeUrl().value())
+                .setTypeUrl(enclosedTypeUrl().value())
                 .vBuild();
     }
 
@@ -194,7 +194,7 @@ public interface Signal<I extends SignalId,
         MessageId commandQualifier = MessageId
                 .newBuilder()
                 .setId(pack(id()))
-                .setTypeUrl(typeUrl().value())
+                .setTypeUrl(enclosedTypeUrl().value())
                 .buildPartial();
         Origin origin = Origin
                 .newBuilder()

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.2.2`
+# Dependencies of `io.spine:spine-client:1.2.3`
 
 ## Runtime
 1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.12.0
@@ -381,12 +381,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 17:55:18 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 18 15:49:17 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.2.2`
+# Dependencies of `io.spine:spine-core:1.2.3`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -743,12 +743,12 @@ This report was generated on **Fri Nov 15 17:55:18 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 17:55:18 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 18 15:49:20 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.2.2`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.2.3`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1144,12 +1144,12 @@ This report was generated on **Fri Nov 15 17:55:18 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 17:55:19 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 18 15:49:24 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.2.2`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.2.3`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -1699,12 +1699,12 @@ This report was generated on **Fri Nov 15 17:55:19 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 17:55:20 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 18 15:49:29 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.2.2`
+# Dependencies of `io.spine:spine-server:1.2.3`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2117,12 +2117,12 @@ This report was generated on **Fri Nov 15 17:55:20 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 17:55:20 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 18 15:49:36 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.2.2`
+# Dependencies of `io.spine:spine-testutil-client:1.2.3`
 
 ## Runtime
 1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.12.0
@@ -2536,12 +2536,12 @@ This report was generated on **Fri Nov 15 17:55:20 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 17:55:21 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 18 15:49:39 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.2.2`
+# Dependencies of `io.spine:spine-testutil-core:1.2.3`
 
 ## Runtime
 1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.12.0
@@ -2963,12 +2963,12 @@ This report was generated on **Fri Nov 15 17:55:21 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 17:55:21 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 18 15:49:42 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.2.2`
+# Dependencies of `io.spine:spine-testutil-server:1.2.3`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3466,4 +3466,4 @@ This report was generated on **Fri Nov 15 17:55:21 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 17:55:22 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 18 15:49:46 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -381,7 +381,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Nov 13 17:37:47 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:22:10 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -743,7 +743,7 @@ This report was generated on **Wed Nov 13 17:37:47 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Nov 13 17:37:49 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:22:14 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1144,7 +1144,7 @@ This report was generated on **Wed Nov 13 17:37:49 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Nov 13 17:37:52 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:22:21 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1699,7 +1699,7 @@ This report was generated on **Wed Nov 13 17:37:52 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Nov 13 17:37:56 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:22:27 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2117,7 +2117,7 @@ This report was generated on **Wed Nov 13 17:37:56 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Nov 13 17:37:59 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:22:31 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2536,7 +2536,7 @@ This report was generated on **Wed Nov 13 17:37:59 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Nov 13 17:38:01 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:22:38 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2963,7 +2963,7 @@ This report was generated on **Wed Nov 13 17:38:01 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Nov 13 17:38:04 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:22:45 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3466,4 +3466,4 @@ This report was generated on **Wed Nov 13 17:38:04 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Nov 13 17:38:08 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:22:52 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.2.1`
+# Dependencies of `io.spine:spine-client:1.2.2`
 
 ## Runtime
 1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.12.0
@@ -381,12 +381,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 15:13:29 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 13 17:37:47 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.2.1`
+# Dependencies of `io.spine:spine-core:1.2.2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -743,12 +743,12 @@ This report was generated on **Mon Nov 11 15:13:29 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 15:13:30 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 13 17:37:49 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.2.1`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.2.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1144,12 +1144,12 @@ This report was generated on **Mon Nov 11 15:13:30 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 15:13:30 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 13 17:37:52 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.2.1`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.2.2`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -1699,12 +1699,12 @@ This report was generated on **Mon Nov 11 15:13:30 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 15:13:31 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 13 17:37:56 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.2.1`
+# Dependencies of `io.spine:spine-server:1.2.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2117,12 +2117,12 @@ This report was generated on **Mon Nov 11 15:13:31 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 15:13:31 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 13 17:37:59 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.2.1`
+# Dependencies of `io.spine:spine-testutil-client:1.2.2`
 
 ## Runtime
 1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.12.0
@@ -2536,12 +2536,12 @@ This report was generated on **Mon Nov 11 15:13:31 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 15:13:32 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 13 17:38:01 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.2.1`
+# Dependencies of `io.spine:spine-testutil-core:1.2.2`
 
 ## Runtime
 1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.12.0
@@ -2963,12 +2963,12 @@ This report was generated on **Mon Nov 11 15:13:32 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 15:13:32 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 13 17:38:04 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.2.1`
+# Dependencies of `io.spine:spine-testutil-server:1.2.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3466,4 +3466,4 @@ This report was generated on **Mon Nov 11 15:13:32 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 15:13:33 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 13 17:38:08 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.2.2</version>
+<version>1.2.3</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.2.1</version>
+<version>1.2.2</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -70,7 +70,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.3</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -82,13 +82,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.3</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.3</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -130,7 +130,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.3</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -142,13 +142,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.3</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.3</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -210,12 +210,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.3</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.3</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/server/src/main/java/io/spine/server/commandbus/ExecutorCommandScheduler.java
+++ b/server/src/main/java/io/spine/server/commandbus/ExecutorCommandScheduler.java
@@ -79,7 +79,7 @@ public class ExecutorCommandScheduler extends CommandScheduler implements Loggin
         } catch (Throwable t) {
             _error().withCause(t)
                     .log("Error posting command `%s` with ID `%s`: `%s`.",
-                         command.typeUrl(),
+                         command.enclosedTypeUrl(),
                          command.getId()
                                 .getUuid(),
                          t.getLocalizedMessage());

--- a/server/src/main/java/io/spine/server/type/EventClass.java
+++ b/server/src/main/java/io/spine/server/type/EventClass.java
@@ -80,7 +80,7 @@ public final class EventClass extends MessageClass<EventMessage> {
      * <p>Named {@code from} to avoid collision with {@link #of(Message)}.
      */
     public static EventClass from(Event event) {
-        return from(event.typeUrl());
+        return from(event.enclosedTypeUrl());
     }
 
     /**

--- a/server/src/main/java/io/spine/system/server/TraceEventObserver.java
+++ b/server/src/main/java/io/spine/system/server/TraceEventObserver.java
@@ -77,7 +77,8 @@ public final class TraceEventObserver extends AbstractEventSubscriber implements
             tracer.processedBy(event.getReceiver(), event.getEntityType());
         } catch (Exception e) {
             _error().withCause(e)
-                    .log("Error during trace construction on event `%s`.", payload.typeUrl());
+                    .log("Error during trace construction on event `%s`.",
+                         payload.enclosedTypeUrl());
         }
     }
 }

--- a/server/src/test/java/io/spine/server/stand/StandTest.java
+++ b/server/src/test/java/io/spine/server/stand/StandTest.java
@@ -457,7 +457,7 @@ class StandTest extends TenantAwareTest {
                                       .messageId();
             assertThat(origin.asCommandId()).isEqualTo(cmd.id());
             assertThat(origin.getTypeUrl()).isEqualTo(cmd.command()
-                                                         .typeUrl()
+                                                         .enclosedTypeUrl()
                                                          .value());
             Any packedMessage = event.getMessage();
             CustomerCreated eventMessage = unpack(packedMessage, CustomerCreated.class);

--- a/server/src/test/java/io/spine/system/server/CommandLogTest.java
+++ b/server/src/test/java/io/spine/system/server/CommandLogTest.java
@@ -274,7 +274,7 @@ class CommandLogTest {
             CommandRejected rejected = eventAccumulator.assertReceivedEvent(CommandRejected.class);
             assertEquals(commandId, rejected.getId());
             Event rejectionEvent = rejected.getRejectionEvent();
-            TypeUrl rejectionType = rejectionEvent.typeUrl();
+            TypeUrl rejectionType = rejectionEvent.enclosedTypeUrl();
             TypeUrl expectedType = TypeUrl.of(expectedRejectionClass);
             assertEquals(expectedType, rejectionType);
         }

--- a/server/src/test/java/io/spine/system/server/SystemContextFeaturesTest.java
+++ b/server/src/test/java/io/spine/system/server/SystemContextFeaturesTest.java
@@ -123,7 +123,7 @@ class SystemContextFeaturesTest {
         systemBus.post(event);
         EventFilter filter = EventFilter
                 .newBuilder()
-                .setEventType(event.typeUrl().toTypeName().value())
+                .setEventType(event.enclosedTypeUrl().toTypeName().value())
                 .vBuild();
         EventStreamQuery query = EventStreamQuery
                 .newBuilder()

--- a/version.gradle
+++ b/version.gradle
@@ -25,14 +25,14 @@
  *  as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.2.2'
+final def spineVersion = '1.2.3'
 
 ext {
     // The version of the modules in this project.
     versionToPublish = spineVersion
 
     // Depend on `base` for the general definitions and a model compiler.
-    spineBaseVersion = '1.2.3'
+    spineBaseVersion = spineVersion
 
     // Depend on `time` for `ZoneId`, `ZoneOffset` and other date/time types and utilities.
     spineTimeVersion = '1.2.1'

--- a/version.gradle
+++ b/version.gradle
@@ -29,7 +29,7 @@ final def spineVersion = '1.2.3'
 
 ext {
     // The version of the modules in this project.
-    versionToPublish = '1.2.2'
+    versionToPublish = spineVersion
 
     // Depend on `base` for the general definitions and a model compiler.
     spineBaseVersion = spineVersion

--- a/version.gradle
+++ b/version.gradle
@@ -25,15 +25,15 @@
  *  as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.2.1'
+final def spineVersion = '1.2.2'
 
 ext {
     // The version of the modules in this project.
     versionToPublish = spineVersion
 
     // Depend on `base` for the general definitions and a model compiler.
-    spineBaseVersion = spineVersion
+    spineBaseVersion = '1.2.3'
 
     // Depend on `time` for `ZoneId`, `ZoneOffset` and other date/time types and utilities.
-    spineTimeVersion = spineVersion
+    spineTimeVersion = '1.2.1'
 }


### PR DESCRIPTION
This PR addresses #1191.

It introduces the `TargetMixin` which allows to check if the target is valid.

By "valid" we assume the target is of `EntityState`/`EventMessage` type and has filters which target existing message fields.

By default, the check is run in `TopicBuilder` on topic creation. Thus, all "standard" API for topic creation will run the check. But, if the topic is manually created and passed to the `SubscriptionService`, it should be checked also manually.

For queries, the target validness check is not run, as the mistake in declared type/filters will be revealed at once, removing the need to double check it on the client.

Spine version advances to `1.2.3`.