### PR TITLE
Extend `Filters` API with strongly-typed columns support

### DIFF
--- a/client/src/main/java/io/spine/client/Filters.java
+++ b/client/src/main/java/io/spine/client/Filters.java
@@ -26,11 +26,15 @@ import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
 import io.spine.annotation.Internal;
+import io.spine.base.EntityColumn;
+import io.spine.base.EntityStateField;
+import io.spine.base.EventMessageField;
 import io.spine.base.Field;
 import io.spine.base.FieldPath;
 import io.spine.client.CompositeFilter.CompositeOperator;
 import io.spine.code.proto.FieldName;
 import io.spine.core.Event;
+import io.spine.core.EventContextField;
 import io.spine.core.Version;
 
 import java.util.Collection;
@@ -82,6 +86,7 @@ import static java.util.Arrays.stream;
  * @see EntityStateFilter
  * @see EventFilter
  */
+@SuppressWarnings("ClassWithTooManyMethods") // A lot of method overloads for filter creation.
 public final class Filters {
 
     /** Prevents this utility class instantiation. */
@@ -95,7 +100,7 @@ public final class Filters {
      *         the field path or the entity column name for entity filters
      * @param value
      *         the requested value
-     * @return new instance of Filter
+     * @return a new instance of {@code Filter}
      */
     public static Filter eq(String fieldPath, Object value) {
         checkNotNull(fieldPath);
@@ -104,21 +109,155 @@ public final class Filters {
     }
 
     /**
+     * Creates a new equality {@link Filter}.
+     *
+     * @param column
+     *         the entity column to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter eq(EntityColumn column, Object value) {
+        checkNotNull(column);
+        checkNotNull(value);
+        return QueryFilter.eq(column, value).filter();
+    }
+
+    /**
+     * Creates a new equality {@link Filter}.
+     *
+     * @param field
+     *         the entity state field to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter eq(EntityStateField field, Object value) {
+        checkNotNull(field);
+        checkNotNull(value);
+        return EntityStateFilter.eq(field, value).filter();
+    }
+
+    /**
+     * Creates a new equality {@link Filter}.
+     *
+     * @param field
+     *         the event message field to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter eq(EventMessageField field, Object value) {
+        checkNotNull(field);
+        checkNotNull(value);
+        return EventFilter.eq(field, value).filter();
+    }
+
+    /**
+     * Creates a new equality {@link Filter}.
+     *
+     * <p>The field path in the filter will be automatically prepended with {@code "context."} to
+     * enable filtering by {@linkplain io.spine.core.EventContext event context}.
+     *
+     * @param field
+     *         the event context field to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter eq(EventContextField field, Object value) {
+        checkNotNull(field);
+        checkNotNull(value);
+        return EventFilter.eq(field, value).filter();
+    }
+
+    /**
      * Creates a new "greater than" {@link Filter}.
      *
-     * <p>For the supported types description see <a href="#types">Comparison types section</a>.
+     * <p>For the supported types description, see <a href="#types">Comparison types section</a>.
      *
      * @param fieldPath
      *         the field path or the entity column name for entity filters
      * @param value
      *         the requested value
-     * @return new instance of Filter
+     * @return a new instance of {@code Filter}
      */
     public static Filter gt(String fieldPath, Object value) {
         checkNotNull(fieldPath);
         checkNotNull(value);
         checkSupportedOrderingComparisonType(value.getClass());
         return createFilter(fieldPath, value, GREATER_THAN);
+    }
+
+    /**
+     * Creates a new "greater than" {@link Filter}.
+     *
+     * <p>For the supported types description, see <a href="#types">Comparison types section</a>.
+     *
+     * @param column
+     *         the entity column to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter gt(EntityColumn column, Object value) {
+        checkNotNull(column);
+        checkNotNull(value);
+        return QueryFilter.gt(column, value).filter();
+    }
+
+    /**
+     * Creates a new "greater than" {@link Filter}.
+     *
+     * <p>For the supported types description, see <a href="#types">Comparison types section</a>.
+     *
+     * @param field
+     *         the entity state field to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter gt(EntityStateField field, Object value) {
+        checkNotNull(field);
+        checkNotNull(value);
+        return EntityStateFilter.gt(field, value).filter();
+    }
+
+    /**
+     * Creates a new "greater than" {@link Filter}.
+     *
+     * <p>For the supported types description, see <a href="#types">Comparison types section</a>.
+     *
+     * @param field
+     *         the event message field to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter gt(EventMessageField field, Object value) {
+        checkNotNull(field);
+        checkNotNull(value);
+        return EventFilter.gt(field, value).filter();
+    }
+
+    /**
+     * Creates a new "greater than" {@link Filter}.
+     *
+     * <p>The field path in the filter will be automatically prepended with {@code "context."} to
+     * enable filtering by {@linkplain io.spine.core.EventContext event context}.
+     *
+     * <p>For the supported types description, see <a href="#types">Comparison types section</a>.
+     *
+     * @param field
+     *         the event context field to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter gt(EventContextField field, Object value) {
+        checkNotNull(field);
+        checkNotNull(value);
+        return EventFilter.gt(field, value).filter();
     }
 
     /**
@@ -130,13 +269,84 @@ public final class Filters {
      *         the field path or the entity column name for entity filters
      * @param value
      *         the requested value
-     * @return new instance of Filter
+     * @return a new instance of {@code Filter}
      */
     public static Filter lt(String fieldPath, Object value) {
         checkNotNull(fieldPath);
         checkNotNull(value);
         checkSupportedOrderingComparisonType(value.getClass());
         return createFilter(fieldPath, value, LESS_THAN);
+    }
+
+    /**
+     * Creates a new "less than" {@link Filter}.
+     *
+     * <p>For the supported types description, see <a href="#types">Comparison types section</a>.
+     *
+     * @param column
+     *         the entity column to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter lt(EntityColumn column, Object value) {
+        checkNotNull(column);
+        checkNotNull(value);
+        return QueryFilter.lt(column, value).filter();
+    }
+
+    /**
+     * Creates a new "less than" {@link Filter}.
+     *
+     * <p>For the supported types description, see <a href="#types">Comparison types section</a>.
+     *
+     * @param field
+     *         the entity state field to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter lt(EntityStateField field, Object value) {
+        checkNotNull(field);
+        checkNotNull(value);
+        return EntityStateFilter.lt(field, value).filter();
+    }
+
+    /**
+     * Creates a new "less than" {@link Filter}.
+     *
+     * <p>For the supported types description, see <a href="#types">Comparison types section</a>.
+     *
+     * @param field
+     *         the event message field to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter lt(EventMessageField field, Object value) {
+        checkNotNull(field);
+        checkNotNull(value);
+        return EventFilter.lt(field, value).filter();
+    }
+
+    /**
+     * Creates a new "less than" {@link Filter}.
+     *
+     * <p>The field path in the filter will be automatically prepended with {@code "context."} to
+     * enable filtering by {@linkplain io.spine.core.EventContext event context}.
+     *
+     * <p>For the supported types description, see <a href="#types">Comparison types section</a>.
+     *
+     * @param field
+     *         the event context field to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter lt(EventContextField field, Object value) {
+        checkNotNull(field);
+        checkNotNull(value);
+        return EventFilter.lt(field, value).filter();
     }
 
     /**
@@ -148,13 +358,84 @@ public final class Filters {
      *         the field path or the entity column name for entity filters
      * @param value
      *         the requested value
-     * @return new instance of Filter
+     * @return a new instance of {@code Filter}
      */
     public static Filter ge(String fieldPath, Object value) {
         checkNotNull(fieldPath);
         checkNotNull(value);
         checkSupportedOrderingComparisonType(value.getClass());
         return createFilter(fieldPath, value, GREATER_OR_EQUAL);
+    }
+
+    /**
+     * Creates a new "greater or equal" {@link Filter}.
+     *
+     * <p>See <a href="#types">Comparison types</a> section for the supported types description.
+     *
+     * @param column
+     *         the entity column to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter ge(EntityColumn column, Object value) {
+        checkNotNull(column);
+        checkNotNull(value);
+        return QueryFilter.ge(column, value).filter();
+    }
+
+    /**
+     * Creates a new "greater or equal" {@link Filter}.
+     *
+     * <p>See <a href="#types">Comparison types</a> section for the supported types description.
+     *
+     * @param field
+     *         the entity state field to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter ge(EntityStateField field, Object value) {
+        checkNotNull(field);
+        checkNotNull(value);
+        return EntityStateFilter.ge(field, value).filter();
+    }
+
+    /**
+     * Creates a new "greater or equal" {@link Filter}.
+     *
+     * <p>See <a href="#types">Comparison types</a> section for the supported types description.
+     *
+     * @param field
+     *         the event message field to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter ge(EventMessageField field, Object value) {
+        checkNotNull(field);
+        checkNotNull(value);
+        return EventFilter.ge(field, value).filter();
+    }
+
+    /**
+     * Creates a new "greater or equal" {@link Filter}.
+     *
+     * <p>The field path in the filter will be automatically prepended with {@code "context."} to
+     * enable filtering by {@linkplain io.spine.core.EventContext event context}.
+     *
+     * <p>See <a href="#types">Comparison types</a> section for the supported types description.
+     *
+     * @param field
+     *         the event context field to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter ge(EventContextField field, Object value) {
+        checkNotNull(field);
+        checkNotNull(value);
+        return EventFilter.ge(field, value).filter();
     }
 
     /**
@@ -166,13 +447,84 @@ public final class Filters {
      *         the field path or the entity column name for entity filters
      * @param value
      *         the requested value
-     * @return new instance of Filter
+     * @return new instance of {@code Filter}
      */
     public static Filter le(String fieldPath, Object value) {
         checkNotNull(fieldPath);
         checkNotNull(value);
         checkSupportedOrderingComparisonType(value.getClass());
         return createFilter(fieldPath, value, LESS_OR_EQUAL);
+    }
+
+    /**
+     * Creates a new "less or equal" {@link Filter}.
+     *
+     * <p>See <a href="#types">Comparison types</a> section for the supported types description.
+     *
+     * @param column
+     *         the entity column to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter le(EntityColumn column, Object value) {
+        checkNotNull(column);
+        checkNotNull(value);
+        return QueryFilter.le(column, value).filter();
+    }
+
+    /**
+     * Creates a new "less or equal" {@link Filter}.
+     *
+     * <p>See <a href="#types">Comparison types</a> section for the supported types description.
+     *
+     * @param field
+     *         the entity state field to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter le(EntityStateField field, Object value) {
+        checkNotNull(field);
+        checkNotNull(value);
+        return EntityStateFilter.le(field, value).filter();
+    }
+
+    /**
+     * Creates a new "less or equal" {@link Filter}.
+     *
+     * <p>See <a href="#types">Comparison types</a> section for the supported types description.
+     *
+     * @param field
+     *         the event message field to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter le(EventMessageField field, Object value) {
+        checkNotNull(field);
+        checkNotNull(value);
+        return EventFilter.le(field, value).filter();
+    }
+
+    /**
+     * Creates a new "less or equal" {@link Filter}.
+     *
+     * <p>The field path in the filter will be automatically prepended with {@code "context."} to
+     * enable filtering by {@linkplain io.spine.core.EventContext event context}.
+     *
+     * <p>See <a href="#types">Comparison types</a> section for the supported types description.
+     *
+     * @param field
+     *         the event context field to filter by
+     * @param value
+     *         the requested value
+     * @return a new instance of {@code Filter}
+     */
+    public static Filter le(EventContextField field, Object value) {
+        checkNotNull(field);
+        checkNotNull(value);
+        return EventFilter.le(field, value).filter();
     }
 
     /**

--- a/client/src/main/java/io/spine/client/Filters.java
+++ b/client/src/main/java/io/spine/client/Filters.java
@@ -669,8 +669,8 @@ public final class Filters {
      * Creates a filter of events which can apply conditions from the passed
      * {@code CompositeFilter} to both event message and its context.
      *
-     * <p>The filter is deemed addressing the event context if the field path specified in it
-     * starts with the {@code "context."} prefix.
+     * <p>The filter is deemed addressing the {@linkplain io.spine.core.EventContext event context}
+     * if the field path specified in it starts with the {@code "context."} prefix.
      */
     @Internal
     public static Predicate<Event> toEventFilter(CompositeFilter filterData) {

--- a/client/src/main/java/io/spine/client/Filters.java
+++ b/client/src/main/java/io/spine/client/Filters.java
@@ -120,7 +120,7 @@ public final class Filters {
     public static Filter eq(EntityColumn column, Object value) {
         checkNotNull(column);
         checkNotNull(value);
-        return QueryFilter.eq(column, value).filter();
+        return createFilter(column.name(), value, EQUAL);
     }
 
     /**
@@ -135,7 +135,7 @@ public final class Filters {
     public static Filter eq(EntityStateField field, Object value) {
         checkNotNull(field);
         checkNotNull(value);
-        return EntityStateFilter.eq(field, value).filter();
+        return createFilter(field.getField(), value, EQUAL);
     }
 
     /**
@@ -150,7 +150,7 @@ public final class Filters {
     public static Filter eq(EventMessageField field, Object value) {
         checkNotNull(field);
         checkNotNull(value);
-        return EventFilter.eq(field, value).filter();
+        return createFilter(field.getField(), value, EQUAL);
     }
 
     /**
@@ -168,7 +168,7 @@ public final class Filters {
     public static Filter eq(EventContextField field, Object value) {
         checkNotNull(field);
         checkNotNull(value);
-        return EventFilter.eq(field, value).filter();
+        return createContextFilter(field.getField(), value, EQUAL);
     }
 
     /**
@@ -203,7 +203,7 @@ public final class Filters {
     public static Filter gt(EntityColumn column, Object value) {
         checkNotNull(column);
         checkNotNull(value);
-        return QueryFilter.gt(column, value).filter();
+        return createFilter(column.name(), value, GREATER_THAN);
     }
 
     /**
@@ -220,7 +220,7 @@ public final class Filters {
     public static Filter gt(EntityStateField field, Object value) {
         checkNotNull(field);
         checkNotNull(value);
-        return EntityStateFilter.gt(field, value).filter();
+        return createFilter(field.getField(), value, GREATER_THAN);
     }
 
     /**
@@ -237,7 +237,7 @@ public final class Filters {
     public static Filter gt(EventMessageField field, Object value) {
         checkNotNull(field);
         checkNotNull(value);
-        return EventFilter.gt(field, value).filter();
+        return createFilter(field.getField(), value, GREATER_THAN);
     }
 
     /**
@@ -257,7 +257,7 @@ public final class Filters {
     public static Filter gt(EventContextField field, Object value) {
         checkNotNull(field);
         checkNotNull(value);
-        return EventFilter.gt(field, value).filter();
+        return createContextFilter(field.getField(), value, GREATER_THAN);
     }
 
     /**
@@ -292,7 +292,7 @@ public final class Filters {
     public static Filter lt(EntityColumn column, Object value) {
         checkNotNull(column);
         checkNotNull(value);
-        return QueryFilter.lt(column, value).filter();
+        return createFilter(column.name(), value, LESS_THAN);
     }
 
     /**
@@ -309,7 +309,7 @@ public final class Filters {
     public static Filter lt(EntityStateField field, Object value) {
         checkNotNull(field);
         checkNotNull(value);
-        return EntityStateFilter.lt(field, value).filter();
+        return createFilter(field.getField(), value, LESS_THAN);
     }
 
     /**
@@ -326,7 +326,7 @@ public final class Filters {
     public static Filter lt(EventMessageField field, Object value) {
         checkNotNull(field);
         checkNotNull(value);
-        return EventFilter.lt(field, value).filter();
+        return createFilter(field.getField(), value, LESS_THAN);
     }
 
     /**
@@ -346,7 +346,7 @@ public final class Filters {
     public static Filter lt(EventContextField field, Object value) {
         checkNotNull(field);
         checkNotNull(value);
-        return EventFilter.lt(field, value).filter();
+        return createContextFilter(field.getField(), value, LESS_THAN);
     }
 
     /**
@@ -381,7 +381,7 @@ public final class Filters {
     public static Filter ge(EntityColumn column, Object value) {
         checkNotNull(column);
         checkNotNull(value);
-        return QueryFilter.ge(column, value).filter();
+        return createFilter(column.name(), value, GREATER_OR_EQUAL);
     }
 
     /**
@@ -398,7 +398,7 @@ public final class Filters {
     public static Filter ge(EntityStateField field, Object value) {
         checkNotNull(field);
         checkNotNull(value);
-        return EntityStateFilter.ge(field, value).filter();
+        return createFilter(field.getField(), value, GREATER_OR_EQUAL);
     }
 
     /**
@@ -415,7 +415,7 @@ public final class Filters {
     public static Filter ge(EventMessageField field, Object value) {
         checkNotNull(field);
         checkNotNull(value);
-        return EventFilter.ge(field, value).filter();
+        return createFilter(field.getField(), value, GREATER_OR_EQUAL);
     }
 
     /**
@@ -435,7 +435,7 @@ public final class Filters {
     public static Filter ge(EventContextField field, Object value) {
         checkNotNull(field);
         checkNotNull(value);
-        return EventFilter.ge(field, value).filter();
+        return createContextFilter(field.getField(), value, GREATER_OR_EQUAL);
     }
 
     /**
@@ -470,7 +470,7 @@ public final class Filters {
     public static Filter le(EntityColumn column, Object value) {
         checkNotNull(column);
         checkNotNull(value);
-        return QueryFilter.le(column, value).filter();
+        return createFilter(column.name(), value, LESS_OR_EQUAL);
     }
 
     /**
@@ -487,7 +487,7 @@ public final class Filters {
     public static Filter le(EntityStateField field, Object value) {
         checkNotNull(field);
         checkNotNull(value);
-        return EntityStateFilter.le(field, value).filter();
+        return createFilter(field.getField(), value, LESS_OR_EQUAL);
     }
 
     /**
@@ -504,7 +504,7 @@ public final class Filters {
     public static Filter le(EventMessageField field, Object value) {
         checkNotNull(field);
         checkNotNull(value);
-        return EventFilter.le(field, value).filter();
+        return createFilter(field.getField(), value, LESS_OR_EQUAL);
     }
 
     /**
@@ -524,7 +524,7 @@ public final class Filters {
     public static Filter le(EventContextField field, Object value) {
         checkNotNull(field);
         checkNotNull(value);
-        return EventFilter.le(field, value).filter();
+        return createContextFilter(field.getField(), value, LESS_OR_EQUAL);
     }
 
     /**

--- a/client/src/test/java/io/spine/client/FiltersTest.java
+++ b/client/src/test/java/io/spine/client/FiltersTest.java
@@ -21,14 +21,22 @@
 package io.spine.client;
 
 import com.google.common.testing.NullPointerTester;
+import com.google.protobuf.Any;
 import com.google.protobuf.DoubleValue;
 import com.google.protobuf.StringValue;
 import com.google.protobuf.Timestamp;
+import io.spine.base.EntityColumn;
+import io.spine.base.EntityStateField;
+import io.spine.base.EventMessageField;
 import io.spine.base.Field;
 import io.spine.base.FieldPath;
 import io.spine.client.Filter.Operator;
+import io.spine.core.EventContext;
+import io.spine.core.EventContextField;
 import io.spine.core.Version;
 import io.spine.core.Versions;
+import io.spine.test.client.ClProjectCreated;
+import io.spine.test.client.TestEntity;
 import io.spine.test.client.TestEntityOwner;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -59,6 +67,7 @@ import static io.spine.test.client.TestEntityOwner.Role.ADMIN;
 import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
 import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
 import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
+import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -138,6 +147,66 @@ class FiltersTest {
             assertEquals(FIELD, actual);
             assertEquals(pack(REQUESTED_VALUE), filter.getValue());
             assertEquals(operator, filter.getOperator());
+        }
+    }
+
+    @Nested
+    @DisplayName("create filter based on a typed")
+    class CreateFilterByTyped {
+
+        @Test
+        @DisplayName("column")
+        void column() {
+            EntityColumn column = TestEntity.Column.firstField();
+            String value = "expected-filter-value";
+            String expectedPath = column.name()
+                                        .value();
+            checkCreates(eq(column, value), expectedPath, value, EQUAL);
+        }
+
+        @Test
+        @DisplayName("entity state field")
+        void entityStateField() {
+            EntityStateField field = TestEntity.Field.thirdField();
+            int value = 142;
+            String expectedPath = field.getField()
+                                       .toString();
+            checkCreates(gt(field, value), expectedPath, value, GREATER_THAN);
+        }
+
+        @Test
+        @DisplayName("event message field")
+        void eventMessageField() {
+            EventMessageField field = ClProjectCreated.Field.name().value();
+            String value = "expected-project-name";
+            String expectedPath = field.getField()
+                                       .toString();
+            checkCreates(eq(field, value), expectedPath, value, EQUAL);
+        }
+
+        @Test
+        @DisplayName("event context field")
+        void eventContextField() {
+            EventContextField field = EventContext.Field.external();
+            boolean value = true;
+            String expectedPath = format("context.%s", field.getField());
+            checkCreates(eq(field, value), expectedPath, value, EQUAL);
+        }
+
+        private void checkCreates(Filter filter,
+                                  String expectedPath,
+                                  Object expectedValue,
+                                  Operator expectedOperator) {
+            String fieldPath = Field.withPath(filter.getFieldPath())
+                                    .toString();
+            assertThat(fieldPath).isEqualTo(expectedPath);
+
+            Any value = filter.getValue();
+            Any packedExpectedValue = toAny(expectedValue);
+            assertThat(value).isEqualTo(packedExpectedValue);
+
+            Operator operator = filter.getOperator();
+            assertThat(operator).isEqualTo(expectedOperator);
         }
     }
 

--- a/client/src/test/java/io/spine/client/FiltersTest.java
+++ b/client/src/test/java/io/spine/client/FiltersTest.java
@@ -91,6 +91,10 @@ class FiltersTest {
     void passNullToleranceCheck() {
         new NullPointerTester()
                 .setDefault(Filter.class, Filter.getDefaultInstance())
+                .setDefault(EntityColumn.class, TestEntity.Column.firstField())
+                .setDefault(EntityStateField.class, TestEntity.Field.owner())
+                .setDefault(EventMessageField.class, ClProjectCreated.Field.name())
+                .setDefault(EventContextField.class, EventContext.Field.pastMessage())
                 .testAllPublicStaticMethods(Filters.class);
     }
 

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.4.11`
+# Dependencies of `io.spine:spine-client:1.4.12`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -415,12 +415,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Mar 04 15:47:54 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 16:02:31 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.4.11`
+# Dependencies of `io.spine:spine-core:1.4.12`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -791,12 +791,12 @@ This report was generated on **Wed Mar 04 15:47:54 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Mar 04 15:47:55 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 16:02:32 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.4.11`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.4.12`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1206,12 +1206,12 @@ This report was generated on **Wed Mar 04 15:47:55 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Mar 04 15:47:56 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 16:02:32 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.4.11`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.4.12`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1681,12 +1681,12 @@ This report was generated on **Wed Mar 04 15:47:56 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Mar 04 15:47:57 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 16:02:33 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.4.11`
+# Dependencies of `io.spine:spine-server:1.4.12`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2113,12 +2113,12 @@ This report was generated on **Wed Mar 04 15:47:57 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Mar 04 15:47:58 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 16:02:34 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.4.11`
+# Dependencies of `io.spine:spine-testutil-client:1.4.12`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2586,12 +2586,12 @@ This report was generated on **Wed Mar 04 15:47:58 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Mar 04 15:48:00 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 16:02:37 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.4.11`
+# Dependencies of `io.spine:spine-testutil-core:1.4.12`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3067,12 +3067,12 @@ This report was generated on **Wed Mar 04 15:48:00 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Mar 04 15:48:02 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 16:02:38 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.4.11`
+# Dependencies of `io.spine:spine-testutil-server:1.4.12`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3584,4 +3584,4 @@ This report was generated on **Wed Mar 04 15:48:02 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Mar 04 15:48:05 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 16:02:42 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.4.12`
+# Dependencies of `io.spine:spine-client:1.4.13`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -415,12 +415,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Mar 05 16:02:31 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 18:26:36 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.4.12`
+# Dependencies of `io.spine:spine-core:1.4.13`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -791,12 +791,12 @@ This report was generated on **Thu Mar 05 16:02:31 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Mar 05 16:02:32 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 18:26:38 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.4.12`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.4.13`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1206,12 +1206,12 @@ This report was generated on **Thu Mar 05 16:02:32 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Mar 05 16:02:32 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 18:26:38 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.4.12`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.4.13`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1681,12 +1681,12 @@ This report was generated on **Thu Mar 05 16:02:32 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Mar 05 16:02:33 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 18:26:39 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.4.12`
+# Dependencies of `io.spine:spine-server:1.4.13`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2113,12 +2113,12 @@ This report was generated on **Thu Mar 05 16:02:33 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Mar 05 16:02:34 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 18:26:40 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.4.12`
+# Dependencies of `io.spine:spine-testutil-client:1.4.13`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2586,12 +2586,12 @@ This report was generated on **Thu Mar 05 16:02:34 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Mar 05 16:02:37 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 18:26:42 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.4.12`
+# Dependencies of `io.spine:spine-testutil-core:1.4.13`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3067,12 +3067,12 @@ This report was generated on **Thu Mar 05 16:02:37 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Mar 05 16:02:38 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 18:26:44 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.4.12`
+# Dependencies of `io.spine:spine-testutil-server:1.4.13`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3584,4 +3584,4 @@ This report was generated on **Thu Mar 05 16:02:38 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Mar 05 16:02:42 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 05 18:26:47 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.4.11</version>
+<version>1.4.12</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -70,7 +70,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.4.9</version>
+    <version>1.4.10</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -82,13 +82,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.4.9</version>
+    <version>1.4.10</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.4.9</version>
+    <version>1.4.10</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -130,7 +130,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.4.9</version>
+    <version>1.4.10</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -142,13 +142,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.4.9</version>
+    <version>1.4.10</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.4.9</version>
+    <version>1.4.10</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -210,12 +210,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>1.4.9</version>
+    <version>1.4.10</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.4.9</version>
+    <version>1.4.10</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.4.12</version>
+<version>1.4.13</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.4.12'
+final def spineVersion = '1.4.13'
 
 ext {
     // The version of the modules in this project.

--- a/version.gradle
+++ b/version.gradle
@@ -25,14 +25,14 @@
  * as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.4.11'
+final def spineVersion = '1.4.12'
 
 ext {
     // The version of the modules in this project.
     versionToPublish = spineVersion
 
     // Depend on `base` for the general definitions and a model compiler.
-    spineBaseVersion = '1.4.9'
+    spineBaseVersion = '1.4.10'
 
     // Depend on `time` for `ZoneId`, `ZoneOffset` and other date/time types and utilities.
     spineTimeVersion = '1.4.7'


### PR DESCRIPTION
This PR addresses #1244.

The `Filters` utility is extended with methods that allow to create `Filter` instances from strongly-typed columns and fields.

This should be convenient for users that do not rely on high-level `Client` API and use plain `QueryService`, `SubscriptionService`, etc. instead.

Spine version advances to `1.4.13`.