### PR TITLE
`QueryableRepository` to respond to `EntityQuery`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.42`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.43`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -475,12 +475,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 17 16:53:59 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 16:42:09 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.42`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.43`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -915,12 +915,12 @@ This report was generated on **Tue Aug 17 16:53:59 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 17 16:54:00 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 16:42:10 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.42`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.43`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1395,12 +1395,12 @@ This report was generated on **Tue Aug 17 16:54:00 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 17 16:54:01 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 16:42:10 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.42`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.43`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1931,12 +1931,12 @@ This report was generated on **Tue Aug 17 16:54:01 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 17 16:54:02 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 16:42:11 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.42`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.43`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2419,12 +2419,12 @@ This report was generated on **Tue Aug 17 16:54:02 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 17 16:54:02 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 16:42:12 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.42`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.43`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2954,12 +2954,12 @@ This report was generated on **Tue Aug 17 16:54:02 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 17 16:54:04 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 16:42:14 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.42`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.43`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3489,12 +3489,12 @@ This report was generated on **Tue Aug 17 16:54:04 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 17 16:54:06 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 16:42:16 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.42`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.43`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -4068,4 +4068,4 @@ This report was generated on **Tue Aug 17 16:54:06 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Aug 17 16:54:08 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 16:42:19 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.42</version>
+<version>2.0.0-SNAPSHOT.43</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
@@ -36,11 +36,13 @@ import io.spine.client.ResponseFormat;
 import io.spine.client.TargetFilters;
 import io.spine.core.Event;
 import io.spine.core.Version;
+import io.spine.query.EntityQuery;
 import io.spine.query.RecordQuery;
 import io.spine.server.ContextSpec;
 import io.spine.server.entity.EntityRecord;
 import io.spine.server.entity.storage.EntityRecordStorage;
 import io.spine.server.entity.storage.EntityRecordWithColumns;
+import io.spine.server.entity.storage.ToEntityRecordQuery;
 import io.spine.server.storage.AbstractStorage;
 import io.spine.server.storage.QueryConverter;
 import io.spine.server.storage.StorageFactory;
@@ -322,7 +324,8 @@ public class AggregateStorage<I, S extends EntityState<I>>
     protected Iterator<EntityRecord> readStates(TargetFilters filters, ResponseFormat format) {
         ensureStatesQueryable();
         RecordQuery<I, EntityRecord> query = convert(filters, format, stateStorage.recordSpec());
-        return stateStorage.readAll(query);
+        Iterator<EntityRecord> result = stateStorage.readAll(query);
+        return result;
     }
 
     /**
@@ -337,8 +340,24 @@ public class AggregateStorage<I, S extends EntityState<I>>
      */
     protected Iterator<EntityRecord> readStates(ResponseFormat format) {
         ensureStatesQueryable();
-        RecordQuery<I, EntityRecord> query = QueryConverter.newQuery(stateStorage.recordSpec(), format);
-        return stateStorage.readAll(query);
+        RecordQuery<I, EntityRecord> query =
+                QueryConverter.newQuery(stateStorage.recordSpec(), format);
+        Iterator<EntityRecord> result = stateStorage.readAll(query);
+        return result;
+    }
+
+    /**
+     * Reads the aggregate states from the storage according to the specified query.
+     *
+     * @param query
+     *         the query to execute
+     * @return an iterator over the records
+     */
+    protected Iterator<EntityRecord> readStates(EntityQuery<I, S, ?> query) {
+        ensureStatesQueryable();
+        RecordQuery<I, EntityRecord> recordQuery = ToEntityRecordQuery.transform(query);
+        Iterator<EntityRecord> result = stateStorage.readAll(recordQuery);
+        return result;
     }
 
     private void ensureStatesQueryable() {

--- a/server/src/main/java/io/spine/server/entity/QueryableRepository.java
+++ b/server/src/main/java/io/spine/server/entity/QueryableRepository.java
@@ -27,16 +27,26 @@
 package io.spine.server.entity;
 
 import io.spine.annotation.Internal;
+import io.spine.base.EntityState;
 import io.spine.client.ResponseFormat;
 import io.spine.client.TargetFilters;
+import io.spine.query.EntityQuery;
 
 import java.util.Iterator;
 
+import static io.spine.protobuf.AnyPacker.unpack;
+
 /**
- * A repository which may be queried for {@linkplain EntityRecord entity records}.
+ * A repository which may be queried for {@linkplain EntityRecord entity records}
+ * or states of stored entities.
+ *
+ * @param <I>
+ *         the type of identifiers of stored entities
+ * @param <S>
+ *         the type of stored entity states
  */
 @Internal
-public interface QueryableRepository {
+public interface QueryableRepository<I, S extends EntityState<I>> {
 
     /**
      * Queries this repository for the records according to the specified filters and returns
@@ -58,4 +68,29 @@ public interface QueryableRepository {
      * @return an iterator over the results
      */
     Iterator<EntityRecord> findRecords(ResponseFormat format);
+
+    /**
+     * Queries this repository for the states of stored entities.
+     *
+     * @param query
+     *         the query to execute
+     * @return an iterator over the results
+     */
+    Iterator<S> findStates(EntityQuery<I, S, ?> query);
+
+    /**
+     * Unpacks the {@code Entity} state stored in the provided {@link EntityRecord} into
+     * a message of type {@code S}.
+     *
+     * <p>It is a responsibility of a caller to submit the {@code EntityRecord}s which
+     * store the states of a compatible type.
+     *
+     * @param record
+     *         record storing the packed state of type {@code S}
+     * @return unpacked {@code Entity} state
+     */
+    @SuppressWarnings("unchecked")  /* Ensured by the repository contract. */
+    default S stateFrom(EntityRecord record) {
+        return (S) unpack(record.getState());
+    }
 }

--- a/server/src/main/java/io/spine/server/stand/EntityQueryProcessor.java
+++ b/server/src/main/java/io/spine/server/stand/EntityQueryProcessor.java
@@ -43,9 +43,9 @@ import static com.google.common.collect.Streams.stream;
  */
 class EntityQueryProcessor implements QueryProcessor {
 
-    private final QueryableRepository repository;
+    private final QueryableRepository<?, ?> repository;
 
-    EntityQueryProcessor(QueryableRepository repository) {
+    EntityQueryProcessor(QueryableRepository<?, ?> repository) {
         this.repository = repository;
     }
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -40,7 +40,7 @@
 /**
  * Version of this library.
  */
-val coreJava = "2.0.0-SNAPSHOT.42"
+val coreJava = "2.0.0-SNAPSHOT.43"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.


### PR DESCRIPTION
This changeset addresses #1328.

While the original issue speaks of appending the `QueryableRepository` with a method to return `Entity` instances, this changeset appends it with an endpoint to search for `Entity` states. 

The reason behind it is that is it hardly possible to make the `Aggregate` bulk search efficient — as it would involve executing a number of very different queries all at once.

Therefore, it is just possible to search for `Entity` states via `EntityQuery` now, in addition to the combination of `TargetFilters` and `ResponseFormat`.

The library version is set to `2.0.0-SNAPSHOT.43`.