### PR TITLE
Improve custom environments support

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -406,7 +406,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 18 15:24:36 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 18 15:45:58 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -777,7 +777,7 @@ This report was generated on **Tue Aug 18 15:24:36 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 18 15:24:37 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 18 15:45:59 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1183,7 +1183,7 @@ This report was generated on **Tue Aug 18 15:24:37 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 18 15:24:37 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 18 15:46:00 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1659,7 +1659,7 @@ This report was generated on **Tue Aug 18 15:24:37 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 18 15:24:38 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 18 15:46:00 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2082,7 +2082,7 @@ This report was generated on **Tue Aug 18 15:24:38 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 18 15:24:39 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 18 15:46:01 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2542,7 +2542,7 @@ This report was generated on **Tue Aug 18 15:24:39 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 18 15:24:41 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 18 15:46:04 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3010,7 +3010,7 @@ This report was generated on **Tue Aug 18 15:24:41 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 18 15:24:44 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 18 15:46:05 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3514,4 +3514,4 @@ This report was generated on **Tue Aug 18 15:24:44 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 18 15:24:48 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 18 15:46:08 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.5.24`
+# Dependencies of `io.spine:spine-client:1.5.25`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -406,12 +406,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Aug 14 14:46:46 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 18 15:24:36 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.5.24`
+# Dependencies of `io.spine:spine-core:1.5.25`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -777,12 +777,12 @@ This report was generated on **Fri Aug 14 14:46:46 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Aug 14 14:46:46 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 18 15:24:37 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.5.24`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.5.25`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1183,12 +1183,12 @@ This report was generated on **Fri Aug 14 14:46:46 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Aug 14 14:46:47 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 18 15:24:37 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.5.24`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.5.25`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1659,12 +1659,12 @@ This report was generated on **Fri Aug 14 14:46:47 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Aug 14 14:46:47 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 18 15:24:38 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.5.24`
+# Dependencies of `io.spine:spine-server:1.5.25`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2082,12 +2082,12 @@ This report was generated on **Fri Aug 14 14:46:47 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Aug 14 14:46:47 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 18 15:24:39 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.5.24`
+# Dependencies of `io.spine:spine-testutil-client:1.5.25`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2542,12 +2542,12 @@ This report was generated on **Fri Aug 14 14:46:47 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Aug 14 14:46:49 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 18 15:24:41 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.5.24`
+# Dependencies of `io.spine:spine-testutil-core:1.5.25`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3010,12 +3010,12 @@ This report was generated on **Fri Aug 14 14:46:49 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Aug 14 14:46:50 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 18 15:24:44 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.5.24`
+# Dependencies of `io.spine:spine-testutil-server:1.5.25`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3514,4 +3514,4 @@ This report was generated on **Fri Aug 14 14:46:50 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Aug 14 14:46:51 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 18 15:24:48 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.5.24</version>
+<version>1.5.25</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/EnvSetting.java
+++ b/server/src/main/java/io/spine/server/EnvSetting.java
@@ -137,7 +137,7 @@ final class EnvSetting<V> {
     }
 
     /**
-     * Applies the passed operation to this setting regardless of the current environment.
+     * Applies the passed operation to this setting regardless of current environment.
      *
      * <p>This means the operation is applied to all passed setting {@linkplain #environmentValues
      * values} on a per-environment basis.

--- a/server/src/main/java/io/spine/server/EnvSetting.java
+++ b/server/src/main/java/io/spine/server/EnvSetting.java
@@ -139,8 +139,8 @@ final class EnvSetting<V> {
     /**
      * Applies the passed operation to this setting regardless of the current environment.
      *
-     * <p>This means the operation is applied to all passed setting
-     * {@linkplain #environmentValues values}.
+     * <p>This means the operation is applied to all passed setting {@linkplain #environmentValues
+     * values} on a per-environment basis.
      *
      * @apiNote The not yet run {@linkplain #fallbacks fallback suppliers} are ignored to avoid the
      *        unnecessary value instantiation.

--- a/server/src/main/java/io/spine/server/EnvSetting.java
+++ b/server/src/main/java/io/spine/server/EnvSetting.java
@@ -21,7 +21,6 @@
 package io.spine.server;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.spine.annotation.Internal;
 import io.spine.base.EnvironmentType;
 
 import java.util.HashMap;
@@ -86,7 +85,6 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  * @param <V>
  *         the type of value
  */
-@Internal
 final class EnvSetting<V> {
 
     private final Map<Class<? extends EnvironmentType>, V> environmentValues =
@@ -135,6 +133,21 @@ final class EnvSetting<V> {
         Optional<V> value = valueFor(type);
         if (value.isPresent()) {
             operation.accept(value.get());
+        }
+    }
+
+    /**
+     * Applies the passed operation to this setting regardless of the current environment.
+     *
+     * <p>This means the operation is applied to all passed setting
+     * {@linkplain #environmentValues values}.
+     *
+     * @apiNote The not yet run {@linkplain #fallbacks fallback suppliers} are ignored to avoid the
+     *        unnecessary value instantiation.
+     */
+    void apply(SettingOperation<V> operation) throws Exception {
+        for (V v : environmentValues.values()) {
+            operation.accept(v);
         }
     }
 

--- a/server/src/main/java/io/spine/server/EnvSetting.java
+++ b/server/src/main/java/io/spine/server/EnvSetting.java
@@ -142,7 +142,7 @@ final class EnvSetting<V> {
      * <p>This means the operation is applied to all passed setting {@linkplain #environmentValues
      * values} on a per-environment basis.
      *
-     * @apiNote The not yet run {@linkplain #fallbacks fallback suppliers} are ignored to avoid the
+     * @apiNote The not yet run {@linkplain #fallbacks fallback suppliers} are ignored to avoid an
      *        unnecessary value instantiation.
      */
     void apply(SettingOperation<V> operation) throws Exception {

--- a/server/src/main/java/io/spine/server/ServerEnvironment.java
+++ b/server/src/main/java/io/spine/server/ServerEnvironment.java
@@ -442,9 +442,9 @@ public final class ServerEnvironment implements AutoCloseable {
      */
     @Override
     public void close() throws Exception {
-        tracerFactory.ifPresentForEnvironment(Production.class, AutoCloseable::close);
-        transportFactory.ifPresentForEnvironment(Production.class, AutoCloseable::close);
-        storageFactory.ifPresentForEnvironment(Production.class, AutoCloseable::close);
+        tracerFactory.apply(AutoCloseable::close);
+        transportFactory.apply(AutoCloseable::close);
+        storageFactory.apply(AutoCloseable::close);
     }
 
     private static <V> void use(V value, EnvSetting<V> setting, EnvironmentType type) {

--- a/server/src/main/java/io/spine/server/event/model/StateSubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/StateSubscriberMethod.java
@@ -26,7 +26,7 @@ import io.spine.base.Environment;
 import io.spine.base.EventMessage;
 import io.spine.base.Field;
 import io.spine.base.FieldPath;
-import io.spine.base.Production;
+import io.spine.base.Tests;
 import io.spine.core.BoundedContext;
 import io.spine.core.BoundedContextName;
 import io.spine.logging.Logging;
@@ -107,7 +107,7 @@ public final class StateSubscriberMethod extends SubscriberMethod implements Log
     private BoundedContextName contextOf(Class<?> cls) {
         Model model = Model.inContextOf(cls);
         BoundedContextName name = model.contextName();
-        if (Environment.instance().is(Production.class) && name.equals(assumingTests())) {
+        if (!Environment.instance().is(Tests.class) && name.equals(assumingTests())) {
             _warn().log(
                     "The class `%s` belongs to the Bounded Context named `%s`," +
                     " which is used for testing. As such, it should not be used in production." +

--- a/server/src/main/java/io/spine/system/server/SystemSettings.java
+++ b/server/src/main/java/io/spine/system/server/SystemSettings.java
@@ -24,7 +24,7 @@ import com.google.common.base.Objects;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.spine.annotation.Internal;
 import io.spine.base.Environment;
-import io.spine.base.Production;
+import io.spine.base.Tests;
 
 /**
  * A configuration of features of a system context.
@@ -61,10 +61,10 @@ public final class SystemSettings implements SystemFeatures {
                 .disableCommandLog()
                 .enableAggregateQuerying()
                 .forgetEvents();
-        if (Environment.instance().is(Production.class)) {
-            settings.enableParallelPosting();
-        } else {
+        if (Environment.instance().is(Tests.class)) {
             settings.disableParallelPosting();
+        } else {
+            settings.enableParallelPosting();
         }
         return settings;
     }

--- a/server/src/test/java/io/spine/server/EnvSettingTest.java
+++ b/server/src/test/java/io/spine/server/EnvSettingTest.java
@@ -205,8 +205,8 @@ class EnvSettingTest {
     }
 
     @Test
-    @DisplayName("run an operation against all values")
-    void runConsumerForAll() throws Exception {
+    @DisplayName("run an operation for all present values")
+    void runOperationForAll() throws Exception {
         MemoizingStorageFactory prodStorageFactory = new MemoizingStorageFactory();
         MemoizingStorageFactory testingStorageFactory = new MemoizingStorageFactory();
         MemoizingStorageFactory localStorageFactory = new MemoizingStorageFactory();

--- a/server/src/test/java/io/spine/server/ServerEnvironmentTest.java
+++ b/server/src/test/java/io/spine/server/ServerEnvironmentTest.java
@@ -21,6 +21,7 @@
 package io.spine.server;
 
 import io.spine.base.Environment;
+import io.spine.base.EnvironmentType;
 import io.spine.base.Production;
 import io.spine.base.Tests;
 import io.spine.server.delivery.Delivery;
@@ -504,32 +505,33 @@ class ServerEnvironmentTest {
 
         @Test
         @DisplayName("close the production transport, tracer and storage factories")
+        void productionCloses() throws Exception {
+            testClosesEnv(Production.class);
+        }
+
+        @Test
+        @DisplayName("close the testing transport, tracer and storage factories")
         void testCloses() throws Exception {
+            testClosesEnv(Tests.class);
+        }
+
+        @Test
+        @DisplayName("close the custom env transport, tracer and storage factories")
+        void customEnvCloses() throws Exception {
+            testClosesEnv(Local.class);
+        }
+
+        private void testClosesEnv(Class<? extends EnvironmentType> envType) throws Exception {
             ServerEnvironment serverEnv = ServerEnvironment.instance();
-            serverEnv.use(transportFactory, Production.class)
-                     .use(storageFactory, Production.class)
-                     .use(tracerFactory, Production.class);
+            serverEnv.use(transportFactory, envType)
+                     .use(storageFactory, envType)
+                     .use(tracerFactory, envType);
 
             serverEnv.close();
 
             assertThat(transportFactory.isOpen()).isFalse();
             assertThat(storageFactory.isClosed()).isTrue();
             assertThat(tracerFactory.closed()).isTrue();
-        }
-
-        @Test
-        @DisplayName("leave the testing transport, tracer and storage factories open")
-        void testDoesNotClose() throws Exception {
-            ServerEnvironment serverEnv = ServerEnvironment.instance();
-            serverEnv.use(transportFactory, Tests.class)
-                     .use(storageFactory, Tests.class)
-                     .use(tracerFactory, Tests.class);
-
-            serverEnv.close();
-
-            assertThat(tracerFactory.closed()).isFalse();
-            assertThat(transportFactory.isOpen()).isTrue();
-            assertThat(storageFactory.isClosed()).isFalse();
         }
     }
 

--- a/server/src/test/java/io/spine/system/server/SystemSettingsTest.java
+++ b/server/src/test/java/io/spine/system/server/SystemSettingsTest.java
@@ -23,8 +23,8 @@ package io.spine.system.server;
 import io.spine.base.Environment;
 import io.spine.base.Production;
 import io.spine.base.Tests;
+import io.spine.server.given.environment.Local;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -67,19 +67,36 @@ class SystemSettingsTest {
             assertFalse(features.includePersistentEvents());
         }
 
-        @Test
-        @Disabled
-        @DisplayName("allow parallel posting for system events")
-        void parallelism() {
-            Environment env = Environment.instance();
+        @Nested
+        @DisplayName("allow parallel posting of system events")
+        class AllowParallelPosting {
 
+            private final Environment env = Environment.instance();
+
+            @Test
+            @DisplayName("in the `Production` environment")
+            void forProductionEnv() {
+                env.setTo(Production.class);
+                assertTrue(SystemSettings.defaults()
+                                         .postEventsInParallel());
+            }
+
+            @Test
+            @DisplayName("in a custom environment")
+            void forCustomEnv() {
+                env.setTo(Local.class);
+                assertTrue(SystemSettings.defaults()
+                                         .postEventsInParallel());
+            }
+        }
+
+        @Test
+        @DisplayName("disallow parallel posting of system events in the test environment")
+        void disallowParallelPostingForTest() {
+            Environment env = Environment.instance();
             assumeTrue(env.is(Tests.class));
             assertFalse(SystemSettings.defaults()
                                       .postEventsInParallel());
-
-            env.setTo(Production.class);
-            assertTrue(SystemSettings.defaults()
-                                     .postEventsInParallel());
         }
     }
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 
 val spineBaseVersion: String by extra("1.5.23")
 val spineTimeVersion: String by extra("1.5.21")
-val versionToPublish: String by extra("1.5.24")
+val versionToPublish: String by extra("1.5.25")


### PR DESCRIPTION
This PR fixes issue #1291.

Parts of the framework where the `Production` environment usage was hard-coded are changed to support the custom environment types.

Please note, that the `Tests` environment is still treated specially in some cases. For example, the parallel posting of system events is disabled for tests as some of them rely on the eventual consistency of the data.

The library version advances to `1.5.25`.