### PR TITLE
Make exceptions a bit more informative

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -74,6 +74,7 @@
     <inspection_tool class="BigDecimalEquals" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="BreakStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="BreakStatementWithLabel" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="BusyWait" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CallToNativeMethodWhileLocked" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CallToStringConcatCanBeReplacedByOperator" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CastConflictsWithInstanceof" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -214,6 +215,7 @@
       <option name="commentsAreContent" value="true" />
     </inspection_tool>
     <inspection_tool class="EmptyDirectory" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="EmptyInitializer" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="EmptySynchronizedStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="EnumSwitchStatementWhichMissesCases" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="TYPO" enabled="true">
@@ -250,6 +252,7 @@
       <option name="myCountEnumConstants" value="false" />
       <option name="m_limit" value="20" />
     </inspection_tool>
+    <inspection_tool class="FieldMayBeFinal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="FieldMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="FinalizeNotProtected" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="FloatingPointEquality" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -324,6 +327,7 @@
       <option name="ignoreAbstractClasses" value="true" />
     </inspection_tool>
     <inspection_tool class="InstanceofThis" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="InstantiationOfUtilityClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="IntLiteralMayBeLongLiteral" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="IntegerMultiplicationImplicitCastToLong" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreNonOverflowingCompileTimeConstants" value="true" />
@@ -336,6 +340,7 @@
     <inspection_tool class="InterfaceNeverImplemented" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreInterfacesThatOnlyDeclareConstants" value="true" />
     </inspection_tool>
+    <inspection_tool class="IteratorHasNextCallsIteratorNext" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="IteratorNextDoesNotThrowNoSuchElementException" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="JDBCExecuteWithNonConstantString" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="JDBCPrepareStatementWithNonConstantString" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -381,6 +386,7 @@
     <inspection_tool class="LabeledStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="LengthOneStringInIndexOf" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="LengthOneStringsInConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ListIndexOfReplaceableByContains" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ListenerMayUseAdapter" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="checkForEmptyMethods" value="true" />
     </inspection_tool>
@@ -468,7 +474,6 @@
       <option name="ignoreForLoopDeclarations" value="true" />
     </inspection_tool>
     <inspection_tool class="MultipleTopLevelClassesInFile" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MultipleVariablesInDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NakedNotify" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NativeMethods" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NestedAssignment" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -489,7 +494,6 @@
         <extension name="JUnit4MethodNamingConvention" enabled="true">
           <option name="m_regex" value="[a-z][A-Za-z\d]*" />
           <option name="m_minLength" value="2" />
-          <option name="m_maxLength" value="64" />
         </extension>
       </scope>
       <scope name="Production" level="WARNING" enabled="true">
@@ -633,15 +637,13 @@
       <option name="nameString" value="aa,abc,bad,bar,bar2,baz,baz1,baz2,baz3,bb,blah,bogus,bool,cc,dd,defau1t,dummy,dummy2,ee,fa1se,ff,foo,foo1,foo2,foo3,foobar,four,fred,fred1,fred2,gg,hh,hello,hello1,hello2,hello3,ii,nu11,one,silly,silly2,string,two,then,three,whi1e,var" />
     </inspection_tool>
     <inspection_tool class="RandomDoubleForRandomInteger" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="RawUseOfParameterizedType" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="ignoreParametersOfOverridingMethods" value="true" />
-    </inspection_tool>
     <inspection_tool class="ReadObjectAndWriteObjectPrivate" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="RedundantImplements" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreSerializable" value="false" />
       <option name="ignoreCloneable" value="false" />
     </inspection_tool>
     <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="RedundantSuppression" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
@@ -711,6 +713,9 @@
     <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SwitchStatementWithTooFewBranches" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="m_limit" value="2" />
+    </inspection_tool>
     <inspection_tool class="SwitchStatementsWithoutDefault" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreFullyCoveredEnums" value="true" />
     </inspection_tool>
@@ -727,11 +732,13 @@
     <inspection_tool class="SystemSetSecurityManager" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TailRecursion" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TestOnlyProblems" enabled="true" level="TYPO" enabled_by_default="true" />
+    <inspection_tool class="TextLabelInSwitchStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThisEscapedInConstructor" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadDeathRethrown" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadDumpStack" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadLocalNotStaticFinal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadPriority" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ThreadRun" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadStartInConstruction" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadStopSuspendResume" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadWithDefaultRunMethod" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -811,6 +818,13 @@
     <inspection_tool class="UnnecessaryQualifierForThis" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnnecessarySuperQualifier" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnnecessaryUnaryMinus" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="UnpredictableBigDecimalConstructorCall" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoreReferences" value="true" />
+      <option name="ignoreComplexLiterals" value="false" />
+    </inspection_tool>
+    <inspection_tool class="UnqualifiedInnerClassAccess" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreReferencesToLocalInnerClasses" value="true" />
+    </inspection_tool>
     <inspection_tool class="UnsecureRandomNumberGeneration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnstableApiUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="Tests" level="WEAK WARNING" enabled="false" />

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.5.3`
+# Dependencies of `io.spine:spine-client:1.5.4`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -415,12 +415,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 23 17:33:12 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 25 18:42:14 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.5.3`
+# Dependencies of `io.spine:spine-core:1.5.4`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -791,12 +791,12 @@ This report was generated on **Mon Mar 23 17:33:12 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 23 17:33:13 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 25 18:42:15 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.5.3`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.5.4`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1206,12 +1206,12 @@ This report was generated on **Mon Mar 23 17:33:13 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 23 17:33:13 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 25 18:42:15 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.5.3`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.5.4`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1681,12 +1681,12 @@ This report was generated on **Mon Mar 23 17:33:13 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 23 17:33:14 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 25 18:42:17 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.5.3`
+# Dependencies of `io.spine:spine-server:1.5.4`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2113,12 +2113,12 @@ This report was generated on **Mon Mar 23 17:33:14 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 23 17:33:14 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 25 18:42:18 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.5.3`
+# Dependencies of `io.spine:spine-testutil-client:1.5.4`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2586,12 +2586,12 @@ This report was generated on **Mon Mar 23 17:33:14 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 23 17:33:15 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 25 18:42:20 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.5.3`
+# Dependencies of `io.spine:spine-testutil-core:1.5.4`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3067,12 +3067,12 @@ This report was generated on **Mon Mar 23 17:33:15 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 23 17:33:16 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 25 18:42:21 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.5.3`
+# Dependencies of `io.spine:spine-testutil-server:1.5.4`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3584,4 +3584,4 @@ This report was generated on **Mon Mar 23 17:33:16 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 23 17:33:18 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 25 18:42:25 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.5.3</version>
+<version>1.5.4</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -64,7 +64,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Suppliers.memoize;
-import static com.google.protobuf.TextFormat.shortDebugString;
 import static io.spine.option.EntityOption.Kind.AGGREGATE;
 import static io.spine.server.aggregate.model.AggregateClass.asAggregateClass;
 import static io.spine.server.tenant.TenantAwareRunner.with;
@@ -433,7 +432,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
                       .findFirst()
                       .orElseThrow(() -> newIllegalStateException(
                               "Unable to route import event `%s`. Event: %s",
-                              messageType, shortDebugString(message))
+                              messageType)
                       );
             return id;
         };
@@ -618,10 +617,9 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
         tx.commitIfActive();
         if (!success) {
             lifecycleOf(id).onCorruptedState(outcome);
-            throw newIllegalStateException(
-                    "Aggregate %s (ID: %s) cannot be loaded.%n",
-                    aggregateClass().value().getName(), result.idAsString()
-            );
+            throw newIllegalStateException("Aggregate `%s` (ID: %s) cannot be loaded.%n",
+                                           aggregateClass().value().getName(),
+                                           result.idAsString());
         }
         return result;
     }

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -431,8 +431,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
             I id = ids.stream()
                       .findFirst()
                       .orElseThrow(() -> newIllegalStateException(
-                              "Unable to route import event `%s`. Event: %s",
-                              messageType)
+                              "Unable to route import event `%s`.", messageType)
                       );
             return id;
         };
@@ -530,7 +529,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      */
     protected AggregateStorage<I> aggregateStorage() {
         @SuppressWarnings("unchecked") // We check the type on initialization.
-        AggregateStorage<I> result = (AggregateStorage<I>) storage();
+                AggregateStorage<I> result = (AggregateStorage<I>) storage();
         return result;
     }
 
@@ -618,7 +617,8 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
         if (!success) {
             lifecycleOf(id).onCorruptedState(outcome);
             throw newIllegalStateException("Aggregate `%s` (ID: %s) cannot be loaded.%n",
-                                           aggregateClass().value().getName(),
+                                           aggregateClass().value()
+                                                           .getName(),
                                            result.idAsString());
         }
         return result;

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -64,6 +64,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Suppliers.memoize;
+import static com.google.protobuf.TextFormat.shortDebugString;
 import static io.spine.option.EntityOption.Kind.AGGREGATE;
 import static io.spine.server.aggregate.model.AggregateClass.asAggregateClass;
 import static io.spine.server.tenant.TenantAwareRunner.with;
@@ -431,7 +432,8 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
             I id = ids.stream()
                       .findFirst()
                       .orElseThrow(() -> newIllegalStateException(
-                              "Unable to route import event `%s`.", messageType)
+                              "Unable to route import event `%s`. Event: %s",
+                              messageType, shortDebugString(message))
                       );
             return id;
         };
@@ -616,9 +618,10 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
         tx.commitIfActive();
         if (!success) {
             lifecycleOf(id).onCorruptedState(outcome);
-            throw newIllegalStateException("Aggregate %s (ID: %s) cannot be loaded.%n",
-                                           aggregateClass().value().getName(),
-                                           result.idAsString());
+            throw newIllegalStateException(
+                    "Aggregate %s (ID: %s) cannot be loaded.%n",
+                    aggregateClass().value().getName(), result.idAsString()
+            );
         }
         return result;
     }

--- a/server/src/main/java/io/spine/server/commandbus/CommandAckMonitor.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandAckMonitor.java
@@ -112,7 +112,11 @@ final class CommandAckMonitor extends DelegatingObserver<Ack> {
                                      .build();
             case REJECTION:
             default:
-                throw newIllegalArgumentException("Invalid status %s.", status.getStatusCase());
+                throw newIllegalArgumentException(
+                        "Command `%s` has invalid status `%s`.",
+                        commandId.getUuid(),
+                        status.getStatusCase()
+                );
         }
     }
 

--- a/server/src/main/java/io/spine/server/entity/AbstractEntity.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractEntity.java
@@ -460,8 +460,9 @@ public abstract class AbstractEntity<I, S extends EntityState>
         if (currentVersionNumber > newVersionNumber) {
             throw newIllegalArgumentException(
                     "A version with the lower number (%d) passed to `updateVersion()` " +
-                            "of the entity with the version number %d.",
-                    newVersionNumber, currentVersionNumber);
+                            "of the entity `%s` (`%s`) with the version number %d.",
+                    newVersionNumber, thisClass(), idAsString(), currentVersionNumber
+            );
         }
         setVersion(newVersion);
     }

--- a/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
+++ b/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
@@ -496,7 +496,9 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
     private void checkEntityIsTransactional() {
         checkState(TransactionalEntity.class.isAssignableFrom(entityClass()),
                    "`%s` is not a transactional entity type. The requested operation is only " +
-                           "supported for transactional entity types.");
+                           "supported for transactional entity types.",
+                   entityClass().getCanonicalName()
+        );
     }
 
     /**

--- a/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
+++ b/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
@@ -428,7 +428,8 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
 
     private E findOrThrow(I id) {
         return find(id).orElseThrow(() -> newIllegalArgumentException(
-                "An entity `%s` with ID `%s` is not found in the repository.", entityClass(), id
+                "An entity `%s` with ID `%s` is not found in the repository.",
+                entityClass().getCanonicalName(), id
         ));
     }
 

--- a/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
+++ b/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
@@ -150,7 +150,6 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
      *         if the entity with the given ID is not found in the repository
      * @throws IllegalStateException
      *         if the repository manages a non-transactional entity type
-     *
      * @see Migration
      * @see #applyMigration(Set, Migration) the batch version of the method
      */
@@ -188,7 +187,6 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
      *
      * @throws IllegalStateException
      *         if the repository manages a non-transactional entity type
-     *
      * @see Migration
      */
     @SuppressWarnings("unchecked") // Checked at runtime.
@@ -230,7 +228,8 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
      *
      * <p>Note: The storage must be assigned before calling this method.
      *
-     * @param entities the {@linkplain Entity Entities} to store
+     * @param entities
+     *         the {@linkplain Entity Entities} to store
      */
     public void store(Collection<E> entities) {
         Map<I, EntityRecordWithColumns> records = newHashMapWithExpectedSize(entities.size());
@@ -244,7 +243,8 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
     /**
      * Finds an entity with the passed ID.
      *
-     * @param id the ID of the entity to find
+     * @param id
+     *         the ID of the entity to find
      * @return the entity or {@link Optional#empty()} if there is no entity with such ID
      */
     @Override
@@ -257,7 +257,8 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
      * Finds an entity with the passed ID even if the entity is
      * {@linkplain WithLifecycle#isActive() active}.
      *
-     * @param id the ID of the entity to find
+     * @param id
+     *         the ID of the entity to find
      * @return the entity or {@link Optional#empty()} if there is no entity with such ID,
      *         or the entity is not active
      */
@@ -290,7 +291,8 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
      *
      * <p>The new entity is created if and only if there is no record with the corresponding ID.
      *
-     * @param id the ID of the entity to load
+     * @param id
+     *         the ID of the entity to load
      * @return the entity with the specified ID
      */
     protected E findOrCreate(I id) {
@@ -426,7 +428,7 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
 
     private E findOrThrow(I id) {
         return find(id).orElseThrow(() -> newIllegalArgumentException(
-                "An entity with ID `%s` is not found in the repository.", id
+                "An entity `%s` with ID `%s` is not found in the repository.", entityClass(), id
         ));
     }
 
@@ -524,7 +526,7 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
             Message idAsMessage = unpack(idAsAny);
 
             @SuppressWarnings("unchecked")
-                // As the message class is the same as expected, the conversion is safe.
+            // As the message class is the same as expected, the conversion is safe.
             I id = (I) idAsMessage;
             return id;
         }

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.5.3'
+final def spineVersion = '1.5.4'
 
 ext {
     // The version of the modules in this project.


### PR DESCRIPTION
In the PR I have added some more informative context to exceptions thrown by the framework.

The initial trigger for the change was an exception thrown by the migration process with as little info as:
```
java.lang.IllegalArgumentException: An entity with ID `order_id {
  date {
    year: 2020
    month: JANUARY
    day: 15
  }
  number: 1
}
` is not found in the repository.
	at io.spine.util.Exceptions.newIllegalArgumentException(Exceptions.java:164)
	at io.spine.server.entity.RecordBasedRepository.lambda$findOrThrow$1(RecordBasedRepository.java:428)
```