### PR TITLE
`AggregateHistoryCorrupted` event

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.2.1`
+# Dependencies of `io.spine:spine-client:1.2.2`
 
 ## Runtime
 1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.12.0
@@ -381,12 +381,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 17:35:17 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:55:18 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.2.1`
+# Dependencies of `io.spine:spine-core:1.2.2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -743,12 +743,12 @@ This report was generated on **Fri Nov 15 17:35:17 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 17:35:17 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:55:18 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.2.1`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.2.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1144,12 +1144,12 @@ This report was generated on **Fri Nov 15 17:35:17 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 17:35:18 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:55:19 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.2.1`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.2.2`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -1699,12 +1699,12 @@ This report was generated on **Fri Nov 15 17:35:18 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 17:35:18 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:55:20 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.2.1`
+# Dependencies of `io.spine:spine-server:1.2.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2117,12 +2117,12 @@ This report was generated on **Fri Nov 15 17:35:18 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 17:35:19 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:55:20 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.2.1`
+# Dependencies of `io.spine:spine-testutil-client:1.2.2`
 
 ## Runtime
 1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.12.0
@@ -2536,12 +2536,12 @@ This report was generated on **Fri Nov 15 17:35:19 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 17:35:19 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:55:21 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.2.1`
+# Dependencies of `io.spine:spine-testutil-core:1.2.2`
 
 ## Runtime
 1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.12.0
@@ -2963,12 +2963,12 @@ This report was generated on **Fri Nov 15 17:35:19 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 17:35:19 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:55:21 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.2.1`
+# Dependencies of `io.spine:spine-testutil-server:1.2.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3466,4 +3466,4 @@ This report was generated on **Fri Nov 15 17:35:19 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 17:35:20 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:55:22 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -381,7 +381,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 15:13:29 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 16:18:16 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -743,7 +743,7 @@ This report was generated on **Mon Nov 11 15:13:29 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 15:13:30 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 16:18:16 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1144,7 +1144,7 @@ This report was generated on **Mon Nov 11 15:13:30 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 15:13:30 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 16:18:17 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1699,7 +1699,7 @@ This report was generated on **Mon Nov 11 15:13:30 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 15:13:31 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 16:18:17 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2117,7 +2117,7 @@ This report was generated on **Mon Nov 11 15:13:31 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 15:13:31 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 16:18:18 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2536,7 +2536,7 @@ This report was generated on **Mon Nov 11 15:13:31 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 15:13:32 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 16:18:18 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2963,7 +2963,7 @@ This report was generated on **Mon Nov 11 15:13:32 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 15:13:32 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 16:18:19 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3466,4 +3466,4 @@ This report was generated on **Mon Nov 11 15:13:32 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 11 15:13:33 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 16:18:19 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -381,7 +381,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 16:18:16 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:35:17 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -743,7 +743,7 @@ This report was generated on **Fri Nov 15 16:18:16 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 16:18:16 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:35:17 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1144,7 +1144,7 @@ This report was generated on **Fri Nov 15 16:18:16 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 16:18:17 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:35:18 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1699,7 +1699,7 @@ This report was generated on **Fri Nov 15 16:18:17 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 16:18:17 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:35:18 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2117,7 +2117,7 @@ This report was generated on **Fri Nov 15 16:18:17 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 16:18:18 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:35:19 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2536,7 +2536,7 @@ This report was generated on **Fri Nov 15 16:18:18 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 16:18:18 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:35:19 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2963,7 +2963,7 @@ This report was generated on **Fri Nov 15 16:18:18 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 16:18:19 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:35:19 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3466,4 +3466,4 @@ This report was generated on **Fri Nov 15 16:18:19 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Nov 15 16:18:19 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 15 17:35:20 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.2.1</version>
+<version>1.2.2</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -37,6 +37,7 @@ import io.spine.server.command.model.CommandHandlerMethod;
 import io.spine.server.dispatch.BatchDispatchOutcome;
 import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.entity.EventPlayer;
+import io.spine.server.entity.RecentHistory;
 import io.spine.server.event.EventReactor;
 import io.spine.server.event.model.EventReactorMethod;
 import io.spine.server.type.CommandEnvelope;
@@ -411,6 +412,17 @@ public abstract class Aggregate<I,
     @Override
     protected final void clearRecentHistory() {
         super.clearRecentHistory();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Opens the method to this package for testing.
+     */
+    @VisibleForTesting
+    @Override
+    protected final RecentHistory recentHistory() {
+        return super.recentHistory();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -21,7 +21,6 @@ package io.spine.server.aggregate;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Any;
 import com.google.protobuf.Empty;
 import io.spine.annotation.Internal;
@@ -304,7 +303,6 @@ public abstract class Aggregate<I,
      *         if applying events caused an exception, which is set as the {@code cause} for
      *         the thrown instance
      */
-    @CanIgnoreReturnValue
     final BatchDispatchOutcome play(AggregateHistory history) {
         Snapshot snapshot = history.getSnapshot();
         if (isNotDefault(snapshot)) {
@@ -313,9 +311,7 @@ public abstract class Aggregate<I,
         List<Event> events = history.getEventList();
         eventCountAfterLastSnapshot = events.size();
         BatchDispatchOutcome batchDispatchOutcome = play(events);
-        if (batchDispatchOutcome.getSuccessful()) {
-            remember(events);
-        }
+        remember(events);
         return batchDispatchOutcome;
     }
 

--- a/server/src/main/java/io/spine/server/entity/Phase.java
+++ b/server/src/main/java/io/spine/server/entity/Phase.java
@@ -64,8 +64,9 @@ public abstract class Phase<I> {
      * @return the result of the task execution
      */
     final DispatchOutcome propagate() {
+        DispatchOutcome outcome = performDispatch();
         return DispatchOutcomeHandler
-                .from(performDispatch())
+                .from(outcome)
                 .onSuccess(this::incrementTransaction)
                 .handle();
     }

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -307,18 +307,19 @@ public abstract class Transaction<I,
      */
     private DispatchOutcome propagateFailsafe(Phase<I> phase) {
         try {
+            DispatchOutcome outcome = phase.propagate();
             return DispatchOutcomeHandler
-                    .from(phase.propagate())
+                    .from(outcome)
                     .onError(this::rollback)
                     .onRejection(this::rollback)
                     .handle();
         } catch (Throwable t) {
-            rollback(causeOf(t));
+            Error rootCause = causeOf(t);
+            rollback(rootCause);
             return DispatchOutcome
                     .newBuilder()
-                    .setPropagatedSignal(phase.signal()
-                                              .messageId())
-                    .setError(causeOf(t))
+                    .setPropagatedSignal(phase.signal().messageId())
+                    .setError(rootCause)
                     .vBuild();
         }
     }

--- a/server/src/main/proto/spine/system/server/diagnostic_events.proto
+++ b/server/src/main/proto/spine/system/server/diagnostic_events.proto
@@ -77,3 +77,53 @@ message RoutingFailed {
     // The error which occurred during the routing.
     base.Error error = 3;
 }
+
+// An event emitted when an Aggregate cannot load its history due to an error while applying
+// historical events.
+//
+// The event is emitted upon each attempt to load the Aggregate.
+//
+// An Aggregate with a corrupted state cannot handle new signals.
+//
+// The Aggregate state accessible to read side is undefined. It may reflect the state of the
+// Aggregate after the last successful event, or may have advanced further, including changes caused
+// by the erroneous event. An `EntityStateChanged` event must be emitted after the error is resolved
+// to catch up the read-side on the valid Aggregate state.
+//
+// The error may take place some time after the erroneous event was emitted. In this case, there may
+// be newer events in the Aggregate history.
+//
+// The framework does not provide a turn-key solution for resolving this kind of data corruption.
+// Depending on the situation, there may be different approaches to the problem. Most common ones
+// are:
+//   - Change the logic in the event applier, so that a runtime error is not produced for the given
+//     event.
+//   - Manually change the event in the database. Note that the erroneous event may have been
+//     propagated to other entities. Re-writing part of the system's history might lead to
+//     inconsistent data.
+//   - Manually delete the event in the database. Just like the previous approach, this is
+//     a dangerous operation as the consequences of changing the history are unpredictable.
+//
+message AggregateHistoryCorrupted {
+
+    // The Aggregate ID.
+    core.MessageId entity = 1;
+
+    // The type of the Aggregate.
+    EntityTypeName entity_type = 2;
+
+    // The ID of the last event which could be applied successfully.
+    core.MessageId last_successful_event = 3;
+
+    // The ID of the event which caused an error.
+    core.MessageId erroneous_event = 4;
+
+    // The error which occurred while applying the `erroneous_event`.
+    base.Error error = 5;
+
+    // Count of events which come after the `erroneous_event` in the Aggregate history.
+    //
+    // The events are not applied to the Aggregate when loading, i.e. applying for these events was
+    // interrupted.
+    uint32 interrupted_events = 6;
+}

--- a/server/src/main/proto/spine/system/server/diagnostic_events.proto
+++ b/server/src/main/proto/spine/system/server/diagnostic_events.proto
@@ -83,7 +83,7 @@ message RoutingFailed {
 //
 // The event is emitted upon each attempt to load the Aggregate.
 //
-// An Aggregate with a corrupted state cannot handle new signals.
+// An Aggregate with a corrupted history cannot handle new signals.
 //
 // The Aggregate state accessible to read side is undefined. It may reflect the state of the
 // Aggregate after the last successful event, or may have advanced further, including changes caused
@@ -91,7 +91,8 @@ message RoutingFailed {
 // to catch up the read-side on the valid Aggregate state.
 //
 // The error may take place some time after the erroneous event was emitted. In this case, there may
-// be newer events in the Aggregate history.
+// be newer events in the Aggregate history. Those events cannot be applied to the Aggregate either.
+// See `interrupted_events` for the number of such events.
 //
 // The framework does not provide a turn-key solution for resolving this kind of data corruption.
 // Depending on the situation, there may be different approaches to the problem. Most common ones

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryTest.java
@@ -22,7 +22,6 @@ package io.spine.server.aggregate;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import com.google.protobuf.Timestamp;
 import io.grpc.stub.StreamObserver;
 import io.spine.base.Identifier;
 import io.spine.core.Ack;
@@ -43,7 +42,6 @@ import io.spine.server.aggregate.given.repo.RejectingRepository;
 import io.spine.server.aggregate.given.repo.RejectionReactingAggregate;
 import io.spine.server.aggregate.given.repo.RejectionReactingRepository;
 import io.spine.server.commandbus.CommandBus;
-import io.spine.server.entity.LifecycleFlags;
 import io.spine.server.entity.Repository;
 import io.spine.server.tenant.TenantAwareOperation;
 import io.spine.server.type.CommandClass;
@@ -313,67 +311,6 @@ public class AggregateRepositoryTest {
                     .isEqualTo(id);
             assertThat(passedRequest.batchSize())
                     .isEqualTo(nonDefaultSnapshotTrigger + 1);
-        }
-
-        /**
-         * An {@link AggregateStorage} whose purpose is to intercept the incoming
-         * {@linkplain AggregateReadRequest read request}.
-         */
-        private final class TestAggregateStorage extends AggregateStorage<ProjectId> {
-
-            private final AggregateStorage<ProjectId> delegate;
-            private AggregateReadRequest<ProjectId> memoizedRequest;
-
-            private TestAggregateStorage(AggregateStorage<ProjectId> delegate) {
-                super(delegate.isMultitenant());
-                this.delegate = delegate;
-            }
-
-            @Override
-            public Optional<AggregateHistory> read(AggregateReadRequest<ProjectId> request) {
-                memoizedRequest = request;
-                return Optional.empty();
-            }
-
-            @Override
-            protected void writeRecord(ProjectId id, AggregateEventRecord record) {
-                delegate.writeRecord(id, record);
-            }
-
-            @Override
-            protected Iterator<AggregateEventRecord>
-            historyBackward(AggregateReadRequest<ProjectId> request) {
-                return delegate.historyBackward(request);
-            }
-
-            @Override
-            protected void truncate(int snapshotIndex) {
-                delegate.truncate(snapshotIndex);
-            }
-
-            @Override
-            protected void truncate(int snapshotIndex, Timestamp date) {
-                delegate.truncate(snapshotIndex, date);
-            }
-
-            @Override
-            protected Iterator<ProjectId> distinctAggregateIds() {
-                return delegate.distinctAggregateIds();
-            }
-
-            @Override
-            public Optional<LifecycleFlags> readLifecycleFlags(ProjectId id) {
-                return delegate.readLifecycleFlags(id);
-            }
-
-            @Override
-            public void writeLifecycleFlags(ProjectId id, LifecycleFlags flags) {
-                delegate.writeLifecycleFlags(id, flags);
-            }
-
-            private AggregateReadRequest<ProjectId> memoizedRequest() {
-                return memoizedRequest;
-            }
         }
     }
 

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryTest.java
@@ -27,6 +27,7 @@ import io.spine.base.Identifier;
 import io.spine.core.Ack;
 import io.spine.core.Command;
 import io.spine.core.Event;
+import io.spine.core.Events;
 import io.spine.server.BoundedContext;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.aggregate.given.klasse.EngineAggregate;
@@ -42,6 +43,7 @@ import io.spine.server.aggregate.given.repo.RejectingRepository;
 import io.spine.server.aggregate.given.repo.RejectionReactingAggregate;
 import io.spine.server.aggregate.given.repo.RejectionReactingRepository;
 import io.spine.server.commandbus.CommandBus;
+import io.spine.server.entity.RecentHistory;
 import io.spine.server.entity.Repository;
 import io.spine.server.tenant.TenantAwareOperation;
 import io.spine.server.type.CommandClass;
@@ -72,6 +74,7 @@ import io.spine.testing.server.blackbox.SingleTenantBlackBoxContext;
 import io.spine.testing.server.model.ModelTests;
 import io.spine.type.TypeUrl;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -84,6 +87,7 @@ import java.util.Set;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
+import static io.spine.base.Time.currentTime;
 import static io.spine.grpc.StreamObservers.noOpObserver;
 import static io.spine.protobuf.Messages.isNotDefault;
 import static io.spine.server.aggregate.AggregateRepository.DEFAULT_SNAPSHOT_TRIGGER;
@@ -382,6 +386,29 @@ public class AggregateRepositoryTest {
 
         // This should iterate through all and fail.
         assertThrows(IllegalStateException.class, () -> Lists.newArrayList(iterator));
+    }
+
+    @SuppressWarnings("CheckReturnValue")
+    @Test
+    @DisplayName("throw an ISE when history is corrupted")
+    void throwWhenCorrupted() {
+        ProjectAggregate aggregate = givenStoredAggregate();
+        RecentHistory history = aggregate.recentHistory();
+        Event.Builder eventBuilder = history.stream()
+                                       .findFirst()
+                                       .orElseGet(Assertions::fail)
+                                       .toBuilder();
+        eventBuilder.setId(Events.generateId());
+        eventBuilder.getContextBuilder().setTimestamp(currentTime());
+        Event duplicateEvent = eventBuilder.build();
+        AggregateHistory corruptedHistory = AggregateHistory
+                .newBuilder()
+                .addEvent(duplicateEvent)
+                .build();
+        ProjectId id = aggregate.id();
+        repository().aggregateStorage()
+                    .write(id, corruptedHistory);
+        assertThrows(IllegalStateException.class, () -> repository().find(id));
     }
 
     @Nested

--- a/server/src/test/java/io/spine/server/aggregate/TestAggregateStorage.java
+++ b/server/src/test/java/io/spine/server/aggregate/TestAggregateStorage.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.aggregate;
+
+import com.google.protobuf.Timestamp;
+import io.spine.server.entity.LifecycleFlags;
+import io.spine.test.aggregate.ProjectId;
+
+import java.util.Iterator;
+import java.util.Optional;
+
+/**
+ * An {@link AggregateStorage} whose purpose is to intercept the incoming
+ * {@linkplain AggregateReadRequest read request}.
+ */
+final class TestAggregateStorage extends AggregateStorage<ProjectId> {
+
+    private final AggregateStorage<ProjectId> delegate;
+    private AggregateReadRequest<ProjectId> memoizedRequest;
+
+    TestAggregateStorage(AggregateStorage<ProjectId> delegate) {
+        super(delegate.isMultitenant());
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Optional<AggregateHistory> read(AggregateReadRequest<ProjectId> request) {
+        memoizedRequest = request;
+        return Optional.empty();
+    }
+
+    @Override
+    protected void writeRecord(ProjectId id, AggregateEventRecord record) {
+        delegate.writeRecord(id, record);
+    }
+
+    @Override
+    protected Iterator<AggregateEventRecord>
+    historyBackward(AggregateReadRequest<ProjectId> request) {
+        return delegate.historyBackward(request);
+    }
+
+    @Override
+    protected void truncate(int snapshotIndex) {
+        delegate.truncate(snapshotIndex);
+    }
+
+    @Override
+    protected void truncate(int snapshotIndex, Timestamp date) {
+        delegate.truncate(snapshotIndex, date);
+    }
+
+    @Override
+    protected Iterator<ProjectId> distinctAggregateIds() {
+        return delegate.distinctAggregateIds();
+    }
+
+    @Override
+    public Optional<LifecycleFlags> readLifecycleFlags(ProjectId id) {
+        return delegate.readLifecycleFlags(id);
+    }
+
+    @Override
+    public void writeLifecycleFlags(ProjectId id, LifecycleFlags flags) {
+        delegate.writeLifecycleFlags(id, flags);
+    }
+
+    AggregateReadRequest<ProjectId> memoizedRequest() {
+        return memoizedRequest;
+    }
+}

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.2.1'
+final def spineVersion = '1.2.2'
 
 ext {
     // The version of the modules in this project.

--- a/version.gradle
+++ b/version.gradle
@@ -25,11 +25,11 @@
  *  as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.2.2'
+final def spineVersion = '1.2.1'
 
 ext {
     // The version of the modules in this project.
-    versionToPublish = spineVersion
+    versionToPublish = '1.2.2'
 
     // Depend on `base` for the general definitions and a model compiler.
     spineBaseVersion = spineVersion


### PR DESCRIPTION
Sometimes, when an `Apply` method logic changes, or when the infrastructure fails, causing double delivery, Aggregates may obtain a faulty history. In this case, an event (or event**s**) which has already been applied to the Aggregate cause an error during a replay. This renders the Aggregate unable to update its own state beyond the erroneous event.

Starting now, the behaviour of such Aggregates changes:
1. An Aggregate with a corrupted history cannot handle signals.
2. A special system event — `AggregateHistoryCorrupted` — is emitted each time this Aggregate receives signal.

Note that signals dispatched to an Aggregate with a corrupted history are considered delivered, even though the Aggregate never received them. This way, we avoid retrying the delivery each time when a new worker instance picks up the shard to which the Aggregate belongs.