### PR TITLE
Build failure on Error Prone warnings

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -70,7 +70,7 @@ object Versions {
     val checkerFramework = "3.3.0"
     val errorProne       = "2.3.4"
     val errorProneJavac  = "9+181-r4173-1" // taken from here: https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.8/build.gradle.kts
-    val errorPronePlugin = "1.1.1"
+    val errorPronePlugin = "1.2.1"
     val pmd              = "6.24.0"
     val checkstyle       = "8.29"
     val protobufPlugin   = "0.8.12"
@@ -102,7 +102,7 @@ object Versions {
     /**
      * Version of the SLF4J library.
      *
-     * Spine used to log with SLF4J. Now we use Flogger. Whenever a coice comes up, we recommend to
+     * Spine used to log with SLF4J. Now we use Flogger. Whenever a choice comes up, we recommend to
      * use the latter.
      *
      * Some third-party libraries may clash with different versions of the library. Thus, we specify
@@ -229,7 +229,7 @@ object Test {
             "com.google.truth.extensions:truth-proto-extension:${Versions.truth}"
     )
     @Deprecated("Use Flogger over SLF4J.",
-                replaceWith = ReplaceWith("Deps.runtime.floggerSystemBackend"))
+            replaceWith = ReplaceWith("Deps.runtime.floggerSystemBackend"))
     @Suppress("DEPRECATION") // Version of SLF4J.
     val slf4j         = "org.slf4j:slf4j-jdk14:${Versions.slf4j}"
 }

--- a/core/src/main/proto/spine/core/event.proto
+++ b/core/src/main/proto/spine/core/event.proto
@@ -29,7 +29,6 @@ option java_multiple_files = true;
 option java_outer_classname = "EventProto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 
 import "spine/core/actor_context.proto";
@@ -126,7 +125,7 @@ message EventContext {
 
     // An ID of the root command, which lead to this event.
     //
-    // If the event is a reaction to another event, then this attribute holds the identifier 
+    // If the event is a reaction to another event, then this attribute holds the identifier
     // of the very first command in this chain.
     //
     // This field is not populated if the event was imported.

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.5.20</version>
+<version>1.5.21</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,6 +25,6 @@
  * as we want to manage the versions in a single source.
  */
 
-val spineBaseVersion: String by extra("1.5.20")
-val spineTimeVersion: String by extra("1.5.20")
+val spineBaseVersion: String by extra("1.5.21")
+val spineTimeVersion: String by extra("1.5.21")
 val versionToPublish: String by extra("1.5.21")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 
 val spineBaseVersion: String by extra("1.5.19")
 val spineTimeVersion: String by extra("1.5.19")
-val versionToPublish: String by extra("1.5.20")
+val versionToPublish: String by extra("1.5.21")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,6 +25,6 @@
  * as we want to manage the versions in a single source.
  */
 
-val spineBaseVersion: String by extra("1.5.19")
-val spineTimeVersion: String by extra("1.5.19")
+val spineBaseVersion: String by extra("1.5.20")
+val spineTimeVersion: String by extra("1.5.20")
 val versionToPublish: String by extra("1.5.21")


### PR DESCRIPTION
This PR prepares `core-java` for https://github.com/SpineEventEngine/config/pull/122.

It makes sure that the build yields no warnings.