### PR TITLE
Improve event and state assertions

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.5.6`
+# Dependencies of `io.spine:spine-client:1.5.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -415,12 +415,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Apr 01 21:03:34 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 06 16:04:39 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.5.6`
+# Dependencies of `io.spine:spine-core:1.5.7`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -791,12 +791,12 @@ This report was generated on **Wed Apr 01 21:03:34 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Apr 01 21:03:35 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 06 16:04:39 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.5.6`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.5.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1206,12 +1206,12 @@ This report was generated on **Wed Apr 01 21:03:35 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Apr 01 21:03:35 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 06 16:04:40 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.5.6`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.5.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1681,12 +1681,12 @@ This report was generated on **Wed Apr 01 21:03:35 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Apr 01 21:03:35 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 06 16:04:40 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.5.6`
+# Dependencies of `io.spine:spine-server:1.5.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2113,12 +2113,12 @@ This report was generated on **Wed Apr 01 21:03:35 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Apr 01 21:03:36 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 06 16:04:40 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.5.6`
+# Dependencies of `io.spine:spine-testutil-client:1.5.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2586,12 +2586,12 @@ This report was generated on **Wed Apr 01 21:03:36 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Apr 01 21:03:38 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 06 16:04:42 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.5.6`
+# Dependencies of `io.spine:spine-testutil-core:1.5.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3067,12 +3067,12 @@ This report was generated on **Wed Apr 01 21:03:38 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Apr 01 21:03:39 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 06 16:04:43 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.5.6`
+# Dependencies of `io.spine:spine-testutil-server:1.5.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3584,4 +3584,4 @@ This report was generated on **Wed Apr 01 21:03:39 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Apr 01 21:03:42 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Apr 06 16:04:44 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.5.6</version>
+<version>1.5.7</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -70,7 +70,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.5.1</version>
+    <version>1.5.4</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -82,13 +82,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.5.1</version>
+    <version>1.5.4</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.5.1</version>
+    <version>1.5.4</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -130,7 +130,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.5.1</version>
+    <version>1.5.4</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -142,13 +142,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.5.1</version>
+    <version>1.5.4</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.5.1</version>
+    <version>1.5.4</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -210,12 +210,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>1.5.1</version>
+    <version>1.5.4</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.5.1</version>
+    <version>1.5.4</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/server/src/test/java/io/spine/server/aggregate/EventImportTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/EventImportTest.java
@@ -198,7 +198,7 @@ class EventImportTest {
         private void assertRouted(EventEnvelope event) {
             EntitySubject assertEntity =
                     context().importsEvent(event.outerObject())
-                             .assertEntity(EngineAggregate.class, engineId);
+                             .assertEntity(engineId, EngineAggregate.class);
             assertEntity.exists();
         }
     }

--- a/server/src/test/java/io/spine/server/delivery/DeliveryTest.java
+++ b/server/src/test/java/io/spine/server/delivery/DeliveryTest.java
@@ -343,7 +343,7 @@ public class DeliveryTest extends AbstractDeliveryTest {
 
         for (DCreateTask command : commands) {
             String taskId = command.getId();
-            EntitySubject subject = context.assertEntity(TaskView.class, taskId);
+            EntitySubject subject = context.assertEntity(taskId, TaskView.class);
             subject.exists();
 
             TaskView actualView = (TaskView) subject.actual();

--- a/server/src/test/java/io/spine/server/delivery/NastyClient.java
+++ b/server/src/test/java/io/spine/server/delivery/NastyClient.java
@@ -134,9 +134,7 @@ class NastyClient {
                     .setId(calcId)
                     .setSum(sumForTarget)
                     .build();
-            context.assertEntity(calcId, CalcAggregate.class)
-                   .hasStateThat()
-                   .comparingExpectedFieldsOnly()
+            context.assertState(calcId, Calc.class)
                    .isEqualTo(expectedState);
 
         }

--- a/server/src/test/java/io/spine/server/delivery/NastyClient.java
+++ b/server/src/test/java/io/spine/server/delivery/NastyClient.java
@@ -134,7 +134,7 @@ class NastyClient {
                     .setId(calcId)
                     .setSum(sumForTarget)
                     .build();
-            context.assertEntity(CalcAggregate.class, calcId)
+            context.assertEntity(calcId, CalcAggregate.class)
                    .hasStateThat()
                    .comparingExpectedFieldsOnly()
                    .isEqualTo(expectedState);

--- a/server/src/test/java/io/spine/server/procman/ProcessManagerTest.java
+++ b/server/src/test/java/io/spine/server/procman/ProcessManagerTest.java
@@ -334,15 +334,18 @@ class ProcessManagerTest {
             context.assertEvents()
                    .withType(StandardRejections.EntityAlreadyArchived.class)
                    .hasSize(1);
-            context.assertEntity(TestProcessManager.class, TestProcessManager.ID)
-                   .doesNotExist();
+            assertNoEntity();
         }
 
         @Test
         @DisplayName("exception")
         void exception() {
             context.receivesCommand(throwRuntimeException());
-            context.assertEntity(TestProcessManager.class, TestProcessManager.ID)
+            assertNoEntity();
+        }
+
+        private void assertNoEntity() {
+            context.assertEntity(TestProcessManager.ID, TestProcessManager.class)
                    .doesNotExist();
         }
     }

--- a/server/src/test/java/io/spine/server/projection/StateRoutingTest.java
+++ b/server/src/test/java/io/spine/server/projection/StateRoutingTest.java
@@ -76,7 +76,7 @@ class StateRoutingTest {
                               .build()
         );
 
-        context.assertEntityWithState(ArtistMood.class, BRETON)
+        context.assertEntityWithState(BRETON, ArtistMood.class)
                .hasStateThat()
                .comparingExpectedFieldsOnly()
                .isEqualTo(ArtistMood.newBuilder()
@@ -99,7 +99,7 @@ class StateRoutingTest {
         );
 
         ProtoSubject assertWorks =
-                context.assertEntity(WorksProjection.class, artist)
+                context.assertEntity(artist, WorksProjection.class)
                        .hasStateThat();
         Works expectedWork =
                 Works.newBuilder()

--- a/server/src/test/java/io/spine/server/projection/StateRoutingTest.java
+++ b/server/src/test/java/io/spine/server/projection/StateRoutingTest.java
@@ -20,7 +20,6 @@
 
 package io.spine.server.projection;
 
-import com.google.common.truth.extensions.proto.ProtoSubject;
 import com.google.protobuf.Any;
 import com.google.protobuf.StringValue;
 import io.spine.base.Identifier;
@@ -76,9 +75,7 @@ class StateRoutingTest {
                               .build()
         );
 
-        context.assertEntityWithState(BRETON, ArtistMood.class)
-               .hasStateThat()
-               .comparingExpectedFieldsOnly()
+        context.assertState(BRETON, ArtistMood.class)
                .isEqualTo(ArtistMood.newBuilder()
                                     .setMood(ArtistMood.Mood.ANGER)
                                     .build());
@@ -98,14 +95,11 @@ class StateRoutingTest {
                         .build()
         );
 
-        ProtoSubject assertWorks =
-                context.assertEntity(artist, WorksProjection.class)
-                       .hasStateThat();
-        Works expectedWork =
+        context.assertState(
+                artist,
                 Works.newBuilder()
                      .addWork(automaticDrawing)
-                     .build();
-        assertWorks.comparingExpectedFieldsOnly()
-                   .isEqualTo(expectedWork);
+                     .build()
+        );
     }
 }

--- a/server/src/test/java/io/spine/server/projection/e2e/ProjectionEndToEndTest.java
+++ b/server/src/test/java/io/spine/server/projection/e2e/ProjectionEndToEndTest.java
@@ -95,7 +95,7 @@ class ProjectionEndToEndTest {
                                          firstTaskAdded,
                                          secondTaskAdded);
 
-        context.assertEntityWithState(ProjectTaskNames.class, producerId)
+        context.assertEntityWithState(producerId, ProjectTaskNames.class)
                 .hasStateThat()
                 .isEqualTo(ProjectTaskNames
                                    .newBuilder()
@@ -126,7 +126,7 @@ class ProjectionEndToEndTest {
                 .newBuilder()
                 .setUuid(producerId.getUuid())
                 .build();
-        receiver.assertEntityWithState(GroupName.class, groupId)
+        receiver.assertEntityWithState(groupId, GroupName.class)
                 .hasStateThat()
                 .isEqualTo(GroupName.newBuilder()
                                     .setId(groupId)

--- a/server/src/test/java/io/spine/server/projection/e2e/ProjectionEndToEndTest.java
+++ b/server/src/test/java/io/spine/server/projection/e2e/ProjectionEndToEndTest.java
@@ -95,15 +95,18 @@ class ProjectionEndToEndTest {
                                          firstTaskAdded,
                                          secondTaskAdded);
 
-        context.assertEntityWithState(producerId, ProjectTaskNames.class)
-                .hasStateThat()
-                .isEqualTo(ProjectTaskNames
-                                   .newBuilder()
-                                   .setProjectId(producerId)
-                                   .setProjectName(created.getName())
-                                   .addTaskName(firstTaskAdded.getTask().getTitle())
-                                   .addTaskName(secondTaskAdded.getTask().getTitle())
-                                   .build());
+        context.assertState(
+                producerId,
+                ProjectTaskNames
+                        .newBuilder()
+                        .setProjectId(producerId)
+                        .setProjectName(created.getName())
+                        .addTaskName(firstTaskAdded.getTask()
+                                                   .getTitle())
+                        .addTaskName(secondTaskAdded.getTask()
+                                                    .getTitle())
+                        .build()
+        );
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/route/EventRoutingIntegrationTest.java
+++ b/server/src/test/java/io/spine/server/route/EventRoutingIntegrationTest.java
@@ -70,7 +70,7 @@ class EventRoutingIntegrationTest {
         );
         context.receivesEvent(event);
 
-        context.assertEntity(SessionProjection.class, sessionId)
+        context.assertEntity(sessionId, SessionProjection.class)
                .hasStateThat()
                .comparingExpectedFieldsOnly()
                .isEqualTo(session);

--- a/server/src/test/java/io/spine/system/server/ConstraintViolatedTest.java
+++ b/server/src/test/java/io/spine/system/server/ConstraintViolatedTest.java
@@ -57,7 +57,7 @@ class ConstraintViolatedTest {
                               .setTextToValidate(invalidText)
                               .vBuild()
         );
-        context.assertEntity(ViolationsWatch.class, DEFAULT)
+        context.assertEntity(DEFAULT, ViolationsWatch.class)
                .hasStateThat()
                .isEqualTo(InvalidText.newBuilder()
                                      .setId(DEFAULT)
@@ -84,7 +84,7 @@ class ConstraintViolatedTest {
                                                 .setValue("a@b.c"))
                         .vBuild()
         );
-        context.assertEntity(ViolationsWatch.class, DEFAULT)
+        context.assertEntity(DEFAULT, ViolationsWatch.class)
                .hasStateThat()
                .isEqualTo(InvalidText.newBuilder()
                                      .setId(DEFAULT)

--- a/server/src/test/java/io/spine/system/server/MirrorProjectionTest.java
+++ b/server/src/test/java/io/spine/system/server/MirrorProjectionTest.java
@@ -46,7 +46,7 @@ class MirrorProjectionTest {
         EntityStateChanged event = entityStateChanged();
         context()
                 .receivesEvent(event)
-                .assertEntityWithState(Mirror.class, ID)
+                .assertEntityWithState(ID, Mirror.class)
                 .hasStateThat()
                 .comparingExpectedFieldsOnly()
                 .isEqualTo(Mirror.newBuilder()
@@ -61,7 +61,7 @@ class MirrorProjectionTest {
         EventMessage event = entityArchived();
         EntitySubject assertMirror = context()
                 .receivesEvents(entityStateChanged(), event)
-                .assertEntityWithState(Mirror.class, ID);
+                .assertEntityWithState(ID, Mirror.class);
         assertMirror.archivedFlag()
                     .isTrue();
         assertMirror.deletedFlag()
@@ -81,7 +81,7 @@ class MirrorProjectionTest {
         EventMessage event = entityDeleted();
         EntitySubject assertMirror = context()
                 .receivesEvents(entityStateChanged(), event)
-                .assertEntityWithState(Mirror.class, ID);
+                .assertEntityWithState(ID, Mirror.class);
         assertMirror.archivedFlag()
                     .isFalse();
         assertMirror.deletedFlag()
@@ -101,7 +101,7 @@ class MirrorProjectionTest {
         EventMessage event = entityExtracted();
         EntitySubject assertMirror = context()
                 .receivesEvents(entityStateChanged(), entityArchived(), event)
-                .assertEntityWithState(Mirror.class, ID);
+                .assertEntityWithState(ID, Mirror.class);
         assertMirror.archivedFlag()
                     .isFalse();
         assertMirror.deletedFlag()
@@ -116,7 +116,7 @@ class MirrorProjectionTest {
         EventMessage event = entityRestored();
         EntitySubject assertMirror = context()
                 .receivesEvents(entityStateChanged(), entityDeleted(), event)
-                .assertEntityWithState(Mirror.class, ID);
+                .assertEntityWithState(ID, Mirror.class);
         assertMirror.archivedFlag()
                     .isFalse();
         assertMirror.deletedFlag()

--- a/server/src/test/java/io/spine/system/server/MirrorProjectionTest.java
+++ b/server/src/test/java/io/spine/system/server/MirrorProjectionTest.java
@@ -67,8 +67,6 @@ class MirrorProjectionTest {
         assertMirror.deletedFlag()
                     .isFalse();
         assertMirror.hasStateThat()
-                    .isNotEqualToDefaultInstance();
-        assertMirror.hasStateThat()
                     .comparingExpectedFieldsOnly()
                     .isEqualTo(Mirror.newBuilder()
                                      .setLifecycle(LifecycleFlags.newBuilder().setArchived(true))

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxContext.java
@@ -22,6 +22,7 @@ package io.spine.testing.server.blackbox;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.truth.extensions.proto.ProtoFluentAssertion;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Message;
 import io.spine.base.CommandMessage;
@@ -185,7 +186,7 @@ public abstract class BlackBoxContext implements Logging {
     }
 
     @VisibleForTesting
-    BoundedContext context() {
+    final BoundedContext context() {
         return context;
     }
 
@@ -193,7 +194,7 @@ public abstract class BlackBoxContext implements Logging {
      * Appends the passed event to the history of the context under the test.
      */
     @CanIgnoreReturnValue
-    public BlackBoxContext append(Event event) {
+    public final BlackBoxContext append(Event event) {
         checkNotNull(event);
         EventStore eventStore =
                 context.eventBus()
@@ -210,7 +211,7 @@ public abstract class BlackBoxContext implements Logging {
      * @apiNote Returned value can be ignored when this method invoked for test setup.
      */
     @CanIgnoreReturnValue
-    public BlackBoxContext receivesCommand(CommandMessage domainCommand) {
+    public final BlackBoxContext receivesCommand(CommandMessage domainCommand) {
         return receivesCommands(singletonList(domainCommand));
     }
 
@@ -227,7 +228,7 @@ public abstract class BlackBoxContext implements Logging {
      * @apiNote Returned value can be ignored when this method invoked for test setup.
      */
     @CanIgnoreReturnValue
-    public BlackBoxContext
+    public final BlackBoxContext
     receivesCommands(CommandMessage first, CommandMessage second, CommandMessage... rest) {
         return receivesCommands(asList(first, second, rest));
     }
@@ -257,7 +258,7 @@ public abstract class BlackBoxContext implements Logging {
      * @apiNote Returned value can be ignored when this method invoked for test setup.
      */
     @CanIgnoreReturnValue
-    public BlackBoxContext receivesEvent(EventMessage messageOrEvent) {
+    public final BlackBoxContext receivesEvent(EventMessage messageOrEvent) {
         return receivesEvents(singletonList(messageOrEvent));
     }
 
@@ -279,7 +280,7 @@ public abstract class BlackBoxContext implements Logging {
      * @apiNote Returned value can be ignored when this method invoked for test setup.
      */
     @CanIgnoreReturnValue
-    public BlackBoxContext
+    public final BlackBoxContext
     receivesEvents(EventMessage first, EventMessage second, EventMessage... rest) {
         return receivesEvents(asList(first, second, rest));
     }
@@ -296,7 +297,7 @@ public abstract class BlackBoxContext implements Logging {
      * @apiNote Returned value can be ignored when this method invoked for test setup.
      */
     @CanIgnoreReturnValue
-    public BlackBoxContext receivesExternalEvent(Message messageOrEvent) {
+    public final BlackBoxContext receivesExternalEvent(Message messageOrEvent) {
         setup().postExternalEvent(messageOrEvent);
         return this;
     }
@@ -321,7 +322,7 @@ public abstract class BlackBoxContext implements Logging {
      */
     @SuppressWarnings("unused") // IDEA does not see the usage of this method from tests.
     @CanIgnoreReturnValue
-    public BlackBoxContext
+    public final BlackBoxContext
     receivesExternalEvents(EventMessage first, EventMessage second, EventMessage... other) {
         return receivesExternalEvents(asList(first, second, other));
     }
@@ -353,7 +354,7 @@ public abstract class BlackBoxContext implements Logging {
      * @apiNote Returned value can be ignored when this method invoked for test setup.
      */
     @CanIgnoreReturnValue
-    public BlackBoxContext
+    public final BlackBoxContext
     receivesEventsProducedBy(Object producerId, EventMessage first, EventMessage... rest) {
         List<Event> sentEvents = setup().postEvents(producerId, first, rest);
         postedEvents.addAll(sentEvents);
@@ -401,7 +402,7 @@ public abstract class BlackBoxContext implements Logging {
      * @apiNote Returned value can be ignored when this method invoked for test setup.
      */
     @CanIgnoreReturnValue
-    public BlackBoxContext
+    public final BlackBoxContext
     importsEvents(EventMessage first, EventMessage second, EventMessage... rest) {
         return importAll(asList(first, second, rest));
     }
@@ -421,7 +422,7 @@ public abstract class BlackBoxContext implements Logging {
      * <p>Instead of a checked {@link java.io.IOException IOException}, wraps any issues
      * that may occur while closing, into an {@link IllegalStateException}.
      */
-    public void close() {
+    public final void close() {
         try {
             context.close();
         } catch (Exception e) {
@@ -479,7 +480,7 @@ public abstract class BlackBoxContext implements Logging {
      * Obtains immutable list of all the events in this Bounded Context.
      */
     @VisibleForTesting
-    ImmutableList<Event> allEvents() {
+    final ImmutableList<Event> allEvents() {
         return select(this.events);
     }
 
@@ -492,24 +493,46 @@ public abstract class BlackBoxContext implements Logging {
 
     /**
      * Obtains a Subject for an entity of the passed class with the given ID.
+     *
+     * @deprecated please use {@link #assertEntity(Object, Class)}
      */
-    public <I, E extends Entity<I, ? extends EntityState>>
+    @Deprecated
+    public final <I, E extends Entity<I, ? extends EntityState>>
     EntitySubject assertEntity(Class<E> entityClass, I id) {
-        @Nullable Entity<I, ?> found = findEntity(entityClass, id);
+        return assertEntity(id, entityClass);
+    }
+
+    /**
+     * Obtains a Subject for an entity of the passed class with the given ID.
+     */
+    public final <I, E extends Entity<I, ? extends EntityState>>
+    EntitySubject assertEntity(I id, Class<E> entityClass) {
+        @Nullable Entity<I, ?> found = findEntity(id, entityClass);
         return EntitySubject.assertEntity(found);
     }
 
     private <I> @Nullable Entity<I, ?>
-    findEntity(Class<? extends Entity<I, ?>> entityClass, I id) {
+    findEntity(I id, Class<? extends Entity<I, ?>> entityClass) {
         Class<? extends EntityState> stateClass = stateClassOf(entityClass);
         return findByState(stateClass, id);
     }
 
     /**
      * Obtains a Subject for an entity which has the state of the passed class with the given ID.
+     *
+     * @deprecated please use {@link #assertEntityWithState(Object, Class)}
      */
-    public <I, S extends EntityState> EntitySubject
+    @Deprecated
+    public final <I, S extends EntityState> EntitySubject
     assertEntityWithState(Class<S> stateClass, I id) {
+        return assertEntityWithState(id, stateClass);
+    }
+
+    /**
+     * Obtains a Subject for an entity which has the state of the passed class with the given ID.
+     */
+    public final <I, S extends EntityState>
+    EntitySubject assertEntityWithState(I id, Class<S> stateClass) {
         @Nullable Entity<I, S> found = findByState(stateClass, id);
         return EntitySubject.assertEntity(found);
     }
@@ -523,7 +546,7 @@ public abstract class BlackBoxContext implements Logging {
     }
 
     @VisibleForTesting
-    Repository<?, ?> repositoryOf(Class<? extends EntityState> stateClass) {
+    final Repository<?, ?> repositoryOf(Class<? extends EntityState> stateClass) {
         Repository<?, ?> repository =
                 context.internalAccess()
                        .getRepository(stateClass);
@@ -533,15 +556,38 @@ public abstract class BlackBoxContext implements Logging {
     /**
      * Obtains the subject for checking commands generated by the entities of this Bounded Context.
      */
-    public CommandSubject assertCommands() {
+    public final CommandSubject assertCommands() {
         return CommandSubject.assertThat(commands());
     }
 
     /**
      * Obtains the subject for checking events emitted by the entities of this Bounded Context.
      */
-    public EventSubject assertEvents() {
+    public final EventSubject assertEvents() {
         return EventSubject.assertThat(events());
+    }
+
+
+    /**
+     * Asserts that the context generated only one event of the passed type.
+     *
+     * @param eventClass
+     *         the type of the event to assert
+     * @return the subject for further assertions
+     */
+    public final ProtoFluentAssertion assertEvent(Class<? extends EventMessage> eventClass) {
+        EventSubject assertEvents =
+                assertEvents().withType(eventClass);
+        assertEvents.hasSize(1);
+        return assertEvents.message(0)
+                           .comparingExpectedFieldsOnly();
+    }
+
+    /**
+     * Asserts that the context generated only one passed event.
+     */
+    public final void assertEvent(EventMessage event) {
+        assertEvent(event.getClass()).isEqualTo(event);
     }
 
     /**

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/BlackBoxContextTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/BlackBoxContextTest.java
@@ -149,12 +149,13 @@ abstract class BlackBoxContextTest<T extends BlackBoxContext> {
     @DisplayName("ignore sent events in emitted")
     void ignoreSentEvents() {
         BbProjectId id = newProjectId();
-        EventSubject assertEvents = context
-                .receivesCommand(createProject(id))
-                .receivesEvent(taskAdded(id))
-                .assertEvents();
-        assertEvents.hasSize(1);
-        assertEvents.withType(BbProjectCreated.class).isNotEmpty();
+        context.receivesCommand(createProject(id))
+                .receivesEvent(taskAdded(id));
+        context.assertEvent(
+                BbProjectCreated
+                        .newBuilder()
+                        .setProjectId(id)
+                        .build());
     }
 
     @Nested
@@ -167,7 +168,7 @@ abstract class BlackBoxContextTest<T extends BlackBoxContext> {
             BbCreateProject createProject = createProject();
             BbProject expectedProject = createdProjectState(createProject);
             context.receivesCommand(createProject)
-                   .assertEntityWithState(expectedProject.getClass(), createProject.getProjectId())
+                   .assertEntityWithState(createProject.getProjectId(), expectedProject.getClass())
                    .hasStateThat()
                    .isEqualTo(expectedProject);
         }
@@ -178,7 +179,7 @@ abstract class BlackBoxContextTest<T extends BlackBoxContext> {
             BbCreateProject createProject = createProject();
             BbProjectView expectedProject = createProjectView(createProject);
             context.receivesCommand(createProject)
-                   .assertEntityWithState(expectedProject.getClass(), createProject.getProjectId())
+                   .assertEntityWithState(createProject.getProjectId(), expectedProject.getClass())
                    .hasStateThat()
                    .isEqualTo(expectedProject);
         }
@@ -511,7 +512,7 @@ abstract class BlackBoxContextTest<T extends BlackBoxContext> {
         @Test
         @DisplayName("via entity class")
         void entityClass() {
-            EntitySubject subject = context.assertEntity(BbInitProcess.class, id);
+            EntitySubject subject = context.assertEntity(id, BbInitProcess.class);
             assertThat(subject)
                     .isNotNull();
             subject.isInstanceOf(BbInitProcess.class);
@@ -520,7 +521,7 @@ abstract class BlackBoxContextTest<T extends BlackBoxContext> {
         @Test
         @DisplayName("via entity state class")
         void entityStateClass() {
-            EntitySubject subject = context.assertEntityWithState(BbInit.class, id);
+            EntitySubject subject = context.assertEntityWithState(id, BbInit.class);
             assertThat(subject)
                     .isNotNull();
             subject.hasStateThat()
@@ -535,7 +536,7 @@ abstract class BlackBoxContextTest<T extends BlackBoxContext> {
 
             @BeforeEach
             void getSubj() {
-                assertProcessManager = context.assertEntity(BbInitProcess.class, id);
+                assertProcessManager = context.assertEntity(id, BbInitProcess.class);
             }
 
             @Test
@@ -670,7 +671,7 @@ abstract class BlackBoxContextTest<T extends BlackBoxContext> {
             BbAssignSelf assignSelf = assignSelf(id);
             context.withActor(actor)
                    .receivesCommands(createProject, assignSelf)
-                   .assertEntityWithState(BbProject.class, id)
+                   .assertEntityWithState(id, BbProject.class)
                    .hasStateThat()
                    .comparingExpectedFieldsOnly()
                    .isEqualTo(BbProject
@@ -690,7 +691,7 @@ abstract class BlackBoxContextTest<T extends BlackBoxContext> {
             context.withActor(actor)
                    .in(zoneId)
                    .receivesCommand(createProject)
-                   .assertEntityWithState(BbProject.class, id)
+                   .assertEntityWithState(id, BbProject.class)
                    .exists();
             EventSubject events = context.assertEvents()
                                          .withType(BbProjectCreated.class);
@@ -718,7 +719,7 @@ abstract class BlackBoxContextTest<T extends BlackBoxContext> {
             ZoneId zoneId = ZoneIds.of("UTC-1");
             context.in(zoneId)
                    .receivesCommand(createProject)
-                   .assertEntityWithState(BbProject.class, id)
+                   .assertEntityWithState(id, BbProject.class)
                    .exists();
             EventSubject events = context.assertEvents()
                                          .withType(BbProjectCreated.class);

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/BlackBoxContextTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/BlackBoxContextTest.java
@@ -179,9 +179,7 @@ abstract class BlackBoxContextTest<T extends BlackBoxContext> {
             BbCreateProject createProject = createProject();
             BbProjectView expectedProject = createProjectView(createProject);
             context.receivesCommand(createProject)
-                   .assertEntityWithState(createProject.getProjectId(), expectedProject.getClass())
-                   .hasStateThat()
-                   .isEqualTo(expectedProject);
+                   .assertState(createProject.getProjectId(), expectedProject);
         }
 
         private BbProjectView createProjectView(BbCreateProject createProject) {
@@ -671,14 +669,11 @@ abstract class BlackBoxContextTest<T extends BlackBoxContext> {
             BbAssignSelf assignSelf = assignSelf(id);
             context.withActor(actor)
                    .receivesCommands(createProject, assignSelf)
-                   .assertEntityWithState(id, BbProject.class)
-                   .hasStateThat()
-                   .comparingExpectedFieldsOnly()
-                   .isEqualTo(BbProject
-                                      .newBuilder()
-                                      .setId(id)
-                                      .addAssignee(actor)
-                                      .buildPartial());
+                   .assertState(id,
+                                BbProject.newBuilder()
+                                         .setId(id)
+                                         .addAssignee(actor)
+                                         .buildPartial());
         }
 
         @Test

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/MultiTenantContextTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/MultiTenantContextTest.java
@@ -72,7 +72,7 @@ class MultiTenantContextTest
                .assertEvents()
                .withType(BbProjectCreated.class)
                .hasSize(1);
-        context.assertEntityWithState(BbProject.class, createJohnProject.getProjectId())
+        context.assertEntityWithState(createJohnProject.getProjectId(), BbProject.class)
                .hasStateThat()
                .isEqualTo(createdProjectState(createJohnProject));
         // Verify project was created for Carl.
@@ -82,7 +82,7 @@ class MultiTenantContextTest
                 .withType(BbProjectCreated.class)
                 .hasSize(1);
         contextForCarl
-                .assertEntityWithState(BbProject.class, createCarlProject.getProjectId())
+                .assertEntityWithState(createCarlProject.getProjectId(), BbProject.class)
                 .hasStateThat()
                 .isEqualTo(createdProjectState(createCarlProject));
         // Verify nothing happened for a new user.
@@ -101,7 +101,7 @@ class MultiTenantContextTest
         assertThrows(
                 IllegalStateException.class,
                 () -> BlackBoxContext.from(BoundedContextBuilder.assumingTests(true))
-                                     .assertEntityWithState(BbProject.class, "verify state")
+                                     .assertEntityWithState("verify state", BbProject.class)
         );
     }
 }

--- a/version.gradle
+++ b/version.gradle
@@ -25,14 +25,14 @@
  * as we want to manage the versions in a single source.
  */
 
-final def spineVersion = '1.5.6'
+final def spineVersion = '1.5.7'
 
 ext {
     // The version of the modules in this project.
     versionToPublish = spineVersion
 
     // Depend on `base` for the general definitions and a model compiler.
-    spineBaseVersion = '1.5.1'
+    spineBaseVersion = '1.5.4'
 
     // Depend on `time` for `ZoneId`, `ZoneOffset` and other date/time types and utilities.
     spineTimeVersion = '1.5.0'


### PR DESCRIPTION
This PR adds assertion methods for events and entity states to `BlackBoxContext`. 

Entity and entity state assertion methods now accept an ID as the first parameter. Methods that used to have the ID as the second parameter were deprecated in favour of ones with the new order.
