### PR TITLE
System events performance improvement

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -415,7 +415,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 30 20:17:37 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 31 14:18:02 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -791,7 +791,7 @@ This report was generated on **Mon Mar 30 20:17:37 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 30 20:17:44 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 31 14:18:02 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1206,7 +1206,7 @@ This report was generated on **Mon Mar 30 20:17:44 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 30 20:17:59 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 31 14:18:02 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1681,7 +1681,7 @@ This report was generated on **Mon Mar 30 20:17:59 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 30 20:18:06 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 31 14:18:03 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2113,7 +2113,7 @@ This report was generated on **Mon Mar 30 20:18:06 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 30 20:18:31 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 31 14:18:03 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2586,7 +2586,7 @@ This report was generated on **Mon Mar 30 20:18:31 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 30 20:18:35 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 31 14:18:06 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3067,7 +3067,7 @@ This report was generated on **Mon Mar 30 20:18:35 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 30 20:18:37 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 31 14:18:07 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3584,4 +3584,4 @@ This report was generated on **Mon Mar 30 20:18:37 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 30 20:18:42 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 31 14:18:09 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.5.4`
+# Dependencies of `io.spine:spine-client:1.5.5`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -415,12 +415,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 30 13:11:03 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 30 20:17:37 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.5.4`
+# Dependencies of `io.spine:spine-core:1.5.5`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -791,12 +791,12 @@ This report was generated on **Mon Mar 30 13:11:03 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 30 13:11:04 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 30 20:17:44 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.5.4`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.5.5`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1206,12 +1206,12 @@ This report was generated on **Mon Mar 30 13:11:04 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 30 13:11:04 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 30 20:17:59 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.5.4`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.5.5`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1681,12 +1681,12 @@ This report was generated on **Mon Mar 30 13:11:04 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 30 13:11:05 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 30 20:18:06 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.5.4`
+# Dependencies of `io.spine:spine-server:1.5.5`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2113,12 +2113,12 @@ This report was generated on **Mon Mar 30 13:11:05 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 30 13:11:06 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 30 20:18:31 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.5.4`
+# Dependencies of `io.spine:spine-testutil-client:1.5.5`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2586,12 +2586,12 @@ This report was generated on **Mon Mar 30 13:11:06 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 30 13:11:08 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 30 20:18:35 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.5.4`
+# Dependencies of `io.spine:spine-testutil-core:1.5.5`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3067,12 +3067,12 @@ This report was generated on **Mon Mar 30 13:11:08 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 30 13:11:09 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 30 20:18:37 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.5.4`
+# Dependencies of `io.spine:spine-testutil-server:1.5.5`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3584,4 +3584,4 @@ This report was generated on **Mon Mar 30 13:11:09 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Mar 30 13:11:12 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 30 20:18:42 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.5.4</version>
+<version>1.5.5</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/BoundedContextBuilder.java
+++ b/server/src/main/java/io/spine/server/BoundedContextBuilder.java
@@ -47,8 +47,8 @@ import io.spine.server.type.EventEnvelope;
 import io.spine.system.server.NoOpSystemClient;
 import io.spine.system.server.SystemClient;
 import io.spine.system.server.SystemContext;
-import io.spine.system.server.SystemFeatures;
 import io.spine.system.server.SystemReadSide;
+import io.spine.system.server.SystemSettings;
 import io.spine.system.server.SystemWriteSide;
 
 import java.util.ArrayList;
@@ -88,7 +88,7 @@ public final class BoundedContextBuilder implements Logging {
      */
     private final Collection<EventDispatcher> eventDispatchers = new ArrayList<>();
 
-    private final SystemFeatures systemFeatures;
+    private final SystemSettings systemFeatures;
 
     private Stand stand;
     private Supplier<AggregateRootDirectory> rootDirectory;
@@ -106,7 +106,7 @@ public final class BoundedContextBuilder implements Logging {
      * @see BoundedContext#multitenant
      */
     BoundedContextBuilder(ContextSpec spec) {
-        this(spec, SystemFeatures.defaults());
+        this(spec, SystemSettings.defaults());
     }
 
     /**
@@ -119,7 +119,7 @@ public final class BoundedContextBuilder implements Logging {
      * @see BoundedContext#singleTenant
      * @see BoundedContext#multitenant
      */
-    private BoundedContextBuilder(ContextSpec spec, SystemFeatures systemFeatures) {
+    private BoundedContextBuilder(ContextSpec spec, SystemSettings systemFeatures) {
         this.spec = checkNotNull(spec);
         this.systemFeatures = checkNotNull(systemFeatures);
     }
@@ -509,9 +509,9 @@ public final class BoundedContextBuilder implements Logging {
      *
      * <p>Users may enable or disable some features of the system context.
      *
-     * @see SystemFeatures
+     * @see SystemSettings
      */
-    public SystemFeatures systemFeatures() {
+    public SystemSettings systemFeatures() {
         return systemFeatures;
     }
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -54,6 +54,7 @@ import io.spine.server.type.EventEnvelope;
 import io.spine.server.type.SignalEnvelope;
 import io.spine.system.server.Mirror;
 import io.spine.system.server.MirrorRepository;
+import io.spine.system.server.SystemSettings;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import java.util.Optional;
@@ -511,7 +512,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, ?, ?>>
      * Returns a {@link MirrorRepository} of a corresponding {@link BoundedContext}.
      *
      * <p>Returns {@code Optional.empty()} if aggregate mirroring is
-     * {@linkplain io.spine.system.server.SystemFeatures disabled} in the system context.
+     * {@linkplain SystemSettings disabled} in the system context.
      */
     private Optional<MirrorRepository> mirrorRepository() {
         Optional<MirrorRepository> result = context().systemClient()

--- a/server/src/main/java/io/spine/system/server/SystemConfig.java
+++ b/server/src/main/java/io/spine/system/server/SystemConfig.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.system.server;
+
+import com.google.common.base.Objects;
+import com.google.errorprone.annotations.Immutable;
+
+/**
+ * An immutable set of features of a {@link SystemContext}.
+ */
+@Immutable
+final class SystemConfig implements SystemFeatures {
+
+    private final boolean commandLog;
+    private final boolean aggregateMirrors;
+    private final boolean storeEvents;
+    private final boolean parallelPosting;
+
+    SystemConfig(boolean commandLog,
+                 boolean aggregateMirrors,
+                 boolean storeEvents,
+                 boolean parallelPosting) {
+        this.commandLog = commandLog;
+        this.aggregateMirrors = aggregateMirrors;
+        this.storeEvents = storeEvents;
+        this.parallelPosting = parallelPosting;
+    }
+
+    @Override
+    public boolean includeCommandLog() {
+        return commandLog;
+    }
+
+    @Override
+    public boolean includeAggregateMirroring() {
+        return aggregateMirrors;
+    }
+
+    @Override
+    public boolean includePersistentEvents() {
+        return storeEvents;
+    }
+
+    @Override
+    public boolean postEventsInParallel() {
+        return parallelPosting;
+    }
+
+    @SuppressWarnings("OverlyComplexBooleanExpression")
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SystemConfig)) {
+            return false;
+        }
+        SystemConfig config = (SystemConfig) o;
+        return commandLog == config.commandLog &&
+                aggregateMirrors == config.aggregateMirrors &&
+                storeEvents == config.storeEvents &&
+                parallelPosting == config.parallelPosting;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(commandLog, aggregateMirrors, storeEvents, parallelPosting);
+    }
+}

--- a/server/src/main/java/io/spine/system/server/SystemFeatures.java
+++ b/server/src/main/java/io/spine/system/server/SystemFeatures.java
@@ -20,170 +20,35 @@
 
 package io.spine.system.server;
 
-import com.google.common.base.Objects;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import io.spine.annotation.Internal;
-
 /**
- * A configuration of features of a system context.
- *
- * <p>Users may choose to turn certain system features on or off depending on the required
- * performance.
+ * A configuration of a {@link SystemContext}.
  */
-public final class SystemFeatures {
-
-    private boolean commandLog;
-    private boolean aggregateMirrors;
-    private boolean storeEvents;
-
-    /**
-     * Prevents direct instantiation.
-     */
-    private SystemFeatures() {
-    }
-
-    /**
-     * Obtains the default configuration.
-     *
-     * <p>By default, the system context:
-     * <ol>
-     *     <li>Enables querying of the latest {@code Aggregate} states.
-     *     <li>Does not store {@link io.spine.system.server.CommandLog CommandLog}.
-     *     <li>Does not store system events.
-     * </ol>
-     */
-    public static SystemFeatures defaults() {
-        return new SystemFeatures()
-                .disableCommandLog()
-                .enableAggregateQuerying()
-                .forgetEvents();
-    }
-
-    /**
-     * Enables the configured system context to store
-     * {@link io.spine.system.server.CommandLog CommandLog}s for domain commands.
-     *
-     * @return self for method chaining
-     * @see #disableCommandLog()
-     */
-    @CanIgnoreReturnValue
-    public SystemFeatures enableCommandLog() {
-        this.commandLog = true;
-        return this;
-    }
-
-    /**
-     * Disables {@linkplain io.spine.system.server.CommandLog CommandLog}.
-     *
-     * <p>This is the default setting.
-     *
-     * @return self for method chaining
-     * @see #enableCommandLog()
-     */
-    @CanIgnoreReturnValue
-    public SystemFeatures disableCommandLog() {
-        this.commandLog = false;
-        return this;
-    }
-
-    /**
-     * Enables querying of the latest domain {@code Aggregate} states.
-     *
-     * <p>The system context stores domain {@code Aggregate} states in the form of
-     * {@link io.spine.system.server.Mirror} projections.
-     *
-     * <p>This is the default setting.
-     *
-     * @return self for method chaining
-     * @see #disableAggregateQuerying()
-     */
-    @CanIgnoreReturnValue
-    public SystemFeatures enableAggregateQuerying() {
-        this.aggregateMirrors = true;
-        return this;
-    }
-
-    /**
-     * Disables querying of the latest domain {@code Aggregate} states.
-     *
-     * @return self for method chaining
-     * @see #enableAggregateQuerying()
-     */
-    @CanIgnoreReturnValue
-    public SystemFeatures disableAggregateQuerying() {
-        this.aggregateMirrors = false;
-        return this;
-    }
-
-    /**
-     * Configures the the system context to store system events.
-     *
-     * @return self for method chaining
-     */
-    public SystemFeatures persistEvents() {
-        this.storeEvents = true;
-        return this;
-    }
-
-    /**
-     * Configures the the system context NOT to store system events for better performance.
-     *
-     * <p>This is the default setting.
-     *
-     * @return self for method chaining
-     */
-    public SystemFeatures forgetEvents() {
-        this.storeEvents = false;
-        return this;
-    }
+interface SystemFeatures {
 
     /**
      * Obtains the {@link io.spine.system.server.CommandLog CommandLog} setting.
      *
      * @return {@code true} if the {@code CommandLog} should be stored, {@code false} otherwise
      */
-    boolean includeCommandLog() {
-        return commandLog;
-    }
+    boolean includeCommandLog();
 
     /**
      * Obtains the {@code Aggregate} mirrors setting.
      *
      * @return {@code true} if the Aggregate mirrors should be stored, {@code false} otherwise
      */
-    boolean includeAggregateMirroring() {
-        return aggregateMirrors;
-    }
+    boolean includeAggregateMirroring();
 
     /**
      * Obtains the system events persistence setting.
      *
      * @return {@code true} if system events should be stored, {@code false} otherwise
      */
-    @Internal
-    public boolean includePersistentEvents() {
-        return storeEvents;
-    }
-
-    @SuppressWarnings("NonFinalFieldReferenceInEquals")
-        // `SystemFeatures` is designed to be mutable.
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof SystemFeatures)) {
-            return false;
-        }
-        SystemFeatures features = (SystemFeatures) o;
-        return commandLog == features.commandLog &&
-                aggregateMirrors == features.aggregateMirrors &&
-                storeEvents == features.storeEvents;
-    }
-
-    @SuppressWarnings("NonFinalFieldReferencedInHashCode") // See `equals`.
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(commandLog, aggregateMirrors, storeEvents);
-    }
+    boolean includePersistentEvents();
+    /**
+     * Checks if the system events are allowed to be posted in parallel.
+     *
+     * @return {@code true} if it's OK to post system event is parallel, {@code false} otherwise
+     */
+    boolean postEventsInParallel();
 }

--- a/server/src/main/java/io/spine/system/server/SystemSettings.java
+++ b/server/src/main/java/io/spine/system/server/SystemSettings.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.system.server;
+
+import com.google.common.base.Objects;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.spine.annotation.Internal;
+
+/**
+ * A configuration of features of a system context.
+ *
+ * <p>Users may choose to turn certain system features on or off depending on the required
+ * performance.
+ */
+public final class SystemSettings implements SystemFeatures {
+
+    private boolean commandLog;
+    private boolean aggregateMirrors;
+    private boolean storeEvents;
+    private boolean parallelPosting;
+
+    /**
+     * Prevents direct instantiation.
+     */
+    private SystemSettings() {
+    }
+
+    /**
+     * Obtains the default configuration.
+     *
+     * <p>By default, the system context:
+     * <ol>
+     *     <li>Enables querying of the latest {@code Aggregate} states.
+     *     <li>Does not store {@link io.spine.system.server.CommandLog CommandLog}.
+     *     <li>Does not store system events.
+     * </ol>
+     */
+    public static SystemSettings defaults() {
+        return new SystemSettings()
+                .disableCommandLog()
+                .enableAggregateQuerying()
+                .forgetEvents();
+    }
+
+    /**
+     * Enables the configured system context to store
+     * {@link io.spine.system.server.CommandLog CommandLog}s for domain commands.
+     *
+     * @return self for method chaining
+     * @see #disableCommandLog()
+     */
+    @CanIgnoreReturnValue
+    public SystemSettings enableCommandLog() {
+        this.commandLog = true;
+        return this;
+    }
+
+    /**
+     * Disables {@linkplain io.spine.system.server.CommandLog CommandLog}.
+     *
+     * <p>This is the default setting.
+     *
+     * @return self for method chaining
+     * @see #enableCommandLog()
+     */
+    @CanIgnoreReturnValue
+    public SystemSettings disableCommandLog() {
+        this.commandLog = false;
+        return this;
+    }
+
+    /**
+     * Enables querying of the latest domain {@code Aggregate} states.
+     *
+     * <p>The system context stores domain {@code Aggregate} states in the form of
+     * {@link io.spine.system.server.Mirror} projections.
+     *
+     * <p>This is the default setting.
+     *
+     * @return self for method chaining
+     * @see #disableAggregateQuerying()
+     */
+    @CanIgnoreReturnValue
+    public SystemSettings enableAggregateQuerying() {
+        this.aggregateMirrors = true;
+        return this;
+    }
+
+    /**
+     * Disables querying of the latest domain {@code Aggregate} states.
+     *
+     * @return self for method chaining
+     * @see #enableAggregateQuerying()
+     */
+    @CanIgnoreReturnValue
+    public SystemSettings disableAggregateQuerying() {
+        this.aggregateMirrors = false;
+        return this;
+    }
+
+    /**
+     * Configures the the system context to store system events.
+     *
+     * @return self for method chaining
+     */
+    public SystemSettings persistEvents() {
+        this.storeEvents = true;
+        return this;
+    }
+
+    /**
+     * Configures the the system context NOT to store system events for better performance.
+     *
+     * <p>This is the default setting.
+     *
+     * @return self for method chaining
+     */
+    public SystemSettings forgetEvents() {
+        this.storeEvents = false;
+        return this;
+    }
+
+    /**
+     * Configures the system context clients to post system events in parallel.
+     *
+     * <p>The events are posted using {@link java.util.concurrent.ForkJoinPool#commonPool()}.
+     *
+     * <p>This is the default setting.
+     *
+     * @return self for method chaining
+     */
+    public SystemSettings enableParallelPosting() {
+        this.parallelPosting = true;
+        return this;
+    }
+
+    /**
+     * Configures the system context clients NOT to post system events in parallel.
+     *
+     * <p>Choosing this configuration option may effect performance.
+     *
+     * @return self for method chaining
+     */
+    public SystemSettings disableParallelPosting() {
+        this.parallelPosting = false;
+        return this;
+    }
+
+    @Internal
+    @Override
+    public boolean includeCommandLog() {
+        return commandLog;
+    }
+
+    @Internal
+    @Override
+    public boolean includeAggregateMirroring() {
+        return aggregateMirrors;
+    }
+
+    @Internal
+    @Override
+    public boolean includePersistentEvents() {
+        return storeEvents;
+    }
+
+    @Internal
+    @Override
+    public boolean postEventsInParallel() {
+        return parallelPosting;
+    }
+
+    /**
+     * Copies these settings into an immutable feature set.
+     */
+    SystemConfig freeze() {
+        return new SystemConfig(commandLog, aggregateMirrors, storeEvents, parallelPosting);
+    }
+
+    @SuppressWarnings({"OverlyComplexBooleanExpression", "NonFinalFieldReferenceInEquals"})
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SystemSettings)) {
+            return false;
+        }
+        SystemSettings settings = (SystemSettings) o;
+        return commandLog == settings.commandLog &&
+                aggregateMirrors == settings.aggregateMirrors &&
+                storeEvents == settings.storeEvents &&
+                parallelPosting == settings.parallelPosting;
+    }
+
+    @SuppressWarnings("NonFinalFieldReferencedInHashCode")
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(commandLog, aggregateMirrors, storeEvents, parallelPosting);
+    }
+}

--- a/server/src/main/java/io/spine/system/server/SystemSettings.java
+++ b/server/src/main/java/io/spine/system/server/SystemSettings.java
@@ -57,7 +57,8 @@ public final class SystemSettings implements SystemFeatures {
         return new SystemSettings()
                 .disableCommandLog()
                 .enableAggregateQuerying()
-                .forgetEvents();
+                .forgetEvents()
+                .enableParallelPosting();
     }
 
     /**
@@ -147,6 +148,7 @@ public final class SystemSettings implements SystemFeatures {
      *
      * @return self for method chaining
      */
+    @CanIgnoreReturnValue
     public SystemSettings enableParallelPosting() {
         this.parallelPosting = true;
         return this;
@@ -159,6 +161,7 @@ public final class SystemSettings implements SystemFeatures {
      *
      * @return self for method chaining
      */
+    @CanIgnoreReturnValue
     public SystemSettings disableParallelPosting() {
         this.parallelPosting = false;
         return this;

--- a/server/src/test/java/io/spine/system/server/SystemSettingsTest.java
+++ b/server/src/test/java/io/spine/system/server/SystemSettingsTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("SystemFeatures should")
-class SystemFeaturesTest {
+class SystemSettingsTest {
 
     @Nested
     @DisplayName("by default")
@@ -37,21 +37,21 @@ class SystemFeaturesTest {
         @Test
         @DisplayName("enable aggregate mirroring")
         void mirrors() {
-            SystemFeatures features = SystemFeatures.defaults();
+            SystemSettings features = SystemSettings.defaults();
             assertTrue(features.includeAggregateMirroring());
         }
 
         @Test
         @DisplayName("disable command log")
         void commands() {
-            SystemFeatures features = SystemFeatures.defaults();
+            SystemSettings features = SystemSettings.defaults();
             assertFalse(features.includeCommandLog());
         }
 
         @Test
         @DisplayName("disable event store")
         void events() {
-            SystemFeatures features = SystemFeatures.defaults();
+            SystemSettings features = SystemSettings.defaults();
             assertFalse(features.includePersistentEvents());
         }
     }
@@ -62,7 +62,7 @@ class SystemFeaturesTest {
         @Test
         @DisplayName("aggregate mirroring")
         void mirrors() {
-            SystemFeatures features = SystemFeatures
+            SystemSettings features = SystemSettings
                     .defaults()
                     .disableAggregateQuerying();
             assertFalse(features.includeAggregateMirroring());
@@ -71,7 +71,7 @@ class SystemFeaturesTest {
         @Test
         @DisplayName("command log")
         void commands() {
-            SystemFeatures features = SystemFeatures
+            SystemSettings features = SystemSettings
                     .defaults()
                     .enableCommandLog();
             assertTrue(features.includeCommandLog());
@@ -80,7 +80,7 @@ class SystemFeaturesTest {
         @Test
         @DisplayName("event store")
         void events() {
-            SystemFeatures features = SystemFeatures
+            SystemSettings features = SystemSettings
                     .defaults()
                     .persistEvents();
             assertTrue(features.includePersistentEvents());

--- a/server/src/test/java/io/spine/system/server/SystemSettingsTest.java
+++ b/server/src/test/java/io/spine/system/server/SystemSettingsTest.java
@@ -20,12 +20,15 @@
 
 package io.spine.system.server;
 
+import io.spine.base.Environment;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @DisplayName("SystemFeatures should")
 class SystemSettingsTest {
@@ -33,6 +36,11 @@ class SystemSettingsTest {
     @Nested
     @DisplayName("by default")
     class Defaults {
+
+        @AfterEach
+        void resetEnv() {
+            Environment.instance().reset();
+        }
 
         @Test
         @DisplayName("enable aggregate mirroring")
@@ -53,6 +61,18 @@ class SystemSettingsTest {
         void events() {
             SystemSettings features = SystemSettings.defaults();
             assertFalse(features.includePersistentEvents());
+        }
+
+        @Test
+        @DisplayName("allow parallel posting for system events")
+        void parallelism() {
+            Environment env = Environment.instance();
+
+            assumeTrue(env.isTests());
+            assertFalse(SystemSettings.defaults().postEventsInParallel());
+
+            env.setToProduction();
+            assertTrue(SystemSettings.defaults().postEventsInParallel());
         }
     }
 
@@ -84,6 +104,15 @@ class SystemSettingsTest {
                     .defaults()
                     .persistEvents();
             assertTrue(features.includePersistentEvents());
+        }
+
+        @Test
+        @DisplayName("system events to be posted in synch")
+        void parallelism() {
+            SystemSettings features = SystemSettings
+                    .defaults()
+                    .disableParallelPosting();
+            assertFalse(features.postEventsInParallel());
         }
     }
 }

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.5.4'
+final def spineVersion = '1.5.5'
 
 ext {
     // The version of the modules in this project.


### PR DESCRIPTION
In this PR we allow system events to be posted in parallel. This improves performance in certain conditions.

The parallel publishing is enabled by default for production use and disabled for tests, since some tests rely on eventual consistency. It can be disabled for separate (or all) Bounded Contexts:
```java
BoundedContextBuilder builder = BoundedContext.singleTenant("example");
// ...
builder.systemFeatures().disableParallelPosting();
```

### Performance
For commands, we ran a test with 2000 commands posted from a single thread.
When system events are emitted synchronously, the test runs in 200-210 ms. After enabling parallelism, the runtime is shortened to 190-200 ms. 

For commands and imported events, the time of a synchronous run is close to 1030 ms, and for a paralleled run — 990 ms.

If the `CommandLog` system feature is enabled, the test runs in 970 ms in synch mode in paralleled mode — 970 ms.

Fixes #779.