### PR TITLE
Simplify unicast event routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ the [Spine Examples][spine-examples] GitHub organization.
 
 Building Spine modules and libraries requires JDK 8. 
 
-The support of JDK 11 is planned for the [version 2.0.0][v2] of the framework.
+The support of JDK 11 is planned for the [version 3.0][v3] of the framework.
 
 Gradle is used as a build and dependency management system.
 
@@ -64,5 +64,5 @@ If you need to use API with one of these annotations, please [contact us][email-
 [quick-start]: https://spine.io/docs/quick-start
 [spine-examples]: https://github.com/spine-examples
 [todo-list]: https://github.com/spine-examples/todo-list
-[v2]: https://github.com/orgs/SpineEventEngine/projects/11
+[v3]: https://github.com/orgs/SpineEventEngine/projects/11
 [config]: https://github.com/SpineEventEngine/config/

--- a/core/src/test/java/io/spine/change/IntMismatchTest.java
+++ b/core/src/test/java/io/spine/change/IntMismatchTest.java
@@ -20,7 +20,6 @@
 
 package io.spine.change;
 
-import com.google.common.testing.NullPointerTester;
 import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -33,9 +32,6 @@ import static io.spine.change.IntMismatch.unexpectedValue;
 import static io.spine.change.IntMismatch.unpackActual;
 import static io.spine.change.IntMismatch.unpackExpected;
 import static io.spine.change.IntMismatch.unpackNewValue;
-import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
-import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
-import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -49,19 +45,6 @@ class IntMismatchTest extends UtilityClassTest<IntMismatch> {
 
     IntMismatchTest() {
         super(IntMismatch.class);
-    }
-
-    @Test
-    @DisplayName(HAVE_PARAMETERLESS_CTOR)
-    void haveUtilityConstructor() {
-        assertHasPrivateParameterlessCtor(IntMismatch.class);
-    }
-
-    @Test
-    @DisplayName(NOT_ACCEPT_NULLS)
-    void passNullToleranceCheck() {
-        new NullPointerTester()
-                .testAllPublicStaticMethods(IntMismatch.class);
     }
 
     @Nested

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.6.5`
+# Dependencies of `io.spine:spine-client:1.6.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -406,12 +406,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Oct 24 18:58:53 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 26 20:11:39 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.6.5`
+# Dependencies of `io.spine:spine-core:1.6.6`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -777,12 +777,12 @@ This report was generated on **Sat Oct 24 18:58:53 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Oct 24 18:58:53 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 26 20:11:40 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.6.5`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.6.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1183,12 +1183,12 @@ This report was generated on **Sat Oct 24 18:58:53 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Oct 24 18:58:54 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 26 20:11:40 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.6.5`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.6.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1659,12 +1659,12 @@ This report was generated on **Sat Oct 24 18:58:54 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Oct 24 18:58:54 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 26 20:11:41 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.6.5`
+# Dependencies of `io.spine:spine-server:1.6.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2082,12 +2082,12 @@ This report was generated on **Sat Oct 24 18:58:54 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Oct 24 18:58:55 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 26 20:11:41 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.6.5`
+# Dependencies of `io.spine:spine-testutil-client:1.6.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2542,12 +2542,12 @@ This report was generated on **Sat Oct 24 18:58:55 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Oct 24 18:58:57 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 26 20:11:43 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.6.5`
+# Dependencies of `io.spine:spine-testutil-core:1.6.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3010,12 +3010,12 @@ This report was generated on **Sat Oct 24 18:58:57 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Oct 24 18:58:58 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 26 20:11:44 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.6.5`
+# Dependencies of `io.spine:spine-testutil-server:1.6.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3514,4 +3514,4 @@ This report was generated on **Sat Oct 24 18:58:58 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Oct 24 18:59:00 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 26 20:11:46 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -406,7 +406,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Oct 24 01:41:26 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 24 18:58:53 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -777,7 +777,7 @@ This report was generated on **Sat Oct 24 01:41:26 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Oct 24 01:41:27 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 24 18:58:53 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1183,7 +1183,7 @@ This report was generated on **Sat Oct 24 01:41:27 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Oct 24 01:41:27 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 24 18:58:54 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1659,7 +1659,7 @@ This report was generated on **Sat Oct 24 01:41:27 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Oct 24 01:41:28 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 24 18:58:54 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2082,7 +2082,7 @@ This report was generated on **Sat Oct 24 01:41:28 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Oct 24 01:41:28 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 24 18:58:55 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2542,7 +2542,7 @@ This report was generated on **Sat Oct 24 01:41:28 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Oct 24 01:41:30 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 24 18:58:57 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3010,7 +3010,7 @@ This report was generated on **Sat Oct 24 01:41:30 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Oct 24 01:41:31 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 24 18:58:58 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3514,4 +3514,4 @@ This report was generated on **Sat Oct 24 01:41:31 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Sat Oct 24 01:41:34 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 24 18:59:00 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -406,7 +406,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 22 19:37:44 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 24 01:41:26 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -777,7 +777,7 @@ This report was generated on **Thu Oct 22 19:37:44 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 22 19:37:45 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 24 01:41:27 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1183,7 +1183,7 @@ This report was generated on **Thu Oct 22 19:37:45 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 22 19:37:46 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 24 01:41:27 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1659,7 +1659,7 @@ This report was generated on **Thu Oct 22 19:37:46 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 22 19:37:46 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 24 01:41:28 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2082,7 +2082,7 @@ This report was generated on **Thu Oct 22 19:37:46 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 22 19:37:47 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 24 01:41:28 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2542,7 +2542,7 @@ This report was generated on **Thu Oct 22 19:37:47 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 22 19:37:49 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 24 01:41:30 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3010,7 +3010,7 @@ This report was generated on **Thu Oct 22 19:37:49 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 22 19:37:51 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 24 01:41:31 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3514,4 +3514,4 @@ This report was generated on **Thu Oct 22 19:37:51 EEST 2020** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Oct 22 19:37:54 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 24 01:41:34 EEST 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020, TeamDev. All rights reserved.
+  ~
+  ~ Redistribution and use in source and/or binary forms, with or without
+  ~ modification, must retain the above copyright notice and the following
+  ~ disclaimer.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  ~ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  ~ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  ~ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  ~ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  ~ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  ~ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 <modelVersion>4.0.0</modelVersion>
 
@@ -12,7 +32,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.6.5</version>
+<version>1.6.6</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -70,7 +90,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.6.5</version>
+    <version>1.6.6</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -82,13 +102,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.6.5</version>
+    <version>1.6.6</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.6.5</version>
+    <version>1.6.6</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -130,7 +150,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.6.5</version>
+    <version>1.6.6</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -142,13 +162,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.6.5</version>
+    <version>1.6.6</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.6.5</version>
+    <version>1.6.6</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -204,12 +224,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>1.6.5</version>
+    <version>1.6.6</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.6.5</version>
+    <version>1.6.6</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/server/src/main/java/io/spine/server/route/EventFnRoute.java
+++ b/server/src/main/java/io/spine/server/route/EventFnRoute.java
@@ -30,8 +30,8 @@ import java.util.function.Function;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * An event route with one target entity which ID is obtained as a function
- * on an event message.
+ * An event route with one target entity ID of which is obtained as a function
+ * on an event message or {@code BiFunction} on an event message and its context.
  *
  * @param <I>
  *         the type of the target entity ID

--- a/server/src/main/java/io/spine/server/route/EventFnRoute.java
+++ b/server/src/main/java/io/spine/server/route/EventFnRoute.java
@@ -43,11 +43,17 @@ final class EventFnRoute<I, E extends EventMessage> implements EventRoute<I, E> 
     private static final long serialVersionUID = 0L;
     private final BiFunction<E, EventContext, I> fn;
 
+    /**
+     * Creates a new event route which obtains target entity ID from an event message.
+     */
     EventFnRoute(Function<E, I> fn) {
-        checkNotNull(fn);
-        this.fn = (e, ctx) -> fn.apply(e);
+        this((e, ctx) -> fn.apply(e));
     }
 
+    /**
+     * Creates an event route which obtains target entity ID from an event message and
+     * a its context.
+     */
     EventFnRoute(BiFunction<E, EventContext, I> fn) {
         this.fn = checkNotNull(fn);
     }

--- a/server/src/main/java/io/spine/server/route/EventRouting.java
+++ b/server/src/main/java/io/spine/server/route/EventRouting.java
@@ -28,6 +28,8 @@ import io.spine.system.server.event.EntityStateChanged;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -149,6 +151,54 @@ public final class EventRouting<I>
                 (Route<EventMessage, EventContext, Set<I>>) via;
         addRoute(eventType, casted);
         return this;
+    }
+
+    /**
+     * Sets a custom route for the passed event type by obtaining the target entity
+     * ID from the passed function.
+     *
+     * <p>This is a convenience method for configuring routing when an event is to be delivered
+     * to only one entity which ID is calculated from the event message. A simplest case of that
+     * would be passing a method reference for an accessor of a field of the event message
+     * which contains the ID of interest.
+     *
+     * @param eventType
+     *         the type of the event to route
+     * @param via
+     *         the function for obtaining the target entity ID
+     * @param <E>
+     *         the type of the event message
+     * @return {@code this} to allow chained calls when configuring routing
+     * @see #route(Class, EventRoute)
+     * @see #unicast(Class, BiFunction)
+     */
+    @CanIgnoreReturnValue
+    public <E extends EventMessage>
+    EventRouting<I> unicast(Class<E> eventType, Function<E, I> via) {
+        return route(eventType, new EventFnRoute<>(via));
+    }
+
+    /**
+     * Sets a custom route for the passed event type by obtaining the target entity
+     * ID from the passed function over event message and its context.
+     *
+     * <p>This is a convenience method for configuring routing when an event is to be delivered
+     * to only one entity which ID is calculated from the event message and its context.
+     *
+     * @param eventType
+     *         the type of the event to route
+     * @param via
+     *         the supplier of the target entity ID
+     * @param <E>
+     *         the type of the event message
+     * @return {@code this} to allow chained calls when configuring routing
+     * @see #route(Class, EventRoute)
+     * @see #unicast(Class, Function)
+     */
+    @CanIgnoreReturnValue
+    public <E extends EventMessage>
+    EventRouting<I> unicast(Class<E> eventType, BiFunction<E, EventContext, I> via) {
+        return route(eventType, new EventFnRoute<>(via));
     }
 
     /**

--- a/server/src/main/java/io/spine/server/route/EventRouting.java
+++ b/server/src/main/java/io/spine/server/route/EventRouting.java
@@ -175,6 +175,7 @@ public final class EventRouting<I>
     @CanIgnoreReturnValue
     public <E extends EventMessage>
     EventRouting<I> unicast(Class<E> eventType, Function<E, I> via) {
+        checkNotNull(via);
         return route(eventType, new EventFnRoute<>(via));
     }
 
@@ -198,6 +199,7 @@ public final class EventRouting<I>
     @CanIgnoreReturnValue
     public <E extends EventMessage>
     EventRouting<I> unicast(Class<E> eventType, BiFunction<E, EventContext, I> via) {
+        checkNotNull(via);
         return route(eventType, new EventFnRoute<>(via));
     }
 

--- a/server/src/test/java/io/spine/server/delivery/InboxIdsTest.java
+++ b/server/src/test/java/io/spine/server/delivery/InboxIdsTest.java
@@ -25,7 +25,6 @@ import io.spine.test.delivery.Calc;
 import io.spine.testing.UtilityClassTest;
 import io.spine.type.TypeUrl;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 /**
  * Tests of the {@link InboxIds} utility.
@@ -34,7 +33,7 @@ import org.junit.jupiter.api.Test;
 class InboxIdsTest extends UtilityClassTest<InboxIds> {
 
     InboxIdsTest() {
-        super(InboxIds.class);
+        super(InboxIds.class, NullPointerTester.Visibility.PACKAGE);
     }
 
     @Override
@@ -42,15 +41,5 @@ class InboxIdsTest extends UtilityClassTest<InboxIds> {
         super.configure(tester);
         tester.setDefault(InboxId.class, InboxId.getDefaultInstance())
               .setDefault(TypeUrl.class, TypeUrl.of(Calc.class));
-    }
-
-    @Test
-    @DisplayName("not accept nulls in package-private static methods if the arg is non-Nullable")
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-        /* This test does assert via `NullPointerTester. */
-    void nullCheckPublicStaticMethods() {
-        NullPointerTester tester = new NullPointerTester();
-        configure(tester);
-        tester.testStaticMethods(getUtilityClass(), NullPointerTester.Visibility.PACKAGE);
     }
 }

--- a/server/src/test/java/io/spine/server/delivery/given/CounterView.java
+++ b/server/src/test/java/io/spine/server/delivery/given/CounterView.java
@@ -30,8 +30,6 @@ import io.spine.test.delivery.DCounter;
 import io.spine.test.delivery.NumberAdded;
 import io.spine.type.TypeUrl;
 
-import static io.spine.server.route.EventRoute.withId;
-
 /**
  * Counts the incoming events.
  *
@@ -65,8 +63,7 @@ public final class CounterView extends Projection<String, DCounter, DCounter.Bui
         @Override
         protected void setupEventRouting(EventRouting<String> routing) {
             super.setupEventRouting(routing);
-            routing.route(NumberAdded.class,
-                          (message, context) -> withId(message.getCalculatorId()));
+            routing.unicast(NumberAdded.class, NumberAdded::getCalculatorId);
         }
     }
 }

--- a/server/src/test/java/io/spine/server/entity/storage/EntityQueriesTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/EntityQueriesTest.java
@@ -63,7 +63,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class EntityQueriesTest extends UtilityClassTest<EntityQueries> {
 
     private EntityQueriesTest() {
-        super(EntityQueries.class);
+        super(EntityQueries.class, NullPointerTester.Visibility.PACKAGE);
     }
 
     @Override
@@ -76,8 +76,7 @@ class EntityQueriesTest extends UtilityClassTest<EntityQueries> {
         tester.setDefault(OrderBy.class, OrderBy.getDefaultInstance())
               .setDefault(TargetFilters.class, TargetFilters.getDefaultInstance())
               .setDefault(RecordStorage.class, storage)
-              .setDefault(Columns.class, Columns.of(TestEntity.class))
-              .testStaticMethods(getUtilityClass(), NullPointerTester.Visibility.PACKAGE);
+              .setDefault(Columns.class, Columns.of(TestEntity.class));
     }
 
     private static EntityQuery<?> createEntityQuery(TargetFilters filters,

--- a/server/src/test/java/io/spine/server/trace/given/airport/TimetableRepository.java
+++ b/server/src/test/java/io/spine/server/trace/given/airport/TimetableRepository.java
@@ -29,8 +29,6 @@ import io.spine.test.trace.FlightRescheduled;
 import io.spine.test.trace.FlightScheduled;
 import io.spine.test.trace.Timetable;
 
-import static io.spine.server.route.EventRoute.withId;
-
 public final class TimetableRepository
         extends ProjectionRepository<AirportId, TimetableProjection, Timetable> {
 
@@ -38,11 +36,8 @@ public final class TimetableRepository
     @Override
     protected void setupEventRouting(EventRouting<AirportId> routing) {
         super.setupEventRouting(routing);
-        routing.route(FlightScheduled.class,
-                      (message, context) -> withId(message.getFrom().getId()))
-               .route(FlightRescheduled.class,
-                      (message, context) -> withId(context.get(AirportId.class)))
-               .route(FlightCanceled.class,
-                      (message, context) -> withId(context.get(AirportId.class)));
+        routing.unicast(FlightScheduled.class, (e) -> e.getFrom().getId())
+               .unicast(FlightRescheduled.class, (e, ctx) -> ctx.get(AirportId.class))
+               .unicast(FlightCanceled.class, (e, ctx) -> ctx.get(AirportId.class));
     }
 }

--- a/server/src/test/java/io/spine/server/type/EmptyClassTest.java
+++ b/server/src/test/java/io/spine/server/type/EmptyClassTest.java
@@ -21,23 +21,20 @@
 package io.spine.server.type;
 
 import com.google.common.testing.SerializableTester;
+import io.spine.testing.SingletonTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertSame;
-
 @DisplayName("EmptyClass should")
-class EmptyClassTest {
+class EmptyClassTest extends SingletonTest<EmptyClass> {
+
+    EmptyClassTest() {
+        super(EmptyClass.class, EmptyClass::instance);
+    }
 
     @Test
     @DisplayName("be serializable")
     void serialize() {
         SerializableTester.reserializeAndAssert(EmptyClass.instance());
-    }
-
-    @Test
-    @DisplayName("return the same instance")
-    void sameInstance() {
-        assertSame(EmptyClass.instance(), EmptyClass.instance());
     }
 }

--- a/testutil-core/src/test/java/io/spine/testing/core/given/GivenVersionTest.java
+++ b/testutil-core/src/test/java/io/spine/testing/core/given/GivenVersionTest.java
@@ -25,9 +25,7 @@ import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
 import static io.spine.testing.TestValues.random;
-import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DisplayName("GivenVersion should")
@@ -35,12 +33,6 @@ class GivenVersionTest extends UtilityClassTest<GivenVersion> {
 
     GivenVersionTest() {
         super(GivenVersion.class);
-    }
-
-    @Test
-    @DisplayName(HAVE_PARAMETERLESS_CTOR)
-    void haveUtilityConstructor() {
-        assertHasPrivateParameterlessCtor(GivenVersion.class);
     }
 
     @Test

--- a/testutil-server/src/main/java/io/spine/testing/server/Assertions.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/Assertions.java
@@ -63,7 +63,7 @@ public final class Assertions {
     }
 
     @SafeVarargs
-    private static <C extends MessageClass, M extends Message>
+    private static <C extends MessageClass<?>, M extends Message>
     void assertContains(Collection<C> collection,
                         Function<Class<M>, C> func,
                         Class<? extends M>...classes) {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,7 +34,7 @@
 /**
  * Version of this library.
  */
-val coreJava = "1.6.5"
+val coreJava = "1.6.6"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -39,7 +39,7 @@ val coreJava = "1.6.6"
 /**
  * Versions of the Spine libraries that `core-java` depends on.
  */
-val base = "1.6.5"
+val base = "1.6.6"
 val time = "1.6.0"
 
 project.extra.apply {


### PR DESCRIPTION
This PR adds `unicast()` methods for `EventRouting` to simplify the cases when an event target is only one entity.

Previously, it was required to wrap the ID of the target entity into `EventRoute.withId()` utility call.

Only some of the `withId()` calls were replaced with simplified calls to make this PR merge sooner. 
We'll migrate to simpler API where appropriate when corresponding framework areas or tests are updated.