### PR TITLE
Reduce `CommandBus`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -415,7 +415,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Mar 04 15:47:54 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 13:10:20 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -791,7 +791,7 @@ This report was generated on **Wed Mar 04 15:47:54 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Mar 04 15:47:55 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 13:10:21 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1206,7 +1206,7 @@ This report was generated on **Wed Mar 04 15:47:55 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Mar 04 15:47:56 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 13:10:21 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1681,7 +1681,7 @@ This report was generated on **Wed Mar 04 15:47:56 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Mar 04 15:47:57 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 13:10:22 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2113,7 +2113,7 @@ This report was generated on **Wed Mar 04 15:47:57 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Mar 04 15:47:58 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 13:10:22 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2586,7 +2586,7 @@ This report was generated on **Wed Mar 04 15:47:58 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Mar 04 15:48:00 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 13:10:25 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3067,7 +3067,7 @@ This report was generated on **Wed Mar 04 15:48:00 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Mar 04 15:48:02 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 13:10:26 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3584,4 +3584,4 @@ This report was generated on **Wed Mar 04 15:48:02 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Mar 04 15:48:05 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 13:10:29 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.4.11`
+# Dependencies of `io.spine:spine-client:1.4.12`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -415,12 +415,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Mar 05 13:10:20 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 15:25:30 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.4.11`
+# Dependencies of `io.spine:spine-core:1.4.12`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -791,12 +791,12 @@ This report was generated on **Thu Mar 05 13:10:20 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Mar 05 13:10:21 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 15:25:30 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.4.11`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.4.12`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1206,12 +1206,12 @@ This report was generated on **Thu Mar 05 13:10:21 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Mar 05 13:10:21 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 15:25:31 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.4.11`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.4.12`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1681,12 +1681,12 @@ This report was generated on **Thu Mar 05 13:10:21 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Mar 05 13:10:22 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 15:25:31 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.4.11`
+# Dependencies of `io.spine:spine-server:1.4.12`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2113,12 +2113,12 @@ This report was generated on **Thu Mar 05 13:10:22 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Mar 05 13:10:22 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 15:25:32 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.4.11`
+# Dependencies of `io.spine:spine-testutil-client:1.4.12`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2586,12 +2586,12 @@ This report was generated on **Thu Mar 05 13:10:22 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Mar 05 13:10:25 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 15:25:34 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.4.11`
+# Dependencies of `io.spine:spine-testutil-core:1.4.12`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3067,12 +3067,12 @@ This report was generated on **Thu Mar 05 13:10:25 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Mar 05 13:10:26 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 15:25:36 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.4.11`
+# Dependencies of `io.spine:spine-testutil-server:1.4.12`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3584,4 +3584,4 @@ This report was generated on **Thu Mar 05 13:10:26 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Mar 05 13:10:29 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 15:25:39 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.4.11</version>
+<version>1.4.12</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -70,7 +70,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.4.9</version>
+    <version>1.4.10</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -82,13 +82,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.4.9</version>
+    <version>1.4.10</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.4.9</version>
+    <version>1.4.10</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -130,7 +130,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.4.9</version>
+    <version>1.4.10</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -142,13 +142,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.4.9</version>
+    <version>1.4.10</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.4.9</version>
+    <version>1.4.10</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -210,12 +210,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>1.4.9</version>
+    <version>1.4.10</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.4.9</version>
+    <version>1.4.10</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/server/src/main/java/io/spine/server/commandbus/CommandValidator.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandValidator.java
@@ -24,14 +24,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.spine.annotation.Internal;
 import io.spine.base.CommandMessage;
-import io.spine.base.Identifier;
 import io.spine.core.Command;
-import io.spine.core.CommandContext;
 import io.spine.core.CommandId;
 import io.spine.core.MessageInvalid;
 import io.spine.core.TenantId;
 import io.spine.server.bus.EnvelopeValidator;
-import io.spine.server.route.DefaultCommandRoute;
 import io.spine.server.type.CommandEnvelope;
 import io.spine.validate.ConstraintViolation;
 import io.spine.validate.Validate;
@@ -58,10 +55,6 @@ import static io.spine.server.commandbus.InvalidCommandException.onConstraintVio
  * </ol>
  */
 final class CommandValidator implements EnvelopeValidator<CommandEnvelope> {
-
-    /** Default route for validating command message fields. */
-    private static final DefaultCommandRoute<Object> defaultRoute =
-            DefaultCommandRoute.newInstance(Object.class);
 
     private final CommandBus commandBus;
 
@@ -156,7 +149,6 @@ final class CommandValidator implements EnvelopeValidator<CommandEnvelope> {
             validateId();
             validateMessage();
             validateContext();
-            validateTargetId();
             return result.build();
         }
 
@@ -179,19 +171,6 @@ final class CommandValidator implements EnvelopeValidator<CommandEnvelope> {
         private void validateContext() {
             if (isDefault(command.context())) {
                 addViolation("Non-default command context must be set.");
-            }
-        }
-
-        private void validateTargetId() {
-            CommandMessage message = command.message();
-            if (!DefaultCommandRoute.exists(message)) {
-                addViolation("The command message does not have a field with a command target ID.");
-                return;
-            }
-
-            Object target = defaultRoute.apply(message, CommandContext.getDefaultInstance());
-            if (Identifier.isEmpty(target)) {
-                addViolation("Command target ID cannot be empty.");
             }
         }
 

--- a/server/src/test/java/io/spine/server/commandbus/CommandValidatorViolationCheckTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandValidatorViolationCheckTest.java
@@ -21,6 +21,7 @@
 package io.spine.server.commandbus;
 
 import com.google.common.truth.Correspondence;
+import com.google.common.truth.IterableSubject;
 import com.google.protobuf.Any;
 import io.spine.base.Time;
 import io.spine.core.Command;
@@ -45,6 +46,12 @@ import static io.spine.testing.core.given.GivenCommandContext.withRandomActor;
 
 @DisplayName("CommandValidator violation check should")
 class CommandValidatorViolationCheckTest {
+
+    private static final Correspondence<@NonNull ConstraintViolation, @NonNull String>
+            messageFormatContains = Correspondence.from(
+                    (actual, expected) -> actual.getMsgFormat().contains(expected),
+                    "has message format"
+            );
 
     @Test
     @DisplayName("validate command and return empty violations list if command is valid")
@@ -84,7 +91,8 @@ class CommandValidatorViolationCheckTest {
 
         List<ConstraintViolation> violations = inspectCommand(commandWithEmptyMessage);
 
-        assertThat(violations)
+        IterableSubject assertViolations = assertThat(violations);
+        assertViolations
                 .hasSize(2);
     }
 
@@ -99,7 +107,6 @@ class CommandValidatorViolationCheckTest {
                 .build();
 
         List<ConstraintViolation> violations = inspectCommand(commandWithoutContext);
-
         assertThat(violations)
                 .hasSize(1);
     }
@@ -110,12 +117,6 @@ class CommandValidatorViolationCheckTest {
         TestActorRequestFactory factory = new TestActorRequestFactory(getClass());
         Command emptyCommand = factory.createCommand(CmdEmpty.getDefaultInstance());
         List<ConstraintViolation> violations = inspectCommand(emptyCommand);
-
-        Correspondence<@NonNull ConstraintViolation, @NonNull String> messageFormatContains =
-                Correspondence.from(
-                        (actual, expected) -> actual.getMsgFormat().contains(expected),
-                        "has message format"
-                );
         assertThat(violations)
                 .comparingElementsUsing(messageFormatContains)
                 .doesNotContain("command target ID");

--- a/server/src/test/java/io/spine/server/commandbus/CommandValidatorViolationCheckTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandValidatorViolationCheckTest.java
@@ -30,6 +30,7 @@ import io.spine.core.CommandId;
 import io.spine.protobuf.AnyPacker;
 import io.spine.server.type.CommandEnvelope;
 import io.spine.test.command.CmdEmpty;
+import io.spine.test.commandbus.command.CmdBusCreateLabels;
 import io.spine.test.commandbus.command.CmdBusCreateProject;
 import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.validate.ConstraintViolation;
@@ -120,6 +121,22 @@ class CommandValidatorViolationCheckTest {
         assertThat(violations)
                 .comparingElementsUsing(messageFormatContains)
                 .doesNotContain("command target ID");
+    }
+
+    @Test
+    @DisplayName("allow messages without an ID as a first field")
+    void noId() {
+        TestActorRequestFactory factory = new TestActorRequestFactory(getClass());
+        CmdBusCreateLabels msg = CmdBusCreateLabels
+                .newBuilder()
+                .addLabel("red")
+                .addLabel("green")
+                .addLabel("blue")
+                .vBuild();
+        Command command = factory.createCommand(msg);
+        List<ConstraintViolation> violations = inspectCommand(command);
+        assertThat(violations)
+                .isEmpty();
     }
 
     private static List<ConstraintViolation> inspectCommand(Command command) {

--- a/server/src/test/proto/spine/test/commandbus/commands.proto
+++ b/server/src/test/proto/spine/test/commandbus/commands.proto
@@ -77,3 +77,12 @@ message CmdBusSetTaskDescription {
     TaskId task_id = 1;
     string description = 3;
 }
+
+// A command to create multiple labels at once.
+//
+// The client does not know how this command is routed. When constructing a command message,
+// the client simply adds the label names. The server takes care of routing the command.
+//
+message CmdBusCreateLabels {
+    repeated string label = 1 [(required) = true];
+}

--- a/version.gradle
+++ b/version.gradle
@@ -25,14 +25,14 @@
  * as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.4.11'
+final def spineVersion = '1.4.12'
 
 ext {
     // The version of the modules in this project.
     versionToPublish = spineVersion
 
     // Depend on `base` for the general definitions and a model compiler.
-    spineBaseVersion = '1.4.9'
+    spineBaseVersion = '1.4.10'
 
     // Depend on `time` for `ZoneId`, `ZoneOffset` and other date/time types and utilities.
     spineTimeVersion = '1.4.7'


### PR DESCRIPTION
Previously, the `CommandBus` checked each command by attempting to route it with the default routing strategy — by the first field.

If a client wants to send a command and it not aware of the receiver, this approach can go wrong. For example, if the first field of a command message happens to be a `repeated`, the validation fails.

At the same time, command's target can override routing (e.g. a `Repository`) or not require one at all (e.g. `AbstractCommandHandler` descendants). It is not possible, however, to pass this information to the `CommandBus` level.

In this PR we remove this validation step.

After this change, if a command routing fails, we will still get an error and a system event. However, not the users will have more flexibility when defining command messages.