### PR TITLE
Extension function `alter`

### DIFF
--- a/buildSrc/src/main/groovy/update-gh-pages.gradle
+++ b/buildSrc/src/main/groovy/update-gh-pages.gradle
@@ -55,6 +55,21 @@ ext {
     repositoryTempDir = Files.createTempDirectory("repoTemp")
 }
 
+/**
+ * Prints a message telling those who read build logs about what happened.
+ */
+if (isSnapshot()) {
+    println("GitHub Pages update will be skipped since this project" +
+            " is a snapshot: `$project.name-$project.version`.")
+}
+
+/**
+ * Tells whether this project is a snapshot.
+ */
+def isSnapshot() {
+    return project.version.toLowerCase().contains("snapshot")
+}
+
 final String propertyName = 'allowInternalJavadoc'
 
 final boolean allowInternalJavadoc = ext.has(propertyName) && ext.get(propertyName)
@@ -87,6 +102,13 @@ task copyJavadoc(type: Copy) {
 task updateGitHubPages {
     description "Updates the Javadoc published to GitHub Pages website."
     dependsOn copyJavadoc
+}
+
+/**
+ * Prevents this task from execution in case this project is in its `SNAPSHOT` version.
+ */
+updateGitHubPages.onlyIf {
+    !isSnapshot()
 }
 
 /**
@@ -128,7 +150,7 @@ static String execute(final File baseDir, final String... command) {
     } else {
         final String errorMsg = "Command `$command` finished with exit code $result.exitCode:" +
                 " ${System.lineSeparator()}${result.error}" +
-                " ${System.lineSeparator()}${result.out}"
+                " ${System.lineSeparator()}${result.out}."
         throw new IllegalStateException(errorMsg)
     }
 }
@@ -194,7 +216,7 @@ Host github.com-publish
 
     execute 'git', 'clone', GIT_HOST, "$repoBaseDir"
     execute repoBaseDir, "git", "checkout", GH_PAGES_BRANCH
-    logger.debug("Updating generated documentation on GitHub Pages in directory `$docDir`")
+    logger.debug("Updating generated documentation on GitHub Pages in directory `$docDir`.")
     docDir.mkdir()
 
     copy {
@@ -202,7 +224,7 @@ Host github.com-publish
         into docDir
     }
 
-    logger.debug("Storing the new version of documentation in directory `$versionedDocDir`")
+    logger.debug("Storing the new version of documentation in directory `$versionedDocDir`.")
     versionedDocDir.mkdir()
     copy {
         from generatedDocs
@@ -224,5 +246,5 @@ Host github.com-publish
 
     execute repoBaseDir, "git", "commit", "--allow-empty", "--message=\"Update Javadoc for module $project.name as for version $project.version\""
     execute repoBaseDir, "git", "push"
-    logger.debug("Updated Javadoc on GitHub Pages in directory `$docDir` sucessfully")
+    logger.debug("Updated Javadoc on GitHub Pages in directory `$docDir` successfully.")
 }

--- a/license-report.md
+++ b/license-report.md
@@ -501,7 +501,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon May 24 14:24:38 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 25 11:01:59 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -967,7 +967,7 @@ This report was generated on **Mon May 24 14:24:38 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon May 24 14:24:39 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 25 11:01:59 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1461,7 +1461,7 @@ This report was generated on **Mon May 24 14:24:39 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon May 24 14:24:39 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 25 11:02:00 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2011,7 +2011,7 @@ This report was generated on **Mon May 24 14:24:39 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon May 24 14:24:41 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 25 11:02:00 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2525,7 +2525,7 @@ This report was generated on **Mon May 24 14:24:41 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon May 24 14:24:42 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 25 11:02:01 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3074,7 +3074,7 @@ This report was generated on **Mon May 24 14:24:42 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon May 24 14:24:44 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 25 11:02:02 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3623,7 +3623,7 @@ This report was generated on **Mon May 24 14:24:44 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon May 24 14:24:45 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 25 11:02:04 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4216,4 +4216,4 @@ This report was generated on **Mon May 24 14:24:45 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon May 24 14:24:48 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 25 11:02:06 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.22`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.23`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -501,12 +501,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 25 11:01:59 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 25 11:32:17 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.22`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.23`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -967,12 +967,12 @@ This report was generated on **Tue May 25 11:01:59 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 25 11:01:59 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 25 11:32:18 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.22`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.23`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1461,12 +1461,12 @@ This report was generated on **Tue May 25 11:01:59 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 25 11:02:00 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 25 11:32:19 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.22`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.23`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2011,12 +2011,12 @@ This report was generated on **Tue May 25 11:02:00 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 25 11:02:00 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 25 11:32:19 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.22`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.23`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2525,12 +2525,12 @@ This report was generated on **Tue May 25 11:02:00 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 25 11:02:01 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 25 11:32:20 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.22`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.23`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3074,12 +3074,12 @@ This report was generated on **Tue May 25 11:02:01 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 25 11:02:02 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 25 11:32:21 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.22`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.23`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3623,12 +3623,12 @@ This report was generated on **Tue May 25 11:02:02 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 25 11:02:04 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 25 11:32:22 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.22`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.23`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -4216,4 +4216,4 @@ This report was generated on **Tue May 25 11:02:04 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 25 11:02:06 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue May 25 11:32:24 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.22</version>
+<version>2.0.0-SNAPSHOT.23</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -64,7 +64,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.29</version>
+    <version>2.0.0-SNAPSHOT.30</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -76,13 +76,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java</artifactId>
-    <version>2.0.0-SNAPSHOT.29</version>
+    <version>2.0.0-SNAPSHOT.30</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.29</version>
+    <version>2.0.0-SNAPSHOT.30</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -142,19 +142,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>2.0.0-SNAPSHOT.29</version>
+    <version>2.0.0-SNAPSHOT.30</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.29</version>
+    <version>2.0.0-SNAPSHOT.30</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.29</version>
+    <version>2.0.0-SNAPSHOT.30</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -192,12 +192,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>2.0.0-SNAPSHOT.29</version>
+    <version>2.0.0-SNAPSHOT.30</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-protoc</artifactId>
-    <version>2.0.0-SNAPSHOT.29</version>
+    <version>2.0.0-SNAPSHOT.30</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/server/src/main/kotlin/io/spine/server/entity/TransactionalEntityExtensions.kt
+++ b/server/src/main/kotlin/io/spine/server/entity/TransactionalEntityExtensions.kt
@@ -41,10 +41,11 @@ import io.spine.validate.ValidatingBuilder
  * ```kotlin
  * @Apply
  * fun event(e: TaskCreated) {
- *     update {
+ *     val builder = update {
  *         title = e.title
  *         description = e.description
  *     }
+ *     // Use `builder` properties.
  * }
  * ```
  *
@@ -53,22 +54,44 @@ import io.spine.validate.ValidatingBuilder
  * @param S the type of the entity state
  * @param B the type of the entity state builder
  *
+ * @see alter for a version of this method that does not return a value
  * @apiNote This function is not `inline` because [TransactionalEntity.builder] is `protected`
  * while inline functions can use only `public` API.
  */
 @Experimental
 public fun <I, E : TransactionalEntity<I, S, B>, S : EntityState<I>, B : ValidatingBuilder<S>>
         E.update(block: B.() -> Unit): B {
-    val builder = builderOf(this)
-    block.invoke(builder)
+    val builder = builder()
+    block(builder)
     return builder
 }
 
 /**
- * Obtains the builder from the passed entity.
+ * Extends [TransactionalEntity] with the `alter` block for changing
+ * properties of the entity state [builder][TransactionalEntity.builder].
  *
- * @apiNote We employ the fact that we are in the same package with [TransactionalEntity] and
- * because of this can access its `protected` API.
+ * For example, a method that applies an event may look like this:
+ *
+ * ```kotlin
+ * @Apply
+ * fun event(e: TaskCreated) = alter {
+ *     title = e.title
+ *     description = e.description
+ * }
+ * ```
+ *
+ * @param I the type of the entity identifiers
+ * @param E the type of the transactional entity
+ * @param S the type of the entity state
+ * @param B the type of the entity state builder
+ *
+ * @see update for a version of this method that returns the value of the builder
+ * @apiNote This function is not `inline` because [TransactionalEntity.builder] is `protected`
+ * while inline functions can use only `public` API.
  */
-private fun <I, S : EntityState<I>, B : ValidatingBuilder<S>>
-        builderOf(e: TransactionalEntity<I, S, B>): B = e.builder()
+@Experimental
+public fun <I, E : TransactionalEntity<I, S, B>, S : EntityState<I>, B : ValidatingBuilder<S>>
+        E.alter(block: B.() -> Unit) {
+    val builder = builder()
+    block(builder)
+}

--- a/server/src/test/kotlin/io/spine/server/entity/TransactionalEntityExtensionsTest.kt
+++ b/server/src/test/kotlin/io/spine/server/entity/TransactionalEntityExtensionsTest.kt
@@ -66,7 +66,8 @@ private fun createEntity() : Fixture {
 }
 
 /**
- * An entity which uses the [TransactionalEntity.update] extension function in its [applyUpdate] method.
+ * An entity which uses the [TransactionalEntity] extension functions in its [applyUpdate]
+ * and [applyAlteration] methods.
  */
 private class Fixture : TransactionalEntity<String, StringEntity, StringEntity.Builder>() {
 

--- a/server/src/test/kotlin/io/spine/server/entity/TransactionalEntityExtensionsTest.kt
+++ b/server/src/test/kotlin/io/spine/server/entity/TransactionalEntityExtensionsTest.kt
@@ -38,8 +38,18 @@ internal class ExtensionsTest {
     fun `add 'update' block handler for passing properties to 'builder'`() {
         val entity = createEntity()
         val str = randomString()
-        entity.apply(str)
-        assertThat(entity.value()).isEqualTo(str)
+        entity.applyUpdate(str)
+        assertThat(entity.value())
+            .isEqualTo(str)
+    }
+
+    @Test
+    fun `add 'alter' block handler for passing properties to 'builder'`() {
+        val entity = createEntity()
+        val str = randomString()
+        entity.txApplyAlteration(str)
+        assertThat(entity.value())
+            .isEqualTo(str)
     }
 }
 
@@ -56,7 +66,7 @@ private fun createEntity() : Fixture {
 }
 
 /**
- * An entity which uses the [TransactionalEntity.update] extension function in its [apply] method.
+ * An entity which uses the [TransactionalEntity.update] extension function in its [applyUpdate] method.
  */
 private class Fixture : TransactionalEntity<String, StringEntity, StringEntity.Builder>() {
 
@@ -64,10 +74,19 @@ private class Fixture : TransactionalEntity<String, StringEntity, StringEntity.B
         setId(randomString())
     }
 
-    fun apply(s: String) {
-        update {
+    fun applyUpdate(s: String) {
+        val builder = update {
             value = s
         }
+        setState(builder.vBuild())
+    }
+
+    fun applyAlteration(s: String): Unit = alter {
+        value = s
+    }
+
+    fun txApplyAlteration(s: String) {
+        applyAlteration(s)
         setState(builder().vBuild())
     }
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -40,12 +40,12 @@
 /**
  * Version of this library.
  */
-val coreJava = "2.0.0-SNAPSHOT.22"
+val coreJava = "2.0.0-SNAPSHOT.23"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.
  */
-val base = "2.0.0-SNAPSHOT.29"
+val base = "2.0.0-SNAPSHOT.30"
 val time = "2.0.0-SNAPSHOT.21"
 
 project.extra.apply {


### PR DESCRIPTION
This PR introduces an extension function `alter(..)` for `TransactionalEntity`-s.

`alter(..)`, just like her sister `update(..)` allows the user to change properties of the entity's builder without the hassle of calling Java-style setter methods.

Unlike `update(..)`, alter does not return any value, allowing it to be used as an expression body in handler methods. Example:
```kotlin
internal class DailyReport : Projection<..> {

    @Subscribe
    internal fun on(e: WorkLogged) = alter {
        workMinutes += e.minutes
    }
}
```

It's recommended to keep the call to `alter(..)` at the same line with the method signature, so that the whole construction resembles a regular method.