### PR TITLE
Add warning logs in `ServerEnvironment`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
@@ -27,6 +27,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
+import java.io.FileNotFoundException
 import java.net.URL
 
 /**
@@ -52,13 +53,13 @@ open class CheckVersionIncrement : DefaultTask() {
         val artifact = "${project.artifactPath()}/${MavenMetadata.FILE_NAME}"
         val repoUrl = repository.releases
         val metadata = fetch(repoUrl, artifact)
-        val versions = metadata.versioning.versions
-        val versionExists = versions.contains(version)
+        val versions = metadata?.versioning?.versions
+        val versionExists = versions?.contains(version) ?: false
         if (versionExists) {
             throw GradleException("""
                     Version `$version` is already published to maven repository `$repoUrl`.
                     Try incrementing the library version.
-                    All available versions are: ${versions.joinToString(separator = ", ")}. 
+                    All available versions are: ${versions?.joinToString(separator = ", ")}. 
                     
                     To disable this check, run Gradle with `-x $name`. 
                     """.trimIndent()
@@ -66,7 +67,7 @@ open class CheckVersionIncrement : DefaultTask() {
         }
     }
 
-    private fun fetch(repository: String, artifact: String): MavenMetadata {
+    private fun fetch(repository: String, artifact: String): MavenMetadata? {
         val url = URL("$repository/$artifact")
         return MavenMetadata.fetchAndParse(url)
     }
@@ -94,9 +95,19 @@ private data class MavenMetadata(var versioning: Versioning = Versioning()) {
             mapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
         }
 
-        fun fetchAndParse(url: URL): MavenMetadata {
-            val metadata = mapper.readValue(url, MavenMetadata::class.java)
-            return metadata
+        /**
+         * Fetches the metadata for the repository and parses the document.
+         *
+         * <p>If the document could not be found, assumes that the module was never
+         * released and thus has no metadata.
+         */
+        fun fetchAndParse(url: URL): MavenMetadata? {
+            return try {
+                val metadata = mapper.readValue(url, MavenMetadata::class.java)
+                metadata
+            } catch (e: FileNotFoundException) {
+                null
+            }
         }
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -94,7 +94,7 @@ object Versions {
     val javaPoet         = "1.12.1"
     val autoService      = "1.0-rc6"
     val autoCommon       = "0.10"
-    val jackson          = "2.9.10.4"
+    val jackson          = "2.9.10.5"
     val animalSniffer    = "1.18"
     val apiguardian      = "1.1.0"
     val javaxAnnotation  = "1.3.2"

--- a/server/src/main/java/io/spine/server/ServerEnvironment.java
+++ b/server/src/main/java/io/spine/server/ServerEnvironment.java
@@ -239,6 +239,7 @@ public final class ServerEnvironment implements AutoCloseable, Logging {
      *
      * @return this instance of {@code ServerEnvironment}
      */
+    @SuppressWarnings("DuplicateStringLiteralInspection") // we do not externalize formats
     @CanIgnoreReturnValue
     public ServerEnvironment use(StorageFactory factory, EnvironmentType envType) {
         checkNotNull(factory);
@@ -256,6 +257,7 @@ public final class ServerEnvironment implements AutoCloseable, Logging {
      *
      * @return this instance of {@code ServerEnvironment}
      */
+    @SuppressWarnings("DuplicateStringLiteralInspection") // we do not externalize formats
     @CanIgnoreReturnValue
     public ServerEnvironment use(StorageFactory factory, Class<? extends EnvironmentType> type) {
         checkNotNull(factory);

--- a/server/src/main/java/io/spine/server/ServerEnvironment.java
+++ b/server/src/main/java/io/spine/server/ServerEnvironment.java
@@ -28,6 +28,7 @@ import io.spine.base.EnvironmentType;
 import io.spine.base.Identifier;
 import io.spine.base.Production;
 import io.spine.base.Tests;
+import io.spine.logging.Logging;
 import io.spine.server.commandbus.CommandScheduler;
 import io.spine.server.commandbus.ExecutorCommandScheduler;
 import io.spine.server.delivery.Delivery;
@@ -72,7 +73,7 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  * returned on {@link #storageFactory()}.
  */
 @SuppressWarnings("ClassWithTooManyMethods" /* there are some deprecated methods to be eliminated later. */)
-public final class ServerEnvironment implements AutoCloseable {
+public final class ServerEnvironment implements AutoCloseable, Logging {
 
     private static final ServerEnvironment INSTANCE = new ServerEnvironment();
 
@@ -241,6 +242,10 @@ public final class ServerEnvironment implements AutoCloseable {
     @CanIgnoreReturnValue
     public ServerEnvironment use(StorageFactory factory, EnvironmentType envType) {
         checkNotNull(factory);
+        if (envType instanceof Production && factory instanceof InMemoryStorageFactory) {
+            _warn().log("`%s` should not be used in production.", factory.getClass()
+                                                                         .getSimpleName());
+        }
         SystemAwareStorageFactory wrapped = wrap(factory);
         use(wrapped, storageFactory, envType);
         return this;
@@ -254,6 +259,10 @@ public final class ServerEnvironment implements AutoCloseable {
     @CanIgnoreReturnValue
     public ServerEnvironment use(StorageFactory factory, Class<? extends EnvironmentType> type) {
         checkNotNull(factory);
+        if (Production.class.equals(type) && factory instanceof InMemoryStorageFactory) {
+            _warn().log("`%s` should not be used in production.", factory.getClass()
+                                                                         .getSimpleName());
+        }
         SystemAwareStorageFactory wrapped = wrap(factory);
         use(wrapped, storageFactory, type);
         return this;

--- a/server/src/main/java/io/spine/server/ServerEnvironment.java
+++ b/server/src/main/java/io/spine/server/ServerEnvironment.java
@@ -235,7 +235,7 @@ public final class ServerEnvironment implements AutoCloseable, Logging {
     }
 
     /**
-     * Assigns the specified {@code TransportFactory} for the specified application environment.
+     * Assigns the specified {@code StorageFactory} for the specified application environment.
      *
      * @return this instance of {@code ServerEnvironment}
      */
@@ -253,7 +253,7 @@ public final class ServerEnvironment implements AutoCloseable, Logging {
     }
 
     /**
-     * Assigns the specified {@code TransportFactory} for the specified application environment.
+     * Assigns the specified {@code StorageFactory} for the specified application environment.
      *
      * @return this instance of {@code ServerEnvironment}
      */
@@ -315,7 +315,7 @@ public final class ServerEnvironment implements AutoCloseable, Logging {
     }
 
     /**
-     * Configures the specified transport factory for the selected type of environment.
+     * Configures the specified {@code TransportFactory} for the selected type of environment.
      *
      * @return this instance of {@code ServerEnvironment}
      */
@@ -326,7 +326,7 @@ public final class ServerEnvironment implements AutoCloseable, Logging {
     }
 
     /**
-     * Configures the specified transport factory for the selected type of environment.
+     * Configures the specified {@code TransportFactory} for the selected type of environment.
      *
      * @return this instance of {@code ServerEnvironment}
      */

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,6 +25,6 @@
  * as we want to manage the versions in a single source.
  */
 
-val spineBaseVersion: String by extra("1.5.21")
+val spineBaseVersion: String by extra("1.5.22")
 val spineTimeVersion: String by extra("1.5.21")
-val versionToPublish: String by extra("1.5.21")
+val versionToPublish: String by extra("1.5.22")


### PR DESCRIPTION
In this PR I have added warning logs on using `InMemoryStorageFactory` in `Production` environment. I guess it should be a good hint for developers trying to figure out why queries return nothing in non-test environments.

Answering the question "how it can happen that we have an in-memory config for Production": it is very tempting to start working with the application using in-memory configurations and then replace them with the actual ones. From my perspective, that's a valid case while developing applications.