### PR TITLE
Remove empty `grand_origin`

### DIFF
--- a/core/src/main/java/io/spine/core/EventMixin.java
+++ b/core/src/main/java/io/spine/core/EventMixin.java
@@ -180,10 +180,9 @@ interface EventMixin
 
     @Override
     default MessageId messageId() {
-        return Signal.super.messageId()
-                           .toBuilder()
-                           .setVersion(context().getVersion())
-                           .build();
+        return identityBuilder()
+                .setVersion(context().getVersion())
+                .vBuild();
     }
 
     @Override

--- a/core/src/main/java/io/spine/core/Signal.java
+++ b/core/src/main/java/io/spine/core/Signal.java
@@ -154,14 +154,13 @@ public interface Signal<I extends SignalId,
     /**
      * Obtains this signal as an origin of other signals.
      *
-     * <p>This origin is assigned to any signal message produced as a reaction to this one..
+     * <p>This origin is assigned to any signal message produced as a reaction to this one.
      */
     default Origin asMessageOrigin() {
-        MessageId commandQualifier = identityBuilder().buildPartial();
         Origin.Builder originBuilder = Origin
                 .newBuilder()
                 .setActorContext(actorContext())
-                .setMessage(commandQualifier);
+                .setMessage(messageId());
         origin().ifPresent(originBuilder::setGrandOrigin);
         return originBuilder.vBuild();
     }

--- a/core/src/main/java/io/spine/core/Signal.java
+++ b/core/src/main/java/io/spine/core/Signal.java
@@ -158,13 +158,12 @@ public interface Signal<I extends SignalId,
      */
     default Origin asMessageOrigin() {
         MessageId commandQualifier = identityBuilder().buildPartial();
-        Origin origin = Origin
+        Origin.Builder originBuilder = Origin
                 .newBuilder()
                 .setActorContext(actorContext())
-                .setMessage(commandQualifier)
-                .setGrandOrigin(origin().orElse(Origin.getDefaultInstance()))
-                .vBuild();
-        return origin;
+                .setMessage(commandQualifier);
+        origin().ifPresent(originBuilder::setGrandOrigin);
+        return originBuilder.vBuild();
     }
 
     /**

--- a/license-report.md
+++ b/license-report.md
@@ -399,7 +399,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 07 13:34:06 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 07 16:25:35 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -763,7 +763,7 @@ This report was generated on **Mon Dec 07 13:34:06 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 07 13:34:06 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 07 16:25:35 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1162,7 +1162,7 @@ This report was generated on **Mon Dec 07 13:34:06 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 07 13:34:07 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 07 16:25:36 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1627,7 +1627,7 @@ This report was generated on **Mon Dec 07 13:34:07 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 07 13:34:07 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 07 16:25:36 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2039,7 +2039,7 @@ This report was generated on **Mon Dec 07 13:34:07 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 07 13:34:08 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 07 16:25:37 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2493,7 +2493,7 @@ This report was generated on **Mon Dec 07 13:34:08 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 07 13:34:09 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 07 16:25:38 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2947,7 +2947,7 @@ This report was generated on **Mon Dec 07 13:34:09 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 07 13:34:11 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 07 16:25:39 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3445,4 +3445,4 @@ This report was generated on **Mon Dec 07 13:34:11 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Dec 07 13:34:12 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 07 16:25:42 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.6.18`
+# Dependencies of `io.spine:spine-client:1.6.19`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -399,12 +399,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Dec 03 17:11:38 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 07 13:34:06 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.6.18`
+# Dependencies of `io.spine:spine-core:1.6.19`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -763,12 +763,12 @@ This report was generated on **Thu Dec 03 17:11:38 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Dec 03 17:11:48 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 07 13:34:06 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.6.18`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.6.19`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1162,12 +1162,12 @@ This report was generated on **Thu Dec 03 17:11:48 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Dec 03 17:11:51 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 07 13:34:07 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.6.18`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.6.19`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1627,12 +1627,12 @@ This report was generated on **Thu Dec 03 17:11:51 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Dec 03 17:11:56 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 07 13:34:07 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.6.18`
+# Dependencies of `io.spine:spine-server:1.6.19`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2039,12 +2039,12 @@ This report was generated on **Thu Dec 03 17:11:56 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Dec 03 17:12:29 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 07 13:34:08 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.6.18`
+# Dependencies of `io.spine:spine-testutil-client:1.6.19`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2493,12 +2493,12 @@ This report was generated on **Thu Dec 03 17:12:29 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Dec 03 17:12:34 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 07 13:34:09 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.6.18`
+# Dependencies of `io.spine:spine-testutil-core:1.6.19`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2947,12 +2947,12 @@ This report was generated on **Thu Dec 03 17:12:34 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Dec 03 17:12:37 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 07 13:34:11 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.6.18`
+# Dependencies of `io.spine:spine-testutil-server:1.6.19`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3445,4 +3445,4 @@ This report was generated on **Thu Dec 03 17:12:37 EET 2020** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Dec 03 17:12:50 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 07 13:34:12 EET 2020** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.6.18</version>
+<version>1.6.19</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/event/RejectionEnvelope.java
+++ b/server/src/main/java/io/spine/server/event/RejectionEnvelope.java
@@ -26,12 +26,10 @@ import io.spine.base.CommandMessage;
 import io.spine.base.Identifier;
 import io.spine.base.RejectionMessage;
 import io.spine.base.ThrowableMessage;
-import io.spine.core.ActorContext;
 import io.spine.core.Command;
 import io.spine.core.Event;
 import io.spine.core.EventContext;
 import io.spine.core.EventId;
-import io.spine.core.Origin;
 import io.spine.core.RejectionEventContext;
 import io.spine.core.TenantId;
 import io.spine.server.type.AbstractMessageEnvelope;
@@ -153,11 +151,6 @@ public final class RejectionEnvelope
     }
 
     @Override
-    public ActorContext actorContext() {
-        return event.actorContext();
-    }
-
-    @Override
     public EventId id() {
         return event.id();
     }
@@ -180,11 +173,6 @@ public final class RejectionEnvelope
     @Override
     public EventContext context() {
         return event.context();
-    }
-
-    @Override
-    public Origin asMessageOrigin() {
-        return event.asMessageOrigin();
     }
 
     @VisibleForTesting

--- a/server/src/main/java/io/spine/server/type/CommandEnvelope.java
+++ b/server/src/main/java/io/spine/server/type/CommandEnvelope.java
@@ -21,11 +21,9 @@
 package io.spine.server.type;
 
 import io.spine.base.CommandMessage;
-import io.spine.core.ActorContext;
 import io.spine.core.Command;
 import io.spine.core.CommandContext;
 import io.spine.core.CommandId;
-import io.spine.core.Origin;
 import io.spine.core.TenantId;
 import io.spine.type.TypeName;
 
@@ -91,19 +89,6 @@ public final class CommandEnvelope
     @Override
     public CommandClass messageClass() {
         return commandClass;
-    }
-
-    /**
-     * Obtains the actor context of the enclosed command.
-     */
-    @Override
-    public ActorContext actorContext() {
-        return context().getActorContext();
-    }
-
-    @Override
-    public Origin asMessageOrigin() {
-        return command().asMessageOrigin();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/type/EventEnvelope.java
+++ b/server/src/main/java/io/spine/server/type/EventEnvelope.java
@@ -22,12 +22,10 @@ package io.spine.server.type;
 
 import io.spine.base.CommandMessage;
 import io.spine.base.EventMessage;
-import io.spine.core.ActorContext;
 import io.spine.core.Enrichment;
 import io.spine.core.Event;
 import io.spine.core.EventContext;
 import io.spine.core.EventId;
-import io.spine.core.Origin;
 import io.spine.core.RejectionEventContext;
 import io.spine.core.TenantId;
 import io.spine.server.enrich.EnrichmentService;
@@ -103,16 +101,6 @@ public final class EventEnvelope
     @Override
     public EventClass messageClass() {
         return this.eventClass;
-    }
-
-    @Override
-    public ActorContext actorContext() {
-        return outerObject().actorContext();
-    }
-
-    @Override
-    public Origin asMessageOrigin() {
-        return outerObject().asMessageOrigin();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/type/SignalEnvelope.java
+++ b/server/src/main/java/io/spine/server/type/SignalEnvelope.java
@@ -23,6 +23,7 @@ package io.spine.server.type;
 import io.spine.base.MessageContext;
 import io.spine.core.ActorContext;
 import io.spine.core.MessageId;
+import io.spine.core.Origin;
 import io.spine.core.Signal;
 import io.spine.core.SignalId;
 import io.spine.core.TenantId;
@@ -47,12 +48,19 @@ public interface SignalEnvelope<I extends SignalId,
     /**
      * Obtains an actor context for the wrapped message.
      */
-    ActorContext actorContext();
+    default ActorContext actorContext() {
+        return outerObject().actorContext();
+    }
 
     /**
      * Obtains the message ID of the signal.
      */
     default MessageId messageId() {
         return outerObject().messageId();
+    }
+
+    @Override
+    default Origin asMessageOrigin() {
+        return outerObject().asMessageOrigin();
     }
 }

--- a/server/src/test/java/io/spine/core/SignalTest.java
+++ b/server/src/test/java/io/spine/core/SignalTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.core;
+
+import io.spine.server.event.EventFactory;
+import io.spine.server.type.EventEnvelope;
+import io.spine.server.type.given.GivenEvent;
+import io.spine.testing.core.given.GivenUserId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.spine.protobuf.AnyPacker.pack;
+import static io.spine.server.event.EventFactory.on;
+
+/**
+ * Extra tests for {@link Signal}s.
+ *
+ * <p>The main test suite for {@code Signal}s is located in the {@code core} module. This test suite
+ * only hosts tests which rely on the components from the {@code server} module.
+ */
+@DisplayName("`Signal` also should")
+class SignalTest {
+
+    @Test
+    @DisplayName("produce correct origin")
+    void produceOrigin() {
+        Event originalEvent = GivenEvent.arbitrary();
+        UserId producerEntityId = GivenUserId.generated();
+        EventFactory factory = on(EventEnvelope.of(originalEvent), pack(producerEntityId));
+        Event derivativeEvent = factory.createEvent(GivenEvent.message(), null);
+        Origin origin = derivativeEvent.getContext().getPastMessage();
+        assertThat(origin.getMessage())
+                .isEqualTo(originalEvent.messageId());
+        assertThat(origin.hasGrandOrigin())
+                .isFalse();
+    }
+}

--- a/server/src/test/java/io/spine/core/SignalTest.java
+++ b/server/src/test/java/io/spine/core/SignalTest.java
@@ -20,10 +20,12 @@
 
 package io.spine.core;
 
+import io.spine.base.CommandMessage;
 import io.spine.server.event.EventFactory;
 import io.spine.server.type.EventEnvelope;
 import io.spine.server.type.given.GivenEvent;
 import io.spine.testing.core.given.GivenUserId;
+import io.spine.type.TypeUrl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -50,7 +52,12 @@ class SignalTest {
         Origin origin = derivativeEvent.getContext().getPastMessage();
         assertThat(origin.getMessage())
                 .isEqualTo(originalEvent.messageId());
-        assertThat(origin.hasGrandOrigin())
+        Origin grandOrigin = origin.getGrandOrigin();
+        TypeUrl grandOriginType = TypeUrl.parse(grandOrigin.getMessage()
+                                                           .getTypeUrl());
+        assertThat(grandOriginType.toJavaClass())
+                .isAssignableTo(CommandMessage.class);
+        assertThat(grandOrigin.hasGrandOrigin())
                 .isFalse();
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,7 +34,7 @@
 /**
  * Version of this library.
  */
-val coreJava = "1.6.18"
+val coreJava = "1.6.19"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.


### PR DESCRIPTION
In this PR we avoid setting the `Origin.grand_origin` field to an empty value. This allows us to generate intuitive queries in languages other than Java filtering by the message origin.