### PR TITLE
Release `1.6.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository contains the code of:
 The project is under active ongoing development. 
 You are welcome to experiment and [provide your feedback][email-developers].
 
-The latest stable version is [1.5.0][latest-release].  
+The latest stable version is [1.6.0][latest-release].  
 
 ## Quick start and examples
 
@@ -49,7 +49,7 @@ Gradle is used as a build and dependency management system.
 If you need to use API with one of these annotations, please [contact us][email-developers].
 
 [email-developers]: mailto:spine-developers@teamdev.com
-[latest-release]: https://github.com/SpineEventEngine/core-java/releases/tag/v1.5.0
+[latest-release]: https://github.com/SpineEventEngine/core-java/releases/tag/v1.6.0
 [spine-site]: https://spine.io/
 [quick-start]: https://spine.io/docs/quick-start
 [spine-examples]: https://github.com/spine-examples

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.5.30`
+# Dependencies of `io.spine:spine-client:1.6.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -406,12 +406,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 03 20:06:46 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 08 21:43:29 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.5.30`
+# Dependencies of `io.spine:spine-core:1.6.0`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -777,12 +777,12 @@ This report was generated on **Thu Sep 03 20:06:46 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 03 20:06:46 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 08 21:43:30 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.5.30`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.6.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1183,12 +1183,12 @@ This report was generated on **Thu Sep 03 20:06:46 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 03 20:06:46 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 08 21:43:30 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.5.30`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.6.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1659,12 +1659,12 @@ This report was generated on **Thu Sep 03 20:06:46 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 03 20:06:47 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 08 21:43:31 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.5.30`
+# Dependencies of `io.spine:spine-server:1.6.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2082,12 +2082,12 @@ This report was generated on **Thu Sep 03 20:06:47 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 03 20:06:47 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 08 21:43:31 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.5.30`
+# Dependencies of `io.spine:spine-testutil-client:1.6.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2542,12 +2542,12 @@ This report was generated on **Thu Sep 03 20:06:47 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 03 20:06:49 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 08 21:43:33 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.5.30`
+# Dependencies of `io.spine:spine-testutil-core:1.6.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3010,12 +3010,12 @@ This report was generated on **Thu Sep 03 20:06:49 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 03 20:06:50 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 08 21:43:34 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.5.30`
+# Dependencies of `io.spine:spine-testutil-server:1.6.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3514,4 +3514,4 @@ This report was generated on **Thu Sep 03 20:06:50 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Sep 03 20:06:52 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 08 21:43:37 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.5.30</version>
+<version>1.6.0</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -70,25 +70,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.5.31</version>
+    <version>1.6.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-time</artifactId>
-    <version>1.5.24</version>
+    <version>1.6.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.5.31</version>
+    <version>1.6.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.5.31</version>
+    <version>1.6.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -130,25 +130,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.5.31</version>
+    <version>1.6.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-time</artifactId>
-    <version>1.5.24</version>
+    <version>1.6.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.5.31</version>
+    <version>1.6.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.5.31</version>
+    <version>1.6.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -204,12 +204,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>1.5.31</version>
+    <version>1.6.0</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.5.31</version>
+    <version>1.6.0</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,13 +34,13 @@
 /**
  * Version of this library.
  */
-val coreJava = "1.5.30"
+val coreJava = "1.6.0"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.
  */
-val base = "1.5.31"
-val time = "1.5.24"
+val base = "1.6.0"
+val time = "1.6.0"
 
 project.extra.apply {
     this["versionToPublish"] = coreJava


### PR DESCRIPTION
This PR does the release of a `core-java` library version `1.6.0`.

This release brings numerous API improvements, as well as fixes and infrastructure updates to the framework.

## API changes

### Client

1. The ability to `postAndForget()` a command is added to the `Client`.  This method should be called when the user does not care about events/rejections produced by a command.
The previously used `post()` method is reserved for cases when one or more event types are actually observed by the client. The value returned by `post()` can no longer be ignored [#1292].
2. Event subscriptions are now more flexible, allowing to subscribe to events produced by non-entity objects (e.g. `AbstractEventReactor`) as well as events not explicitly declared in any `BoundedContext` [#1258].
3. The `Client` is extended with methods to handle streaming and server errors  when executing requests [#1270].

### Server

1. The custom environments support is introduced [#1274, #1293].
 The `Environment` now exposes API to register user-defined environment types and to determine which one is enabled at any given moment of time.  See the [release notes](https://github.com/SpineEventEngine/base/pull/565) of `base`.
The `ServerEnvironment` allows to configure environment-dependent values, as follows: 
```java
StorageFactory factory = InMemoryStorageFactory.newInstance(); 	
ServerEnvironment.instance()
                 .use(factory, Tests.class); 
```

The Spine framework provides two environments out of the box: `Production` and `Tests`.

2. **Breaking change:** Most of the `@Internal` methods of `BoundedContext` moved to its internal class `InternalAccess` instance of which is available via the `internalAccess()` method. 
The method is available only to the server-side framework code. 
3. Delivery API is extended with a factory method which allows to create asynchronous version of local `Delivery` [#1265].
4. The `Pair` can now be created from an already existing `Optional` [#1296].
5. The proper support to the `CommandBus` filters which throw rejections is added [#1295].

### Model

1. The `@External` annotation is introduced to mark the handler method parameters of an external origin.  It replaces the previously used for this purpose `(external = true)` attribute of `@Subscribe`, `@React` and `@Command` annotation. The attribute is deprecated [#1269].
2. `(set_once)` constraint in entity states is no longer ignored [#1268].
3. `@ByField` is deprecated in favour of `@Where` [#1270].

### Logging

1. The `DiagnosticLog` messages are made more detailed [#1262].
2. The standard framework exceptions are expanded with more info [#1255].

### Testing

Various quality-of-life changes are introduced for the testing API.

See #1249, #1251, #1252, and #1261 for details.

Some of the testing API changes are breaking. They include:

1. `BlackBoxBoundedContext` is renamed to `BlackBoxContext`.
2. Outdated `Verify`-based API is removed.
3. `BlackBoxContext` no longer exposes `eventBus()` and `commandBus()`.
4. The `subscribe(Topic)` semantics changed. See #1249.
5. Simplified combinations of `UserId` and `ZoneId` parameters of `BlackBoxContext`.

## Fixes

The `Migration` logic is fixed to properly support entity state updates [#1298].

## Infrastructure

The project build scripts are migrated to Kotlin [#1278].