### PR TITLE
Root command ID of an Event

### DIFF
--- a/core/src/main/java/io/spine/core/EventContextMixin.java
+++ b/core/src/main/java/io/spine/core/EventContextMixin.java
@@ -25,6 +25,7 @@ import com.google.protobuf.Descriptors;
 import com.google.protobuf.Timestamp;
 import io.spine.annotation.Internal;
 import io.spine.base.Identifier;
+import io.spine.logging.Logging;
 import io.spine.time.InstantConverter;
 import io.spine.validate.FieldAwareMessage;
 
@@ -39,7 +40,8 @@ import static io.spine.util.Exceptions.newIllegalStateException;
 @Immutable
 interface EventContextMixin extends EnrichableMessageContext,
                                     EventContextOrBuilder,
-                                    FieldAwareMessage {
+                                    FieldAwareMessage,
+                                    Logging {
 
     /**
      * Obtains an actor context for the event context.
@@ -93,11 +95,13 @@ interface EventContextMixin extends EnrichableMessageContext,
     /**
      * Obtains the ID of the first signal in a chain.
      *
-     * <p>The root message is typically a {@code Command}. It can be an {@code Event} if the event
-     * was emitted by an actor directly, i.e. it was imported into the system.
+     * <p>The root message is either a {@code Command} or an {@code Event} which was produced by
+     * an actor directly and caused the associated {@code Event} to be emitted.
      *
-     * <p>If the associated message itself is the root of its chain, the ID cannot be assembled and
-     * thus an {@code Optional.empty()} is returned.
+     * <p>If the associated {@code Event} itself is the root of its chain, i.e. it was imported into
+     * the system, the ID cannot be assembled and thus an {@code Optional.empty()} is returned.
+     *
+     * <p>If the origin cannot be determined, an {@code IllegalStateException} is thrown.
      *
      * @see Event#rootMessage()
      */

--- a/core/src/main/java/io/spine/core/EventContextMixin.java
+++ b/core/src/main/java/io/spine/core/EventContextMixin.java
@@ -116,7 +116,7 @@ interface EventContextMixin extends EnrichableMessageContext,
                 @SuppressWarnings("DuplicateStringLiteralInspection") // Coincidence.
                 MessageId id = MessageId
                         .newBuilder()
-                        .setId(Identifier.pack(getCommandId()))
+                        .setId(Identifier.pack(getRootCommandId()))
                         .setTypeUrl("Unknown")
                         .vBuild();
                 return Optional.of(id);

--- a/core/src/main/java/io/spine/core/EventContextMixin.java
+++ b/core/src/main/java/io/spine/core/EventContextMixin.java
@@ -101,7 +101,7 @@ interface EventContextMixin extends EnrichableMessageContext,
      * <p>If the associated {@code Event} itself is the root of its chain, i.e. it was imported into
      * the system, the ID cannot be assembled and thus an {@code Optional.empty()} is returned.
      *
-     * <p>If the origin cannot be determined, an {@code IllegalStateException} is thrown.
+     * <p>If the origin cannot be determined, an {@code Optional.empty()} is returned.
      *
      * @see Event#rootMessage()
      */

--- a/core/src/main/java/io/spine/core/EventContextMixin.java
+++ b/core/src/main/java/io/spine/core/EventContextMixin.java
@@ -119,7 +119,7 @@ interface EventContextMixin extends EnrichableMessageContext,
             default:
                 if (hasRootCommandId()) {
                     @SuppressWarnings("DuplicateStringLiteralInspection") // Coincidence.
-                            MessageId id = MessageId
+                    MessageId id = MessageId
                             .newBuilder()
                             .setId(Identifier.pack(getRootCommandId()))
                             .setTypeUrl("Unknown")

--- a/core/src/main/java/io/spine/core/EventContextMixin.java
+++ b/core/src/main/java/io/spine/core/EventContextMixin.java
@@ -117,13 +117,18 @@ interface EventContextMixin extends EnrichableMessageContext,
             case COMMAND_CONTEXT:
             case ORIGIN_NOT_SET:
             default:
-                @SuppressWarnings("DuplicateStringLiteralInspection") // Coincidence.
-                MessageId id = MessageId
-                        .newBuilder()
-                        .setId(Identifier.pack(getRootCommandId()))
-                        .setTypeUrl("Unknown")
-                        .vBuild();
-                return Optional.of(id);
+                if (hasRootCommandId()) {
+                    @SuppressWarnings("DuplicateStringLiteralInspection") // Coincidence.
+                            MessageId id = MessageId
+                            .newBuilder()
+                            .setId(Identifier.pack(getRootCommandId()))
+                            .setTypeUrl("Unknown")
+                            .vBuild();
+                    return Optional.of(id);
+                } else {
+                    _warn().log("Cannot determine root message ID.");
+                    return Optional.empty();
+                }
         }
     }
 

--- a/core/src/main/java/io/spine/core/EventMixin.java
+++ b/core/src/main/java/io/spine/core/EventMixin.java
@@ -57,6 +57,12 @@ interface EventMixin
         return context().getTimestamp();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Attempts to obtain the ID from the {@code EventContext}. If not successful, assumes that
+     * this {@code Event} is the root message.
+     */
     @Override
     default MessageId rootMessage() {
         return context()

--- a/core/src/main/java/io/spine/core/EventMixin.java
+++ b/core/src/main/java/io/spine/core/EventMixin.java
@@ -59,11 +59,9 @@ interface EventMixin
 
     @Override
     default MessageId rootMessage() {
-        return isImported()
-               ? messageId()
-               : context()
-                       .rootMessage()
-                       .orElseThrow(IllegalStateException::new);
+        return context()
+                .rootMessage()
+                .orElseGet(this::messageId);
     }
 
     @Override

--- a/core/src/main/java/io/spine/core/EventMixin.java
+++ b/core/src/main/java/io/spine/core/EventMixin.java
@@ -31,7 +31,6 @@ import io.spine.validate.FieldAwareMessage;
 
 import java.util.Optional;
 
-import static io.spine.core.EventContext.OriginCase.IMPORT_CONTEXT;
 import static io.spine.protobuf.Messages.isDefault;
 
 /**
@@ -105,18 +104,6 @@ interface EventMixin
         EventContext context = context();
         boolean result = context.hasRejection() || !isDefault(context.getRejection());
         return result;
-    }
-
-    /**
-     * Checks if this event is imported.
-     *
-     * <p>An event can be imported into a system, for example, from a third-party system. In such
-     * case, the event does not have an "origin" signal.
-     *
-     * @return {@code true} if the given event is imported, {@code false} otherwise
-     */
-    default boolean isImported() {
-        return context().getOriginCase() == IMPORT_CONTEXT;
     }
 
     /**

--- a/core/src/main/java/io/spine/core/EventMixin.java
+++ b/core/src/main/java/io/spine/core/EventMixin.java
@@ -82,14 +82,14 @@ interface EventMixin
      * <p>In case the {@code Event} is a reaction to another {@code Event},
      * the identifier of the very first command in this chain is returned.
      *
-     * <p>Throws an {@code IllegalStateException} if the root signal is not a command.
-     *
      * @return the root command ID
+     * @throws IllegalStateException
+     *         if the root signal is not a command
      * @deprecated If an event is imported, it does not have a command ID and this method fails.
-     *             Use {@link #rootMessage()}.
+     *         Use {@link #rootMessage()}.
      */
     @Deprecated
-    default CommandId rootCommandId() {
+    default CommandId rootCommandId() throws IllegalStateException {
         return context().getPastMessage()
                         .root()
                         .asCommandId();

--- a/core/src/main/java/io/spine/core/EventMixin.java
+++ b/core/src/main/java/io/spine/core/EventMixin.java
@@ -61,8 +61,7 @@ interface EventMixin
     default MessageId rootMessage() {
         EventContext.OriginCase origin = context().getOriginCase();
         return origin == PAST_MESSAGE
-               ? context().getPastMessage()
-                          .root()
+               ? context().getPastMessage().root()
                : messageId();
     }
 

--- a/core/src/main/java/io/spine/core/EventMixin.java
+++ b/core/src/main/java/io/spine/core/EventMixin.java
@@ -61,7 +61,8 @@ interface EventMixin
     default MessageId rootMessage() {
         EventContext.OriginCase origin = context().getOriginCase();
         return origin == PAST_MESSAGE
-               ? context().getPastMessage().root()
+               ? context().getPastMessage()
+                          .root()
                : messageId();
     }
 
@@ -75,15 +76,39 @@ interface EventMixin
     /**
      * Obtains the ID of the root command, which lead to this event.
      *
-     * <p> In case the {@code Event} is a reaction to another {@code Event},
+     * <p>In case the {@code Event} is a reaction to another {@code Event},
      * the identifier of the very first command in this chain is returned.
      *
+     * <p>Throws an {@code IllegalStateException} if the root signal is not a command.
+     *
      * @return the root command ID
+     * @deprecated If an event is imported, it does not have a command ID and this method fails.
+     *             Use {@link #rootCommand()}.
      */
+    @Deprecated
     default CommandId rootCommandId() {
         return context().getPastMessage()
                         .root()
                         .asCommandId();
+    }
+
+    /**
+     * Obtains the ID of the root command, which lead to this event.
+     *
+     * <p>In case the {@code Event} is a reaction to another {@code Event}, the identifier of
+     * the very first command in this chain is returned.
+     *
+     * <p>If the root signal is an {@code Event} imported into the system, there can be no root
+     * {@code Command} and the method returns {@code empty}.
+     *
+     * @return the root command ID or {@code Optional.empty()} if the root message is
+     * not a {@code Command}
+     */
+    default Optional<CommandId> rootCommand() {
+        MessageId root = rootMessage();
+        return root.isCommand()
+               ? Optional.of(root.asCommandId())
+               : Optional.empty();
     }
 
     /**

--- a/license-report.md
+++ b/license-report.md
@@ -415,7 +415,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 13:19:42 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 15:33:03 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -791,7 +791,7 @@ This report was generated on **Wed Feb 19 13:19:42 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 13:19:43 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 15:33:04 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1206,7 +1206,7 @@ This report was generated on **Wed Feb 19 13:19:43 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 13:19:43 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 15:33:04 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1681,7 +1681,7 @@ This report was generated on **Wed Feb 19 13:19:43 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 13:19:44 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 15:33:05 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2113,7 +2113,7 @@ This report was generated on **Wed Feb 19 13:19:44 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 13:19:44 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 15:33:05 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2586,7 +2586,7 @@ This report was generated on **Wed Feb 19 13:19:44 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 13:19:47 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 15:33:08 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3067,7 +3067,7 @@ This report was generated on **Wed Feb 19 13:19:47 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 13:19:48 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 15:33:10 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3584,4 +3584,4 @@ This report was generated on **Wed Feb 19 13:19:48 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 13:19:51 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 15:33:14 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -415,7 +415,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Feb 18 18:42:57 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 13:19:42 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -791,7 +791,7 @@ This report was generated on **Tue Feb 18 18:42:57 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Feb 18 18:42:57 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 13:19:43 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1206,7 +1206,7 @@ This report was generated on **Tue Feb 18 18:42:57 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Feb 18 18:42:58 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 13:19:43 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1681,7 +1681,7 @@ This report was generated on **Tue Feb 18 18:42:58 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Feb 18 18:42:58 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 13:19:44 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2113,7 +2113,7 @@ This report was generated on **Tue Feb 18 18:42:58 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Feb 18 18:42:59 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 13:19:44 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2586,7 +2586,7 @@ This report was generated on **Tue Feb 18 18:42:59 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Feb 18 18:43:01 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 13:19:47 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3067,7 +3067,7 @@ This report was generated on **Tue Feb 18 18:43:01 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Feb 18 18:43:03 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 13:19:48 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3584,4 +3584,4 @@ This report was generated on **Tue Feb 18 18:43:03 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Feb 18 18:43:05 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 13:19:51 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -415,7 +415,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Feb 18 17:19:41 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 18:42:57 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -791,7 +791,7 @@ This report was generated on **Tue Feb 18 17:19:41 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Feb 18 17:19:42 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 18:42:57 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1206,7 +1206,7 @@ This report was generated on **Tue Feb 18 17:19:42 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Feb 18 17:19:42 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 18:42:58 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1681,7 +1681,7 @@ This report was generated on **Tue Feb 18 17:19:42 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Feb 18 17:19:43 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 18:42:58 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2113,7 +2113,7 @@ This report was generated on **Tue Feb 18 17:19:43 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Feb 18 17:19:44 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 18:42:59 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2586,7 +2586,7 @@ This report was generated on **Tue Feb 18 17:19:44 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Feb 18 17:19:46 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 18:43:01 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3067,7 +3067,7 @@ This report was generated on **Tue Feb 18 17:19:46 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Feb 18 17:19:47 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 18:43:03 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3584,4 +3584,4 @@ This report was generated on **Tue Feb 18 17:19:47 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Feb 18 17:19:50 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 18:43:05 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.4.6`
+# Dependencies of `io.spine:spine-client:1.4.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -415,12 +415,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Feb 15 11:13:07 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 17:19:41 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.4.6`
+# Dependencies of `io.spine:spine-core:1.4.7`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -791,12 +791,12 @@ This report was generated on **Sat Feb 15 11:13:07 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Feb 15 11:13:08 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 17:19:42 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.4.6`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.4.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1206,12 +1206,12 @@ This report was generated on **Sat Feb 15 11:13:08 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Feb 15 11:13:08 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 17:19:42 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.4.6`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.4.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1681,12 +1681,12 @@ This report was generated on **Sat Feb 15 11:13:08 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Feb 15 11:13:09 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 17:19:43 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.4.6`
+# Dependencies of `io.spine:spine-server:1.4.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2113,12 +2113,12 @@ This report was generated on **Sat Feb 15 11:13:09 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Feb 15 11:13:09 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 17:19:44 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.4.6`
+# Dependencies of `io.spine:spine-testutil-client:1.4.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2586,12 +2586,12 @@ This report was generated on **Sat Feb 15 11:13:09 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Feb 15 11:13:12 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 17:19:46 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.4.6`
+# Dependencies of `io.spine:spine-testutil-core:1.4.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3067,12 +3067,12 @@ This report was generated on **Sat Feb 15 11:13:12 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Feb 15 11:13:14 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 17:19:47 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.4.6`
+# Dependencies of `io.spine:spine-testutil-server:1.4.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3584,4 +3584,4 @@ This report was generated on **Sat Feb 15 11:13:14 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Feb 15 11:13:17 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 17:19:50 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -415,7 +415,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 15:33:03 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 16:08:16 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -791,7 +791,7 @@ This report was generated on **Wed Feb 19 15:33:03 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 15:33:04 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 16:08:16 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1206,7 +1206,7 @@ This report was generated on **Wed Feb 19 15:33:04 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 15:33:04 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 16:08:17 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1681,7 +1681,7 @@ This report was generated on **Wed Feb 19 15:33:04 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 15:33:05 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 16:08:17 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2113,7 +2113,7 @@ This report was generated on **Wed Feb 19 15:33:05 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 15:33:05 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 16:08:18 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2586,7 +2586,7 @@ This report was generated on **Wed Feb 19 15:33:05 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 15:33:08 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 16:08:21 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3067,7 +3067,7 @@ This report was generated on **Wed Feb 19 15:33:08 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 15:33:10 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 16:08:22 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3584,4 +3584,4 @@ This report was generated on **Wed Feb 19 15:33:10 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 15:33:14 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 19 16:08:26 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.4.6</version>
+<version>1.4.7</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/event/RejectionEnvelope.java
+++ b/server/src/main/java/io/spine/server/event/RejectionEnvelope.java
@@ -58,6 +58,7 @@ public final class RejectionEnvelope
      * <p>Represented by a packed {@link com.google.protobuf.StringValue StringValue} of
      * {@code "Unknown"}.
      */
+    @SuppressWarnings("DuplicateStringLiteralInspection") // Coincidence
     private static final Any DEFAULT_EVENT_PRODUCER = Identifier.pack("Unknown");
 
     private final EventEnvelope event;

--- a/server/src/test/java/io/spine/core/EventTest.java
+++ b/server/src/test/java/io/spine/core/EventTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 import static io.spine.protobuf.AnyPacker.pack;
 import static io.spine.server.type.given.EventsTestEnv.commandContext;
 import static io.spine.server.type.given.EventsTestEnv.event;
@@ -127,8 +128,8 @@ public class EventTest extends UtilityClassTest<Events> {
             CommandEnvelope command = generate();
             Event event = newEvent(command);
 
-            assertThat(event.rootCommandId())
-                    .isEqualTo(command.id());
+            assertThat(event.rootCommand())
+                    .hasValue(command.id());
         }
 
         @Test

--- a/server/src/test/java/io/spine/core/EventTest.java
+++ b/server/src/test/java/io/spine/core/EventTest.java
@@ -43,7 +43,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 import static io.spine.protobuf.AnyPacker.pack;
 import static io.spine.server.type.given.EventsTestEnv.commandContext;
 import static io.spine.server.type.given.EventsTestEnv.event;
@@ -128,8 +127,8 @@ public class EventTest extends UtilityClassTest<Events> {
             CommandEnvelope command = generate();
             Event event = newEvent(command);
 
-            assertThat(event.rootCommand())
-                    .hasValue(command.id());
+            assertThat(event.rootMessage().asCommandId())
+                    .isEqualTo(command.id());
         }
 
         @Test

--- a/server/src/test/java/io/spine/server/aggregate/AggregateTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateTest.java
@@ -715,10 +715,7 @@ public class AggregateTest {
 
         private ProtoSubject assertNextCommandId() {
             Event event = history.next();
-            Optional<CommandId> commandId = event.rootCommand();
-            assertThat(commandId)
-                    .isPresent();
-            return assertThat(commandId.get());
+            return assertThat(event.rootMessage().asCommandId());
         }
 
         @Test

--- a/server/src/test/java/io/spine/server/aggregate/AggregateTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateTest.java
@@ -30,6 +30,7 @@ import io.spine.base.Identifier;
 import io.spine.base.Time;
 import io.spine.core.Ack;
 import io.spine.core.Command;
+import io.spine.core.CommandId;
 import io.spine.core.Event;
 import io.spine.core.MessageId;
 import io.spine.core.TenantId;
@@ -87,11 +88,13 @@ import org.junit.jupiter.api.Test;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
 import static io.spine.grpc.StreamObservers.noOpObserver;
 import static io.spine.protobuf.AnyPacker.unpack;
@@ -711,7 +714,11 @@ public class AggregateTest {
         }
 
         private ProtoSubject assertNextCommandId() {
-            return assertThat(history.next().rootCommandId());
+            Event event = history.next();
+            Optional<CommandId> commandId = event.rootCommand();
+            assertThat(commandId)
+                    .isPresent();
+            return assertThat(commandId.get());
         }
 
         @Test

--- a/server/src/test/java/io/spine/server/event/EventRootCommandIdTest.java
+++ b/server/src/test/java/io/spine/server/event/EventRootCommandIdTest.java
@@ -44,7 +44,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 import static io.spine.grpc.StreamObservers.memoizingObserver;
 import static io.spine.grpc.StreamObservers.noOpObserver;
 import static io.spine.server.event.given.EventRootCommandIdTestEnv.TENANT_ID;
@@ -141,8 +140,8 @@ public class EventRootCommandIdTest {
          * Asserts that the ID of the passed command is the root command ID of the passed event.
          */
         private void assertIsRootCommand(Command command, Event event) {
-            assertThat(event.rootCommand())
-                    .hasValue(command.getId());
+            assertThat(event.rootMessage())
+                    .isEqualTo(command.messageId());
         }
     }
 
@@ -174,8 +173,8 @@ public class EventRootCommandIdTest {
             assertThat(events).hasSize(2);
 
             Event reaction = events.get(1);
-            assertThat(reaction.rootCommand())
-                    .hasValue(command.id());
+            assertThat(reaction.rootMessage())
+                    .isEqualTo(command.messageId());
         }
 
         /**
@@ -202,8 +201,8 @@ public class EventRootCommandIdTest {
             assertThat(events).hasSize(2);
 
             Event reaction = events.get(1);
-            assertThat(reaction.rootCommand())
-                    .hasValue(command.id());
+            assertThat(reaction.rootMessage())
+                    .isEqualTo(command.messageId());
 
         }
     }

--- a/server/src/test/java/io/spine/server/event/EventRootCommandIdTest.java
+++ b/server/src/test/java/io/spine/server/event/EventRootCommandIdTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 import static io.spine.grpc.StreamObservers.memoizingObserver;
 import static io.spine.grpc.StreamObservers.noOpObserver;
 import static io.spine.server.event.given.EventRootCommandIdTestEnv.TENANT_ID;
@@ -140,8 +141,8 @@ public class EventRootCommandIdTest {
          * Asserts that the ID of the passed command is the root command ID of the passed event.
          */
         private void assertIsRootCommand(Command command, Event event) {
-            assertThat(event.rootCommandId())
-                    .isEqualTo(command.getId());
+            assertThat(event.rootCommand())
+                    .hasValue(command.getId());
         }
     }
 
@@ -173,8 +174,8 @@ public class EventRootCommandIdTest {
             assertThat(events).hasSize(2);
 
             Event reaction = events.get(1);
-            assertThat(reaction.rootCommandId())
-                    .isEqualTo(command.id());
+            assertThat(reaction.rootCommand())
+                    .hasValue(command.id());
         }
 
         /**
@@ -201,8 +202,8 @@ public class EventRootCommandIdTest {
             assertThat(events).hasSize(2);
 
             Event reaction = events.get(1);
-            assertThat(reaction.rootCommandId())
-                    .isEqualTo(command.id());
+            assertThat(reaction.rootCommand())
+                    .hasValue(command.id());
 
         }
     }

--- a/server/src/test/java/io/spine/server/event/EventRootMessageIdTest.java
+++ b/server/src/test/java/io/spine/server/event/EventRootMessageIdTest.java
@@ -58,6 +58,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static io.spine.grpc.StreamObservers.memoizingObserver;
 import static io.spine.grpc.StreamObservers.noOpObserver;
+import static io.spine.protobuf.AnyPacker.pack;
 import static io.spine.protobuf.AnyPacker.unpack;
 import static io.spine.server.event.EventFactory.forImport;
 import static io.spine.server.event.given.EventRootCommandIdTestEnv.TENANT_ID;
@@ -127,6 +128,7 @@ public class EventRootMessageIdTest {
         Event invalidEvent = Event
                 .newBuilder()
                 .setId(Events.generateId())
+                .setMessage(pack(GivenEvent.message()))
                 .buildPartial();
         assertThat(invalidEvent.rootMessage())
                 .isEqualTo(invalidEvent.messageId());

--- a/server/src/test/java/io/spine/server/event/EventRootMessageIdTest.java
+++ b/server/src/test/java/io/spine/server/event/EventRootMessageIdTest.java
@@ -29,6 +29,7 @@ import io.spine.core.Command;
 import io.spine.core.CommandContext;
 import io.spine.core.CommandId;
 import io.spine.core.Event;
+import io.spine.core.Events;
 import io.spine.core.MessageId;
 import io.spine.core.UserId;
 import io.spine.grpc.MemoizingObserver;
@@ -118,6 +119,17 @@ public class EventRootMessageIdTest {
                 .isEqualTo(event.messageId());
         assertThat(event.context().rootMessage())
                 .isEmpty();
+    }
+
+    @Test
+    @DisplayName("be equal to the event's own ID by default")
+    void empty() {
+        Event invalidEvent = Event
+                .newBuilder()
+                .setId(Events.generateId())
+                .buildPartial();
+        assertThat(invalidEvent.rootMessage())
+                .isEqualTo(invalidEvent.messageId());
     }
 
     @Nested

--- a/server/src/test/java/io/spine/server/event/given/EventRootCommandIdTestEnv.java
+++ b/server/src/test/java/io/spine/server/event/given/EventRootCommandIdTestEnv.java
@@ -33,7 +33,7 @@ import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.AggregateRepository;
 import io.spine.server.aggregate.Apply;
 import io.spine.server.command.Assign;
-import io.spine.server.event.EventRootCommandIdTest;
+import io.spine.server.event.EventRootMessageIdTest;
 import io.spine.server.event.EventStreamQuery;
 import io.spine.server.event.React;
 import io.spine.server.procman.ProcessManager;
@@ -74,7 +74,7 @@ public class EventRootCommandIdTestEnv {
     public static final TenantId TENANT_ID = tenantId();
 
     private static final TestActorRequestFactory requestFactory =
-            new TestActorRequestFactory(EventRootCommandIdTest.class, TENANT_ID);
+            new TestActorRequestFactory(EventRootMessageIdTest.class, TENANT_ID);
 
     /** Prevents instantiation of this utility class. */
     private EventRootCommandIdTestEnv() {
@@ -180,7 +180,7 @@ public class EventRootCommandIdTestEnv {
     /**
      * Routes the {@link ProjectCreated} event to the {@link TeamAggregate} the project belongs to.
      * This is done for the purposes of the
-     * {@linkplain EventRootCommandIdTest.MatchExternalEventHandledBy#aggregate()} test.
+     * {@linkplain EventRootMessageIdTest.MatchExternalEventHandledBy#aggregate()} test.
      */
     public static class TeamAggregateRepository
             extends AggregateRepository<EvTeamId, TeamAggregate> {
@@ -205,7 +205,7 @@ public class EventRootCommandIdTestEnv {
     /**
      * Routes the {@link EvInvitationAccepted} event to the {@link TeamCreationProcessManager} which
      * created the invitation. This is done for the purposes of the
-     * {@linkplain EventRootCommandIdTest.MatchExternalEventHandledBy#processManager()} test.
+     * {@linkplain EventRootMessageIdTest.MatchExternalEventHandledBy#processManager()} test.
      */
     public static final class TeamCreationRepository
             extends ProcessManagerRepository<EvTeamId, TeamCreationProcessManager, EvTeamCreation> {

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.4.6'
+final def spineVersion = '1.4.7'
 
 ext {
     // The version of the modules in this project.


### PR DESCRIPTION
The current methods `Event.rootCommandId()` and `Event.rootMessage()` do not account for:
 - events imported via `ImportBus`;
 - events which do not have `Origin` in there `EventContext`, i.e. the old format events.

The method `Event.rootCommandId()` is being deprecated and the method `Event.rootMessage()` is being adjusted to support old-format events.