### PR TITLE
Fix javadoc build

### DIFF
--- a/client/src/main/java/io/spine/client/CommandRequest.java
+++ b/client/src/main/java/io/spine/client/CommandRequest.java
@@ -67,11 +67,11 @@ public final class CommandRequest extends ClientRequest {
      * Adds the passed consumer to the subscribers of the event of the passed type.
      *
      * @param type
-     *          the type of the event message to be received by the consumer
+     *         the type of the event message to be received by the consumer
      * @param consumer
-     *          the consumer
+     *         the consumer
      * @param <E>
-     *          the type of the event
+     *         the type of the event
      */
     @CanIgnoreReturnValue
     public <E extends EventMessage> CommandRequest
@@ -85,11 +85,11 @@ public final class CommandRequest extends ClientRequest {
      * Adds the passed event consumer to the subscribers of the event of the passed type.
      *
      * @param type
-     *          the type of the event message to be received by the consumer
+     *         the type of the event message to be received by the consumer
      * @param consumer
-     *          the consumer of the event message and its context
+     *         the consumer of the event message and its context
      * @param <E>
-     *          the type of the event
+     *         the type of the event
      */
     @CanIgnoreReturnValue
     public <E extends EventMessage> CommandRequest

--- a/server/src/main/java/io/spine/server/bus/Bus.java
+++ b/server/src/main/java/io/spine/server/bus/Bus.java
@@ -253,12 +253,15 @@ public abstract class Bus<T extends Signal<?, ?, ?>,
      * <p>Any filter in the filter chain may process the message by itself. In this case an observer
      * is notified by the filter directly.
      *
-     * @param messages the message to filter
-     * @param observer the observer to receive the negative outcome of the operation
+     * @param messages
+     *         the message to filter
+     * @param observer
+     *         the observer to receive the negative outcome of the operation
      * @return a map of filtered messages where keys are messages, and values are envelopes with
      *         these messages
-     * @implNote This method returns a map to avoid repeated creation of envelopes when dispatching.
-     * Messages in the returned map come in the same order as in the incoming sequence.
+     * @implNote This method returns a map to avoid repeated creation of envelopes when
+     *         dispatching. Messages in the returned map come in the same order as in
+     *         the incoming sequence.
      */
     private Map<T, E> filter(Iterable<T> messages, StreamObserver<Ack> observer) {
         checkNotNull(messages);


### PR DESCRIPTION
This PR advances `config` dependency to fix build in terms of Javadoc publishing.

The version is not changed since no API changes are introduced (and the previous PR was not published because of the publishing error).
