### PR TITLE
Encapsulate `MessageId` creation

### DIFF
--- a/core/src/main/java/io/spine/core/MessageIdMixin.java
+++ b/core/src/main/java/io/spine/core/MessageIdMixin.java
@@ -28,6 +28,7 @@ import io.spine.annotation.Internal;
 import io.spine.type.TypeUrl;
 import io.spine.validate.FieldAwareMessage;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static io.spine.protobuf.AnyPacker.unpack;
 
@@ -82,6 +83,19 @@ interface MessageIdMixin extends MessageIdOrBuilder, FieldAwareMessage {
     default CommandId asCommandId() {
         checkState(isCommand(), "%s is not a command ID.", getId().getTypeUrl());
         return unpack(getId(), CommandId.class);
+    }
+
+    /**
+     * Creates a new instance copying ID and type URL from this instance, and applying
+     * the passed version.
+     */
+    @SuppressWarnings("ClassReferencesSubclass") // we want to encapsulate copy construction.
+    default MessageId withVersion(Version version) {
+        checkNotNull(version);
+        return MessageId.newBuilder()
+                        .setId(getId())
+                        .setTypeUrl(getTypeUrl())
+                        .vBuild();
     }
 
     @Override

--- a/core/src/main/java/io/spine/core/Signal.java
+++ b/core/src/main/java/io/spine/core/Signal.java
@@ -24,6 +24,7 @@ import com.google.errorprone.annotations.Immutable;
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import io.spine.annotation.GeneratedMixin;
+import io.spine.annotation.Internal;
 import io.spine.annotation.SPI;
 import io.spine.base.KnownMessage;
 import io.spine.base.MessageContext;
@@ -56,7 +57,6 @@ import static io.spine.protobuf.AnyPacker.pack;
 @SPI
 @Immutable
 @GeneratedMixin
-@SuppressWarnings("override") // not marked with `@Override` in the generated code
 public interface Signal<I extends SignalId,
                         M extends KnownMessage,
                         C extends MessageContext>
@@ -136,11 +136,19 @@ public interface Signal<I extends SignalId,
      * Obtains the ID of this message.
      */
     default MessageId messageId() {
+        return identityBuilder().vBuild();
+    }
+
+    /**
+     * Creates the builder for identity of the message, by supplying the ID and the type URL
+     * of the enclosed message.
+     */
+    @Internal
+    default MessageId.Builder identityBuilder() {
         return MessageId
                 .newBuilder()
                 .setId(pack(id()))
-                .setTypeUrl(enclosedTypeUrl().value())
-                .vBuild();
+                .setTypeUrl(enclosedTypeUrl().value());
     }
 
     /**
@@ -149,11 +157,7 @@ public interface Signal<I extends SignalId,
      * <p>This origin is assigned to any signal message produced as a reaction to this one..
      */
     default Origin asMessageOrigin() {
-        MessageId commandQualifier = MessageId
-                .newBuilder()
-                .setId(pack(id()))
-                .setTypeUrl(enclosedTypeUrl().value())
-                .buildPartial();
+        MessageId commandQualifier = identityBuilder().buildPartial();
         Origin origin = Origin
                 .newBuilder()
                 .setActorContext(actorContext())

--- a/core/src/main/proto/spine/core/diagnostics.proto
+++ b/core/src/main/proto/spine/core/diagnostics.proto
@@ -14,18 +14,16 @@ import "google/protobuf/any.proto";
 import "spine/core/actor_context.proto";
 import "spine/core/version.proto";
 
-// An identifier of a domain message.
-//
-// May represent a signal or an entity state.
-//
+// An identifier of a domain message, such as a signal, or an entity state.
 message MessageId {
     option (is).java_type = "io.spine.core.MessageIdMixin";
 
     // The ID of the message.
     //
     // If the message is a signal (an event of a command), `id` has the value of the signal ID (an
-    // `EventId` or a `CommandId`). If the message is an entity state, `id` had the value of
-    // the entity identifier.
+    // `EventId` or a `CommandId`).
+    //
+    // If the message is an entity state, `id` had the value of the entity identifier.
     //
     google.protobuf.Any id = 1 [(required) = true, (validate) = true];
 

--- a/core/src/main/proto/spine/core/diagnostics.proto
+++ b/core/src/main/proto/spine/core/diagnostics.proto
@@ -23,7 +23,7 @@ message MessageId {
     // If the message is a signal (an event of a command), `id` has the value of the signal ID (an
     // `EventId` or a `CommandId`).
     //
-    // If the message is an entity state, `id` had the value of the entity identifier.
+    // If the message is an entity state, `id` has the value of the entity identifier.
     //
     google.protobuf.Any id = 1 [(required) = true, (validate) = true];
 

--- a/license-report.md
+++ b/license-report.md
@@ -402,7 +402,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 16 20:06:02 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 18 17:15:46 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -769,7 +769,7 @@ This report was generated on **Mon Nov 16 20:06:02 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 16 20:06:03 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 18 17:15:46 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1171,7 +1171,7 @@ This report was generated on **Mon Nov 16 20:06:03 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 16 20:06:03 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 18 17:15:46 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1643,7 +1643,7 @@ This report was generated on **Mon Nov 16 20:06:03 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 16 20:06:04 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 18 17:15:47 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2058,7 +2058,7 @@ This report was generated on **Mon Nov 16 20:06:04 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 16 20:06:04 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 18 17:15:47 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2515,7 +2515,7 @@ This report was generated on **Mon Nov 16 20:06:04 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 16 20:06:06 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 18 17:15:49 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2980,7 +2980,7 @@ This report was generated on **Mon Nov 16 20:06:06 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 16 20:06:08 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 18 17:15:50 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3481,4 +3481,4 @@ This report was generated on **Mon Nov 16 20:06:08 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Nov 16 20:06:10 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 18 17:15:51 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/server/src/main/java/io/spine/server/Identity.java
+++ b/server/src/main/java/io/spine/server/Identity.java
@@ -76,4 +76,17 @@ public final class Identity {
                 .setTypeUrl(EMPTY_URL.value())
                 .vBuild();
     }
+
+    /**
+     * Creates the identity of the entity state by its ID and type URL.
+     */
+    public static MessageId ofEntity(Object entityId, TypeUrl entityType) {
+        checkNotNull(entityId);
+        checkNotNull(entityType);
+        return MessageId
+                .newBuilder()
+                .setId(Identifier.pack(entityId))
+                .setTypeUrl(entityType.value())
+                .vBuild();
+    }
 }

--- a/server/src/main/java/io/spine/server/entity/EntityLifecycle.java
+++ b/server/src/main/java/io/spine/server/entity/EntityLifecycle.java
@@ -27,7 +27,6 @@ import com.google.protobuf.Any;
 import io.spine.annotation.Internal;
 import io.spine.base.Error;
 import io.spine.base.EventMessage;
-import io.spine.base.Identifier;
 import io.spine.client.EntityId;
 import io.spine.core.Command;
 import io.spine.core.CommandId;
@@ -39,6 +38,7 @@ import io.spine.core.MessageId;
 import io.spine.core.Origin;
 import io.spine.core.Version;
 import io.spine.option.EntityOption;
+import io.spine.server.Identity;
 import io.spine.server.dispatch.BatchDispatchOutcome;
 import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.entity.model.EntityClass;
@@ -135,11 +135,7 @@ public class EntityLifecycle {
         this.systemWriteSide = checkNotNull(writeSide);
         this.eventFilter = checkNotNull(eventFilter);
         this.typeName = checkNotNull(typeName);
-        this.entityId = MessageId
-                .newBuilder()
-                .setId(Identifier.pack(entityId))
-                .setTypeUrl(entityType.value())
-                .vBuild();
+        this.entityId = Identity.ofEntity(entityId, entityType);
     }
 
     private EntityLifecycle(Builder builder) {
@@ -366,15 +362,10 @@ public class EntityLifecycle {
                                       MessageId root,
                                       ValidationError error,
                                       Version version) {
-        MessageId entityId = MessageId
-                .newBuilder()
-                .setId(this.entityId.getId())
-                .setTypeUrl(this.entityId.getTypeUrl())
-                .setVersion(version)
-                .buildPartial();
+        MessageId withNewVersion = entityId.withVersion(version);
         ConstraintViolated event = ConstraintViolated
                 .newBuilder()
-                .setEntity(entityId)
+                .setEntity(withNewVersion)
                 .setLastMessage(lastMessage)
                 .setRootMessage(root)
                 .addAllViolation(error.getConstraintViolationList())
@@ -442,7 +433,12 @@ public class EntityLifecycle {
                 interruptedCount++;
             }
         }
-        checkNotNull(error);
+        if (error == null) {
+            error = Error.getDefaultInstance();
+        }
+        if (erroneous == null) {
+            erroneous = MessageId.getDefaultInstance();
+        }
         AggregateHistoryCorrupted event = AggregateHistoryCorrupted
                 .newBuilder()
                 .setEntity(entityId)

--- a/server/src/test/java/io/spine/server/IdentityTest.java
+++ b/server/src/test/java/io/spine/server/IdentityTest.java
@@ -20,7 +20,10 @@
 
 package io.spine.server;
 
+import com.google.common.testing.NullPointerTester;
+import com.google.protobuf.Empty;
 import io.spine.testing.UtilityClassTest;
+import io.spine.type.TypeUrl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +34,12 @@ class IdentityTest extends UtilityClassTest<Identity> {
 
     IdentityTest() {
         super(Identity.class);
+    }
+
+    @Override
+    protected void configure(NullPointerTester tester) {
+        super.configure(tester);
+        tester.setDefault(TypeUrl.class, TypeUrl.of(Empty.getDefaultInstance()));
     }
 
     @Test

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,7 +34,7 @@
 /**
  * Version of this library.
  */
-val coreJava = "1.6.7"
+val coreJava = "1.6.8"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.


### PR DESCRIPTION
This PR refactors creation of `MessageId` in some cases slightly consolidating work with this type.

The issue (#1189) which cased this PR was closed without addressing the need, because just making the `type_url` non-required would not improve things much. More work (#1320) would be needed (in v2.0) to make this type and the code around it much easier to understand and support. 