### PR TITLE
Encapsulate checking `Repository` context

### DIFF
--- a/server/src/main/java/io/spine/server/entity/Repository.java
+++ b/server/src/main/java/io/spine/server/entity/Repository.java
@@ -203,7 +203,7 @@ public abstract class Repository<I, E extends Entity<I, ?>>
     public void registerWith(BoundedContext context) {
         checkNotNull(context);
         boolean sameValue = context.equals(this.context);
-        if (this.context != null && !sameValue) {
+        if (hasContext() && !sameValue) {
             throw newIllegalStateException(
                     "The repository `%s` has the Bounded Context (`%s`) assigned." +
                             " This operation can be performed only once." +
@@ -222,14 +222,11 @@ public abstract class Repository<I, E extends Entity<I, ?>>
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * <p>Unlike, {@link #isOpen()}, once the repository is
-     * {@linkplain #registerWith(BoundedContext) initialized}, this method always returns {@code true}.
+     * Tells if the repository is registered in a {@code BoundedContext}.
      */
     @Override
     public boolean isRegistered() {
-        return context != null;
+        return hasContext();
     }
 
     /**
@@ -262,7 +259,7 @@ public abstract class Repository<I, E extends Entity<I, ?>>
      *         if the repository has no context assigned
      */
     protected final BoundedContext context() {
-        checkState(context != null,
+        checkState(hasContext(),
                    "The repository (class: `%s`) is not registered with a `BoundedContext`.",
                    getClass().getName());
         return context;
@@ -364,7 +361,7 @@ public abstract class Repository<I, E extends Entity<I, ?>>
      */
     @Override
     public final boolean isOpen() {
-        return context != null;
+        return hasContext();
     }
 
     @Internal

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,7 +34,7 @@
 /**
  * Version of this library.
  */
-val coreJava = "1.5.28"
+val coreJava = "1.5.29"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.


### PR DESCRIPTION
This PR:
  * Encapsulates checking if a `Repository` has a `context`.
  * Fixes the Javadoc of `Repository.isRegistered()` to reflect what the method does.
