### PR TITLE
Fix enum columns propagation

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -401,7 +401,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 16 22:54:48 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 17 14:13:38 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -763,7 +763,7 @@ This report was generated on **Mon Dec 16 22:54:48 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 16 22:54:53 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 17 14:13:39 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1164,7 +1164,7 @@ This report was generated on **Mon Dec 16 22:54:53 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 16 22:54:59 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 17 14:13:40 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1719,7 +1719,7 @@ This report was generated on **Mon Dec 16 22:54:59 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 16 22:55:08 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 17 14:13:41 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2137,7 +2137,7 @@ This report was generated on **Mon Dec 16 22:55:08 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 16 22:55:15 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 17 14:13:41 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2596,7 +2596,7 @@ This report was generated on **Mon Dec 16 22:55:15 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 16 22:55:24 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 17 14:13:42 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3063,7 +3063,7 @@ This report was generated on **Mon Dec 16 22:55:24 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 16 22:55:31 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 17 14:13:43 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3566,4 +3566,4 @@ This report was generated on **Mon Dec 16 22:55:31 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 16 22:55:39 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Dec 17 14:13:44 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,8 +1,12 @@
 
     
-# Dependencies of `io.spine:spine-client:1.2.9`
+# Dependencies of `io.spine:spine-client:1.2.10`
 
 ## Runtime
+1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
+     * **POM Project URL:** [http://source.android.com/](http://source.android.com/)
+     * **POM License: Apache 2.0** - [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
 1. **Group:** com.google.api.grpc **Name:** proto-google-common-protos **Version:** 1.12.0
      * **POM Project URL:** [https://github.com/googleapis/api-client-staging](https://github.com/googleapis/api-client-staging)
      * **POM License: Apache-2.0** - [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -397,12 +401,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Dec 04 20:52:41 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 16 22:54:48 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.2.9`
+# Dependencies of `io.spine:spine-core:1.2.10`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -759,12 +763,12 @@ This report was generated on **Wed Dec 04 20:52:41 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Dec 04 20:52:41 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 16 22:54:53 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.2.9`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.2.10`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1160,12 +1164,12 @@ This report was generated on **Wed Dec 04 20:52:41 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Dec 04 20:52:41 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 16 22:54:59 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.2.9`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.2.10`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -1715,12 +1719,12 @@ This report was generated on **Wed Dec 04 20:52:41 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Dec 04 20:52:42 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 16 22:55:08 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.2.9`
+# Dependencies of `io.spine:spine-server:1.2.10`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2133,12 +2137,12 @@ This report was generated on **Wed Dec 04 20:52:42 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Dec 04 20:52:42 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 16 22:55:15 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.2.9`
+# Dependencies of `io.spine:spine-testutil-client:1.2.10`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2592,12 +2596,12 @@ This report was generated on **Wed Dec 04 20:52:42 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Dec 04 20:52:42 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 16 22:55:24 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.2.9`
+# Dependencies of `io.spine:spine-testutil-core:1.2.10`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3059,12 +3063,12 @@ This report was generated on **Wed Dec 04 20:52:42 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Dec 04 20:52:43 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 16 22:55:31 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.2.9`
+# Dependencies of `io.spine:spine-testutil-server:1.2.10`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3562,4 +3566,4 @@ This report was generated on **Wed Dec 04 20:52:43 EET 2019** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Dec 04 20:52:43 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 16 22:55:39 EET 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.2.9</version>
+<version>1.2.10</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -70,7 +70,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -82,13 +82,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -130,7 +130,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -142,13 +142,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -210,12 +210,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -479,9 +479,9 @@ public abstract class Transaction<I,
      * getter to the entity state.
      *
      * <p>The enum-typed columns require an additional conversion as the
-     * {@link Message.Builder#setField(Descriptors.FieldDescriptor, Object) setField(...)} method
-     * should receive a {@link com.google.protobuf.Descriptors.EnumValueDescriptor
-     * EnumValueDescriptor} instance per Protobuf rules.
+     * {@link Message.Builder#setField(Descriptors.FieldDescriptor, Object)} method should receive
+     * a {@link com.google.protobuf.Descriptors.EnumValueDescriptor EnumValueDescriptor} instance
+     * per Protobuf rules.
      */
     private void propagateValue(InterfaceBasedColumn column, Message.Builder entityState) {
         Object value = column.valueIn(entity);

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -481,7 +481,7 @@ public abstract class Transaction<I,
      * <p>The enum-typed columns require an additional conversion as the
      * {@link Message.Builder#setField(Descriptors.FieldDescriptor, Object)} method should receive
      * a {@link com.google.protobuf.Descriptors.EnumValueDescriptor EnumValueDescriptor} instance
-     * per Protobuf rules.
+     * by the Protobuf rules.
      */
     private void propagateValue(InterfaceBasedColumn column, Message.Builder entityState) {
         Object value = column.valueIn(entity);

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -24,7 +24,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Any;
+import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
+import com.google.protobuf.ProtocolMessageEnum;
 import io.spine.annotation.Internal;
 import io.spine.base.EntityState;
 import io.spine.base.Error;
@@ -454,7 +456,7 @@ public abstract class Transaction<I,
      *
      * <p>Some of the columns may be {@linkplain InterfaceBasedColumn implemented} with custom
      * getters declared in the entity class. The values of such columns need to be propagated to
-     * the entity state during transaction commit.
+     * the entity state during the transaction commit.
      */
     @SuppressWarnings("unchecked") // Logically correct.
     private S stateWithColumns() {
@@ -467,12 +469,26 @@ public abstract class Transaction<I,
         Message.Builder stateWithColumns = entity.state()
                                                  .toBuilder();
         columns.values()
-               .forEach(column -> {
-                   Object value = column.valueIn(entity);
-                   stateWithColumns.setField(column.protoField().descriptor(), value);
-               });
+               .forEach(column -> propagateValue(column, stateWithColumns));
         S result = (S) stateWithColumns.build();
         return result;
+    }
+
+    /**
+     * Propagates a column value which is obtained with the help of a manually implemented column
+     * getter to the entity state.
+     *
+     * <p>The enum-typed columns require an additional conversion as the
+     * {@link Message.Builder#setField(Descriptors.FieldDescriptor, Object) setField(...)} method
+     * should receive a {@link com.google.protobuf.Descriptors.EnumValueDescriptor
+     * EnumValueDescriptor} instance per Protobuf rules.
+     */
+    private void propagateValue(InterfaceBasedColumn column, Message.Builder entityState) {
+        Object value = column.valueIn(entity);
+        if (value instanceof ProtocolMessageEnum) {
+            value = ((ProtocolMessageEnum) value).getValueDescriptor();
+        }
+        entityState.setField(column.protoField().descriptor(), value);
     }
 
     /**

--- a/server/src/test/java/io/spine/server/entity/given/tx/TxProjection.java
+++ b/server/src/test/java/io/spine/server/entity/given/tx/TxProjection.java
@@ -23,6 +23,7 @@ package io.spine.server.entity.given.tx;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Message;
 import io.spine.core.Subscribe;
+import io.spine.server.entity.given.tx.ProjectionState.ProjectionType;
 import io.spine.server.entity.given.tx.event.TxCreated;
 import io.spine.server.entity.given.tx.event.TxErrorRequested;
 import io.spine.server.entity.given.tx.event.TxStateErrorRequested;
@@ -31,11 +32,12 @@ import io.spine.server.projection.Projection;
 import java.util.List;
 
 import static com.google.common.collect.Lists.newLinkedList;
+import static io.spine.server.entity.given.tx.ProjectionState.ProjectionType.VERY_USEFUL;
 
 /**
  * Test environment projection for {@link io.spine.server.projection.ProjectionTransactionTest}.
  */
-public class TxProjection
+public final class TxProjection
         extends Projection<Id, ProjectionState, ProjectionState.Builder>
         implements ProjectionStateWithColumns {
 
@@ -78,5 +80,10 @@ public class TxProjection
     public int getNameLength() {
         return state().getName()
                       .length();
+    }
+
+    @Override
+    public ProjectionType getType() {
+        return VERY_USEFUL;
     }
 }

--- a/server/src/test/java/io/spine/server/projection/ProjectionTransactionTest.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionTransactionTest.java
@@ -30,6 +30,7 @@ import io.spine.server.entity.TransactionTest;
 import io.spine.server.entity.VersionIncrement;
 import io.spine.server.entity.given.tx.Id;
 import io.spine.server.entity.given.tx.ProjectionState;
+import io.spine.server.entity.given.tx.ProjectionState.ProjectionType;
 import io.spine.server.entity.given.tx.TxProjection;
 import io.spine.server.entity.given.tx.event.TxCreated;
 import io.spine.server.type.EventEnvelope;
@@ -40,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.base.Time.currentTime;
 import static io.spine.protobuf.AnyPacker.unpack;
+import static io.spine.server.entity.given.tx.ProjectionState.ProjectionType.VERY_USEFUL;
 import static java.util.Collections.singleton;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -99,6 +101,7 @@ class ProjectionTransactionTest
                 .setId(id())
                 .setName(nameString)
                 .setNameLength(nameString.length())
+                .setType(VERY_USEFUL)
                 .build();
     }
 
@@ -156,7 +159,7 @@ class ProjectionTransactionTest
     @Test
     @DisplayName("propagate column values to the entity state on commit")
     void propagateColumnValues() {
-        Projection<Id, ProjectionState, ProjectionState.Builder> entity = createEntity();
+        TxProjection entity = (TxProjection) createEntity();
         String name = "some-projection-name";
         TxCreated txCreated = TxCreated
                 .newBuilder()
@@ -168,6 +171,10 @@ class ProjectionTransactionTest
 
         int nameLength = entity.state()
                                .getNameLength();
-        assertThat(nameLength).isEqualTo(name.length());
+        assertThat(nameLength).isEqualTo(entity.getNameLength());
+
+        ProjectionType type = entity.state()
+                                    .getType();
+        assertThat(type).isEqualTo(entity.getType());
     }
 }

--- a/server/src/test/java/io/spine/server/projection/ProjectionTransactionTest.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionTransactionTest.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests for {@link io.spine.server.projection.ProjectionTransaction}.
  */
-@DisplayName("ProjectionTransaction should")
+@DisplayName("`ProjectionTransaction` should")
 class ProjectionTransactionTest
         extends TransactionTest<Id,
         Projection<Id, ProjectionState, ProjectionState.Builder>,
@@ -117,6 +117,7 @@ class ProjectionTransactionTest
                             .contains(actualMessage));
     }
 
+    @SuppressWarnings("rawtypes") // For the brevity of the test.
     @Override
     protected DispatchOutcome applyEvent(Transaction tx, Event event) {
         ProjectionTransaction cast = (ProjectionTransaction) tx;

--- a/server/src/test/proto/spine/test/tx/tx_entities.proto
+++ b/server/src/test/proto/spine/test/tx/tx_entities.proto
@@ -48,4 +48,10 @@ message ProjectionState {
     Id id = 1;
     string name = 2 [(required) = true];
     int32 name_length = 3 [(column) = true];
+    ProjectionType type = 4 [(column) = true];
+
+    enum ProjectionType {
+        USEFUL = 0;
+        VERY_USEFUL = 1;
+    }
 }

--- a/version.gradle
+++ b/version.gradle
@@ -25,14 +25,14 @@
  *  as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.2.9'
+final def spineVersion = '1.2.10'
 
 ext {
     // The version of the modules in this project.
     versionToPublish = spineVersion
 
     // Depend on `base` for the general definitions and a model compiler.
-    spineBaseVersion = '1.2.3'
+    spineBaseVersion = '1.2.4'
 
     // Depend on `time` for `ZoneId`, `ZoneOffset` and other date/time types and utilities.
     spineTimeVersion = '1.2.1'


### PR DESCRIPTION
This PR fixes an issue with the enum-type columns propagation.

For the enumerated types, the `Message.Builder.setField(...)` method requires a `EnumValueDescriptor` as an input rather than the raw enum value. 

This changeset takes that into account when updating the entity column values in a transaction.

Spine version advances to `1.2.10`.