### PR TITLE
More improvements to `ServerEnvironment` configuration

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,9 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <option name="RIGHT_MARGIN" value="100" />
+    <DartCodeStyleSettings>
+      <option name="DELEGATE_TO_DARTFMT" value="false" />
+    </DartCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="PREFER_LONGER_NAMES" value="false" />
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1000" />
@@ -22,9 +25,6 @@
         <ANNO name="org.junit.jupiter.api.Test" />
       </REPEAT_ANNOTATIONS>
     </JavaCodeStyleSettings>
-    <JetCodeStyleSettings>
-      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
-    </JetCodeStyleSettings>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
@@ -70,9 +70,6 @@
           </group>
         </groups>
       </arrangement>
-    </codeStyleSettings>
-    <codeStyleSettings language="kotlin">
-      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -74,6 +74,7 @@
     <inspection_tool class="BigDecimalEquals" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="BreakStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="BreakStatementWithLabel" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="BusyWait" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CallToNativeMethodWhileLocked" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CallToStringConcatCanBeReplacedByOperator" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CastConflictsWithInstanceof" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -214,6 +215,7 @@
       <option name="commentsAreContent" value="true" />
     </inspection_tool>
     <inspection_tool class="EmptyDirectory" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="EmptyInitializer" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="EmptySynchronizedStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="EnumSwitchStatementWhichMissesCases" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="TYPO" enabled="true">
@@ -250,6 +252,7 @@
       <option name="myCountEnumConstants" value="false" />
       <option name="m_limit" value="20" />
     </inspection_tool>
+    <inspection_tool class="FieldMayBeFinal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="FieldMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="FinalizeNotProtected" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="FloatingPointEquality" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -324,7 +327,11 @@
       <option name="ignoreAbstractClasses" value="true" />
     </inspection_tool>
     <inspection_tool class="InstanceofThis" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="InstantiationOfUtilityClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="IntLiteralMayBeLongLiteral" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="IntegerMultiplicationImplicitCastToLong" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoreNonOverflowingCompileTimeConstants" value="true" />
+    </inspection_tool>
     <inspection_tool class="InterfaceNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_regex" value="[A-Z][A-Za-z\d]*" />
       <option name="m_minLength" value="3" />
@@ -333,6 +340,7 @@
     <inspection_tool class="InterfaceNeverImplemented" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreInterfacesThatOnlyDeclareConstants" value="true" />
     </inspection_tool>
+    <inspection_tool class="IteratorHasNextCallsIteratorNext" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="IteratorNextDoesNotThrowNoSuchElementException" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="JDBCExecuteWithNonConstantString" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="JDBCPrepareStatementWithNonConstantString" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -371,12 +379,14 @@
     </inspection_tool>
     <inspection_tool class="JavaLangImport" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="JavaLangReflect" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="JavadocHtmlLint" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="JavadocReference" enabled="true" level="ERROR" enabled_by_default="true">
       <scope name="Tests" level="ERROR" enabled="false" />
     </inspection_tool>
     <inspection_tool class="LabeledStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="LengthOneStringInIndexOf" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="LengthOneStringsInConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ListIndexOfReplaceableByContains" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ListenerMayUseAdapter" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="checkForEmptyMethods" value="true" />
     </inspection_tool>
@@ -464,7 +474,6 @@
       <option name="ignoreForLoopDeclarations" value="true" />
     </inspection_tool>
     <inspection_tool class="MultipleTopLevelClassesInFile" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="MultipleVariablesInDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NakedNotify" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NativeMethods" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NestedAssignment" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -485,7 +494,6 @@
         <extension name="JUnit4MethodNamingConvention" enabled="true">
           <option name="m_regex" value="[a-z][A-Za-z\d]*" />
           <option name="m_minLength" value="2" />
-          <option name="m_maxLength" value="64" />
         </extension>
       </scope>
       <scope name="Production" level="WARNING" enabled="true">
@@ -584,6 +592,7 @@
     <inspection_tool class="OverriddenMethodCallDuringObjectConstruction" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="PackageDotHtmlMayBePackageInfo" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="PackageInMultipleModules" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PackageInfoWithoutPackage" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="PackageNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_regex" value="[a-z]+\d*[a-z]*" />
       <option name="m_minLength" value="2" />
@@ -634,6 +643,7 @@
       <option name="ignoreCloneable" value="false" />
     </inspection_tool>
     <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="RedundantSuppression" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
@@ -703,6 +713,9 @@
     <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SwitchStatementWithTooFewBranches" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="m_limit" value="2" />
+    </inspection_tool>
     <inspection_tool class="SwitchStatementsWithoutDefault" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreFullyCoveredEnums" value="true" />
     </inspection_tool>
@@ -719,13 +732,16 @@
     <inspection_tool class="SystemSetSecurityManager" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TailRecursion" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TestOnlyProblems" enabled="true" level="TYPO" enabled_by_default="true" />
+    <inspection_tool class="TextLabelInSwitchStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThisEscapedInConstructor" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadDeathRethrown" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadDumpStack" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadLocalNotStaticFinal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadPriority" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ThreadRun" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadStartInConstruction" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadStopSuspendResume" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ThreadWithDefaultRunMethod" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreadYield" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThreeNegationsPerMethod" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreInEquals" value="true" />
@@ -733,9 +749,6 @@
     </inspection_tool>
     <inspection_tool class="ThrowCaughtLocally" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreRethrownExceptions" value="false" />
-    </inspection_tool>
-    <inspection_tool class="ThrowableNotThrown" enabled="true" level="WARNING" enabled_by_default="true">
-      <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
     <inspection_tool class="ThrowablePrintStackTrace" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThrownExceptionsPerMethod" enabled="true" level="WARNING" enabled_by_default="true">
@@ -798,13 +811,21 @@
     <inspection_tool class="UnnecessaryJavaDocLink" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreInlineLinkToSuper" value="false" />
     </inspection_tool>
-    <inspection_tool class="UnnecessaryLocalVariable" enabled="false" level="WARNING" enabled_by_default="false">
-      <option name="m_ignoreImmediatelyReturnedVariables" value="false" />
+    <inspection_tool class="UnnecessaryLocalVariable" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="m_ignoreImmediatelyReturnedVariables" value="true" />
       <option name="m_ignoreAnnotatedVariables" value="false" />
     </inspection_tool>
     <inspection_tool class="UnnecessaryQualifierForThis" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnnecessarySuperQualifier" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnnecessaryUnaryMinus" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="UnpredictableBigDecimalConstructorCall" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoreReferences" value="true" />
+      <option name="ignoreComplexLiterals" value="false" />
+    </inspection_tool>
+    <inspection_tool class="UnqualifiedInnerClassAccess" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreReferencesToLocalInnerClasses" value="true" />
+    </inspection_tool>
+    <inspection_tool class="UnnecessaryLocalVariable" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnsecureRandomNumberGeneration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnstableApiUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="Tests" level="WEAK WARNING" enabled="false" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,23 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="EntryPointsManager">
-    <list size="2">
-      <item index="0" class="java.lang.String" itemvalue="io.spine.server.command.Command" />
-      <item index="1" class="java.lang.String" itemvalue="io.spine.server.event.React" />
-    </list>
-  </component>
-  <component name="FrameworkDetectionExcludesConfiguration">
-    <file type="web" url="file://$PROJECT_DIR$" />
-  </component>
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
   <component name="NullableNotNullManager">
-    <option name="myDefaultNullable" value="org.jetbrains.annotations.Nullable" />
-    <option name="myDefaultNotNull" value="org.jetbrains.annotations.NotNull" />
     <option name="myNullables">
       <value>
-        <list size="14">
+        <list size="9">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
           <item index="2" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
@@ -27,17 +16,12 @@
           <item index="6" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
           <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
           <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
-          <item index="9" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNullable" />
-          <item index="10" class="java.lang.String" itemvalue="com.android.annotations.Nullable" />
-          <item index="11" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.Nullable" />
-          <item index="12" class="java.lang.String" itemvalue="io.reactivex.annotations.Nullable" />
-          <item index="13" class="java.lang.String" itemvalue="io.reactivex.rxjava3.annotations.Nullable" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="14">
+        <list size="9">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
           <item index="2" class="java.lang.String" itemvalue="javax.validation.constraints.NotNull" />
@@ -47,14 +31,9 @@
           <item index="6" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
           <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
           <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
-          <item index="9" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNonNull" />
-          <item index="10" class="java.lang.String" itemvalue="com.android.annotations.NonNull" />
-          <item index="11" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.NonNull" />
-          <item index="12" class="java.lang.String" itemvalue="io.reactivex.annotations.NonNull" />
-          <item index="13" class="java.lang.String" itemvalue="io.reactivex.rxjava3.annotations.NonNull" />
         </list>
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
 </project>

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.6.13`
+# Dependencies of `io.spine:spine-client:1.6.14`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -402,12 +402,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Nov 19 21:05:38 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 20 22:25:31 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.6.13`
+# Dependencies of `io.spine:spine-core:1.6.14`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -769,12 +769,12 @@ This report was generated on **Thu Nov 19 21:05:38 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Nov 19 21:05:39 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 20 22:25:31 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.6.13`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.6.14`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1171,12 +1171,12 @@ This report was generated on **Thu Nov 19 21:05:39 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Nov 19 21:05:39 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 20 22:25:32 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.6.13`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.6.14`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1639,12 +1639,12 @@ This report was generated on **Thu Nov 19 21:05:39 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Nov 19 21:05:39 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 20 22:25:32 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.6.13`
+# Dependencies of `io.spine:spine-server:1.6.14`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2054,12 +2054,12 @@ This report was generated on **Thu Nov 19 21:05:39 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Nov 19 21:05:39 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 20 22:25:32 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.6.13`
+# Dependencies of `io.spine:spine-testutil-client:1.6.14`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2511,12 +2511,12 @@ This report was generated on **Thu Nov 19 21:05:39 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Nov 19 21:05:41 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 20 22:25:34 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.6.13`
+# Dependencies of `io.spine:spine-testutil-core:1.6.14`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2976,12 +2976,12 @@ This report was generated on **Thu Nov 19 21:05:41 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Nov 19 21:05:42 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 20 22:25:35 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.6.13`
+# Dependencies of `io.spine:spine-testutil-server:1.6.14`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3477,4 +3477,4 @@ This report was generated on **Thu Nov 19 21:05:42 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Nov 19 21:05:44 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 20 22:25:37 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.6.13</version>
+<version>1.6.14</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -70,7 +70,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -82,13 +82,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -130,7 +130,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -142,13 +142,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -198,12 +198,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/server/src/main/java/io/spine/server/ServerEnvironment.java
+++ b/server/src/main/java/io/spine/server/ServerEnvironment.java
@@ -363,11 +363,17 @@ public final class ServerEnvironment implements AutoCloseable {
     public StorageFactory storageFactory() {
         Class<? extends EnvironmentType> type = environment().type();
         StorageFactory result = storageFactory.optionalValue(type)
-                .orElseThrow(() -> newIllegalStateException(
-                        "The storage factory for environment `%s` was not configured."
-                                + " Please call `.when(environmentType).use(storageFactory)`.",
-                        type.getSimpleName()));
+                .orElseThrow(() -> suggestConfiguringStorageFactory(type));
         return result;
+    }
+
+    private static IllegalStateException
+    suggestConfiguringStorageFactory(Class<? extends EnvironmentType> type) {
+        String typeName = type.getSimpleName();
+        return newIllegalStateException(
+                "The storage factory for the environment `%s` was not configured."
+                        + " Please call `ServerEnvironment.when(%s.class).use(storageFactory);`.",
+                typeName, typeName);
     }
 
     /**
@@ -394,12 +400,18 @@ public final class ServerEnvironment implements AutoCloseable {
     public TransportFactory transportFactory() {
         Class<? extends EnvironmentType> type = environment().type();
         TransportFactory result = transportFactory.optionalValue(type)
-                .orElseThrow(() -> newIllegalStateException(
-                        "Transport factory is not assigned for the current environment `%s`."
-                                + " Please call `.when(environmentType).use(transportFactory)`.",
-                        type.getSimpleName()));
+                .orElseThrow(() -> suggestConfiguringTransportFactory(type));
 
         return result;
+    }
+
+    private static IllegalStateException
+    suggestConfiguringTransportFactory(Class<? extends EnvironmentType> type) {
+        String typeName = type.getSimpleName();
+        return newIllegalStateException(
+                "Transport factory is not assigned for the current environment `%s`."
+                        + " Please call `ServerEnvironment.when(%s.class).use(transportFactory);`.",
+                typeName, typeName);
     }
 
     private static Environment environment() {

--- a/server/src/main/java/io/spine/server/ServerEnvironment.java
+++ b/server/src/main/java/io/spine/server/ServerEnvironment.java
@@ -468,6 +468,8 @@ public final class ServerEnvironment implements AutoCloseable {
 
         /**
          * Assigns the specified {@code Delivery} for the selected environment.
+         *
+         * @see #useDelivery(Fn)
          */
         @CanIgnoreReturnValue
         public TypeConfigurator use(Delivery delivery) {
@@ -480,8 +482,9 @@ public final class ServerEnvironment implements AutoCloseable {
          * Assigns a {@code Delivery} obtained from the passed function.
          *
          * @param fn
-         *      the function to provide the {@code Delivery} in response to
-         *      the currently configured server environment type
+         *         the function to provide the {@code Delivery} in response to
+         *         the currently configured server environment type
+         * @see #use(Delivery)
          */
         @CanIgnoreReturnValue
         public TypeConfigurator useDelivery(Fn<Delivery> fn) {
@@ -492,6 +495,8 @@ public final class ServerEnvironment implements AutoCloseable {
 
         /**
          * Assigns {@code TracerFactory} for the selected environment.
+         *
+         * @see #useTracerFactory(Fn)
          */
         @CanIgnoreReturnValue
         public TypeConfigurator use(TracerFactory factory) {
@@ -504,8 +509,9 @@ public final class ServerEnvironment implements AutoCloseable {
          * Assigns a {@code TracerFactory} obtained from the passed function.
          *
          * @param fn
-         *      the function to provide the {@code TracerFactory} in response to
-         *      the currently configured server environment type
+         *         the function to provide the {@code TracerFactory} in response to
+         *         the currently configured server environment type
+         * @see #use(TracerFactory)
          */
         @CanIgnoreReturnValue
         public TypeConfigurator useTracerFactory(Fn<TracerFactory> fn) {
@@ -516,6 +522,8 @@ public final class ServerEnvironment implements AutoCloseable {
 
         /**
          * Assigns the specified transport factory for the selected environment.
+         *
+         * @see #useTransportFactory(Fn)
          */
         @CanIgnoreReturnValue
         public TypeConfigurator use(TransportFactory factory) {
@@ -528,8 +536,9 @@ public final class ServerEnvironment implements AutoCloseable {
          * Assigns a {@code TransportFactory} obtained from the passed function.
          *
          * @param fn
-         *      the function to provide the {@code TransportFactory} in response to
-         *      the currently configured server environment type
+         *         the function to provide the {@code TransportFactory} in response to
+         *         the currently configured server environment type
+         * @see #use(TransportFactory)
          */
         @CanIgnoreReturnValue
         public TypeConfigurator useTransportFactory(Fn<TransportFactory> fn) {
@@ -540,6 +549,8 @@ public final class ServerEnvironment implements AutoCloseable {
 
         /**
          * Assigns the specified {@code TransportFactory} for the selected environment.
+         *
+         * @see #useStorageFactory(Fn)
          */
         @CanIgnoreReturnValue
         public TypeConfigurator use(StorageFactory factory) {
@@ -552,8 +563,9 @@ public final class ServerEnvironment implements AutoCloseable {
          * Assigns a {@code StorageFactory} obtained from the passed function.
          *
          * @param fn
-         *      the function to provide the {@code StorageFactory} in response to
-         *      the currently configured server environment type
+         *         the function to provide the {@code StorageFactory} in response to
+         *         the currently configured server environment type
+         * @see #use(StorageFactory)
          */
         @CanIgnoreReturnValue
         public TypeConfigurator useStorageFactory(Fn<StorageFactory> fn) {

--- a/server/src/main/java/io/spine/server/ServerEnvironment.java
+++ b/server/src/main/java/io/spine/server/ServerEnvironment.java
@@ -40,6 +40,7 @@ import io.spine.server.transport.TransportFactory;
 import io.spine.server.transport.memory.InMemoryTransportFactory;
 
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -458,8 +459,16 @@ public final class ServerEnvironment implements AutoCloseable {
          */
         @CanIgnoreReturnValue
         public TypeConfigurator use(Delivery delivery) {
+            checkNotNull(delivery);
             se.use(delivery, type);
             return this;
+        }
+
+        @CanIgnoreReturnValue
+        public TypeConfigurator use(Function<Class<? extends EnvironmentType>, Delivery> fn) {
+            checkNotNull(fn);
+            Delivery delivery = fn.apply(type);
+            return use(delivery);
         }
 
         /**
@@ -467,6 +476,7 @@ public final class ServerEnvironment implements AutoCloseable {
          */
         @CanIgnoreReturnValue
         public TypeConfigurator use(TracerFactory factory) {
+            checkNotNull(factory);
             se.tracerFactory.use(factory, type);
             return this;
         }
@@ -476,6 +486,7 @@ public final class ServerEnvironment implements AutoCloseable {
          */
         @CanIgnoreReturnValue
         public TypeConfigurator use(TransportFactory factory) {
+            checkNotNull(factory);
             se.transportFactory.use(factory, type);
             return this;
         }

--- a/server/src/main/java/io/spine/server/ServerEnvironment.java
+++ b/server/src/main/java/io/spine/server/ServerEnvironment.java
@@ -464,8 +464,15 @@ public final class ServerEnvironment implements AutoCloseable {
             return this;
         }
 
+        /**
+         * Assigns a {@code Delivery} obtained from the passed function.
+         *
+         * @param fn
+         *      the function to provide the {@code Delivery} in response to
+         *      the currently configured server environment type
+         */
         @CanIgnoreReturnValue
-        public TypeConfigurator use(Function<Class<? extends EnvironmentType>, Delivery> fn) {
+        public TypeConfigurator useDelivery(Fn<Delivery> fn) {
             checkNotNull(fn);
             Delivery delivery = fn.apply(type);
             return use(delivery);
@@ -482,13 +489,41 @@ public final class ServerEnvironment implements AutoCloseable {
         }
 
         /**
-         * Configures the specified transport factory for the selected environment.
+         * Assigns a {@code TracerFactory} obtained from the passed function.
+         *
+         * @param fn
+         *      the function to provide the {@code TracerFactory} in response to
+         *      the currently configured server environment type
+         */
+        @CanIgnoreReturnValue
+        public TypeConfigurator useTracerFactory(Fn<TracerFactory> fn) {
+            checkNotNull(fn);
+            TracerFactory factory = fn.apply(type);
+            return use(factory);
+        }
+
+        /**
+         * Assigns the specified transport factory for the selected environment.
          */
         @CanIgnoreReturnValue
         public TypeConfigurator use(TransportFactory factory) {
             checkNotNull(factory);
             se.transportFactory.use(factory, type);
             return this;
+        }
+
+        /**
+         * Assigns a {@code TransportFactory} obtained from the passed function.
+         *
+         * @param fn
+         *      the function to provide the {@code TransportFactory} in response to
+         *      the currently configured server environment type
+         */
+        @CanIgnoreReturnValue
+        public TypeConfigurator useTransportFactory(Fn<TransportFactory> fn) {
+            checkNotNull(fn);
+            TransportFactory factory = fn.apply(type);
+            return use(factory);
         }
 
         /**
@@ -500,5 +535,30 @@ public final class ServerEnvironment implements AutoCloseable {
             se.storageFactory.use(wrapped, type);
             return this;
         }
+
+        /**
+         * Assigns a {@code StorageFactory} obtained from the passed function.
+         *
+         * @param fn
+         *      the function to provide the {@code StorageFactory} in response to
+         *      the currently configured server environment type
+         */
+        @CanIgnoreReturnValue
+        public TypeConfigurator useStorageFactory(Fn<StorageFactory> fn) {
+            checkNotNull(fn);
+            StorageFactory factory = fn.apply(type);
+            return use(factory);
+        }
+    }
+
+    /**
+     * A function which accepts a class of {@link EnvironmentType} and returns
+     * a value {@link ServerEnvironment#when(Class) configured} in a {@code ServerEnvironment}.
+     *
+     * @param <R> the type of the configured value
+     */
+    @FunctionalInterface
+    @SuppressWarnings("NewClassNamingConvention") // two letters for this name is fine.
+    public interface Fn<R> extends Function<Class<? extends EnvironmentType>, R> {
     }
 }

--- a/server/src/test/java/io/spine/server/ServerEnvironmentConfigTest.java
+++ b/server/src/test/java/io/spine/server/ServerEnvironmentConfigTest.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server;
+
+import com.google.common.truth.Truth8;
+import io.spine.base.Environment;
+import io.spine.base.EnvironmentType;
+import io.spine.base.Production;
+import io.spine.base.Tests;
+import io.spine.server.delivery.Delivery;
+import io.spine.server.delivery.UniformAcrossAllShards;
+import io.spine.server.given.environment.Local;
+import io.spine.server.storage.StorageFactory;
+import io.spine.server.storage.memory.InMemoryStorageFactory;
+import io.spine.server.storage.system.SystemAwareStorageFactory;
+import io.spine.server.storage.system.given.MemoizingStorageFactory;
+import io.spine.server.trace.given.MemoizingTracerFactory;
+import io.spine.server.transport.ChannelId;
+import io.spine.server.transport.Publisher;
+import io.spine.server.transport.Subscriber;
+import io.spine.server.transport.TransportFactory;
+import io.spine.server.transport.memory.InMemoryTransportFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.spine.server.ServerEnvironment.when;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests configuration of “features” of {@link ServerEnvironment}.
+ *
+ * @see ServerEnvironmentTest
+ */
+@DisplayName("`ServerEnvironment` should allow configuration of")
+class ServerEnvironmentConfigTest {
+
+    private static final Environment environment = Environment.instance();
+    private static final ServerEnvironment serverEnvironment = ServerEnvironment.instance();
+
+    @AfterEach
+    void resetAndBackToTests() {
+        serverEnvironment.reset();
+        environment.reset();
+        environment.setTo(Tests.class);
+    }
+
+    @Nested
+    @DisplayName("`TransportFactory` for")
+    class OfTransportFactory {
+
+        @Nested
+        @DisplayName("`Production`")
+        class ForProd {
+
+            @BeforeEach
+            void turnToProduction() {
+                environment.setTo(Production.class);
+            }
+
+            @Test
+            @DisplayName("throw an `IllegalStateException` if not configured")
+            void throwsIfNotConfigured() {
+                assertThrows(IllegalStateException.class, serverEnvironment::transportFactory);
+            }
+
+            @Test
+            @DisplayName("return configured instance in Production")
+            void productionValue() {
+                TransportFactory factory = new StubTransportFactory();
+                when(Production.class).use(factory);
+                assertThat(serverEnvironment.transportFactory())
+                        .isEqualTo(factory);
+            }
+        }
+
+        @Nested
+        @DisplayName("`Tests`")
+        class ForTests {
+
+            @Test
+            @DisplayName("returning explicitly set value")
+            void setExplicitly() {
+                TransportFactory factory = new StubTransportFactory();
+                when(Tests.class).use(factory);
+                assertThat(serverEnvironment.transportFactory())
+                        .isSameInstanceAs(factory);
+            }
+
+            @Test
+            @DisplayName("returning an `InMemoryTransportFactory` when not set")
+            void notSet() {
+                environment.setTo(Tests.class);
+                assertThat(serverEnvironment.transportFactory())
+                        .isInstanceOf(InMemoryTransportFactory.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("custom environment")
+        class ForCustom {
+
+            @BeforeEach
+            void setCustom() {
+                environment.setTo(Local.class);
+                Local.enable();
+            }
+
+            @Test
+            @DisplayName("throwing an `IllegalStateException` if not set")
+            void illegalState() {
+                assertThrows(IllegalStateException.class, serverEnvironment::transportFactory);
+            }
+
+            @Test
+            @DisplayName("returning a configured instance")
+            void ok() {
+                InMemoryTransportFactory transportFactory = InMemoryTransportFactory.newInstance();
+                when(Local.class)
+                                 .use(transportFactory);
+                assertThat(serverEnvironment.transportFactory())
+                        .isSameInstanceAs(transportFactory);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("`Delivery`")
+    class DeliveryTest {
+
+        @Test
+        @DisplayName("to default back to `Local` if no delivery is set")
+        void backToLocal() {
+            Delivery delivery = serverEnvironment.delivery();
+            assertThat(delivery).isNotNull();
+        }
+
+        @Test
+        @DisplayName("to a custom mechanism")
+        void allowToCustomizeDeliveryStrategy() {
+            Delivery newDelivery = Delivery.newBuilder()
+                                           .setStrategy(UniformAcrossAllShards.forNumber(42))
+                                           .build();
+            Delivery defaultValue = serverEnvironment.delivery();
+            Class<? extends EnvironmentType> currentType = environment.type();
+
+            when(currentType).use(newDelivery);
+
+            assertThat(serverEnvironment.delivery())
+                    .isSameInstanceAs(newDelivery);
+
+            // Restore the default value.
+            when(currentType)
+                             .use(defaultValue);
+        }
+    }
+
+    @Nested
+    @DisplayName("`TracerFactory`")
+    class TracerFactory {
+
+        @Test
+        @DisplayName("returning an instance for the production environment")
+        @SuppressWarnings("OptionalGetWithoutIsPresent")
+        void forProduction() {
+            environment.setTo(Production.class);
+
+            MemoizingTracerFactory memoizingTracer = new MemoizingTracerFactory();
+            when(Production.class).use(memoizingTracer);
+
+            assertThat(serverEnvironment.tracing()
+                                        .get()).isSameInstanceAs(memoizingTracer);
+        }
+
+        @Test
+        @DisplayName("for the testing environment")
+        void forTesting() {
+            MemoizingTracerFactory memoizingTracer = new MemoizingTracerFactory();
+            when(Tests.class)
+                             .use(memoizingTracer);
+
+            Truth8.assertThat(serverEnvironment.tracing())
+                  .hasValue(memoizingTracer);
+        }
+
+        @Test
+        @DisplayName("for a custom environment")
+        void forCustom() {
+            environment.setTo(Local.class);
+
+            MemoizingTracerFactory memoizingTracer = new MemoizingTracerFactory();
+            when(Local.class).use(memoizingTracer);
+
+            Truth8.assertThat(serverEnvironment.tracing())
+                  .hasValue(memoizingTracer);
+        }
+
+        @Test
+        @DisplayName("for a custom environment, returning empty if it's disabled")
+        void forCustomEmpty() {
+            Local.disable();
+
+            MemoizingTracerFactory memoizingTracer = new MemoizingTracerFactory();
+            when(Local.class).use(memoizingTracer);
+
+            Truth8.assertThat(serverEnvironment.tracing())
+                  .isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("`StorageFactory` for")
+    class OfStorageFactory {
+
+        @Nested
+        @DisplayName("`Production`")
+        class ForProduction {
+
+            @BeforeEach
+            void turnToProduction() {
+                environment.setTo(Production.class);
+            }
+
+            @Test
+            @DisplayName("throwing an `IllegalStateException` if not configured")
+            void throwsIfNotConfigured() {
+                assertThrows(IllegalStateException.class, serverEnvironment::storageFactory);
+            }
+
+            @Test
+            @DisplayName("return configured `StorageFactory`")
+            void productionFactory() {
+                StorageFactory factory = InMemoryStorageFactory.newInstance();
+                when(Production.class)
+                                 .use(factory);
+                StorageFactory delegate =
+                        ((SystemAwareStorageFactory) serverEnvironment.storageFactory()).delegate();
+                assertThat(delegate)
+                        .isEqualTo(factory);
+            }
+
+            @Test
+            @DisplayName("return `InMemoryStorageFactory` under Tests")
+            void testsFactory() {
+                environment.setTo(Tests.class);
+
+                StorageFactory factory = serverEnvironment.storageFactory();
+                assertThat(factory)
+                        .isInstanceOf(SystemAwareStorageFactory.class);
+                SystemAwareStorageFactory systemAware = (SystemAwareStorageFactory) factory;
+                assertThat(systemAware.delegate()).isInstanceOf(InMemoryStorageFactory.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("`Tests`")
+        class ForTests {
+
+            @Test
+            @DisplayName("wrapping `SystemAwareStorageFactory` over the passed instance")
+            void getSet() {
+                StorageFactory factory = new MemoizingStorageFactory();
+                when(Tests.class)
+                                 .use(factory);
+
+                StorageFactory delegate =
+                        ((SystemAwareStorageFactory) serverEnvironment.storageFactory()).delegate();
+                assertThat(delegate)
+                        .isEqualTo(factory);
+            }
+        }
+
+        @Nested
+        @DisplayName("a custom environment")
+        class ForCustom {
+
+            @BeforeEach
+            void reset() {
+                environment.setTo(Local.class);
+                Local.enable();
+            }
+
+            @Test
+            @DisplayName("throwing an `IllegalStateException` if not set")
+            void illegalState() {
+                assertThrows(IllegalStateException.class, serverEnvironment::storageFactory);
+            }
+
+            @Test
+            @DisplayName("returning a configured wrapped instance")
+            void returnConfiguredStorageFactory() {
+                InMemoryStorageFactory inMemory = InMemoryStorageFactory.newInstance();
+                when(Local.class)
+                                 .use(inMemory);
+
+                StorageFactory delegate =
+                        ((SystemAwareStorageFactory) serverEnvironment.storageFactory()).delegate();
+                assertThat(delegate)
+                        .isEqualTo(inMemory);
+            }
+        }
+    }
+
+    /**
+     * Stub implementation of {@code TransportFactory} which delegates all the calls
+     * to {@code InMemoryTransportFactory}.
+     */
+    static class StubTransportFactory implements TransportFactory {
+
+        private final TransportFactory delegate = InMemoryTransportFactory.newInstance();
+
+        @Override
+        public Publisher createPublisher(ChannelId id) {
+            return delegate.createPublisher(id);
+        }
+
+        @Override
+        public Subscriber createSubscriber(ChannelId id) {
+            return delegate.createSubscriber(id);
+        }
+
+        @Override
+        public boolean isOpen() {
+            return delegate.isOpen();
+        }
+
+        @Override
+        public void close() throws Exception {
+            delegate.close();
+        }
+    }
+}

--- a/server/src/test/java/io/spine/server/ServerEnvironmentConfigTest.java
+++ b/server/src/test/java/io/spine/server/ServerEnvironmentConfigTest.java
@@ -67,6 +67,7 @@ class ServerEnvironmentConfigTest {
         serverEnvironment.reset();
         environment.reset();
         environment.setTo(Tests.class);
+        Local.disable();
     }
 
     @Test
@@ -387,7 +388,7 @@ class ServerEnvironmentConfigTest {
         class ForCustom {
 
             @BeforeEach
-            void reset() {
+            void setToLocal() {
                 environment.setTo(Local.class);
                 Local.enable();
             }

--- a/server/src/test/java/io/spine/server/ServerEnvironmentConfigTest.java
+++ b/server/src/test/java/io/spine/server/ServerEnvironmentConfigTest.java
@@ -137,8 +137,7 @@ class ServerEnvironmentConfigTest {
             @DisplayName("returning a configured instance")
             void ok() {
                 InMemoryTransportFactory transportFactory = InMemoryTransportFactory.newInstance();
-                when(Local.class)
-                                 .use(transportFactory);
+                when(Local.class).use(transportFactory);
                 assertThat(serverEnvironment.transportFactory())
                         .isSameInstanceAs(transportFactory);
             }
@@ -159,9 +158,10 @@ class ServerEnvironmentConfigTest {
         @Test
         @DisplayName("to a custom mechanism")
         void allowToCustomizeDeliveryStrategy() {
-            Delivery newDelivery = Delivery.newBuilder()
-                                           .setStrategy(UniformAcrossAllShards.forNumber(42))
-                                           .build();
+            Delivery newDelivery =
+                    Delivery.newBuilder()
+                            .setStrategy(UniformAcrossAllShards.forNumber(42))
+                            .build();
             Delivery defaultValue = serverEnvironment.delivery();
             Class<? extends EnvironmentType> currentType = environment.type();
 
@@ -171,8 +171,7 @@ class ServerEnvironmentConfigTest {
                     .isSameInstanceAs(newDelivery);
 
             // Restore the default value.
-            when(currentType)
-                             .use(defaultValue);
+            when(currentType).use(defaultValue);
         }
     }
 
@@ -197,8 +196,7 @@ class ServerEnvironmentConfigTest {
         @DisplayName("for the testing environment")
         void forTesting() {
             MemoizingTracerFactory memoizingTracer = new MemoizingTracerFactory();
-            when(Tests.class)
-                             .use(memoizingTracer);
+            when(Tests.class).use(memoizingTracer);
 
             Truth8.assertThat(serverEnvironment.tracing())
                   .hasValue(memoizingTracer);
@@ -252,10 +250,8 @@ class ServerEnvironmentConfigTest {
             @DisplayName("return configured `StorageFactory`")
             void productionFactory() {
                 StorageFactory factory = InMemoryStorageFactory.newInstance();
-                when(Production.class)
-                                 .use(factory);
-                StorageFactory delegate =
-                        ((SystemAwareStorageFactory) serverEnvironment.storageFactory()).delegate();
+                when(Production.class).use(factory);
+                StorageFactory delegate = systemAwareFactory().delegate();
                 assertThat(delegate)
                         .isEqualTo(factory);
             }
@@ -268,8 +264,9 @@ class ServerEnvironmentConfigTest {
                 StorageFactory factory = serverEnvironment.storageFactory();
                 assertThat(factory)
                         .isInstanceOf(SystemAwareStorageFactory.class);
-                SystemAwareStorageFactory systemAware = (SystemAwareStorageFactory) factory;
-                assertThat(systemAware.delegate()).isInstanceOf(InMemoryStorageFactory.class);
+                StorageFactory delegate = systemAwareFactory().delegate();
+                assertThat(delegate)
+                        .isInstanceOf(InMemoryStorageFactory.class);
             }
         }
 
@@ -281,11 +278,9 @@ class ServerEnvironmentConfigTest {
             @DisplayName("wrapping `SystemAwareStorageFactory` over the passed instance")
             void getSet() {
                 StorageFactory factory = new MemoizingStorageFactory();
-                when(Tests.class)
-                                 .use(factory);
+                when(Tests.class).use(factory);
 
-                StorageFactory delegate =
-                        ((SystemAwareStorageFactory) serverEnvironment.storageFactory()).delegate();
+                StorageFactory delegate = systemAwareFactory().delegate();
                 assertThat(delegate)
                         .isEqualTo(factory);
             }
@@ -311,15 +306,17 @@ class ServerEnvironmentConfigTest {
             @DisplayName("returning a configured wrapped instance")
             void returnConfiguredStorageFactory() {
                 InMemoryStorageFactory inMemory = InMemoryStorageFactory.newInstance();
-                when(Local.class)
-                                 .use(inMemory);
+                when(Local.class).use(inMemory);
 
-                StorageFactory delegate =
-                        ((SystemAwareStorageFactory) serverEnvironment.storageFactory()).delegate();
+                StorageFactory delegate = systemAwareFactory().delegate();
                 assertThat(delegate)
                         .isEqualTo(inMemory);
             }
         }
+    }
+
+    private static SystemAwareStorageFactory systemAwareFactory() {
+        return (SystemAwareStorageFactory) serverEnvironment.storageFactory();
     }
 
     /**

--- a/server/src/test/java/io/spine/server/ServerEnvironmentTest.java
+++ b/server/src/test/java/io/spine/server/ServerEnvironmentTest.java
@@ -20,22 +20,14 @@
 
 package io.spine.server;
 
-import io.spine.base.Environment;
 import io.spine.base.EnvironmentType;
 import io.spine.base.Production;
 import io.spine.base.Tests;
 import io.spine.server.delivery.Delivery;
 import io.spine.server.delivery.UniformAcrossAllShards;
 import io.spine.server.given.environment.Local;
-import io.spine.server.storage.StorageFactory;
-import io.spine.server.storage.memory.InMemoryStorageFactory;
-import io.spine.server.storage.system.SystemAwareStorageFactory;
 import io.spine.server.storage.system.given.MemoizingStorageFactory;
 import io.spine.server.trace.given.MemoizingTracerFactory;
-import io.spine.server.transport.ChannelId;
-import io.spine.server.transport.Publisher;
-import io.spine.server.transport.Subscriber;
-import io.spine.server.transport.TransportFactory;
 import io.spine.server.transport.memory.InMemoryTransportFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,7 +36,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 import static io.spine.server.DeploymentDetector.APP_ENGINE_ENVIRONMENT_DEVELOPMENT_VALUE;
 import static io.spine.server.DeploymentDetector.APP_ENGINE_ENVIRONMENT_PATH;
 import static io.spine.server.DeploymentDetector.APP_ENGINE_ENVIRONMENT_PRODUCTION_VALUE;
@@ -54,9 +45,13 @@ import static io.spine.server.DeploymentType.STANDALONE;
 import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
 import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisplayName("ServerEnvironment should")
+/**
+ * Tests non-configuration aspects of {@link ServerEnvironment}.
+ *
+ * @see ServerEnvironmentConfigTest
+ */
+@DisplayName("`ServerEnvironment` should")
 class ServerEnvironmentTest {
 
     private static final ServerEnvironment serverEnvironment = ServerEnvironment.instance();
@@ -142,338 +137,6 @@ class ServerEnvironmentTest {
         void receivesStandalone() {
             assertEquals(STANDALONE, serverEnvironment.deploymentType());
         }
-    }
-
-    @Nested
-    @DisplayName("configure production `StorageFactory`")
-    class StorageFactoryConfig {
-
-        private final Environment environment = Environment.instance();
-        private final ServerEnvironment serverEnvironment = ServerEnvironment.instance();
-
-        @BeforeEach
-        void turnToProduction() {
-            // Ensure the server environment is clear.
-            serverEnvironment.reset();
-            environment.setTo(Production.class);
-        }
-
-        @AfterEach
-        void backToTests() {
-            environment.setTo(Tests.class);
-            serverEnvironment.reset();
-        }
-
-        @Test
-        @DisplayName("throwing an `IllegalStateException` if not configured in the Production mode")
-        void throwsIfNotConfigured() {
-            assertThrows(IllegalStateException.class, serverEnvironment::storageFactory);
-        }
-
-        @Test
-        @DisplayName("return configured `StorageFactory` when asked in Production")
-        void productionFactory() {
-            StorageFactory factory = InMemoryStorageFactory.newInstance();
-            ServerEnvironment.when(Production.class)
-                             .use(factory);
-            assertThat(((SystemAwareStorageFactory) serverEnvironment.storageFactory()).delegate())
-                    .isEqualTo(factory);
-        }
-
-        @Test
-        @DisplayName("return `InMemoryStorageFactory` under Tests")
-        void testsFactory() {
-            environment.setTo(Tests.class);
-
-            StorageFactory factory = serverEnvironment.storageFactory();
-            assertThat(factory)
-                    .isInstanceOf(SystemAwareStorageFactory.class);
-            SystemAwareStorageFactory systemAware = (SystemAwareStorageFactory) factory;
-            assertThat(systemAware.delegate()).isInstanceOf(InMemoryStorageFactory.class);
-        }
-    }
-
-    @Nested
-    @DisplayName("configure `StorageFactory` for tests")
-    class TestStorageFactoryConfig {
-
-        @AfterEach
-        void resetEnvironment() {
-            serverEnvironment.reset();
-        }
-
-        @Test
-        @DisplayName("wrapping `SystemAwareStorageFactory` over the passed instance")
-        void getSet() {
-            StorageFactory factory = new MemoizingStorageFactory();
-            ServerEnvironment.when(Tests.class)
-                             .use(factory);
-
-            StorageFactory delegate =
-                    ((SystemAwareStorageFactory) serverEnvironment.storageFactory()).delegate();
-            assertThat(delegate)
-                    .isEqualTo(factory);
-        }
-    }
-
-    @Nested
-    @DisplayName("configure `StorageFactory` for a custom environment")
-    class LocalStorageFactoryConfig {
-
-        @BeforeEach
-        void reset() {
-            serverEnvironment.reset();
-            Environment.instance()
-                       .setTo(Local.class);
-            Local.enable();
-        }
-
-        @AfterEach
-        void backToTests() {
-            Environment.instance()
-                       .setTo(Tests.class);
-            serverEnvironment.reset();
-        }
-
-        @Test
-        @DisplayName("throwing an `IllegalStateException` if not set")
-        void illegalState() {
-            assertThrows(IllegalStateException.class, serverEnvironment::storageFactory);
-        }
-
-        @Test
-        @DisplayName("returning a configured wrapped instance")
-        void returnConfiguredStorageFactory() {
-            InMemoryStorageFactory inMemory = InMemoryStorageFactory.newInstance();
-            ServerEnvironment.when(Local.class)
-                             .use(inMemory);
-
-            assertThat(((SystemAwareStorageFactory) serverEnvironment.storageFactory()).delegate())
-                    .isEqualTo(inMemory);
-        }
-    }
-
-    @Nested
-    @DisplayName("configure `TransportFactory` for the production environment")
-    class TransportFactoryConfig {
-
-        private final Environment environment = Environment.instance();
-
-        @BeforeEach
-        void turnToProduction() {
-            // Ensure the instance is clear.
-            serverEnvironment.reset();
-            environment.setTo(Production.class);
-        }
-
-        @AfterEach
-        void backToTests() {
-            environment.setTo(Tests.class);
-            serverEnvironment.reset();
-        }
-
-        @Test
-        @DisplayName("throw an `IllegalStateException` if not configured")
-        void throwsIfNotConfigured() {
-            assertThrows(IllegalStateException.class, serverEnvironment::transportFactory);
-        }
-
-        @Test
-        @DisplayName("return configured instance in Production")
-        void productionValue() {
-            TransportFactory factory = new StubTransportFactory();
-            ServerEnvironment.when(Production.class)
-                             .use(factory);
-            assertThat(serverEnvironment.transportFactory())
-                    .isEqualTo(factory);
-        }
-    }
-
-    @Nested
-    @DisplayName("configure `TransportFactory` for tests")
-    class TestTransportFactoryConfig {
-
-        @AfterEach
-        void resetEnvironment() {
-            serverEnvironment.reset();
-        }
-
-        @Test
-        @DisplayName("returning one when explicitly set")
-        void setExplicitly() {
-            TransportFactory factory = new StubTransportFactory();
-            ServerEnvironment.when(Tests.class)
-                             .use(factory);
-            assertThat(serverEnvironment.transportFactory())
-                    .isSameInstanceAs(factory);
-        }
-
-        @Test
-        @DisplayName("returning an `InMemoryTransportFactory` when not set")
-        void notSet() {
-            Environment.instance()
-                       .setTo(Tests.class);
-            assertThat(serverEnvironment.transportFactory())
-                    .isInstanceOf(InMemoryTransportFactory.class);
-        }
-    }
-
-    @Nested
-    @DisplayName("configure `TransportFactory` for a custom environment")
-    class LocalTransportFactory {
-
-        @BeforeEach
-        void reset() {
-            serverEnvironment.reset();
-            Environment.instance()
-                       .setTo(Local.class);
-            Local.enable();
-        }
-
-        @AfterEach
-        void backToTests() {
-            Environment.instance()
-                       .setTo(Tests.class);
-            serverEnvironment.reset();
-        }
-
-        @Test
-        @DisplayName("throwing an `IllegalStateException` if not set")
-        void illegalState() {
-            assertThrows(IllegalStateException.class, serverEnvironment::transportFactory);
-        }
-
-        @Test
-        @DisplayName("returning a configured instance")
-        void ok() {
-            InMemoryTransportFactory transportFactory = InMemoryTransportFactory.newInstance();
-            ServerEnvironment.when(Local.class)
-                             .use(transportFactory);
-            assertThat(serverEnvironment.transportFactory())
-                    .isSameInstanceAs(transportFactory);
-        }
-    }
-
-    @Nested
-    @DisplayName("configure `TracerFactory`")
-    class TracerFactory {
-
-        @BeforeEach
-        void reset() {
-            serverEnvironment.reset();
-            Environment.instance()
-                       .reset();
-        }
-
-        @AfterEach
-        void backToTests() {
-            Environment.instance()
-                       .setTo(Tests.class);
-            serverEnvironment.reset();
-        }
-
-        @Test
-        @DisplayName("returning an instance for the production environment")
-        @SuppressWarnings("OptionalGetWithoutIsPresent")
-        void forProduction() {
-            Environment.instance()
-                       .setTo(Production.class);
-
-            MemoizingTracerFactory memoizingTracer = new MemoizingTracerFactory();
-            ServerEnvironment.when(Production.class)
-                             .use(memoizingTracer);
-
-            assertThat(serverEnvironment.tracing()
-                                        .get()).isSameInstanceAs(memoizingTracer);
-        }
-
-        @Test
-        @DisplayName("for the testing environment")
-        @SuppressWarnings("OptionalGetWithoutIsPresent")
-        void forTesting() {
-            MemoizingTracerFactory memoizingTracer = new MemoizingTracerFactory();
-            ServerEnvironment.when(Tests.class)
-                             .use(memoizingTracer);
-
-            assertThat(serverEnvironment.tracing()
-                                        .get()).isSameInstanceAs(memoizingTracer);
-        }
-
-        @Test
-        @DisplayName("for a custom environment")
-        @SuppressWarnings("OptionalGetWithoutIsPresent")
-        void forCustom() {
-            Environment.instance()
-                       .setTo(Local.class);
-
-            MemoizingTracerFactory memoizingTracer = new MemoizingTracerFactory();
-            ServerEnvironment.when(Local.class)
-                             .use(memoizingTracer);
-
-            assertThat(serverEnvironment.tracing()
-                                        .get()).isSameInstanceAs(memoizingTracer);
-        }
-
-        @Test
-        @DisplayName("for a custom environment, returning empty if it's disabled")
-        void forCustomEmpty() {
-            Local.disable();
-
-            MemoizingTracerFactory memoizingTracer = new MemoizingTracerFactory();
-            ServerEnvironment.when(Local.class)
-                             .use(memoizingTracer);
-
-            assertThat(serverEnvironment.tracing()).isEmpty();
-        }
-    }
-
-    @Nested
-    @DisplayName("configure `Delivery`")
-    class DeliveryTest {
-
-        @BeforeEach
-        void reset() {
-            serverEnvironment.reset();
-            Environment.instance()
-                       .reset();
-        }
-
-        @AfterEach
-        void backToTests() {
-            Environment.instance()
-                       .setTo(Tests.class);
-            serverEnvironment.reset();
-        }
-
-        @Test
-        @DisplayName("to default back to `Local` if no delivery is set")
-        void backToLocal() {
-            Delivery delivery = serverEnvironment.delivery();
-            assertThat(delivery).isNotNull();
-        }
-
-        @Test
-        @DisplayName("to a custom mechanism")
-        void allowToCustomizeDeliveryStrategy() {
-            Delivery newDelivery = Delivery.newBuilder()
-                                           .setStrategy(UniformAcrossAllShards.forNumber(42))
-                                           .build();
-            ServerEnvironment environment = serverEnvironment;
-            Delivery defaultValue = environment.delivery();
-            Class<? extends EnvironmentType> currentType =
-                    Environment.instance()
-                               .type();
-
-            ServerEnvironment.when(currentType)
-                             .use(newDelivery);
-
-            assertEquals(newDelivery, environment.delivery());
-
-            // Restore the default value.
-            ServerEnvironment.when(currentType)
-                             .use(defaultValue);
-        }
-
     }
 
     @Nested
@@ -566,35 +229,6 @@ class ServerEnvironmentTest {
 
         void setGaeEnvironment(String value) {
             System.setProperty(APP_ENGINE_ENVIRONMENT_PATH, value);
-        }
-    }
-
-    /**
-     * Stub implementation of {@code TransportFactory} which delegates all the calls
-     * to {@code InMemoryTransportFactory}.
-     */
-    private static class StubTransportFactory implements TransportFactory {
-
-        private final TransportFactory delegate = InMemoryTransportFactory.newInstance();
-
-        @Override
-        public Publisher createPublisher(ChannelId id) {
-            return delegate.createPublisher(id);
-        }
-
-        @Override
-        public Subscriber createSubscriber(ChannelId id) {
-            return delegate.createSubscriber(id);
-        }
-
-        @Override
-        public boolean isOpen() {
-            return delegate.isOpen();
-        }
-
-        @Override
-        public void close() throws Exception {
-            delegate.close();
         }
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -39,7 +39,7 @@ val coreJava = "1.6.14"
 /**
  * Versions of the Spine libraries that `core-java` depends on.
  */
-val base = "1.6.12"
+val base = "1.6.13"
 val time = "1.6.11"
 
 project.extra.apply {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,7 +34,7 @@
 /**
  * Version of this library.
  */
-val coreJava = "1.6.13"
+val coreJava = "1.6.14"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.


### PR DESCRIPTION
This PR continues addressing #1315.

Enhancements introduced:
  * It is now possible to configure `ServerEnvironment ` features using `useSomething()` methods that accept a `Function<Class<? extends EnvironmentType>, Something>`.
 * In order to make the declaration a bit more compact `ServerEnvironment.Fn` functional interface was introduced. It's just a function, from the previous point, but with first generic argument hidden.
 * Tests of `ServerEnvironment` that related to the configuration were extracted into a separate test suite.



