### PR TITLE
Deeply nested `Query` filters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -58,3 +58,4 @@ pull text eol=lf
 # Encrypted files
 *.enc binary
 *.gpg binary
+*.weis binary

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AnimalSniffer.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AnimalSniffer.kt
@@ -26,14 +26,6 @@
 
 package io.spine.internal.dependency
 
-/**
- * Versions of one-line dependencies.
- *
- * For versions of other dependencies please see `version` properties of objects declared below.
- *
- * See also: https://github.com/SpineEventEngine/config/issues/171
- */
-
 // https://www.mojohaus.org/animal-sniffer/animal-sniffer-maven-plugin/
 object AnimalSniffer {
     private const val version = "1.19"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -35,4 +35,11 @@ object Kotlin {
     const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
     const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"
     const val stdLibJdk8   = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${version}"
+
+    // https://github.com/Kotlin/dokka
+    object Dokka {
+
+        const val version = "1.4.32"
+        const val pluginId = "org.jetbrains.dokka"
+    }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Truth.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Truth.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/google/truth
 object Truth {
-    private const val version = "1.1.2"
+    private const val version = "1.1.3"
     val libs = listOf(
         "com.google.truth:truth:${version}",
         "com.google.truth.extensions:truth-java8-extension:${version}",

--- a/client/src/main/java/io/spine/client/EntityQueryToProto.java
+++ b/client/src/main/java/io/spine/client/EntityQueryToProto.java
@@ -43,17 +43,19 @@ import io.spine.query.SubjectParameter;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.spine.client.CompositeFilter.CompositeOperator.ALL;
+import static io.spine.client.CompositeFilter.CompositeOperator.EITHER;
 import static io.spine.client.Filter.Operator.EQUAL;
 import static io.spine.client.Filter.Operator.GREATER_OR_EQUAL;
 import static io.spine.client.Filter.Operator.GREATER_THAN;
 import static io.spine.client.Filter.Operator.LESS_OR_EQUAL;
 import static io.spine.client.Filter.Operator.LESS_THAN;
-import static io.spine.client.Filters.all;
 import static io.spine.client.Filters.createFilter;
-import static io.spine.client.Filters.either;
 import static io.spine.client.OrderBy.Direction.ASCENDING;
 import static io.spine.client.OrderBy.Direction.DESCENDING;
 import static io.spine.query.Direction.ASC;
+import static io.spine.query.LogicalOperator.AND;
 import static io.spine.util.Exceptions.newIllegalStateException;
 
 /**
@@ -117,13 +119,14 @@ public final class EntityQueryToProto implements Function<EntityQuery<?, ?, ?>, 
     private static Query toProtoQuery(QueryBuilder builder, EntityQuery<?, ?, ?> query) {
         Subject<?, ?> subject = query.subject();
         addIds(builder, subject);
-        addPredicates(builder, subject.predicates());
+        addPredicates(builder, subject.predicate());
         addSorting(builder, query);
         addLimit(builder, query);
         addFieldMask(builder, query);
         return builder.build();
     }
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")  /* No call chaining here. */
     private static void addFieldMask(QueryBuilder builder, EntityQuery<?, ?, ?> query) {
         FieldMask originMask = query.mask();
         if (!originMask.equals(FieldMask.getDefaultInstance())) {
@@ -131,6 +134,7 @@ public final class EntityQueryToProto implements Function<EntityQuery<?, ?, ?>, 
         }
     }
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")  /* No call chaining here. */
     private static void addLimit(QueryBuilder builder, EntityQuery<?, ?, ?> query) {
         Integer originLimit = query.limit();
         if (originLimit != null) {
@@ -138,6 +142,7 @@ public final class EntityQueryToProto implements Function<EntityQuery<?, ?, ?>, 
         }
     }
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")  /* No call chaining here. */
     private static void addSorting(QueryBuilder builder, EntityQuery<?, ?, ?> query) {
         for (io.spine.query.SortBy<?, ?> sortBy : query.sorting()) {
             String columnName = sortBy.column()
@@ -149,29 +154,41 @@ public final class EntityQueryToProto implements Function<EntityQuery<?, ?, ?>, 
     }
 
     private static void
-    addPredicates(QueryBuilder builder, ImmutableList<? extends QueryPredicate<?>> predicates) {
-        ImmutableSet.Builder<CompositeFilter> filters = ImmutableSet.builder();
-        for (QueryPredicate<?> predicate : predicates) {
-            LogicalOperator logicalOp = predicate.operator();
-            ImmutableList<SubjectParameter<?, ?, ?>> params = predicate.allParams();
-            CompositeFilter aFilter = toFilter(params, logicalOp);
-            filters.add(aFilter);
-        }
-        builder.where(filters.build());
+    addPredicates(QueryBuilder builder, QueryPredicate<?> rootPredicate) {
+        CompositeFilter composite = toCompositeFilter(rootPredicate);
+        builder.where(composite);
     }
 
-    private static CompositeFilter
-    toFilter(ImmutableList<SubjectParameter<?, ?, ?>> params, LogicalOperator logicalOp) {
+    @SuppressWarnings("ResultOfMethodCallIgnored")      /* Builder is using in step-by-step mode. */
+    private static CompositeFilter toCompositeFilter(QueryPredicate<?> predicate) {
+        LogicalOperator operator = predicate.operator();
+        CompositeFilter.Builder builder = CompositeFilter.newBuilder();
+        builder.setOperator(operator == AND ? ALL
+                                             : EITHER);
+        ImmutableList<SubjectParameter<?, ?, ?>> parameters = predicate.allParams();
+        ImmutableList<Filter> filters = toFilters(parameters);
+        builder.addAllFilter(filters);
+
+            ImmutableList<CompositeFilter> childFilters =
+                    predicate.children()
+                             .stream()
+                             .map(EntityQueryToProto::toCompositeFilter)
+                             .collect(toImmutableList());
+            CompositeFilter childCompositeFilter =
+                    builder.addAllCompositeFilter(childFilters)
+                           .vBuild();
+        return childCompositeFilter;
+    }
+
+    private static ImmutableList<Filter>
+    toFilters(ImmutableList<SubjectParameter<?, ?, ?>> params) {
         ImmutableList.Builder<Filter> filters = ImmutableList.builder();
         for (SubjectParameter<?, ?, ?> parameter : params) {
             Filter filter = asProtoFilter(parameter);
             filters.add(filter);
         }
         ImmutableList<Filter> filterList = filters.build();
-        CompositeFilter compositeFilter =
-                logicalOp == LogicalOperator.AND ? all(filterList)
-                                                 : either(filterList);
-        return compositeFilter;
+        return filterList;
     }
 
     private static Filter asProtoFilter(SubjectParameter<?, ?, ?> parameter) {
@@ -198,6 +215,7 @@ public final class EntityQueryToProto implements Function<EntityQuery<?, ?, ?>, 
         return result;
     }
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")  /* No call chaining here. */
     private static void addIds(QueryBuilder builder, Subject<?, ?> subject) {
         ImmutableSet<?> ids = subject.id()
                                      .values();

--- a/client/src/main/java/io/spine/client/EntityQueryToProto.java
+++ b/client/src/main/java/io/spine/client/EntityQueryToProto.java
@@ -119,7 +119,7 @@ public final class EntityQueryToProto implements Function<EntityQuery<?, ?, ?>, 
     private static Query toProtoQuery(QueryBuilder builder, EntityQuery<?, ?, ?> query) {
         Subject<?, ?> subject = query.subject();
         addIds(builder, subject);
-        addPredicates(builder, subject.predicate());
+        addPredicate(builder, subject.predicate());
         addSorting(builder, query);
         addLimit(builder, query);
         addFieldMask(builder, query);
@@ -153,9 +153,8 @@ public final class EntityQueryToProto implements Function<EntityQuery<?, ?, ?>, 
         }
     }
 
-    private static void
-    addPredicates(QueryBuilder builder, QueryPredicate<?> rootPredicate) {
-        CompositeFilter composite = toCompositeFilter(rootPredicate);
+    private static void addPredicate(QueryBuilder builder, QueryPredicate<?> predicate) {
+        CompositeFilter composite = toCompositeFilter(predicate);
         builder.where(composite);
     }
 

--- a/client/src/main/java/io/spine/client/EntityQueryToProto.java
+++ b/client/src/main/java/io/spine/client/EntityQueryToProto.java
@@ -164,19 +164,19 @@ public final class EntityQueryToProto implements Function<EntityQuery<?, ?, ?>, 
         LogicalOperator operator = predicate.operator();
         CompositeFilter.Builder builder = CompositeFilter.newBuilder();
         builder.setOperator(operator == AND ? ALL
-                                             : EITHER);
+                                            : EITHER);
         ImmutableList<SubjectParameter<?, ?, ?>> parameters = predicate.allParams();
         ImmutableList<Filter> filters = toFilters(parameters);
         builder.addAllFilter(filters);
 
-            ImmutableList<CompositeFilter> childFilters =
-                    predicate.children()
-                             .stream()
-                             .map(EntityQueryToProto::toCompositeFilter)
-                             .collect(toImmutableList());
-            CompositeFilter childCompositeFilter =
-                    builder.addAllCompositeFilter(childFilters)
-                           .vBuild();
+        ImmutableList<CompositeFilter> childFilters =
+                predicate.children()
+                         .stream()
+                         .map(EntityQueryToProto::toCompositeFilter)
+                         .collect(toImmutableList());
+        CompositeFilter childCompositeFilter =
+                builder.addAllCompositeFilter(childFilters)
+                       .vBuild();
         return childCompositeFilter;
     }
 

--- a/client/src/main/java/io/spine/client/TargetBuilder.java
+++ b/client/src/main/java/io/spine/client/TargetBuilder.java
@@ -278,23 +278,9 @@ public abstract class TargetBuilder<T extends Message, B extends TargetBuilder<T
      * @see Filters for a convenient way to create {@link io.spine.client.CompositeFilter}
      *      instances
      */
+    @CanIgnoreReturnValue
     public B where(CompositeFilter... predicate) {
         filters = ImmutableSet.copyOf(predicate);
-        return self();
-    }
-
-    /**
-     * Performs the same action as {@link #where(CompositeFilter...)}, but acts as a shortcut
-     * overload for internal use.
-     *
-     * <p>If the passed set is empty, does nothing.
-     */
-    @CanIgnoreReturnValue
-    B where(ImmutableSet<CompositeFilter> predicates) {
-        checkNotNull(predicates);
-        if (predicates.size() > 0) {
-            filters = predicates;
-        }
         return self();
     }
 

--- a/client/src/main/proto/spine/client/filters.proto
+++ b/client/src/main/proto/spine/client/filters.proto
@@ -78,17 +78,23 @@ message TargetFilters {
     repeated CompositeFilter filter = 2 [(validate) = true];
 }
 
-// The filter grouping a number of simple filters with a specified logical operator.
+// A filter grouping a sub-tree of filters with a specified logical operator.
+//
+// May contain both simple filters (i.e. those aimed to match a single field value of the
+// target object) and composite filters.
+//
+// If an instance of `CompositeFilter` has no children, any target object is considered matching.
 message CompositeFilter {
     option (is).java_type = "CompositeFilterMixin";
 
-    // The list of filters.
-    //
-    // If empty, any record is considered matching this filter.
-    repeated Filter filter = 1 [(required) = true, (validate) = true];
+    // The list of simple filters.
+    repeated Filter filter = 1 [(validate) = true];
 
     // The value of the composite operator which determines the behavior of the filter matching.
     CompositeOperator operator = 2 [(required) = true];
+
+    // The list of child composite filters.
+    repeated CompositeFilter composite_filter = 3 [(validate) = true];;
 
     // An enumeration of all supported composite operators upon the filters.
     enum CompositeOperator {
@@ -104,7 +110,7 @@ message CompositeFilter {
     }
 }
 
-// A filter matching some value in the event message/entity state.
+// A simple filter matching some value in the event message/entity state.
 message Filter {
     option (is).java_type = "FilterMixin";
 

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.23`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.24`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -228,16 +228,16 @@
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.2
+1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** commons-io **Name:** commons-io **Version:** 2.6
@@ -457,13 +457,6 @@
      * **POM License: BSD-3-Clause** - [https://asm.ow2.io/license.html](https://asm.ow2.io/license.html)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.0
-     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
-     * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
-     * **POM Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **POM License: BSD-3-Clause** - [https://asm.ow2.io/license.html](https://asm.ow2.io/license.html)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.1
      * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
      * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
@@ -501,12 +494,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 25 11:32:17 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 02 21:28:34 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.23`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.24`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -694,16 +687,16 @@ This report was generated on **Tue May 25 11:32:17 EEST 2021** using [Gradle-Lic
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.2
+1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** commons-io **Name:** commons-io **Version:** 2.6
@@ -923,13 +916,6 @@ This report was generated on **Tue May 25 11:32:17 EEST 2021** using [Gradle-Lic
      * **POM License: BSD-3-Clause** - [https://asm.ow2.io/license.html](https://asm.ow2.io/license.html)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.0
-     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
-     * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
-     * **POM Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **POM License: BSD-3-Clause** - [https://asm.ow2.io/license.html](https://asm.ow2.io/license.html)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.1
      * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
      * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
@@ -967,12 +953,12 @@ This report was generated on **Tue May 25 11:32:17 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 25 11:32:18 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 02 21:28:35 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.23`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.24`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1200,16 +1186,16 @@ This report was generated on **Tue May 25 11:32:18 EEST 2021** using [Gradle-Lic
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.2
+1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** commons-io **Name:** commons-io **Version:** 2.6
@@ -1417,13 +1403,6 @@ This report was generated on **Tue May 25 11:32:18 EEST 2021** using [Gradle-Lic
      * **POM License: BSD-3-Clause** - [https://asm.ow2.io/license.html](https://asm.ow2.io/license.html)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.0
-     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
-     * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
-     * **POM Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **POM License: BSD-3-Clause** - [https://asm.ow2.io/license.html](https://asm.ow2.io/license.html)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.1
      * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
      * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
@@ -1461,12 +1440,12 @@ This report was generated on **Tue May 25 11:32:18 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 25 11:32:19 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 02 21:28:35 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.23`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.24`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1730,16 +1709,16 @@ This report was generated on **Tue May 25 11:32:19 EEST 2021** using [Gradle-Lic
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.2
+1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** com.squareup **Name:** javapoet **Version:** 1.13.0
@@ -1967,13 +1946,6 @@ This report was generated on **Tue May 25 11:32:19 EEST 2021** using [Gradle-Lic
      * **POM License: BSD-3-Clause** - [https://asm.ow2.io/license.html](https://asm.ow2.io/license.html)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.0
-     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
-     * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
-     * **POM Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **POM License: BSD-3-Clause** - [https://asm.ow2.io/license.html](https://asm.ow2.io/license.html)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.1
      * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
      * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
@@ -2011,12 +1983,12 @@ This report was generated on **Tue May 25 11:32:19 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 25 11:32:19 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 02 21:28:36 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.23`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.24`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2248,16 +2220,16 @@ This report was generated on **Tue May 25 11:32:19 EEST 2021** using [Gradle-Lic
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.2
+1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** commons-io **Name:** commons-io **Version:** 2.6
@@ -2481,13 +2453,6 @@ This report was generated on **Tue May 25 11:32:19 EEST 2021** using [Gradle-Lic
      * **POM License: BSD-3-Clause** - [https://asm.ow2.io/license.html](https://asm.ow2.io/license.html)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.0
-     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
-     * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
-     * **POM Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **POM License: BSD-3-Clause** - [https://asm.ow2.io/license.html](https://asm.ow2.io/license.html)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.1
      * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
      * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
@@ -2525,12 +2490,12 @@ This report was generated on **Tue May 25 11:32:19 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 25 11:32:20 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 02 21:28:37 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.23`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.24`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2592,16 +2557,16 @@ This report was generated on **Tue May 25 11:32:20 EEST 2021** using [Gradle-Lic
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.2
+1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.38.0
@@ -2704,7 +2669,7 @@ This report was generated on **Tue May 25 11:32:20 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.0
+1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.1
      * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
      * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
      * **POM Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
@@ -2813,16 +2778,16 @@ This report was generated on **Tue May 25 11:32:20 EEST 2021** using [Gradle-Lic
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.2
+1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** commons-io **Name:** commons-io **Version:** 2.6
@@ -3030,13 +2995,6 @@ This report was generated on **Tue May 25 11:32:20 EEST 2021** using [Gradle-Lic
      * **POM License: BSD-3-Clause** - [https://asm.ow2.io/license.html](https://asm.ow2.io/license.html)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.0
-     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
-     * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
-     * **POM Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **POM License: BSD-3-Clause** - [https://asm.ow2.io/license.html](https://asm.ow2.io/license.html)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.1
      * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
      * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
@@ -3074,12 +3032,12 @@ This report was generated on **Tue May 25 11:32:20 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 25 11:32:21 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 02 21:28:38 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.23`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.24`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3141,16 +3099,16 @@ This report was generated on **Tue May 25 11:32:21 EEST 2021** using [Gradle-Lic
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.2
+1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.38.0
@@ -3253,7 +3211,7 @@ This report was generated on **Tue May 25 11:32:21 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.0
+1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.1
      * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
      * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
      * **POM Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
@@ -3362,16 +3320,16 @@ This report was generated on **Tue May 25 11:32:21 EEST 2021** using [Gradle-Lic
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.2
+1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** commons-io **Name:** commons-io **Version:** 2.6
@@ -3579,13 +3537,6 @@ This report was generated on **Tue May 25 11:32:21 EEST 2021** using [Gradle-Lic
      * **POM License: BSD-3-Clause** - [https://asm.ow2.io/license.html](https://asm.ow2.io/license.html)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.0
-     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
-     * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
-     * **POM Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **POM License: BSD-3-Clause** - [https://asm.ow2.io/license.html](https://asm.ow2.io/license.html)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.1
      * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
      * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
@@ -3623,12 +3574,12 @@ This report was generated on **Tue May 25 11:32:21 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 25 11:32:22 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 02 21:28:39 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.23`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.24`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3690,16 +3641,16 @@ This report was generated on **Tue May 25 11:32:22 EEST 2021** using [Gradle-Lic
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.2
+1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.38.0
@@ -3802,7 +3753,7 @@ This report was generated on **Tue May 25 11:32:22 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
      * **POM License: The Apache License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.0
+1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.1
      * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
      * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
      * **POM Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
@@ -3911,16 +3862,16 @@ This report was generated on **Tue May 25 11:32:22 EEST 2021** using [Gradle-Lic
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.2
+1. **Group:** com.google.truth **Name:** truth **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-java8-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-liteproto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.2
+1. **Group:** com.google.truth.extensions **Name:** truth-proto-extension **Version:** 1.1.3
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1. **Group:** commons-io **Name:** commons-io **Version:** 2.6
@@ -4172,13 +4123,6 @@ This report was generated on **Tue May 25 11:32:22 EEST 2021** using [Gradle-Lic
      * **POM License: BSD-3-Clause** - [https://asm.ow2.io/license.html](https://asm.ow2.io/license.html)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.0
-     * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
-     * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
-     * **POM Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **POM License: BSD-3-Clause** - [https://asm.ow2.io/license.html](https://asm.ow2.io/license.html)
-     * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1. **Group:** org.ow2.asm **Name:** asm **Version:** 9.1
      * **Manifest Project URL:** [http://asm.ow2.org](http://asm.ow2.org)
      * **Manifest License:** BSD-3-Clause;link=https://asm.ow2.io/LICENSE.txt (Not packaged)
@@ -4216,4 +4160,4 @@ This report was generated on **Tue May 25 11:32:22 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue May 25 11:32:24 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 02 21:28:41 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -223,7 +223,7 @@
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.15.7
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.17.0
      * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -248,23 +248,11 @@
      * **POM Project URL:** [https://github.com/java-diff-utils/java-diff-utils](https://github.com/java-diff-utils/java-diff-utils)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.35.1
-     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
 1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.38.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.35.1
-     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
 1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.38.0
-     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.35.1
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -284,7 +272,7 @@
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.35.1
+1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.38.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -494,7 +482,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jun 02 21:28:34 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jun 06 19:28:31 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -682,7 +670,7 @@ This report was generated on **Wed Jun 02 21:28:34 EEST 2021** using [Gradle-Lic
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.15.7
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.17.0
      * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -707,23 +695,11 @@ This report was generated on **Wed Jun 02 21:28:34 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/java-diff-utils/java-diff-utils](https://github.com/java-diff-utils/java-diff-utils)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.35.1
-     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
 1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.38.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.35.1
-     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
 1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.38.0
-     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.35.1
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -743,7 +719,7 @@ This report was generated on **Wed Jun 02 21:28:34 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.35.1
+1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.38.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -953,7 +929,7 @@ This report was generated on **Wed Jun 02 21:28:34 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jun 02 21:28:35 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jun 06 19:28:32 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1181,7 +1157,7 @@ This report was generated on **Wed Jun 02 21:28:35 EEST 2021** using [Gradle-Lic
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.15.7
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.17.0
      * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1230,7 +1206,7 @@ This report was generated on **Wed Jun 02 21:28:35 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.35.1
+1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.38.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -1440,7 +1416,7 @@ This report was generated on **Wed Jun 02 21:28:35 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jun 02 21:28:35 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jun 06 19:28:32 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1704,7 +1680,7 @@ This report was generated on **Wed Jun 02 21:28:35 EEST 2021** using [Gradle-Lic
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.15.7
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.17.0
      * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1761,7 +1737,7 @@ This report was generated on **Wed Jun 02 21:28:35 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.35.1
+1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.38.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -1983,7 +1959,7 @@ This report was generated on **Wed Jun 02 21:28:35 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jun 02 21:28:36 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jun 06 19:28:33 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2215,7 +2191,7 @@ This report was generated on **Wed Jun 02 21:28:36 EEST 2021** using [Gradle-Lic
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.15.7
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.17.0
      * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -2240,23 +2216,11 @@ This report was generated on **Wed Jun 02 21:28:36 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/java-diff-utils/java-diff-utils](https://github.com/java-diff-utils/java-diff-utils)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.35.1
-     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
 1. **Group:** io.grpc **Name:** grpc-api **Version:** 1.38.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.35.1
-     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
 1. **Group:** io.grpc **Name:** grpc-context **Version:** 1.38.0
-     * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
-     * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
-
-1. **Group:** io.grpc **Name:** grpc-core **Version:** 1.35.1
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -2280,7 +2244,7 @@ This report was generated on **Wed Jun 02 21:28:36 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.35.1
+1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.38.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -2490,7 +2454,7 @@ This report was generated on **Wed Jun 02 21:28:36 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jun 02 21:28:37 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jun 06 19:28:33 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2773,7 +2737,7 @@ This report was generated on **Wed Jun 02 21:28:37 EEST 2021** using [Gradle-Lic
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.15.7
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.17.0
      * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -2822,7 +2786,7 @@ This report was generated on **Wed Jun 02 21:28:37 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.35.1
+1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.38.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -3032,7 +2996,7 @@ This report was generated on **Wed Jun 02 21:28:37 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jun 02 21:28:38 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jun 06 19:28:35 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3315,7 +3279,7 @@ This report was generated on **Wed Jun 02 21:28:38 EEST 2021** using [Gradle-Lic
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.15.7
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.17.0
      * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -3364,7 +3328,7 @@ This report was generated on **Wed Jun 02 21:28:38 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.35.1
+1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.38.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -3574,7 +3538,7 @@ This report was generated on **Wed Jun 02 21:28:38 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jun 02 21:28:39 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jun 06 19:28:37 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3857,7 +3821,7 @@ This report was generated on **Wed Jun 02 21:28:39 EEST 2021** using [Gradle-Lic
      * **Manifest Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.15.7
+1. **Group:** com.google.protobuf **Name:** protoc **Version:** 3.17.0
      * **POM Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **POM License: 3-Clause BSD License** - [https://opensource.org/licenses/BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **POM License: The Apache Software License, Version 2.0** - [http://www.apache.org/licenses/LICENSE-2.0.txt](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -3910,7 +3874,7 @@ This report was generated on **Wed Jun 02 21:28:39 EEST 2021** using [Gradle-Lic
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
-1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.35.1
+1. **Group:** io.grpc **Name:** protoc-gen-grpc-java **Version:** 1.38.0
      * **POM Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **POM License: Apache 2.0** - [https://opensource.org/licenses/Apache-2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -4160,4 +4124,4 @@ This report was generated on **Wed Jun 02 21:28:39 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Jun 02 21:28:41 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jun 06 19:28:39 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifierPlugin.java
+++ b/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifierPlugin.java
@@ -47,7 +47,7 @@ import java.nio.file.StandardOpenOption;
 import static io.spine.tools.gradle.JavaTaskName.classes;
 import static io.spine.tools.gradle.JavaTaskName.compileJava;
 import static io.spine.tools.gradle.ModelVerifierTaskName.verifyModel;
-import static io.spine.tools.mc.java.gradle.Extension.getMainDescriptorSet;
+import static io.spine.tools.mc.java.gradle.Extension.getMainDescriptorSetFile;
 import static java.nio.file.Files.exists;
 import static java.nio.file.Files.newInputStream;
 
@@ -120,7 +120,7 @@ public final class ModelVerifierPlugin extends SpinePlugin {
         private void extendKnownTypes(Project project) {
             String pluginExtensionName = ModelCompilerPlugin.extensionName();
             if (project.getExtensions().findByName(pluginExtensionName) != null) {
-                File descriptorFile = getMainDescriptorSet(project);
+                File descriptorFile = getMainDescriptorSetFile(project);
                 tryExtend(descriptorFile);
             } else {
                 _warn().log(

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.23</version>
+<version>2.0.0-SNAPSHOT.24</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -28,19 +28,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.truth</groupId>
     <artifactId>truth</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.truth.extensions</groupId>
     <artifactId>truth-java8-extension</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.truth.extensions</groupId>
     <artifactId>truth-proto-extension</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -64,7 +64,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.30</version>
+    <version>2.0.0-SNAPSHOT.31</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -76,13 +76,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java</artifactId>
-    <version>2.0.0-SNAPSHOT.30</version>
+    <version>2.0.0-SNAPSHOT.31</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.30</version>
+    <version>2.0.0-SNAPSHOT.31</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -142,19 +142,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>2.0.0-SNAPSHOT.30</version>
+    <version>2.0.0-SNAPSHOT.31</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.30</version>
+    <version>2.0.0-SNAPSHOT.31</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.30</version>
+    <version>2.0.0-SNAPSHOT.31</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -192,12 +192,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>2.0.0-SNAPSHOT.30</version>
+    <version>2.0.0-SNAPSHOT.31</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-protoc</artifactId>
-    <version>2.0.0-SNAPSHOT.30</version>
+    <version>2.0.0-SNAPSHOT.31</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.31</version>
+    <version>2.0.0-SNAPSHOT.34</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -76,13 +76,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java</artifactId>
-    <version>2.0.0-SNAPSHOT.31</version>
+    <version>2.0.0-SNAPSHOT.34</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.31</version>
+    <version>2.0.0-SNAPSHOT.34</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -142,19 +142,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>2.0.0-SNAPSHOT.31</version>
+    <version>2.0.0-SNAPSHOT.34</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.31</version>
+    <version>2.0.0-SNAPSHOT.34</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.31</version>
+    <version>2.0.0-SNAPSHOT.34</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -182,22 +182,22 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protoc</artifactId>
-    <version>3.15.7</version>
+    <version>3.17.0</version>
   </dependency>
   <dependency>
     <groupId>io.grpc</groupId>
     <artifactId>protoc-gen-grpc-java</artifactId>
-    <version>1.35.1</version>
+    <version>1.38.0</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>2.0.0-SNAPSHOT.31</version>
+    <version>2.0.0-SNAPSHOT.34</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-protoc</artifactId>
-    <version>2.0.0-SNAPSHOT.31</version>
+    <version>2.0.0-SNAPSHOT.34</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/server/src/main/java/io/spine/server/BoundedContextBuilder.java
+++ b/server/src/main/java/io/spine/server/BoundedContextBuilder.java
@@ -624,7 +624,7 @@ public final class BoundedContextBuilder implements Logging {
     private void initTenantIndex() {
         if (tenantIndex == null) {
             tenantIndex = isMultitenant()
-                          ? TenantIndex.createDefault()
+                          ? TenantIndex.defaultMultitenant()
                           : TenantIndex.singleTenant();
         }
     }

--- a/server/src/main/java/io/spine/server/aggregate/AggregateEventRecordColumn.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateEventRecordColumn.java
@@ -41,8 +41,8 @@ import static io.spine.query.RecordColumn.create;
  */
 @RecordColumns(ofType = AggregateEventRecord.class)
 @SuppressWarnings(
-        {"DuplicateStringLiteralInspection",  // Column names may repeat across records.
-                "BadImport"})                 // `create` looks fine in this context.
+        {"DuplicateStringLiteralInspection",  /* Column names may repeat across records. */
+                "BadImport"})                 /* `create` looks fine in this context. */
 final class AggregateEventRecordColumn {
 
     /**

--- a/server/src/main/java/io/spine/server/delivery/InboxColumn.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxColumn.java
@@ -28,6 +28,7 @@ package io.spine.server.delivery;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Timestamp;
+import io.spine.annotation.SPI;
 import io.spine.query.RecordColumn;
 import io.spine.query.RecordColumns;
 
@@ -38,62 +39,63 @@ import static io.spine.query.RecordColumn.create;
  */
 @RecordColumns(ofType = InboxMessage.class)
 @SuppressWarnings(
-        {"DuplicateStringLiteralInspection",  // Column names may repeat across records.
-                "BadImport"})                 // `create` looks fine in this context.
-final class InboxColumn {
+        {"DuplicateStringLiteralInspection",  /* Column names may repeat across records. */
+                "BadImport"})                 /* `create` looks fine in this context. */
+@SPI
+public final class InboxColumn {
 
     /**
      * Stores the identifier of the signal packed into this inbox message.
      */
-    static final RecordColumn<InboxMessage, InboxSignalId>
+    public static final RecordColumn<InboxMessage, InboxSignalId>
             signal_id = create("signal_id", InboxSignalId.class, InboxMessage::getSignalId);
 
     /**
      * Stores the identifier of the parent inbox.
      */
-    static final RecordColumn<InboxMessage, InboxId>
+    public static final RecordColumn<InboxMessage, InboxId>
             inbox_id = create("inbox_id", InboxId.class, InboxMessage::getInboxId);
 
     /**
      * Stores the index of the shard in which this inbox message resides.
      */
-    static final RecordColumn<InboxMessage, ShardIndex>
+    public static final RecordColumn<InboxMessage, ShardIndex>
             inbox_shard = create("inbox_shard", ShardIndex.class, InboxMessage::shardIndex);
 
     /**
      * Stores {@code true} if this inbox message hold an event; stores {@code false} otherwise.
      */
-    static final RecordColumn<InboxMessage, Boolean>
+    public static final RecordColumn<InboxMessage, Boolean>
             is_event = create("is_event", Boolean.class, InboxMessage::hasEvent);
 
     /**
      * Stores {@code true} if this inbox message hold a command; stores {@code false} otherwise.
      */
-    static final RecordColumn<InboxMessage, Boolean>
+    public static final RecordColumn<InboxMessage, Boolean>
             is_command = create("is_command", Boolean.class, InboxMessage::hasCommand);
 
     /**
      * Stores the label of this inbox message.
      */
-    static final RecordColumn<InboxMessage, InboxLabel>
+    public static final RecordColumn<InboxMessage, InboxLabel>
             label = create("label", InboxLabel.class, InboxMessage::getLabel);
 
     /**
      * Stores the status of the delivery for this inbox message.
      */
-    static final RecordColumn<InboxMessage, InboxMessageStatus>
+    public static final RecordColumn<InboxMessage, InboxMessageStatus>
             status = create("status", InboxMessageStatus.class, InboxMessage::getStatus);
 
     /**
      * Stores the time when the inbox message has been received and placed into the inbox.
      */
-    static final RecordColumn<InboxMessage, Timestamp>
+    public static final RecordColumn<InboxMessage, Timestamp>
             received_at = create("received_at", Timestamp.class, InboxMessage::getWhenReceived);
 
     /**
      * Stores the version of the inbox message.
      */
-    static final RecordColumn<InboxMessage, Integer>
+    public static final RecordColumn<InboxMessage, Integer>
             version = create("version", Integer.class, InboxMessage::getVersion);
 
     /**
@@ -109,7 +111,7 @@ final class InboxColumn {
     /**
      * Returns all the column definitions.
      */
-    static ImmutableList<RecordColumn<InboxMessage, ?>> definitions() {
+    public static ImmutableList<RecordColumn<InboxMessage, ?>> definitions() {
         return ImmutableList.of(signal_id, inbox_id, inbox_shard, is_event,
                                 is_command, label, status, received_at, version);
     }

--- a/server/src/main/java/io/spine/server/entity/storage/EntityRecordSpec.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityRecordSpec.java
@@ -28,8 +28,11 @@ package io.spine.server.entity.storage;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.Immutable;
+import com.google.protobuf.Any;
+import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
 import io.spine.base.EntityState;
+import io.spine.base.Identifier;
 import io.spine.query.Column;
 import io.spine.query.ColumnName;
 import io.spine.server.entity.Entity;
@@ -144,8 +147,27 @@ public final class EntityRecordSpec<I, S extends EntityState<I>, E extends Entit
     }
 
     @Override
-    protected I idValueIn(E source) {
+    public I idValueIn(E source) {
         return source.id();
+    }
+
+    /**
+     * Extracts the entity identifier value from the passed {@code EntityRecord}.
+     *
+     * <p>Callers are responsible for passing the {@code EntityRecord} instances compatible
+     * with the contract of this record specification. In case the type of the identifier
+     * packed into the passed entity record is not {@code I},
+     * a {@code ClassCastException} is thrown.
+     *
+     * @param record
+     *         the source for extraction
+     * @return the value of the entity identifier
+     */
+    @Override
+    @SuppressWarnings("unchecked")      /* See the documentation. */
+    public I idFromRecord(EntityRecord record) {
+        Any packed = record.getEntityId();
+        return (I) Identifier.unpack(packed);
     }
 
     @Override
@@ -164,6 +186,11 @@ public final class EntityRecordSpec<I, S extends EntityState<I>, E extends Entit
      */
     public EntityClass<E> entityClass() {
         return entityClass;
+    }
+
+    @Override
+    public Class<? extends Message> sourceType() {
+        return entityClass.stateClass();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/storage/MessageRecordSpec.java
+++ b/server/src/main/java/io/spine/server/storage/MessageRecordSpec.java
@@ -127,15 +127,25 @@ public final class MessageRecordSpec<I, R extends Message> extends RecordSpec<I,
     }
 
     @Override
-    protected I idValueIn(R source) {
+    public I idValueIn(R source) {
         checkNotNull(source);
         return extractId.apply(source);
+    }
+
+    @Override
+    public I idFromRecord(R record) {
+        return idValueIn(record);
     }
 
     @Override
     public Optional<Column<?, ?>> findColumn(ColumnName name) {
         RecordColumn<R, ?> result = columns.get(name);
         return Optional.ofNullable(result);
+    }
+
+    @Override
+    public Class<R> sourceType() {
+        return storedType();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/storage/RecordStorage.java
+++ b/server/src/main/java/io/spine/server/storage/RecordStorage.java
@@ -277,7 +277,7 @@ public abstract class RecordStorage<I, R extends Message> extends AbstractStorag
      * Creates a new query builder for the records stored in this storage.
      */
     public RecordQueryBuilder<I, R> queryBuilder() {
-        return RecordQuery.newBuilder(recordSpec.idType(), recordSpec().recordType());
+        return RecordQuery.newBuilder(recordSpec.idType(), recordSpec().storedType());
     }
 
     /**

--- a/server/src/main/java/io/spine/server/tenant/TenantIndex.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantIndex.java
@@ -58,7 +58,7 @@ public interface TenantIndex extends AutoCloseable {
     /**
      * Creates default implementation of {@code TenantIndex} for a multi-tenant context.
      */
-    static TenantIndex createDefault() {
+    static TenantIndex defaultMultitenant() {
         StorageFactory factory = ServerEnvironment.instance()
                                                   .storageFactory();
         @SuppressWarnings("ClassReferencesSubclass") // OK for this default impl.

--- a/server/src/test/java/io/spine/server/storage/RecordStorageDelegateTest.java
+++ b/server/src/test/java/io/spine/server/storage/RecordStorageDelegateTest.java
@@ -78,9 +78,25 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  *
  * <p>The aim of this test is to ensure that any storage implementations built on top of
  * the {@code RecordStorageDelegate} is able to utilize the API with the expected results.
+ *
+ * <p>This type is made {@code public}, so that it could be re-used in testing of
+ * Spine libraries sitting on top of real-world storage engines, such as Google Datastore.
+ *
+ * <p>In order to use this type in this manner, one should configure the desired
+ * {@code StorageFactory} implementation before this test suite:
+ *
+ * <pre>
+ *     ServerEnvironment.when(Tests.class)
+ *                      .useStorageFactory(myRealStorageFactory);
+ * </pre>
+ *
+ * {@code StgProjectStorage} used in these tests delegates all of its actions to the underlying
+ * {@code RecordStorage}, which in turn is produced by the pre-configured
+ * {@linkplain ServerEnvironment#storageFactory() current} {@code StorageFactory}.
+ * Therefore all tests will run against the desired storage engine.
  */
 @DisplayName("A `RecordStorageDelegate` descendant should")
-class RecordStorageDelegateTest
+public class RecordStorageDelegateTest
         extends AbstractStorageTest<StgProjectId, StgProject, StgProjectStorage> {
 
     @Override
@@ -351,9 +367,6 @@ class RecordStorageDelegateTest
             assertThat(deleted).isTrue();
             Optional<StgProject> anotherReadResult = storage().read(record.getId());
             assertThat(anotherReadResult).isEmpty();
-
-            boolean deletedAgain = storage().delete(record.getId());
-            assertThat(deletedAgain).isFalse();
         }
 
         @Test

--- a/server/src/test/java/io/spine/server/storage/RecordStorageUnderTest.java
+++ b/server/src/test/java/io/spine/server/storage/RecordStorageUnderTest.java
@@ -35,6 +35,11 @@ import java.util.Iterator;
 /**
  * A record storage made suitable for testing the {@link MessageStorage} API by
  * exposing the methods originally designed as {@code protected} to {@code public}.
+ *
+ * @param <I>
+ *         the type of record identifiers
+ * @param <M>
+ *         the type of stored {@code Message} records
  */
 public abstract class RecordStorageUnderTest<I, M extends Message>
         extends MessageStorage<I, M> {
@@ -47,8 +52,7 @@ public abstract class RecordStorageUnderTest<I, M extends Message>
      * @param delegate
      *         the record storage to delegate the execution to
      */
-    protected RecordStorageUnderTest(ContextSpec context,
-                                     RecordStorage<I, M> delegate) {
+    protected RecordStorageUnderTest(ContextSpec context, RecordStorage<I, M> delegate) {
         super(context, delegate);
     }
 

--- a/server/src/test/java/io/spine/server/storage/RecordStorageUnderTest.java
+++ b/server/src/test/java/io/spine/server/storage/RecordStorageUnderTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage;
+
+import com.google.protobuf.Message;
+import io.spine.query.RecordQuery;
+import io.spine.server.ContextSpec;
+
+import java.util.Iterator;
+
+/**
+ * A record storage made suitable for testing the {@link MessageStorage} API by
+ * exposing the methods originally designed as {@code protected} to {@code public}.
+ */
+public abstract class RecordStorageUnderTest<I, M extends Message>
+        extends MessageStorage<I, M> {
+
+    /**
+     * Creates a new instance.
+     *
+     * @param context
+     *         a specification of Bounded Context in which the created storage is used
+     * @param delegate
+     *         the record storage to delegate the execution to
+     */
+    protected RecordStorageUnderTest(ContextSpec context,
+                                     RecordStorage<I, M> delegate) {
+        super(context, delegate);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Overrides to expose this method as a part of {@code public} API.
+     */
+    @Override
+    public void writeBatch(Iterable<M> messages) {
+        super.writeBatch(messages);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Overrides to expose this method as a part of {@code public} API.
+     */
+    @Override
+    public Iterator<M> readAll() {
+        return super.readAll();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Overrides to expose this method as a part of {@code public} API.
+     */
+    @Override
+    public Iterator<M> readAll(RecordQuery<I, M> query) {
+        return super.readAll(query);
+    }
+}

--- a/server/src/test/java/io/spine/server/storage/given/StgProjectStorage.java
+++ b/server/src/test/java/io/spine/server/storage/given/StgProjectStorage.java
@@ -28,7 +28,7 @@ package io.spine.server.storage.given;
 
 import io.spine.server.ContextSpec;
 import io.spine.server.storage.MessageRecordSpec;
-import io.spine.server.storage.MessageStorage;
+import io.spine.server.storage.RecordStorageUnderTest;
 import io.spine.server.storage.StorageFactory;
 import io.spine.test.storage.StgProject;
 import io.spine.test.storage.StgProjectId;
@@ -44,7 +44,7 @@ import io.spine.test.storage.StgProjectId;
  * @see RecordStorageDelegateTest
  * @see StgColumn
  */
-public class StgProjectStorage extends MessageStorage<StgProjectId, StgProject> {
+public class StgProjectStorage extends RecordStorageUnderTest<StgProjectId, StgProject> {
 
     public StgProjectStorage(ContextSpec context, StorageFactory factory) {
         super(context, factory.createRecordStorage(context, spec()));

--- a/server/src/test/java/io/spine/server/storage/system/given/MemoizingStorageFactory.java
+++ b/server/src/test/java/io/spine/server/storage/system/given/MemoizingStorageFactory.java
@@ -84,7 +84,7 @@ public final class MemoizingStorageFactory implements StorageFactory {
     @Override
     public <I, M extends Message> RecordStorage<I, M>
     createRecordStorage(ContextSpec context, RecordSpec<I, M, ?> recordSpec) {
-        requestedStorages.add(recordSpec.recordType());
+        requestedStorages.add(recordSpec.storedType());
         return nullRef();
     }
 

--- a/testutil-server/src/main/java/io/spine/testing/server/tenant/TenantAwareTest.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/tenant/TenantAwareTest.java
@@ -58,7 +58,7 @@ public abstract class TenantAwareTest {
      */
     public static TenantIndex createTenantIndex(boolean multitenant) {
         return multitenant
-               ? TenantIndex.createDefault()
+               ? TenantIndex.defaultMultitenant()
                : TenantIndex.singleTenant();
     }
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -45,7 +45,7 @@ val coreJava = "2.0.0-SNAPSHOT.24"
 /**
  * Versions of the Spine libraries that `core-java` depends on.
  */
-val base = "2.0.0-SNAPSHOT.31"
+val base = "2.0.0-SNAPSHOT.34"
 val time = "2.0.0-SNAPSHOT.21"
 
 project.extra.apply {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -40,12 +40,12 @@
 /**
  * Version of this library.
  */
-val coreJava = "2.0.0-SNAPSHOT.23"
+val coreJava = "2.0.0-SNAPSHOT.24"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.
  */
-val base = "2.0.0-SNAPSHOT.30"
+val base = "2.0.0-SNAPSHOT.31"
 val time = "2.0.0-SNAPSHOT.21"
 
 project.extra.apply {


### PR DESCRIPTION
This changeset brings the [upcoming changes in Query DSL](https://github.com/SpineEventEngine/base/pull/644) to `client` and `server` modules.

**`Query` Tree**

`core-java` defines Protobuf-based `Query` language. It serves to transfer Query instances over the wire. Previously, it only supported two levels of filters. In scope of this PR any level of nesting in the Query filters becomes supported, both in the Proto definitions, and by the in-memory implementations of `Storage`s. Effectively, a Protobuf `Query` object now holds a tree of filters.

The extension to the Proto definitions is additive. Thus, the previous version of Proto definitions will still work with the proposed implementation.

Here is an example of a query which has more than two levels of nesting:

```java
Car.query()
    .either(car -> car.color().is(Color.RED)
                      .manufacturer().is(Manufacturers.ferrari()),

		car -> car.either(its -> its.color().is(Color.BLACK),
			          or -> or.color().is(Color.WHITE))
		          .acceleration().isGreaterThan(1.4)    // G
		          .topSpeed().isGreaterThan(160)        //MPH
	)
    .price().isLessThan(iAmWillingToSpend)
    .build();
```

**API changes**

* In order to allow convenient querying from outside of its package, `InboxColumn` definitions are made `public`. This is a change required by the dependant libraries, such as Spine's Datastore connector.

* `TenantIndex.createDefault()` has been renamed to `TenantIndex.defaultMultitenant()`, for clarity.