### PR TITLE
Relax changes

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -25,24 +25,6 @@
         <ANNO name="org.junit.jupiter.api.Test" />
       </REPEAT_ANNOTATIONS>
     </JavaCodeStyleSettings>
-    <JetCodeStyleSettings>
-      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-        <value>
-          <package name="java.util" alias="false" withSubpackages="false" />
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-          <package name="io.ktor" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
-        </value>
-      </option>
-    </JetCodeStyleSettings>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>

--- a/core/src/main/java/io/spine/change/Changes.java
+++ b/core/src/main/java/io/spine/change/Changes.java
@@ -31,7 +31,7 @@ import static io.spine.change.ChangePreconditions.checkNotEqual;
  * Utility class for working with field changes.
  */
 @SuppressWarnings("OverlyCoupledClass")
-    /* ... because we want one utility class for all the Changes classes. */
+/* ... because we want one utility class for all the Changes classes. */
 public final class Changes {
 
     /** Prevent instantiation of this utility class. */
@@ -49,10 +49,11 @@ public final class Changes {
         checkNewValueNotEmpty(newValue);
         checkNotEqual(previousValue, newValue);
 
-        StringChange result = StringChange.newBuilder()
-                                          .setPreviousValue(previousValue)
-                                          .setNewValue(newValue)
-                                          .build();
+        StringChange result = StringChange
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .vBuild();
         return result;
     }
 
@@ -66,10 +67,11 @@ public final class Changes {
         checkNotNull(newValue);
         checkNotEqual(previousValue, newValue);
 
-        TimestampChange result = TimestampChange.newBuilder()
-                                                .setPreviousValue(previousValue)
-                                                .setNewValue(newValue)
-                                                .build();
+        TimestampChange result = TimestampChange
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .vBuild();
         return result;
     }
 
@@ -81,10 +83,11 @@ public final class Changes {
     public static DoubleChange of(double previousValue, double newValue) {
         checkNotEqual(previousValue, newValue);
 
-        DoubleChange result = DoubleChange.newBuilder()
-                                          .setPreviousValue(previousValue)
-                                          .setNewValue(newValue)
-                                          .build();
+        DoubleChange result = DoubleChange
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .vBuild();
         return result;
     }
 
@@ -96,10 +99,11 @@ public final class Changes {
     public static FloatChange of(float previousValue, float newValue) {
         checkNotEqual(previousValue, newValue);
 
-        FloatChange result = FloatChange.newBuilder()
-                                        .setPreviousValue(previousValue)
-                                        .setNewValue(newValue)
-                                        .build();
+        FloatChange result = FloatChange
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .vBuild();
         return result;
     }
 
@@ -111,10 +115,11 @@ public final class Changes {
     public static Int32Change ofInt32(int previousValue, int newValue) {
         checkNotEqual(previousValue, newValue);
 
-        Int32Change result = Int32Change.newBuilder()
-                                        .setPreviousValue(previousValue)
-                                        .setNewValue(newValue)
-                                        .build();
+        Int32Change result = Int32Change
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .vBuild();
         return result;
     }
 
@@ -126,10 +131,11 @@ public final class Changes {
     public static Int64Change ofInt64(long previousValue, long newValue) {
         checkNotEqual(previousValue, newValue);
 
-        Int64Change result = Int64Change.newBuilder()
-                                        .setPreviousValue(previousValue)
-                                        .setNewValue(newValue)
-                                        .build();
+        Int64Change result = Int64Change
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .vBuild();
         return result;
     }
 
@@ -141,10 +147,11 @@ public final class Changes {
     public static UInt32Change ofUInt32(int previousValue, int newValue) {
         checkNotEqual(previousValue, newValue);
 
-        UInt32Change result = UInt32Change.newBuilder()
-                                          .setPreviousValue(previousValue)
-                                          .setNewValue(newValue)
-                                          .build();
+        UInt32Change result = UInt32Change
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .vBuild();
         return result;
     }
 
@@ -156,10 +163,11 @@ public final class Changes {
     public static UInt64Change ofUInt64(long previousValue, long newValue) {
         checkNotEqual(previousValue, newValue);
 
-        UInt64Change result = UInt64Change.newBuilder()
-                                          .setPreviousValue(previousValue)
-                                          .setNewValue(newValue)
-                                          .build();
+        UInt64Change result = UInt64Change
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .vBuild();
         return result;
     }
 
@@ -171,10 +179,11 @@ public final class Changes {
     public static SInt32Change ofSInt32(int previousValue, int newValue) {
         checkNotEqual(previousValue, newValue);
 
-        SInt32Change result = SInt32Change.newBuilder()
-                                          .setPreviousValue(previousValue)
-                                          .setNewValue(newValue)
-                                          .build();
+        SInt32Change result = SInt32Change
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .vBuild();
         return result;
     }
 
@@ -186,10 +195,11 @@ public final class Changes {
     public static SInt64Change ofSInt64(long previousValue, long newValue) {
         checkNotEqual(previousValue, newValue);
 
-        SInt64Change result = SInt64Change.newBuilder()
-                                          .setPreviousValue(previousValue)
-                                          .setNewValue(newValue)
-                                          .build();
+        SInt64Change result = SInt64Change
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .vBuild();
         return result;
     }
 
@@ -201,10 +211,11 @@ public final class Changes {
     public static Fixed32Change ofFixed32(int previousValue, int newValue) {
         checkNotEqual(previousValue, newValue);
 
-        Fixed32Change result = Fixed32Change.newBuilder()
-                                            .setPreviousValue(previousValue)
-                                            .setNewValue(newValue)
-                                            .build();
+        Fixed32Change result = Fixed32Change
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .vBuild();
         return result;
     }
 
@@ -216,10 +227,11 @@ public final class Changes {
     public static Fixed64Change ofFixed64(long previousValue, long newValue) {
         checkNotEqual(previousValue, newValue);
 
-        Fixed64Change result = Fixed64Change.newBuilder()
-                                            .setPreviousValue(previousValue)
-                                            .setNewValue(newValue)
-                                            .build();
+        Fixed64Change result = Fixed64Change
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .vBuild();
         return result;
     }
 
@@ -231,10 +243,11 @@ public final class Changes {
     public static Sfixed32Change ofSfixed32(int previousValue, int newValue) {
         checkNotEqual(previousValue, newValue);
 
-        Sfixed32Change result = Sfixed32Change.newBuilder()
-                                              .setPreviousValue(previousValue)
-                                              .setNewValue(newValue)
-                                              .build();
+        Sfixed32Change result = Sfixed32Change
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .vBuild();
         return result;
     }
 
@@ -246,10 +259,11 @@ public final class Changes {
     public static Sfixed64Change ofSfixed64(long previousValue, long newValue) {
         checkNotEqual(previousValue, newValue);
 
-        Sfixed64Change result = Sfixed64Change.newBuilder()
-                                              .setPreviousValue(previousValue)
-                                              .setNewValue(newValue)
-                                              .build();
+        Sfixed64Change result = Sfixed64Change
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .vBuild();
         return result;
     }
 
@@ -261,13 +275,13 @@ public final class Changes {
     public static BytesChange of(ByteString previousValue, ByteString newValue) {
         checkNotNull(previousValue);
         checkNotNull(newValue);
-        checkNewValueNotEmpty(newValue);
         checkNotEqual(previousValue, newValue);
 
-        BytesChange result = BytesChange.newBuilder()
-                                        .setPreviousValue(previousValue)
-                                        .setNewValue(newValue)
-                                        .build();
+        BytesChange result = BytesChange
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .vBuild();
         return result;
     }
 
@@ -279,10 +293,11 @@ public final class Changes {
     public static BooleanChange of(boolean previousValue, boolean newValue) {
         checkNotEqual(previousValue, newValue);
 
-        BooleanChange result = BooleanChange.newBuilder()
-                                            .setPreviousValue(previousValue)
-                                            .setNewValue(newValue)
-                                            .build();
+        BooleanChange result = BooleanChange
+                .newBuilder()
+                .setPreviousValue(previousValue)
+                .setNewValue(newValue)
+                .vBuild();
         return result;
     }
 }

--- a/core/src/main/proto/spine/change/change.proto
+++ b/core/src/main/proto/spine/change/change.proto
@@ -38,7 +38,7 @@ import "google/protobuf/timestamp.proto";
 // For all types the following rule apply: `new_value` field must not be equal to `previous_value`.
 //
 
-// Definition of a change in a string field.
+// A change in a string field.
 message StringChange {
 
     // The value of the field that's changing.
@@ -57,7 +57,7 @@ message StringChange {
     string new_value = 2 [(required) = true];
 }
 
-// Definition of a change in a `Timestamp` field.
+// A change in a `Timestamp` field.
 message TimestampChange {
 
     // The value of the field that's changing.
@@ -67,7 +67,7 @@ message TimestampChange {
     google.protobuf.Timestamp new_value = 2;
 }
 
-// Definition of a change in a `double` field.
+// A change in a `double` field.
 message DoubleChange {
 
     // The value of the field that's changing.
@@ -77,7 +77,7 @@ message DoubleChange {
     double new_value = 2;
 }
 
-// Definition of a change in a `float` field.
+// A change in a `float` field.
 message FloatChange {
 
     // The value of the field that's changing.
@@ -87,7 +87,7 @@ message FloatChange {
     float new_value = 2;
 }
 
-// Definition of a change in a `int32` field.
+// A change in a `int32` field.
 message Int32Change {
 
     // The value of the field that's changing.
@@ -97,7 +97,7 @@ message Int32Change {
     int32 new_value = 2;
 }
 
-// Definition of a change in a `int64` field.
+// A change in a `int64` field.
 message Int64Change {
 
     // The value of the field that's changing.
@@ -107,7 +107,7 @@ message Int64Change {
     int64 new_value = 2;
 }
 
-// Definition of a change in a `uint32` field.
+// A change in a `uint32` field.
 message UInt32Change {
 
     // The value of the field that's changing.
@@ -117,7 +117,7 @@ message UInt32Change {
     uint32 new_value = 2;
 }
 
-// Definition of a change in a `uint64` field.
+// A change in a `uint64` field.
 message UInt64Change {
 
     // The value of the field that's changing.
@@ -127,7 +127,7 @@ message UInt64Change {
     uint64 new_value = 2;
 }
 
-// Definition of a change in a `sint32` field.
+// A change in a `sint32` field.
 message SInt32Change {
 
     // The value of the field that's changing.
@@ -137,7 +137,7 @@ message SInt32Change {
     sint32 new_value = 2;
 }
 
-// Definition of a change in a `sint64` field.
+// A change in a `sint64` field.
 message SInt64Change {
 
     // The value of the field that's changing.
@@ -147,7 +147,7 @@ message SInt64Change {
     sint64 new_value = 2;
 }
 
-// Definition of a change in a `fixed32` field.
+// A change in a `fixed32` field.
 message Fixed32Change {
 
     // The value of the field that's changing.
@@ -157,7 +157,7 @@ message Fixed32Change {
     fixed32 new_value = 2;
 }
 
-// Definition of a change in a `fixed64` field.
+// A change in a `fixed64` field.
 message Fixed64Change {
 
     // The value of the field that's changing.
@@ -167,7 +167,7 @@ message Fixed64Change {
     fixed64 new_value = 2;
 }
 
-// Definition of a change in a `sfixed32` field.
+// A change in a `sfixed32` field.
 message Sfixed32Change {
 
     // The value of the field that's changing.
@@ -177,7 +177,7 @@ message Sfixed32Change {
     sfixed32 new_value = 2;
 }
 
-// Definition of a change in a `sfixed64` field.
+// A change in a `sfixed64` field.
 message Sfixed64Change {
 
     // The value of the field that's changing.
@@ -187,7 +187,7 @@ message Sfixed64Change {
     sfixed64 new_value = 2;
 }
 
-// Definition of a change in a `bool` field.
+// A change in a `bool` field.
 message BooleanChange {
 
     // The value of the field that's changing.
@@ -197,7 +197,7 @@ message BooleanChange {
     bool new_value = 2;
 }
 
-// Definition of a change in a `bytes` field.
+// A change in a `bytes` field.
 message BytesChange {
 
     // The value of the field that's changing.

--- a/core/src/main/proto/spine/change/change.proto
+++ b/core/src/main/proto/spine/change/change.proto
@@ -42,19 +42,10 @@ import "google/protobuf/timestamp.proto";
 message StringChange {
 
     // The value of the field that's changing.
-    //
-    // This field is blank if the target field is blank too.
-    //
     string previous_value = 1;
 
     // The new value of the field.
-    //
-    // This field must be populated. If you want to clear a field, use a special command.
-    // We encourage separate commands for removal to make event handlers more straightforward.
-    // Usually removal of a value and changing a value should have different consequences.
-    // Hence separate handles.
-    //
-    string new_value = 2 [(required) = true];
+    string new_value = 2;
 }
 
 // A change in a `Timestamp` field.
@@ -204,5 +195,5 @@ message BytesChange {
     bytes previous_value = 1;
 
     // The new value of the field.
-    bytes new_value = 2 [(required) = true];
+    bytes new_value = 2;
 }

--- a/core/src/test/java/io/spine/change/ChangesTest.java
+++ b/core/src/test/java/io/spine/change/ChangesTest.java
@@ -29,11 +29,13 @@ import io.spine.time.testing.TimeTests;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.UUID;
 
 import static com.google.protobuf.ByteString.copyFromUtf8;
 import static io.spine.base.Time.currentTime;
+import static io.spine.testing.TestValues.randomString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -41,15 +43,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
                                         of preconditions */,
                    "ResultOfMethodCallIgnored" /* ...when methods throw exceptions */,
                    "OverlyCoupledClass" /* we test many data types and utility methods */})
-@DisplayName("Changes utility should")
+@DisplayName("`Changes` utility should")
 class ChangesTest extends UtilityClassTest<Changes> {
-
-    private static final String ERR_PREVIOUS_VALUE_CANNOT_BE_NULL =
-            "do_not_accept_null_previousValue";
-    private static final String ERR_NEW_VALUE_CANNOT_BE_NULL =
-            "do_not_accept_null_newValue";
-    private static final String ERR_VALUES_CANNOT_BE_EQUAL =
-            "do_not_accept_equal_values";
 
     ChangesTest() {
         super(Changes.class);
@@ -67,7 +62,7 @@ class ChangesTest extends UtilityClassTest<Changes> {
     class Create {
 
         @Test
-        @DisplayName("String")
+        @DisplayName("`String`")
         void forStrings() {
             String previousValue = randomUuid();
             String newValue = randomUuid();
@@ -79,7 +74,7 @@ class ChangesTest extends UtilityClassTest<Changes> {
         }
 
         @Test
-        @DisplayName("ByteString")
+        @DisplayName("`ByteString`")
         void forByteStrings() {
             ByteString previousValue = copyFromUtf8(randomUuid());
             ByteString newValue = copyFromUtf8(randomUuid());
@@ -91,7 +86,7 @@ class ChangesTest extends UtilityClassTest<Changes> {
         }
 
         @Test
-        @DisplayName("Timestamp")
+        @DisplayName("`Timestamp`")
         void forTimestamps() {
             Timestamp fiveMinutesAgo = TimeTests.Past.minutesAgo(5);
             Timestamp now = currentTime();
@@ -103,7 +98,7 @@ class ChangesTest extends UtilityClassTest<Changes> {
         }
 
         @Test
-        @DisplayName("boolean")
+        @DisplayName("`boolean`")
         void forBooleans() {
             boolean s1 = true;
             boolean s2 = false;
@@ -115,7 +110,7 @@ class ChangesTest extends UtilityClassTest<Changes> {
         }
 
         @Test
-        @DisplayName("double")
+        @DisplayName("`double`")
         void forDoubles() {
             double s1 = 1957.1004;
             double s2 = 1957.1103;
@@ -127,7 +122,7 @@ class ChangesTest extends UtilityClassTest<Changes> {
         }
 
         @Test
-        @DisplayName("int32")
+        @DisplayName("`int32`")
         void forInt32s() {
             int s1 = 1550;
             int s2 = 1616;
@@ -139,7 +134,7 @@ class ChangesTest extends UtilityClassTest<Changes> {
         }
 
         @Test
-        @DisplayName("int64")
+        @DisplayName("`int64`")
         void forInt64s() {
             long s1 = 16420225L;
             long s2 = 17270320L;
@@ -151,7 +146,7 @@ class ChangesTest extends UtilityClassTest<Changes> {
         }
 
         @Test
-        @DisplayName("float")
+        @DisplayName("`float`")
         void forFloats() {
             float s1 = 1473.0219f;
             float s2 = 1543.0524f;
@@ -163,7 +158,7 @@ class ChangesTest extends UtilityClassTest<Changes> {
         }
 
         @Test
-        @DisplayName("uint32")
+        @DisplayName("`uint32`")
         void forUint32s() {
             int s1 = 16440925;
             int s2 = 17100919;
@@ -175,7 +170,7 @@ class ChangesTest extends UtilityClassTest<Changes> {
         }
 
         @Test
-        @DisplayName("uint64")
+        @DisplayName("`uint64`")
         void forUint64s() {
             long s1 = 16290414L;
             long s2 = 16950708L;
@@ -187,7 +182,7 @@ class ChangesTest extends UtilityClassTest<Changes> {
         }
 
         @Test
-        @DisplayName("sint32")
+        @DisplayName("`sint32`")
         void forSint32s() {
             int s1 = 16550106;
             int s2 = 17050816;
@@ -199,7 +194,7 @@ class ChangesTest extends UtilityClassTest<Changes> {
         }
 
         @Test
-        @DisplayName("sint64")
+        @DisplayName("`sint64`")
         void forSint64s() {
             long s1 = 1666L;
             long s2 = 1736L;
@@ -211,7 +206,7 @@ class ChangesTest extends UtilityClassTest<Changes> {
         }
 
         @Test
-        @DisplayName("fixed32")
+        @DisplayName("`fixed32`")
         void forFixed32s() {
             int s1 = 17070415;
             int s2 = 17830918;
@@ -223,7 +218,7 @@ class ChangesTest extends UtilityClassTest<Changes> {
         }
 
         @Test
-        @DisplayName("fixed64")
+        @DisplayName("`fixed64`")
         void forFixed64s() {
             long s1 = 17240422L;
             long s2 = 18040212L;
@@ -235,7 +230,7 @@ class ChangesTest extends UtilityClassTest<Changes> {
         }
 
         @Test
-        @DisplayName("sfixed32")
+        @DisplayName("`sfixed32`")
         void forSfixed32s() {
             int s1 = 1550;
             int s2 = 1616;
@@ -247,7 +242,7 @@ class ChangesTest extends UtilityClassTest<Changes> {
         }
 
         @Test
-        @DisplayName("sfixed64")
+        @DisplayName("`sfixed64`")
         void forSfixed64s() {
             long s1 = 16420225L;
             long s2 = 17270320L;
@@ -269,112 +264,112 @@ class ChangesTest extends UtilityClassTest<Changes> {
     class NotAcceptEqual {
 
         @Test
-        @DisplayName("String")
+        @DisplayName("`String`")
         void strings() {
-            String value = ERR_VALUES_CANNOT_BE_EQUAL;
+            String value = randomString();
             assertThrows(IllegalArgumentException.class, () -> Changes.of(value, value));
         }
 
         @Test
-        @DisplayName("ByteString")
+        @DisplayName("`ByteString`")
         void byteStrings() {
-            ByteString value = copyFromUtf8(ERR_VALUES_CANNOT_BE_EQUAL);
+            ByteString value = copyFromUtf8(randomString());
             assertThrows(IllegalArgumentException.class, () -> Changes.of(value, value));
         }
 
         @Test
-        @DisplayName("TimeStamp")
+        @DisplayName("`Timestamp`")
         void timestamps() {
             Timestamp now = currentTime();
             assertThrows(IllegalArgumentException.class, () -> Changes.of(now, now));
         }
 
         @Test
-        @DisplayName("boolean")
+        @DisplayName("`boolean`")
         void booleans() {
             boolean value = true;
             assertThrows(IllegalArgumentException.class, () -> Changes.of(value, value));
         }
 
         @Test
-        @DisplayName("double")
+        @DisplayName("`double`")
         void doubles() {
             double value = 1961.0412;
             assertThrows(IllegalArgumentException.class, () -> Changes.of(value, value));
         }
 
         @Test
-        @DisplayName("float")
+        @DisplayName("`float`")
         void floats() {
             float value = 1543.0f;
             assertThrows(IllegalArgumentException.class, () -> Changes.of(value, value));
         }
 
         @Test
-        @DisplayName("int32")
+        @DisplayName("`int32`")
         void int32s() {
             int value = 1614;
             assertThrows(IllegalArgumentException.class, () -> Changes.of(value, value));
         }
 
         @Test
-        @DisplayName("int64")
+        @DisplayName("`int64`")
         void int64s() {
             long value = 1666L;
             assertThrows(IllegalArgumentException.class, () -> Changes.of(value, value));
         }
 
         @Test
-        @DisplayName("uint32")
+        @DisplayName("`uint32`")
         void uint32s() {
             int value = 1776;
             assertThrows(IllegalArgumentException.class, () -> Changes.ofUInt32(value, value));
         }
 
         @Test
-        @DisplayName("uint64")
+        @DisplayName("`uint64`")
         void uint64s() {
             long value = 1690L;
             assertThrows(IllegalArgumentException.class, () -> Changes.ofUInt64(value, value));
         }
 
         @Test
-        @DisplayName("sint32")
+        @DisplayName("`sint32`")
         void sint32s() {
             int value = 1694;
             assertThrows(IllegalArgumentException.class, () -> Changes.ofSInt32(value, value));
         }
 
         @Test
-        @DisplayName("sint64")
+        @DisplayName("`sint64`")
         void sint64s() {
             long value = 1729L;
             assertThrows(IllegalArgumentException.class, () -> Changes.ofSInt64(value, value));
         }
 
         @Test
-        @DisplayName("fixed32")
+        @DisplayName("`fixed32`")
         void fixed32s() {
             int value = 1736;
             assertThrows(IllegalArgumentException.class, () -> Changes.ofFixed32(value, value));
         }
 
         @Test
-        @DisplayName("fixed64")
+        @DisplayName("`fixed64`")
         void fixed64s() {
             long value = 1755L;
             assertThrows(IllegalArgumentException.class, () -> Changes.ofFixed64(value, value));
         }
 
         @Test
-        @DisplayName("sfixed32")
+        @DisplayName("`sfixed32`")
         void sfixed32s() {
             int value = 1614;
             assertThrows(IllegalArgumentException.class, () -> Changes.ofSfixed32(value, value));
         }
 
         @Test
-        @DisplayName("sfixed64")
+        @DisplayName("`sfixed64`")
         void sfixed64s() {
             long value = 1666L;
             assertThrows(IllegalArgumentException.class, () -> Changes.ofSfixed64(value, value));
@@ -382,48 +377,47 @@ class ChangesTest extends UtilityClassTest<Changes> {
     }
 
     @Nested
-    @DisplayName("fail to create value change from null")
+    @DisplayName("fail to create value change from `null`")
     class NotAcceptNull {
 
         @Test
-        @DisplayName("String previousValue")
+        @DisplayName("`String` `previousValue`")
         void stringPrevious() {
-            assertThrows(NullPointerException.class,
-                         () -> Changes.of(null, ERR_PREVIOUS_VALUE_CANNOT_BE_NULL));
+            assertThrowsNpe(() -> Changes.of(null, randomString()));
         }
 
         @Test
-        @DisplayName("String newValue")
+        @DisplayName("`String` `newValue`")
         void stringNew() {
-            assertThrows(NullPointerException.class,
-                         () -> Changes.of(ERR_NEW_VALUE_CANNOT_BE_NULL, null));
+            assertThrowsNpe(() -> Changes.of(randomString(), null));
         }
 
         @Test
-        @DisplayName("ByteString previousValue")
+        @DisplayName("`ByteString` `previousValue`")
         void byteStringPrevious() {
-            assertThrows(NullPointerException.class,
-                         () -> Changes.of(null,
-                                          copyFromUtf8(ERR_PREVIOUS_VALUE_CANNOT_BE_NULL)));
+            assertThrowsNpe(() -> Changes.of(null, copyFromUtf8(randomString())));
         }
 
         @Test
-        @DisplayName("ByteString newValue")
+        @DisplayName("`ByteString` `newValue`")
         void byteStringNew() {
-            assertThrows(NullPointerException.class,
-                         () -> Changes.of(copyFromUtf8(ERR_NEW_VALUE_CANNOT_BE_NULL), null));
+            assertThrowsNpe(() -> Changes.of(copyFromUtf8(randomString()), null));
         }
 
         @Test
-        @DisplayName("Timestamp previousValue")
+        @DisplayName("`Timestamp` `previousValue`")
         void timestampPrevious() {
-            assertThrows(NullPointerException.class, () -> Changes.of(null, currentTime()));
+            assertThrowsNpe(() -> Changes.of(null, currentTime()));
         }
 
         @Test
-        @DisplayName("Timestamp newValue")
+        @DisplayName("`Timestamp` `newValue`")
         void timestampNew() {
-            assertThrows(NullPointerException.class, () -> Changes.of(currentTime(), null));
+            assertThrowsNpe(() -> Changes.of(currentTime(), null));
+        }
+
+        void assertThrowsNpe(Executable executable) {
+            assertThrows(NullPointerException.class, executable);
         }
     }
 }

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.6.1`
+# Dependencies of `io.spine:spine-client:1.6.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -406,12 +406,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Oct 09 22:48:26 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 14 18:03:26 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.6.1`
+# Dependencies of `io.spine:spine-core:1.6.2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -777,12 +777,12 @@ This report was generated on **Fri Oct 09 22:48:26 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Oct 09 22:48:26 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 14 18:03:26 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.6.1`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.6.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1183,12 +1183,12 @@ This report was generated on **Fri Oct 09 22:48:26 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Oct 09 22:48:27 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 14 18:03:27 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.6.1`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.6.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1659,12 +1659,12 @@ This report was generated on **Fri Oct 09 22:48:27 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Oct 09 22:48:38 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 14 18:03:28 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.6.1`
+# Dependencies of `io.spine:spine-server:1.6.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2082,12 +2082,12 @@ This report was generated on **Fri Oct 09 22:48:38 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Oct 09 22:48:39 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 14 18:03:29 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.6.1`
+# Dependencies of `io.spine:spine-testutil-client:1.6.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2542,12 +2542,12 @@ This report was generated on **Fri Oct 09 22:48:39 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Oct 09 22:48:41 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 14 18:03:31 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.6.1`
+# Dependencies of `io.spine:spine-testutil-core:1.6.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3010,12 +3010,12 @@ This report was generated on **Fri Oct 09 22:48:41 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Oct 09 22:48:42 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 14 18:03:32 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.6.1`
+# Dependencies of `io.spine:spine-testutil-server:1.6.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3514,4 +3514,4 @@ This report was generated on **Fri Oct 09 22:48:42 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Fri Oct 09 22:48:46 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 14 18:03:36 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.6.1</version>
+<version>1.6.2</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -70,7 +70,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.2</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -82,13 +82,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.2</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.2</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -130,7 +130,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.2</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -142,13 +142,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.2</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.2</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -204,12 +204,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.2</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.2</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,7 +34,7 @@
 /**
  * Version of this library.
  */
-val coreJava = "1.6.1"
+val coreJava = "1.6.2"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -39,7 +39,7 @@ val coreJava = "1.6.2"
 /**
  * Versions of the Spine libraries that `core-java` depends on.
  */
-val base = "1.6.0"
+val base = "1.6.2"
 val time = "1.6.0"
 
 project.extra.apply {


### PR DESCRIPTION
This PR relaxes validation requirements for `StringChange` and `BytesChange` types. Previously, `new_value` fields were required. It was so to encourage introducing commands that would start from `Clear` (e.g. `ClearDescription`) instead of having a command that would just accept a blank new value.

The intention was good, but it introduced the following problems:
  1. It's too much headache when it comes to editing values that we don't want to die for. E.g. a text field may be cleared just because the previous one was outdate and the user did not invent a new one non-blank one.  _Requiring_ having special handling for empty values with a separate command and event is too much.
  2. We cannot require `new_value` for fields of simple types. Such inconsistency makes the problem no.1 is even bigger.

