### PR TITLE
Existing entity migration API

### DIFF
--- a/client/src/main/java/io/spine/client/CompositeQueryFilter.java
+++ b/client/src/main/java/io/spine/client/CompositeQueryFilter.java
@@ -20,6 +20,7 @@
 
 package io.spine.client;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.spine.base.EntityState;
 import io.spine.client.CompositeFilter.CompositeOperator;
 
@@ -64,5 +65,11 @@ public final class CompositeQueryFilter extends TypedCompositeFilter<EntityState
         checkNotNull(first);
         checkNotNull(rest);
         return new CompositeQueryFilter(asList(first, rest), EITHER);
+    }
+
+    @VisibleForTesting
+    @Override
+    public CompositeFilter value() {
+        return super.value();
     }
 }

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.4.8`
+# Dependencies of `io.spine:spine-client:1.4.9`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -415,12 +415,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Feb 21 15:36:05 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 23 21:01:45 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.4.8`
+# Dependencies of `io.spine:spine-core:1.4.9`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -791,12 +791,12 @@ This report was generated on **Fri Feb 21 15:36:05 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Feb 21 15:36:06 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 23 21:01:46 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.4.8`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.4.9`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1206,12 +1206,12 @@ This report was generated on **Fri Feb 21 15:36:06 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Feb 21 15:36:06 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 23 21:01:47 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.4.8`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.4.9`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1681,12 +1681,12 @@ This report was generated on **Fri Feb 21 15:36:06 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Feb 21 15:36:07 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 23 21:01:49 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.4.8`
+# Dependencies of `io.spine:spine-server:1.4.9`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2113,12 +2113,12 @@ This report was generated on **Fri Feb 21 15:36:07 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Feb 21 15:36:08 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 23 21:01:50 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.4.8`
+# Dependencies of `io.spine:spine-testutil-client:1.4.9`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2586,12 +2586,12 @@ This report was generated on **Fri Feb 21 15:36:08 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Feb 21 15:36:13 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 23 21:01:52 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.4.8`
+# Dependencies of `io.spine:spine-testutil-core:1.4.9`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3067,12 +3067,12 @@ This report was generated on **Fri Feb 21 15:36:13 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Feb 21 15:36:15 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 23 21:01:54 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.4.8`
+# Dependencies of `io.spine:spine-testutil-server:1.4.9`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3584,4 +3584,4 @@ This report was generated on **Fri Feb 21 15:36:15 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Feb 21 15:36:19 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 23 21:01:58 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.4.7`
+# Dependencies of `io.spine:spine-client:1.4.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -415,12 +415,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 16:08:16 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 13:13:45 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.4.7`
+# Dependencies of `io.spine:spine-core:1.4.8`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -791,12 +791,12 @@ This report was generated on **Wed Feb 19 16:08:16 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 16:08:16 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 13:13:45 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.4.7`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.4.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1206,12 +1206,12 @@ This report was generated on **Wed Feb 19 16:08:16 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 16:08:17 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 13:13:45 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.4.7`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.4.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1681,12 +1681,12 @@ This report was generated on **Wed Feb 19 16:08:17 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 16:08:17 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 13:13:45 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.4.7`
+# Dependencies of `io.spine:spine-server:1.4.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2113,12 +2113,12 @@ This report was generated on **Wed Feb 19 16:08:17 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 16:08:18 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 13:13:46 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.4.7`
+# Dependencies of `io.spine:spine-testutil-client:1.4.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2586,12 +2586,12 @@ This report was generated on **Wed Feb 19 16:08:18 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 16:08:21 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 13:13:47 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.4.7`
+# Dependencies of `io.spine:spine-testutil-core:1.4.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3067,12 +3067,12 @@ This report was generated on **Wed Feb 19 16:08:21 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 16:08:22 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 13:13:48 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.4.7`
+# Dependencies of `io.spine:spine-testutil-server:1.4.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3584,4 +3584,4 @@ This report was generated on **Wed Feb 19 16:08:22 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Feb 19 16:08:26 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Feb 20 13:13:50 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.4.8</version>
+<version>1.4.9</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -70,25 +70,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.4.6</version>
+    <version>1.4.7</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-time</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.7</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.4.6</version>
+    <version>1.4.7</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.4.6</version>
+    <version>1.4.7</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -130,25 +130,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.4.6</version>
+    <version>1.4.7</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-time</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.7</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.4.6</version>
+    <version>1.4.7</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.4.6</version>
+    <version>1.4.7</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -210,12 +210,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>1.4.6</version>
+    <version>1.4.7</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.4.6</version>
+    <version>1.4.7</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.4.7</version>
+<version>1.4.8</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/entity/Migration.java
+++ b/server/src/main/java/io/spine/server/entity/Migration.java
@@ -30,11 +30,6 @@ import java.util.function.Consumer;
  *
  * @param <E>
  *         the entity type
- *
- * @apiNote An entity migration is considered a purely technical procedure and is not a valid
- *        <strong>domain</strong> reason for an entity to change. Thus, it does not advance an
- *        entity version and is not supposed to invoke any standard routines that are invoked on
- *        entity change (distribution of system events, delivery of subscription updates, etc.).
  */
 public interface Migration<E extends Entity<?, ?>> extends Consumer<E> {
 

--- a/server/src/main/java/io/spine/server/entity/Migration.java
+++ b/server/src/main/java/io/spine/server/entity/Migration.java
@@ -25,8 +25,11 @@ import java.util.function.Consumer;
 /**
  * A stored {@link Entity} transformation done to account for the domain model changes.
  *
- * <p>Being a {@link Consumer}, the migration is expected to be performed in place, on a given
+ * <p>Being a {@link Consumer}, the migration is expected to occur in place, on a given
  * {@link Entity} instance.
+ *
+ * <p>A performed migration is always preceded by an {@link Entity} load by ID and is finalized by
+ * {@linkplain Repository#store(Entity) saving} the transformed entity back into the storage.
  *
  * @param <E>
  *         the entity type

--- a/server/src/main/java/io/spine/server/entity/Migration.java
+++ b/server/src/main/java/io/spine/server/entity/Migration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.entity;
+
+import java.util.function.Consumer;
+
+/**
+ * A stored {@link Entity} transformation done to account for the domain model changes.
+ *
+ * <p>Being a {@link Consumer}, the migration is expected to be performed in place, on a given
+ * {@link Entity} instance.
+ *
+ * @param <E>
+ *         the entity type
+ *
+ * @apiNote An entity migration is considered a purely technical procedure and is not a valid
+ *        <strong>domain</strong> reason for an entity to change. Thus, it does not advance an
+ *        entity version and is not supposed to invoke any standard routines that are invoked on
+ *        entity change (distribution of system events, delivery of subscription updates, etc.).
+ */
+public interface Migration<E extends Entity<?, ?>> extends Consumer<E> {
+
+    /**
+     * Performs an entity migration.
+     *
+     * <p>This method is a syntactic sugar for more natural looking API.
+     */
+    default void apply(E entity) {
+        accept(entity);
+    }
+}

--- a/server/src/main/java/io/spine/server/entity/Migration.java
+++ b/server/src/main/java/io/spine/server/entity/Migration.java
@@ -28,8 +28,8 @@ import java.util.function.Consumer;
  * <p>Being a {@link Consumer}, the migration is expected to occur in place, on a given
  * {@link Entity} instance.
  *
- * <p>A performed migration is always preceded by an {@link Entity} load by ID and is finalized by
- * {@linkplain Repository#store(Entity) saving} the transformed entity back into the storage.
+ * <p>The performed migration is always preceded by an {@link Entity} load by ID and is finalized
+ * by {@linkplain Repository#store(Entity) saving} the transformed entity back into the storage.
  *
  * @param <E>
  *         the entity type

--- a/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
+++ b/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
@@ -126,7 +126,7 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
     }
 
     /**
-     * Applies a {@link Migration} operation to entities with the given IDs.
+     * Applies a {@link Migration} operation to multiple entities in batch.
      *
      * @see #applyMigration(I, Migration)
      */

--- a/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
+++ b/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
@@ -131,6 +131,9 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
      * @see #applyMigration(I, Migration)
      */
     public final void applyMigration(Set<I> ids, Migration<E> migration) {
+        checkNotNull(ids);
+        checkNotNull(migration);
+
         TargetFilters filters = Targets.someOf(entityModelClass().stateClass(), ids)
                                        .getFilters();
         Iterator<E> entities = find(filters, ResponseFormat.getDefaultInstance());

--- a/server/src/main/java/io/spine/server/entity/Repository.java
+++ b/server/src/main/java/io/spine/server/entity/Repository.java
@@ -125,6 +125,33 @@ public abstract class Repository<I, E extends Entity<I, ?>>
     public abstract Optional<E> find(I id);
 
     /**
+     * Applies a given {@link Migration} operation to the entity with the given ID.
+     *
+     * <p>The operation is performed in three steps:
+     * <ol>
+     *     <li>Load an entity by the given ID.
+     *     <li>Apply the migration operation to it in place.
+     *     <li>Store the entity back to the repository.
+     * </ol>
+     *
+     * @throws IllegalArgumentException
+     *         if the entity with a given ID is not found in the repository
+     *
+     * @see Migration
+     */
+    public final void applyMigration(I id, Migration<E> migration) {
+        checkNotNull(id);
+        checkNotNull(migration);
+
+        Optional<E> found = find(id);
+        checkArgument(found.isPresent(),
+                      "An entity with ID `%s` is not found in the repository.", id);
+        E entity = found.get();
+        migration.apply(entity);
+        store(entity);
+    }
+
+    /**
      * Returns an iterator over the entities managed by the repository that match the passed filter.
      *
      * <p>The returned iterator does not support removal.

--- a/server/src/main/java/io/spine/server/entity/Repository.java
+++ b/server/src/main/java/io/spine/server/entity/Repository.java
@@ -125,12 +125,12 @@ public abstract class Repository<I, E extends Entity<I, ?>>
     public abstract Optional<E> find(I id);
 
     /**
-     * Applies a given {@link Migration} operation to the entity with the given ID.
+     * Applies a given {@link Migration} operation to an entity with the given ID.
      *
      * <p>The operation is performed in three steps:
      * <ol>
      *     <li>Load an entity by the given ID.
-     *     <li>Apply the migration operation to it in place.
+     *     <li>Transform it through the migration operation.
      *     <li>Store the entity back to the repository.
      * </ol>
      *

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -24,7 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Any;
-import com.google.protobuf.Descriptors;
+import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
 import com.google.protobuf.ProtocolMessageEnum;
 import io.spine.annotation.Internal;
@@ -479,16 +479,21 @@ public abstract class Transaction<I,
      * getter to the entity state.
      *
      * <p>The enum-typed columns require an additional conversion as the
-     * {@link Message.Builder#setField(Descriptors.FieldDescriptor, Object)} method should receive
+     * {@link Message.Builder#setField(FieldDescriptor, Object)} method should receive
      * a {@link com.google.protobuf.Descriptors.EnumValueDescriptor EnumValueDescriptor} instance
      * by the Protobuf rules.
      */
     private void propagateValue(InterfaceBasedColumn column, Message.Builder entityState) {
         Object value = column.valueIn(entity);
+        FieldDescriptor fieldDescriptor = column.protoField()
+                                                .descriptor();
+        if (value == null) {
+            value = fieldDescriptor.getDefaultValue();
+        }
         if (value instanceof ProtocolMessageEnum) {
             value = ((ProtocolMessageEnum) value).getValueDescriptor();
         }
-        entityState.setField(column.protoField().descriptor(), value);
+        entityState.setField(fieldDescriptor, value);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/entity/TransactionBasedMigration.java
+++ b/server/src/main/java/io/spine/server/entity/TransactionBasedMigration.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.entity;
+
+import io.spine.base.EntityState;
+import io.spine.protobuf.ValidatingBuilder;
+
+/**
+ * A migration operation that is tied to an entity {@link Transaction}.
+ *
+ * <p>The operation always ends with a transaction {@linkplain Transaction#commit() commit}.
+ *
+ * @param <I>
+ *         the type of entity identifiers
+ * @param <E>
+ *         the type of entity
+ * @param <S>
+ *         the type of entity state objects
+ * @param <B>
+ *         the type of a {@code ValidatingBuilder} for the entity state
+ */
+public abstract class TransactionBasedMigration<I,
+                                                E extends TransactionalEntity<I, S, B>,
+                                                S extends EntityState,
+                                                B extends ValidatingBuilder<S>>
+        implements Migration<E> {
+
+    @Override
+    public void accept(E entity) {
+        Transaction<I, E, S, B> tx = startTransaction(entity);
+        tx.commit();
+    }
+
+    /**
+     * Opens a new {@code Transaction} on the entity.
+     */
+    protected abstract Transaction<I, E, S, B> startTransaction(E entity);
+}

--- a/server/src/main/java/io/spine/server/entity/storage/Columns.java
+++ b/server/src/main/java/io/spine/server/entity/storage/Columns.java
@@ -128,9 +128,9 @@ public final class Columns {
      *
      * @implNote This method assumes that the {@linkplain InterfaceBasedColumn interface-based}
      *         column values are already propagated to the entity state as they are finalized by
-     *         the moment of transaction {@linkplain Transaction#commit() commit}. It thus extracts
-     *         values from the entity state directly, avoiding any recalculation to prevent
-     *         possible inconsistencies in the model as well as performance drops.
+     *         the moment of transaction {@linkplain Transaction#commit() commit}. The values are
+     *         thus extracted from the entity state directly, avoiding any recalculation to prevent
+     *         possible inconsistencies in the stored data as well as performance drops.
      */
     public Map<ColumnName, @Nullable Object> valuesIn(Entity<?, ?> source) {
         checkNotNull(source);

--- a/server/src/main/java/io/spine/server/entity/storage/Columns.java
+++ b/server/src/main/java/io/spine/server/entity/storage/Columns.java
@@ -122,8 +122,9 @@ public final class Columns {
      * Extracts column values from the entity.
      *
      * <p>The {@linkplain ColumnDeclaredInProto proto-based} columns are extracted from the entity
-     * state while the system columns are obtained from the entity itself via the corresponding
-     * getters.
+     * in case the entity implements the {@link io.spine.base.EntityWithColumns EntityWithColumns}
+     * interface or from the entity state if not. The system columns are always obtained from
+     * the entity itself via the corresponding getters.
      */
     public Map<ColumnName, @Nullable Object> valuesIn(Entity<?, ?> source) {
         checkNotNull(source);
@@ -135,7 +136,7 @@ public final class Columns {
                 (name, column) -> result.put(name, column.valueIn(source.state()))
         );
         interfaceBasedColumns.forEach(
-                (name, column) -> result.put(name, column.valueIn(source.state()))
+                (name, column) -> result.put(name, column.valueIn(source))
         );
         return result;
     }

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerColumnsUpdate.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerColumnsUpdate.java
@@ -22,18 +22,23 @@ package io.spine.server.procman;
 
 import io.spine.base.EntityState;
 import io.spine.protobuf.ValidatingBuilder;
+import io.spine.server.entity.Migration;
 import io.spine.server.entity.Transaction;
 import io.spine.server.entity.TransactionBasedMigration;
 
 /**
  * A migration operation that does the update of interface-based columns of a process manager.
  *
+ * <p>When {@linkplain io.spine.server.entity.Repository#applyMigration(I, Migration) applied} to
+ * an entity, this operation will trigger the recalculation of entity storage fields according to
+ * the current implementation of {@link io.spine.base.EntityWithColumns}-derived methods.
+ *
  * <p>The operation relies on the fact that column values are calculated and propagated to the
  * entity state on a transaction {@linkplain Transaction#commit() commit}.
  *
  * @apiNote An entity columns update is considered a purely technical procedure and is not a valid
  *        <strong>domain</strong> reason for an entity to change. Thus, it does not advance an
- *        entity version and does not invoke any standard routines that are invoked on entity
+ *        entity version and does not trigger any standard routines that are invoked on entity
  *        change (distribution of system events, delivery of subscription updates, etc.).
  *
  * @see io.spine.server.entity.storage.InterfaceBasedColumn

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerColumnsUpdate.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerColumnsUpdate.java
@@ -31,7 +31,7 @@ import io.spine.server.entity.TransactionBasedMigration;
  * <p>The operation relies on the fact that column values are calculated and propagated to the
  * entity state on a transaction {@linkplain Transaction#commit() commit}.
  *
- * @apiNote The entity columns update is considered a purely technical procedure and is not a valid
+ * @apiNote An entity columns update is considered a purely technical procedure and is not a valid
  *        <strong>domain</strong> reason for an entity to change. Thus, it does not advance an
  *        entity version and does not invoke any standard routines that are invoked on entity
  *        change (distribution of system events, delivery of subscription updates, etc.).

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerColumnsUpdate.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerColumnsUpdate.java
@@ -31,12 +31,12 @@ import io.spine.server.entity.TransactionBasedMigration;
  * <p>The operation relies on the fact that column values are calculated and propagated to the
  * entity state on a transaction {@linkplain Transaction#commit() commit}.
  *
- * @apiNote The entity columns update is considered a purely technical procedure and not a valid
+ * @apiNote The entity columns update is considered a purely technical procedure and is not a valid
  *        <strong>domain</strong> reason for an entity to change. Thus, it does not advance an
  *        entity version and does not invoke any standard routines that are invoked on entity
  *        change (distribution of system events, delivery of subscription updates, etc.).
  *
- * @see io.spine.server.entity.storage.InterfaceBasedColumn the interface-based column definition
+ * @see io.spine.server.entity.storage.InterfaceBasedColumn
  */
 public final class ProcessManagerColumnsUpdate<I,
                                                P extends ProcessManager<I, S, B>,

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerColumnsUpdate.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerColumnsUpdate.java
@@ -28,9 +28,13 @@ import io.spine.server.entity.TransactionBasedMigration;
 /**
  * A migration operation that does the update of interface-based columns of a process manager.
  *
- * @implNote As interface-based columns get recalculated and propagated to the entity state on a
- *         transaction {@linkplain Transaction#commit() commit}, all this migration operation does
- *         is starting a new {@link Transaction}.
+ * <p>The operation relies on the fact that column values are calculated and propagated to the
+ * entity state on a transaction {@linkplain Transaction#commit() commit}.
+ *
+ * @apiNote The entity columns update is considered a purely technical procedure and not a valid
+ *        <strong>domain</strong> reason for an entity to change. Thus, it does not advance an
+ *        entity version and does not invoke any standard routines that are invoked on entity
+ *        change (distribution of system events, delivery of subscription updates, etc.).
  *
  * @see io.spine.server.entity.storage.InterfaceBasedColumn the interface-based column definition
  */

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerColumnsUpdate.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerColumnsUpdate.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.procman;
+
+import io.spine.base.EntityState;
+import io.spine.protobuf.ValidatingBuilder;
+import io.spine.server.entity.Transaction;
+import io.spine.server.entity.TransactionBasedMigration;
+
+/**
+ * A migration operation that does the update of interface-based columns of a process manager.
+ *
+ * @implNote As interface-based columns get recalculated and propagated to the entity state on a
+ *         transaction {@linkplain Transaction#commit() commit}, all this migration operation does
+ *         is starting a new {@link Transaction}.
+ *
+ * @see io.spine.server.entity.storage.InterfaceBasedColumn the interface-based column definition
+ */
+public final class ProcessManagerColumnsUpdate<I,
+                                               P extends ProcessManager<I, S, B>,
+                                               S extends EntityState,
+                                               B extends ValidatingBuilder<S>>
+        extends TransactionBasedMigration<I, P, S, B> {
+
+    @SuppressWarnings("unchecked") // Logically correct.
+    @Override
+    protected Transaction<I, P, S, B> startTransaction(P processManager) {
+        PmTransaction<I, S, B> tx = new PmTransaction<>(processManager);
+        return (Transaction<I, P, S, B>) tx;
+    }
+}

--- a/server/src/main/java/io/spine/server/projection/ProjectionColumnsUpdate.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionColumnsUpdate.java
@@ -31,7 +31,7 @@ import io.spine.server.entity.TransactionBasedMigration;
  * <p>The operation relies on the fact that column values are calculated and propagated to the
  * entity state on a transaction {@linkplain Transaction#commit() commit}.
  *
- * @apiNote The entity columns update is considered a purely technical procedure and is not a valid
+ * @apiNote An entity columns update is considered a purely technical procedure and is not a valid
  *        <strong>domain</strong> reason for an entity to change. Thus, it does not advance an
  *        entity version and does not invoke any standard routines that are invoked on entity
  *        change (distribution of system events, delivery of subscription updates, etc.).

--- a/server/src/main/java/io/spine/server/projection/ProjectionColumnsUpdate.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionColumnsUpdate.java
@@ -22,18 +22,23 @@ package io.spine.server.projection;
 
 import io.spine.base.EntityState;
 import io.spine.protobuf.ValidatingBuilder;
+import io.spine.server.entity.Migration;
 import io.spine.server.entity.Transaction;
 import io.spine.server.entity.TransactionBasedMigration;
 
 /**
  * A migration operation that does the update of interface-based columns of a projection.
  *
+ * <p>When {@linkplain io.spine.server.entity.Repository#applyMigration(I, Migration) applied} to
+ * an entity, this operation will trigger the recalculation of entity storage fields according to
+ * the current implementation of {@link io.spine.base.EntityWithColumns}-derived methods.
+ *
  * <p>The operation relies on the fact that column values are calculated and propagated to the
  * entity state on a transaction {@linkplain Transaction#commit() commit}.
  *
  * @apiNote An entity columns update is considered a purely technical procedure and is not a valid
  *        <strong>domain</strong> reason for an entity to change. Thus, it does not advance an
- *        entity version and does not invoke any standard routines that are invoked on entity
+ *        entity version and does not trigger any standard routines that are invoked on entity
  *        change (distribution of system events, delivery of subscription updates, etc.).
  *
  * @see io.spine.server.entity.storage.InterfaceBasedColumn

--- a/server/src/main/java/io/spine/server/projection/ProjectionColumnsUpdate.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionColumnsUpdate.java
@@ -31,12 +31,12 @@ import io.spine.server.entity.TransactionBasedMigration;
  * <p>The operation relies on the fact that column values are calculated and propagated to the
  * entity state on a transaction {@linkplain Transaction#commit() commit}.
  *
- * @apiNote The entity columns update is considered a purely technical procedure and not a valid
+ * @apiNote The entity columns update is considered a purely technical procedure and is not a valid
  *        <strong>domain</strong> reason for an entity to change. Thus, it does not advance an
  *        entity version and does not invoke any standard routines that are invoked on entity
  *        change (distribution of system events, delivery of subscription updates, etc.).
  *
- * @see io.spine.server.entity.storage.InterfaceBasedColumn the interface-based column definition
+ * @see io.spine.server.entity.storage.InterfaceBasedColumn
  */
 public final class ProjectionColumnsUpdate<I,
         P extends Projection<I, S, B>,

--- a/server/src/main/java/io/spine/server/projection/ProjectionColumnsUpdate.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionColumnsUpdate.java
@@ -28,9 +28,13 @@ import io.spine.server.entity.TransactionBasedMigration;
 /**
  * A migration operation that does the update of interface-based columns of a projection.
  *
- * @implNote As interface-based columns get recalculated and propagated to the entity state on a
- *         transaction {@linkplain Transaction#commit() commit}, all this migration operation does
- *         is starting a new {@link Transaction}.
+ * <p>The operation relies on the fact that column values are calculated and propagated to the
+ * entity state on a transaction {@linkplain Transaction#commit() commit}.
+ *
+ * @apiNote The entity columns update is considered a purely technical procedure and not a valid
+ *        <strong>domain</strong> reason for an entity to change. Thus, it does not advance an
+ *        entity version and does not invoke any standard routines that are invoked on entity
+ *        change (distribution of system events, delivery of subscription updates, etc.).
  *
  * @see io.spine.server.entity.storage.InterfaceBasedColumn the interface-based column definition
  */

--- a/server/src/main/java/io/spine/server/projection/ProjectionColumnsUpdate.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionColumnsUpdate.java
@@ -39,9 +39,9 @@ import io.spine.server.entity.TransactionBasedMigration;
  * @see io.spine.server.entity.storage.InterfaceBasedColumn
  */
 public final class ProjectionColumnsUpdate<I,
-        P extends Projection<I, S, B>,
-        S extends EntityState,
-        B extends ValidatingBuilder<S>>
+                                           P extends Projection<I, S, B>,
+                                           S extends EntityState,
+                                           B extends ValidatingBuilder<S>>
         extends TransactionBasedMigration<I, P, S, B> {
 
     @SuppressWarnings("unchecked") // Logically correct.

--- a/server/src/main/java/io/spine/server/projection/ProjectionColumnsUpdate.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionColumnsUpdate.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.projection;
+
+import io.spine.base.EntityState;
+import io.spine.protobuf.ValidatingBuilder;
+import io.spine.server.entity.Transaction;
+import io.spine.server.entity.TransactionBasedMigration;
+
+/**
+ * A migration operation that does the update of interface-based columns of a projection.
+ *
+ * @implNote As interface-based columns get recalculated and propagated to the entity state on a
+ *         transaction {@linkplain Transaction#commit() commit}, all this migration operation does
+ *         is starting a new {@link Transaction}.
+ *
+ * @see io.spine.server.entity.storage.InterfaceBasedColumn the interface-based column definition
+ */
+public final class ProjectionColumnsUpdate<I,
+        P extends Projection<I, S, B>,
+        S extends EntityState,
+        B extends ValidatingBuilder<S>>
+        extends TransactionBasedMigration<I, P, S, B> {
+
+    @SuppressWarnings("unchecked") // Logically correct.
+    @Override
+    protected Transaction<I, P, S, B> startTransaction(P entity) {
+        return (Transaction<I, P, S, B>) ProjectionTransaction.start(entity);
+    }
+}

--- a/server/src/test/java/io/spine/server/entity/given/tx/TxProjection.java
+++ b/server/src/test/java/io/spine/server/entity/given/tx/TxProjection.java
@@ -28,6 +28,7 @@ import io.spine.server.entity.given.tx.event.TxCreated;
 import io.spine.server.entity.given.tx.event.TxErrorRequested;
 import io.spine.server.entity.given.tx.event.TxStateErrorRequested;
 import io.spine.server.projection.Projection;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.List;
 
@@ -43,8 +44,15 @@ public final class TxProjection
 
     private final List<Message> receivedEvents = newLinkedList();
 
-    public TxProjection(Id id) {
+    private final boolean isNullType;
+
+    public TxProjection(Id id, boolean isNullType) {
         super(id);
+        this.isNullType = isNullType;
+    }
+
+    public TxProjection(Id id) {
+        this(id, false);
     }
 
     @Subscribe
@@ -83,7 +91,10 @@ public final class TxProjection
     }
 
     @Override
-    public ProjectionType getType() {
+    public @Nullable ProjectionType getType() {
+        if (isNullType) {
+            return null;
+        }
         return VERY_USEFUL;
     }
 }

--- a/server/src/test/java/io/spine/server/entity/storage/ColumnsTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ColumnsTest.java
@@ -22,9 +22,11 @@ package io.spine.server.entity.storage;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.NullPointerTester;
+import com.google.protobuf.Timestamp;
 import io.spine.server.entity.storage.given.TaskListViewProjection;
 import io.spine.server.entity.storage.given.TaskViewProjection;
 import io.spine.server.storage.LifecycleFlagField;
+import io.spine.test.entity.TaskView;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -118,14 +120,10 @@ class ColumnsTest {
                 ColumnName.of("archived"), projection.isArchived(),
                 ColumnName.of("deleted"), projection.isDeleted(),
                 ColumnName.of("version"), projection.version(),
-                ColumnName.of("name"), projection.state()
-                                                 .getName(),
-                ColumnName.of("estimate_in_days"), projection.state()
-                                                             .getEstimateInDays(),
-                ColumnName.of("status"), projection.state()
-                                                   .getStatus(),
-                ColumnName.of("due_date"), projection.state()
-                                                     .getDueDate()
+                ColumnName.of("name"), "some-name",
+                ColumnName.of("estimate_in_days"), 42,
+                ColumnName.of("status"), TaskView.Status.CREATED,
+                ColumnName.of("due_date"), Timestamp.getDefaultInstance()
         );
     }
 

--- a/server/src/test/java/io/spine/server/entity/storage/ColumnsTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ColumnsTest.java
@@ -22,11 +22,9 @@ package io.spine.server.entity.storage;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.NullPointerTester;
-import com.google.protobuf.Timestamp;
 import io.spine.server.entity.storage.given.TaskListViewProjection;
 import io.spine.server.entity.storage.given.TaskViewProjection;
 import io.spine.server.storage.LifecycleFlagField;
-import io.spine.test.entity.TaskView;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -120,10 +118,14 @@ class ColumnsTest {
                 ColumnName.of("archived"), projection.isArchived(),
                 ColumnName.of("deleted"), projection.isDeleted(),
                 ColumnName.of("version"), projection.version(),
-                ColumnName.of("name"), "some-name",
-                ColumnName.of("estimate_in_days"), 42,
-                ColumnName.of("status"), TaskView.Status.CREATED,
-                ColumnName.of("due_date"), Timestamp.getDefaultInstance()
+                ColumnName.of("name"), projection.state()
+                                                 .getName(),
+                ColumnName.of("estimate_in_days"), projection.state()
+                                                             .getEstimateInDays(),
+                ColumnName.of("status"), projection.state()
+                                                   .getStatus(),
+                ColumnName.of("due_date"), projection.state()
+                                                     .getDueDate()
         );
     }
 

--- a/server/src/test/java/io/spine/server/entity/storage/given/TaskViewProjection.java
+++ b/server/src/test/java/io/spine/server/entity/storage/given/TaskViewProjection.java
@@ -49,6 +49,6 @@ public final class TaskViewProjection
 
     @Override
     public Timestamp getDueDate() {
-        return Timestamp.getDefaultInstance();
+        return state().getDueDate();
     }
 }

--- a/server/src/test/java/io/spine/server/procman/ProcessManagerRepositoryTest.java
+++ b/server/src/test/java/io/spine/server/procman/ProcessManagerRepositoryTest.java
@@ -635,7 +635,6 @@ class ProcessManagerRepositoryTest
         }
     }
 
-
     @Test
     @DisplayName("update columns via migration operation")
     void updateColumns() {

--- a/server/src/test/java/io/spine/server/procman/ProcessManagerRepositoryTest.java
+++ b/server/src/test/java/io/spine/server/procman/ProcessManagerRepositoryTest.java
@@ -695,7 +695,7 @@ class ProcessManagerRepositoryTest
         // Apply the column update to two of the three entities.
         repository.applyMigration(ImmutableSet.of(id1, id2), new ProcessManagerColumnsUpdate<>());
 
-        // Check that entities to which migration has been applied now have column values updated.
+        // Check that entities to which the migration has been applied now have columns updated.
         QueryFilter filter1 = QueryFilter.eq(Project.Column.idString(), id1.toString());
         QueryFilter filter2 = QueryFilter.eq(Project.Column.idString(), id2.toString());
         QueryFilter filter3 = QueryFilter.eq(Project.Column.idString(), id3.toString());

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.4.7'
+final def spineVersion = '1.4.8'
 
 ext {
     // The version of the modules in this project.

--- a/version.gradle
+++ b/version.gradle
@@ -25,15 +25,15 @@
  * as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.4.8'
+final def spineVersion = '1.4.9'
 
 ext {
     // The version of the modules in this project.
     versionToPublish = spineVersion
 
     // Depend on `base` for the general definitions and a model compiler.
-    spineBaseVersion = '1.4.6'
+    spineBaseVersion = '1.4.7'
 
     // Depend on `time` for `ZoneId`, `ZoneOffset` and other date/time types and utilities.
-    spineTimeVersion = '1.4.1'
+    spineTimeVersion = '1.4.7'
 }


### PR DESCRIPTION
This PR adds the API for the existing entities transformation in order to account for the latest model changes. 

As a particular case of this migration, the PR adds the operations which perform the interface-based entity columns update for projections and process managers.

### Applying the migration operation

The `Repository` API is extended with the `applyMigration(entityId, migration)` method, which looks up an existing entity by ID and applies a `Migration` operation to it, before storing it back to the repository.

The `Migration` is a `Consumer` of a single entity instance which applies some transformations to the entity in place.

All `RecordBasedRepository` descendants support applying the migration operation to entities in batch, as they have ways to store/look up multiple entity records.

### Entity columns update

The two `Migration`s currently implemented are `ProjectionColumnsUpdate` and `ProcessManagerColumnsUpdate`. They trigger the recalculation of interface-based columns of an entity, propagating the new values to the stored fields as well as the serialized entity state.

The column update can be applied as follows:
```java
// Projection.
projectionRepository.applyMigration(ImmutableSet.of(id1, id2), new ProjectionColumnsUpdate<>());

// Process manager.
pmRepository.applyMigration(ImmutableSet.of(id1, id2), new ProcessManagerColumnsUpdate<>());
```

### Other

Spine version advances to `1.4.9`.