### PR TITLE
Improve signals dispatching

### DIFF
--- a/server/src/main/java/io/spine/server/event/model/EventReceivingClassDelegate.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReceivingClassDelegate.java
@@ -144,14 +144,14 @@ public class EventReceivingClassDelegate<T extends EventReceiver,
             return ImmutableSet.of();
         }
         ImmutableSet<M> stateHandlers = handlers.handlersOf(updateEvent);
-        ImmutableSet<StateClass> result = stateHandlers
-                .stream()
-                .filter(StateSubscriberMethod.class::isInstance)
-                .map(StateSubscriberMethod.class::cast)
-                .filter(external ? HandlerMethod::isExternal : HandlerMethod::isDomestic)
-                .map(StateSubscriberMethod::stateType)
-                .map(StateClass::from)
-                .collect(toImmutableSet());
+        ImmutableSet<StateClass> result =
+                stateHandlers.stream()
+                             .filter(StateSubscriberMethod.class::isInstance)
+                             .map(StateSubscriberMethod.class::cast)
+                             .filter(external ? HandlerMethod::isExternal : HandlerMethod::isDomestic)
+                             .map(StateSubscriberMethod::stateType)
+                             .map(StateClass::from)
+                             .collect(toImmutableSet());
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/event/model/EventReceivingClassDelegate.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReceivingClassDelegate.java
@@ -120,8 +120,6 @@ public class EventReceivingClassDelegate<T extends EventReceiver,
 
     /**
      * Obtains the method which handles the passed event class.
-     *
-     * @throws IllegalStateException if there is such method in the class
      */
     public ImmutableSet<M> handlersOf(EventClass eventClass, MessageClass originClass) {
         return handlers.handlersOf(eventClass, originClass);
@@ -130,7 +128,8 @@ public class EventReceivingClassDelegate<T extends EventReceiver,
     /**
      * Obtains the method which handles the passed event class.
      *
-     * @throws IllegalStateException if there is such method in the class
+     * @throws IllegalStateException
+     *         if there is no such method in the class
      */
     public M handlerOf(EventClass eventClass, MessageClass originClass) {
         return handlers.handlerOf(eventClass, originClass);
@@ -145,14 +144,14 @@ public class EventReceivingClassDelegate<T extends EventReceiver,
             return ImmutableSet.of();
         }
         ImmutableSet<M> stateHandlers = handlers.handlersOf(updateEvent);
-        ImmutableSet<StateClass> result =
-                stateHandlers.stream()
-                        .filter(h -> h instanceof StateSubscriberMethod)
-                        .map(h -> (StateSubscriberMethod) h)
-                        .filter(external ? HandlerMethod::isExternal : HandlerMethod::isDomestic)
-                        .map(StateSubscriberMethod::stateType)
-                        .map(StateClass::from)
-                        .collect(toImmutableSet());
+        ImmutableSet<StateClass> result = stateHandlers
+                .stream()
+                .filter(h -> h instanceof StateSubscriberMethod)
+                .map(h -> (StateSubscriberMethod) h)
+                .filter(external ? HandlerMethod::isExternal : HandlerMethod::isDomestic)
+                .map(StateSubscriberMethod::stateType)
+                .map(StateClass::from)
+                .collect(toImmutableSet());
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/event/model/EventReceivingClassDelegate.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReceivingClassDelegate.java
@@ -46,8 +46,8 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
  */
 @Immutable(containerOf = "M")
 public class EventReceivingClassDelegate<T extends EventReceiver,
-                                         P extends MessageClass<?>,
-                                         M extends HandlerMethod<?, EventClass, ?, P>>
+        P extends MessageClass<?>,
+        M extends HandlerMethod<?, EventClass, ?, P>>
         extends ModelClass<T> {
 
     private static final long serialVersionUID = 0L;
@@ -145,13 +145,14 @@ public class EventReceivingClassDelegate<T extends EventReceiver,
         }
         ImmutableSet<M> stateHandlers = handlers.handlersOf(updateEvent);
         ImmutableSet<StateClass> result =
-                stateHandlers.stream()
-                             .filter(StateSubscriberMethod.class::isInstance)
-                             .map(StateSubscriberMethod.class::cast)
-                             .filter(external ? HandlerMethod::isExternal : HandlerMethod::isDomestic)
-                             .map(StateSubscriberMethod::stateType)
-                             .map(StateClass::from)
-                             .collect(toImmutableSet());
+                stateHandlers
+                        .stream()
+                        .filter(StateSubscriberMethod.class::isInstance)
+                        .map(StateSubscriberMethod.class::cast)
+                        .filter(external ? HandlerMethod::isExternal : HandlerMethod::isDomestic)
+                        .map(StateSubscriberMethod::stateType)
+                        .map(StateClass::from)
+                        .collect(toImmutableSet());
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/event/model/EventReceivingClassDelegate.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReceivingClassDelegate.java
@@ -146,8 +146,8 @@ public class EventReceivingClassDelegate<T extends EventReceiver,
         ImmutableSet<M> stateHandlers = handlers.handlersOf(updateEvent);
         ImmutableSet<StateClass> result = stateHandlers
                 .stream()
-                .filter(h -> h instanceof StateSubscriberMethod)
-                .map(h -> (StateSubscriberMethod) h)
+                .filter(StateSubscriberMethod.class::isInstance)
+                .map(StateSubscriberMethod.class::cast)
                 .filter(external ? HandlerMethod::isExternal : HandlerMethod::isDomestic)
                 .map(StateSubscriberMethod::stateType)
                 .map(StateClass::from)

--- a/server/src/main/java/io/spine/server/event/model/EventReceivingClassDelegate.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReceivingClassDelegate.java
@@ -121,7 +121,7 @@ public class EventReceivingClassDelegate<T extends EventReceiver,
     /**
      * Obtains the method which handles the passed event class.
      */
-    public ImmutableSet<M> handlersOf(EventClass eventClass, MessageClass originClass) {
+    public ImmutableSet<M> handlersOf(EventClass eventClass, MessageClass<?> originClass) {
         return handlers.handlersOf(eventClass, originClass);
     }
 
@@ -131,7 +131,7 @@ public class EventReceivingClassDelegate<T extends EventReceiver,
      * @throws IllegalStateException
      *         if there is no such method in the class
      */
-    public M handlerOf(EventClass eventClass, MessageClass originClass) {
+    public M handlerOf(EventClass eventClass, MessageClass<?> originClass) {
         return handlers.handlerOf(eventClass, originClass);
     }
 

--- a/server/src/main/java/io/spine/server/model/HandlerMap.java
+++ b/server/src/main/java/io/spine/server/model/HandlerMap.java
@@ -162,14 +162,13 @@ public final class HandlerMap<M extends MessageClass<?>,
      * <p>If there is no handler matching both the message and origin class, a handler will be
      * searched by the message class only.
      *
-     * <p>If there is no such method or several such methods, an {@link IllegalStateException} is
-     * thrown.
-     *
      * @param messageClass
      *         the message class of the handled message
      * @return a handler method
      * @throws IllegalStateException
-     *         if there is no such method or several such methods found in the map
+     *         if there is no such handler methods found
+     * @throws DuplicateHandlerMethodError
+     *         if there are several handler methods found
      */
     public H handlerOf(M messageClass, MessageClass originClass) {
         ImmutableSet<H> methods = handlersOf(messageClass, originClass);

--- a/server/src/main/java/io/spine/server/model/HandlerMap.java
+++ b/server/src/main/java/io/spine/server/model/HandlerMap.java
@@ -135,7 +135,7 @@ public final class HandlerMap<M extends MessageClass<?>,
      * <p>If there is no handler matching both the message and origin class, handlers will be
      * searched by the message class only.
      *
-     * <p>May return an empty set if no handlers found for a specified criteria.
+     * <p>If no handlers for a specified criteria is found, returns an empty set.
      *
      * @param messageClass
      *         the message class of the handled message

--- a/server/src/main/java/io/spine/server/model/HandlerMap.java
+++ b/server/src/main/java/io/spine/server/model/HandlerMap.java
@@ -37,7 +37,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.spine.server.model.MethodScan.findMethodsBy;
@@ -86,8 +85,7 @@ public final class HandlerMap<M extends MessageClass<?>,
         return new HandlerMap<>(map, messageClasses);
     }
 
-    private HandlerMap(ImmutableSetMultimap<DispatchKey, H> map,
-                       ImmutableSet<M> messageClasses) {
+    private HandlerMap(ImmutableSetMultimap<DispatchKey, H> map, ImmutableSet<M> messageClasses) {
         this.map = map;
         this.messageClasses = messageClasses;
     }
@@ -132,34 +130,17 @@ public final class HandlerMap<M extends MessageClass<?>,
     }
 
     /**
-     * Obtains the method for handling by the passed key.
-     *
-     * @param key
-     *         the key of the handler to get
-     * @return a handler method
-     * @throws IllegalStateException
-     *         if there is no method found in the map
-     */
-    private ImmutableSet<H> handlersOf(DispatchKey key) {
-        ImmutableSet<H> handlers = map.get(key);
-        checkState(!handlers.isEmpty(),
-                   "Unable to find handler with the key: %s.", key);
-        return handlers;
-    }
-
-    /**
      * Obtains methods for handling messages of the given class and with the given origin.
      *
      * <p>If there is no handler matching both the message and origin class, handlers will be
      * searched by the message class only.
      *
+     * <p>May return an empty set if no handlers found for a specified criteria.
+     *
      * @param messageClass
      *         the message class of the handled message
      * @param originClass
      *         the class of the message, from which the handled message is originate
-     * @return a handler method
-     * @throws IllegalStateException
-     *         if there is no method found in the map
      */
     public ImmutableSet<H> handlersOf(M messageClass, MessageClass<?> originClass) {
         DispatchKey key =
@@ -171,7 +152,8 @@ public final class HandlerMap<M extends MessageClass<?>,
         DispatchKey presentKey = map.containsKey(key)
                                  ? key
                                  : new DispatchKey(messageClass.value(), null, null);
-        return handlersOf(presentKey);
+        ImmutableSet<H> handlers = map.get(presentKey);
+        return handlers;
     }
 
     /**
@@ -200,8 +182,6 @@ public final class HandlerMap<M extends MessageClass<?>,
      * @param messageClass
      *         the message class of the handled message
      * @return handlers method
-     * @throws IllegalStateException
-     *         if there is no method found in the map
      */
     public ImmutableSet<H> handlersOf(M messageClass) {
         return handlersOf(messageClass, EmptyClass.instance());
@@ -217,7 +197,9 @@ public final class HandlerMap<M extends MessageClass<?>,
      *         the message class of the handled message
      * @return a handler method
      * @throws IllegalStateException
-     *         if there is no such method or several such methods found in the map
+     *         if there is no such handler methods found
+     * @throws DuplicateHandlerMethodError
+     *         if there are several handler methods found
      */
     public H handlerOf(M messageClass) {
         ImmutableSet<H> methods = handlersOf(messageClass);
@@ -233,11 +215,9 @@ public final class HandlerMap<M extends MessageClass<?>,
     private void checkSingle(Collection<H> handlers, M targetType) {
         int count = handlers.size();
         if (count == 0) {
-            _error().log("No handler method found for the type `%s`.", targetType);
-            throw newIllegalStateException(
-                    "Unexpected number of handlers for messages of class %s: %d.%n%s",
-                    targetType, count, handlers
-            );
+            String error = String.format("No handler method found for the type `%s`.", targetType);
+            _error().log(error);
+            throw newIllegalStateException(error);
         } else if (count > 1) {
             /*
               The map should have found all the duplicates during construction.

--- a/server/src/main/java/io/spine/server/model/HandlerMap.java
+++ b/server/src/main/java/io/spine/server/model/HandlerMap.java
@@ -166,9 +166,9 @@ public final class HandlerMap<M extends MessageClass<?>,
      *         the message class of the handled message
      * @return a handler method
      * @throws IllegalStateException
-     *         if there is no such handler methods found
+     *         if no handler methods were found
      * @throws DuplicateHandlerMethodError
-     *         if there are several handler methods found
+     *         if multiple handler methods were found
      */
     public H handlerOf(M messageClass, MessageClass originClass) {
         ImmutableSet<H> methods = handlersOf(messageClass, originClass);
@@ -196,9 +196,9 @@ public final class HandlerMap<M extends MessageClass<?>,
      *         the message class of the handled message
      * @return a handler method
      * @throws IllegalStateException
-     *         if there is no such handler methods found
+     *         if no handler methods were found
      * @throws DuplicateHandlerMethodError
-     *         if there are several handler methods found
+     *         if multiple handler methods were found
      */
     public H handlerOf(M messageClass) {
         ImmutableSet<H> methods = handlersOf(messageClass);

--- a/server/src/main/java/io/spine/server/model/HandlerMap.java
+++ b/server/src/main/java/io/spine/server/model/HandlerMap.java
@@ -170,7 +170,7 @@ public final class HandlerMap<M extends MessageClass<?>,
      * @throws DuplicateHandlerMethodError
      *         if multiple handler methods were found
      */
-    public H handlerOf(M messageClass, MessageClass originClass) {
+    public H handlerOf(M messageClass, MessageClass<?> originClass) {
         ImmutableSet<H> methods = handlersOf(messageClass, originClass);
         return singleMethod(methods, messageClass);
     }

--- a/server/src/main/java/io/spine/server/model/MethodScan.java
+++ b/server/src/main/java/io/spine/server/model/MethodScan.java
@@ -28,7 +28,6 @@ import io.spine.type.MessageClass;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * A class method scan operation.
@@ -86,11 +85,8 @@ final class MethodScan<H extends HandlerMethod<?, ?, ?, ?>> {
     }
 
     private void scanMethod(Method method) {
-        Optional<H> handlerMethod = signature.classify(method);
-        if (handlerMethod.isPresent()) {
-            H handler = handlerMethod.get();
-            remember(handler);
-        }
+        signature.classify(method)
+                 .ifPresent(this::remember);
     }
 
     private void remember(H handler) {

--- a/server/src/main/java/io/spine/server/projection/Projection.java
+++ b/server/src/main/java/io/spine/server/projection/Projection.java
@@ -24,6 +24,7 @@ import io.spine.annotation.Internal;
 import io.spine.base.EntityState;
 import io.spine.base.Error;
 import io.spine.core.Event;
+import io.spine.core.EventValidationError;
 import io.spine.protobuf.ValidatingBuilder;
 import io.spine.server.dispatch.BatchDispatchOutcome;
 import io.spine.server.dispatch.DispatchOutcome;
@@ -130,10 +131,12 @@ public abstract class Projection<I,
     private DispatchOutcome unhandledEvent(EventEnvelope event) {
         Error error = Error
                 .newBuilder()
+                .setType(EventValidationError.getDescriptor().getFullName())
                 .setCode(UNSUPPORTED_EVENT_VALUE)
-                .setMessage(format("Projection %s cannot handle event %s.",
-                                   thisClass(),
-                                   event.messageTypeName()))
+                .setMessage(format(
+                        "Projection `%s` cannot handle event `%s`.",
+                        thisClass(), event.messageTypeName()
+                ))
                 .buildPartial();
         return DispatchOutcome
                 .newBuilder()

--- a/server/src/test/java/io/spine/server/model/HandlerMapTest.java
+++ b/server/src/test/java/io/spine/server/model/HandlerMapTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static io.spine.server.projection.model.ProjectionClass.asProjectionClass;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("`HandlerMap` should")
@@ -126,7 +127,7 @@ class HandlerMapTest {
                     .newBuilder()
                     .setId(project)
                     .vBuild();
-            context().receivesCommand(createProject);
+            assertDoesNotThrow(() -> context().receivesCommand(createProject));
         }
     }
 }

--- a/server/src/test/java/io/spine/server/model/HandlerMapTest.java
+++ b/server/src/test/java/io/spine/server/model/HandlerMapTest.java
@@ -20,10 +20,15 @@
 
 package io.spine.server.model;
 
+import io.spine.base.Identifier;
+import io.spine.model.contexts.projects.ProjectId;
+import io.spine.model.contexts.projects.command.SigCreateProject;
+import io.spine.server.BoundedContextBuilder;
 import io.spine.server.command.model.CommandHandlerSignature;
 import io.spine.server.model.given.map.DupEventFilterValue;
 import io.spine.server.model.given.map.DupEventFilterValueWhere;
 import io.spine.server.model.given.map.DuplicateCommandHandlers;
+import io.spine.server.model.given.map.RejectionsDispatchingTestEnv;
 import io.spine.server.model.given.map.TwoFieldsInSubscription;
 import io.spine.server.model.given.method.OneParamSignature;
 import io.spine.server.model.given.method.StubHandler;
@@ -31,6 +36,7 @@ import io.spine.server.type.EventClass;
 import io.spine.string.StringifierRegistry;
 import io.spine.string.Stringifiers;
 import io.spine.test.event.ProjectStarred;
+import io.spine.testing.server.blackbox.ContextAwareTest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -96,5 +102,31 @@ class HandlerMapTest {
                 HandlerMap.create(StubHandler.class, new OneParamSignature());
         assertThrows(IllegalStateException.class,
                      () -> map.handlerOf(EventClass.from(ProjectStarred.class)));
+    }
+
+    @Nested
+    @DisplayName("gracefully handle a missing handler for a rejection with a specific origin")
+    class SpecificRejection extends ContextAwareTest {
+
+        @Override
+        protected BoundedContextBuilder contextBuilder() {
+            return BoundedContextBuilder
+                    .assumingTests()
+                    .add(RejectionsDispatchingTestEnv.ProjectAgg.class)
+                    .addEventDispatcher(new RejectionsDispatchingTestEnv.CompletionWatch());
+        }
+
+        @Test
+        void handleThrownRejectionGracefully() {
+            ProjectId project = ProjectId
+                    .newBuilder()
+                    .setId(Identifier.newUuid())
+                    .vBuild();
+            SigCreateProject createProject = SigCreateProject
+                    .newBuilder()
+                    .setId(project)
+                    .vBuild();
+            context().receivesCommand(createProject);
+        }
     }
 }

--- a/server/src/test/java/io/spine/server/model/given/map/RejectionsDispatchingTestEnv.java
+++ b/server/src/test/java/io/spine/server/model/given/map/RejectionsDispatchingTestEnv.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.model.given.map;
+
+import io.spine.core.Subscribe;
+import io.spine.model.contexts.projects.Project;
+import io.spine.model.contexts.projects.ProjectId;
+import io.spine.model.contexts.projects.command.SigCreateProject;
+import io.spine.model.contexts.projects.command.SigStartProject;
+import io.spine.model.contexts.projects.event.SigProjectCreated;
+import io.spine.model.contexts.projects.event.SigProjectStarted;
+import io.spine.model.contexts.projects.rejection.ProjectRejections;
+import io.spine.model.contexts.projects.rejection.SigProjectAlreadyCompleted;
+import io.spine.server.aggregate.Aggregate;
+import io.spine.server.aggregate.Apply;
+import io.spine.server.command.Assign;
+import io.spine.server.event.AbstractEventSubscriber;
+
+public final class RejectionsDispatchingTestEnv {
+
+    private RejectionsDispatchingTestEnv() {
+    }
+
+    /**
+     * A test aggregate that throws {@link SigProjectAlreadyCompleted} rejection for any
+     * handled command.
+     */
+    public static final class ProjectAgg extends Aggregate<ProjectId, Project, Project.Builder> {
+
+        @Assign
+        SigProjectStarted handle(SigStartProject c) throws SigProjectAlreadyCompleted {
+            throw SigProjectAlreadyCompleted
+                    .newBuilder()
+                    .setProject(c.getId())
+                    .build();
+        }
+
+        @Assign
+        SigProjectCreated handle(SigCreateProject c) throws SigProjectAlreadyCompleted {
+            throw SigProjectAlreadyCompleted
+                    .newBuilder()
+                    .setProject(c.getId())
+                    .build();
+        }
+
+        @Apply
+        private void on(SigProjectStarted e) {
+            // do nothing.
+        }
+
+        @Apply
+        private void on(SigProjectCreated e) {
+            // do nothing.
+        }
+    }
+
+    /**
+     * A test environment for the rejection subscriptions tests.
+     *
+     * <p>The subscriber is interested in the rejection thrown upon trying to
+     * {@linkplain SigStartProject start} the project, but not in rejections thrown when the project
+     * is just being {@linkplain SigCreateProject created}.
+     */
+    public static final class CompletionWatch extends AbstractEventSubscriber {
+
+        @Subscribe
+        void on(ProjectRejections.SigProjectAlreadyCompleted rejection, SigStartProject cmd) {
+            // do nothing.
+        }
+    }
+}

--- a/server/src/test/proto/spine/test/model/contexts/projects/rejections.proto
+++ b/server/src/test/proto/spine/test/model/contexts/projects/rejections.proto
@@ -42,3 +42,7 @@ message SigOwnerAlreadyAssigned {
     ProjectId project_id = 1;
     core.UserId current_owner = 2;
 }
+
+message SigProjectAlreadyCompleted {
+    ProjectId project = 1;
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,7 +34,7 @@
 /**
  * Version of this library.
  */
-val coreJava = "1.6.19"
+val coreJava = "1.6.20"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.


### PR DESCRIPTION
This PR fixes #1318.

In the PR I have relaxed the `HandlerMap` check on missing handlers while it is totally OK to **not** have a specific handler within a specific class. It's then up to the caller to verify and check how to behave when a handler is missing. In our case, all the respective callers already do check and filter out situations when no handlers are available. The only change one may notice is the error text available via the `HandlerFailedUnexpectedly` event, instead of the `IllegalStateException`, we'll see the `EventValidationError` with the `UNSUPPORTED_EVENT` code.