### PR TITLE
Getting rid of Projection-specific API in `EntityLifecycle`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.43`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.44`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -475,12 +475,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 16:42:09 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 18:49:58 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.43`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.44`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -915,12 +915,12 @@ This report was generated on **Wed Aug 18 16:42:09 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 16:42:10 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 18:49:59 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.43`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.44`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1395,12 +1395,12 @@ This report was generated on **Wed Aug 18 16:42:10 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 16:42:10 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 18:49:59 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.43`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.44`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1931,12 +1931,12 @@ This report was generated on **Wed Aug 18 16:42:10 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 16:42:11 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 18:50:00 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.43`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.44`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2419,12 +2419,12 @@ This report was generated on **Wed Aug 18 16:42:11 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 16:42:12 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 18:50:00 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.43`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.44`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2954,12 +2954,12 @@ This report was generated on **Wed Aug 18 16:42:12 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 16:42:14 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 18:50:02 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.43`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.44`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3489,12 +3489,12 @@ This report was generated on **Wed Aug 18 16:42:14 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 16:42:16 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 18:50:03 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.43`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.44`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -4068,4 +4068,4 @@ This report was generated on **Wed Aug 18 16:42:16 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 16:42:19 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 18 18:50:05 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.43</version>
+<version>2.0.0-SNAPSHOT.44</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/delivery/CatchUpProcess.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpProcess.java
@@ -44,10 +44,10 @@ import io.spine.server.ServerEnvironment;
 import io.spine.server.delivery.event.CatchUpCompleted;
 import io.spine.server.delivery.event.CatchUpRequested;
 import io.spine.server.delivery.event.CatchUpStarted;
+import io.spine.server.delivery.event.EntityPreparedForCatchUp;
 import io.spine.server.delivery.event.HistoryEventsRecalled;
 import io.spine.server.delivery.event.HistoryFullyRecalled;
 import io.spine.server.delivery.event.LiveEventsPickedUp;
-import io.spine.server.delivery.event.ProjectionStateCleared;
 import io.spine.server.delivery.event.ShardProcessed;
 import io.spine.server.delivery.event.ShardProcessingRequested;
 import io.spine.server.event.AbstractStatefulReactor;
@@ -360,7 +360,7 @@ public final class CatchUpProcess<I>
      *      to default before the dispatching of the first historical event.
      *
      *      <li>The number of the projection instances to catch-up is remembered. The process
-     *      then waits for {@link ProjectionStateCleared} events to arrive for each of
+     *      then waits for {@link EntityPreparedForCatchUp} events to arrive for each of
      *      the instances before reading the events from the history.
      * </ol>
      *
@@ -393,8 +393,8 @@ public final class CatchUpProcess<I>
     }
 
     /**
-     * Waits until all the projection instances report their state has been cleared and they
-     * are ready for the historical events to be dispatched.
+     * Waits until all the projection instances report they are ready for the history events
+     * to be dispatched.
      *
      * <p>Once all the instances are ready, performs the first reading from the event history
      * and dispatches the results to the inboxes of respective projections.
@@ -405,7 +405,7 @@ public final class CatchUpProcess<I>
      */
     @React
     EitherOf3<HistoryEventsRecalled, HistoryFullyRecalled, Nothing>
-    handle(ProjectionStateCleared event) {
+    handle(EntityPreparedForCatchUp event) {
         int leftToClear = builder().getInstancesToClear() - 1;
         builder().setInstancesToClear(leftToClear);
         if (leftToClear > 0) {

--- a/server/src/main/java/io/spine/server/entity/EntityLifecycle.java
+++ b/server/src/main/java/io/spine/server/entity/EntityLifecycle.java
@@ -47,7 +47,7 @@ import io.spine.core.Version;
 import io.spine.option.EntityOption;
 import io.spine.server.Identity;
 import io.spine.server.delivery.CatchUpId;
-import io.spine.server.delivery.event.ProjectionStateCleared;
+import io.spine.server.delivery.event.EntityPreparedForCatchUp;
 import io.spine.server.dispatch.BatchDispatchOutcome;
 import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.entity.model.EntityClass;
@@ -404,16 +404,14 @@ public class EntityLifecycle {
     }
 
     /**
-     * Invoked when this entity is a projection, which state has just been cleared
-     * as a part of a catch-up process with the given ID.
+     * Invoked when this entity has prepared itself for the catch-up.
      *
-     * @param catchUpId the ID of the catch-up process, in scope of which the state
-     *                  has been cleared
+     * @param catchUpId the ID of the catch-up process
      */
-    public void onProjectionStateCleared(CatchUpId catchUpId) {
+    public void onEntityPreparedForCatchUp(CatchUpId catchUpId) {
         Any packedId = Identifier.pack(entityId);
-        ProjectionStateCleared event =
-                ProjectionStateCleared.newBuilder()
+        EntityPreparedForCatchUp event =
+                EntityPreparedForCatchUp.newBuilder()
                                       .setId(catchUpId)
                                       .setInstanceId(packedId)
                                       .vBuild();

--- a/server/src/main/java/io/spine/server/entity/EntityLifecycle.java
+++ b/server/src/main/java/io/spine/server/entity/EntityLifecycle.java
@@ -406,15 +406,16 @@ public class EntityLifecycle {
     /**
      * Invoked when this entity has prepared itself for the catch-up.
      *
-     * @param catchUpId the ID of the catch-up process
+     * @param catchUpId
+     *         the ID of the catch-up process
      */
     public void onEntityPreparedForCatchUp(CatchUpId catchUpId) {
         Any packedId = Identifier.pack(entityId);
         EntityPreparedForCatchUp event =
                 EntityPreparedForCatchUp.newBuilder()
-                                      .setId(catchUpId)
-                                      .setInstanceId(packedId)
-                                      .vBuild();
+                        .setId(catchUpId)
+                        .setInstanceId(packedId)
+                        .vBuild();
         postEvent(event);
     }
 

--- a/server/src/main/java/io/spine/server/entity/EntityLifecycle.java
+++ b/server/src/main/java/io/spine/server/entity/EntityLifecycle.java
@@ -118,10 +118,6 @@ public class EntityLifecycle {
 
     /**
      * The message ID of of the associated {@link Entity} state.
-     *
-     * <p>Most commands posted by the {@code EntityLifecycle} are handled by
-     * the {@code io.spine.system.server.EntityHistoryAggregate}.
-     * Thus, storing an ID as a field is convenient.
      */
     private final MessageId entityId;
 

--- a/server/src/main/java/io/spine/server/projection/CatchUpEndpoint.java
+++ b/server/src/main/java/io/spine/server/projection/CatchUpEndpoint.java
@@ -77,6 +77,6 @@ final class CatchUpEndpoint<I, P extends Projection<I, S, ?>, S extends EntitySt
         repository.recordStorage()
                   .delete(entityId);
         repository.lifecycleOf(entityId)
-                  .onProjectionStateCleared(event.getId());
+                  .onEntityPreparedForCatchUp(event.getId());
     }
 }

--- a/server/src/main/proto/spine/server/catchup/catch_up_events.proto
+++ b/server/src/main/proto/spine/server/catchup/catch_up_events.proto
@@ -56,12 +56,13 @@ message CatchUpStarted {
     CatchUpId id = 1;
 }
 
-// The state of the projection instance has been cleared at the start of the catch-up.
-message ProjectionStateCleared {
+// The entity included into the catch-up process has received the `CatchUp` start signal
+// is ready to receive the events.
+message EntityPreparedForCatchUp {
 
     CatchUpId id = 1;
 
-    // The identifier of the projection instance.
+    // The identifier of the instance to which the catch-up start has been propagated.
     google.protobuf.Any instance_id = 2;
 }
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -40,7 +40,7 @@
 /**
  * Version of this library.
  */
-val coreJava = "2.0.0-SNAPSHOT.43"
+val coreJava = "2.0.0-SNAPSHOT.44"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.


### PR DESCRIPTION
This PR addresses the root issue described in #1324.

Previously, `EntityLifecycle` operated with the term "projection" in its API. This changeset renames the method and the corresponding system event, so that they are less specific.

The library version is set to `2.0.0-SNAPSHOT.44`.
