### PR TITLE
Simplify the declaration of `ImmutableList<RecordColumn<R, ?>>` with `Columns<R>`.

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.44`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.47`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -475,12 +475,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 18:49:58 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 20 17:20:31 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.44`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.47`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -915,12 +915,12 @@ This report was generated on **Wed Aug 18 18:49:58 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 18:49:59 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 20 17:20:32 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.44`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.47`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1395,12 +1395,12 @@ This report was generated on **Wed Aug 18 18:49:59 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 18:49:59 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 20 17:20:32 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.44`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.47`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1931,12 +1931,12 @@ This report was generated on **Wed Aug 18 18:49:59 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 18:50:00 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 20 17:20:33 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.44`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.47`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2419,12 +2419,12 @@ This report was generated on **Wed Aug 18 18:50:00 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 18:50:00 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 20 17:20:34 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.44`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.47`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2954,12 +2954,12 @@ This report was generated on **Wed Aug 18 18:50:00 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 18:50:02 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 20 17:20:36 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.44`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.47`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3489,12 +3489,12 @@ This report was generated on **Wed Aug 18 18:50:02 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 18:50:03 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 20 17:20:37 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.44`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.47`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -4068,4 +4068,4 @@ This report was generated on **Wed Aug 18 18:50:03 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 18 18:50:05 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 20 17:20:39 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.44</version>
+<version>2.0.0-SNAPSHOT.47</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -64,7 +64,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.40</version>
+    <version>2.0.0-SNAPSHOT.47</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -82,13 +82,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java</artifactId>
-    <version>2.0.0-SNAPSHOT.40</version>
+    <version>2.0.0-SNAPSHOT.47</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.40</version>
+    <version>2.0.0-SNAPSHOT.47</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -148,19 +148,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>2.0.0-SNAPSHOT.40</version>
+    <version>2.0.0-SNAPSHOT.47</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.40</version>
+    <version>2.0.0-SNAPSHOT.47</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.40</version>
+    <version>2.0.0-SNAPSHOT.47</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -198,12 +198,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>2.0.0-SNAPSHOT.40</version>
+    <version>2.0.0-SNAPSHOT.47</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-protoc</artifactId>
-    <version>2.0.0-SNAPSHOT.40</version>
+    <version>2.0.0-SNAPSHOT.47</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/server/src/main/java/io/spine/server/aggregate/AggregateEventRecordColumn.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateEventRecordColumn.java
@@ -26,11 +26,11 @@
 
 package io.spine.server.aggregate;
 
-import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import com.google.protobuf.Any;
 import com.google.protobuf.Timestamp;
 import io.spine.query.Column;
+import io.spine.query.Columns;
 import io.spine.query.RecordColumn;
 import io.spine.query.RecordColumns;
 
@@ -82,8 +82,8 @@ final class AggregateEventRecordColumn {
     /**
      * Returns all the column definitions.
      */
-    static ImmutableList<RecordColumn<AggregateEventRecord, ?>> definitions() {
-        return ImmutableList.of(aggregate_id, created, version, snapshot);
+    static Columns<AggregateEventRecord> definitions() {
+        return Columns.of(aggregate_id, created, version, snapshot);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/delivery/CatchUpColumn.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpColumn.java
@@ -26,8 +26,8 @@
 
 package io.spine.server.delivery;
 
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Timestamp;
+import io.spine.query.Columns;
 import io.spine.query.RecordColumn;
 import io.spine.query.RecordColumns;
 
@@ -74,7 +74,7 @@ public class CatchUpColumn {
     /**
      * Returns all the column definitions.
      */
-    public static ImmutableList<RecordColumn<CatchUp, ?>> definitions() {
-        return ImmutableList.of(status, when_last_read, projection_type);
+    public static Columns<CatchUp> definitions() {
+        return Columns.of(status, when_last_read, projection_type);
     }
 }

--- a/server/src/main/java/io/spine/server/delivery/InboxColumn.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxColumn.java
@@ -113,6 +113,6 @@ public final class InboxColumn {
      */
     public static Columns<InboxMessage> definitions() {
         return Columns.of(signal_id, inbox_id, inbox_shard, is_event,
-                                is_command, label, status, received_at, version);
+                          is_command, label, status, received_at, version);
     }
 }

--- a/server/src/main/java/io/spine/server/delivery/InboxColumn.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxColumn.java
@@ -26,9 +26,9 @@
 
 package io.spine.server.delivery;
 
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Timestamp;
 import io.spine.annotation.SPI;
+import io.spine.query.Columns;
 import io.spine.query.RecordColumn;
 import io.spine.query.RecordColumns;
 
@@ -111,8 +111,8 @@ public final class InboxColumn {
     /**
      * Returns all the column definitions.
      */
-    public static ImmutableList<RecordColumn<InboxMessage, ?>> definitions() {
-        return ImmutableList.of(signal_id, inbox_id, inbox_shard, is_event,
+    public static Columns<InboxMessage> definitions() {
+        return Columns.of(signal_id, inbox_id, inbox_shard, is_event,
                                 is_command, label, status, received_at, version);
     }
 }

--- a/server/src/main/java/io/spine/server/entity/storage/EntityColumns.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityColumns.java
@@ -43,7 +43,7 @@ import java.util.stream.Stream;
  */
 @Immutable
 @SuppressWarnings("Immutable")  /* Effectively immutable. */
-public final class EntityColumns<E extends Entity<?, ?>> implements Iterable<Column<E, ?>> {
+final class EntityColumns<E extends Entity<?, ?>> implements Iterable<Column<E, ?>> {
 
     private final ImmutableSet<Column<E, ?>> columns;
 

--- a/server/src/main/java/io/spine/server/entity/storage/EntityColumns.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityColumns.java
@@ -42,15 +42,15 @@ import java.util.stream.Stream;
  *         the type of {@code Entity} serving as a source for the column values
  */
 @Immutable
-@SuppressWarnings("Immutable")      /* Effectively immutable. */
-public final class Columns<E extends Entity<?, ?>> implements Iterable<Column<E, ?>> {
+@SuppressWarnings("Immutable")  /* Effectively immutable. */
+public final class EntityColumns<E extends Entity<?, ?>> implements Iterable<Column<E, ?>> {
 
     private final ImmutableSet<Column<E, ?>> columns;
 
     /**
      * Creates a new instance from the passed columns.
      */
-    Columns(Set<Column<E, ?>> columns) {
+    EntityColumns(Set<Column<E, ?>> columns) {
         this.columns = ImmutableSet.copyOf(columns);
     }
 

--- a/server/src/main/java/io/spine/server/entity/storage/EntityRecordSpec.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityRecordSpec.java
@@ -70,9 +70,9 @@ public final class EntityRecordSpec<I, S extends EntityState<I>, E extends Entit
      */
     private final EntityClass<E> entityClass;
 
-    private final Columns<E> columns;
+    private final EntityColumns<E> columns;
 
-    private EntityRecordSpec(EntityClass<E> entityClass, Columns<E> columns) {
+    private EntityRecordSpec(EntityClass<E> entityClass, EntityColumns<E> columns) {
         super(idClass(entityClass), EntityRecord.class);
         this.entityClass = entityClass;
         this.columns = columns;

--- a/server/src/main/java/io/spine/server/entity/storage/Scanner.java
+++ b/server/src/main/java/io/spine/server/entity/storage/Scanner.java
@@ -101,7 +101,7 @@ final class Scanner<S extends EntityState<?>, E extends Entity<?, S>> {
      * <p>The result includes both lifecycle columns and the columns declared
      * in the {@code Entity} state.
      */
-    Columns<E> columns() {
+    EntityColumns<E> columns() {
         Set<Column<E, ?>> accumulator = new HashSet<>();
 
         StateColumns<S> stateColumns = stateColumns();
@@ -114,7 +114,7 @@ final class Scanner<S extends EntityState<?>, E extends Entity<?, S>> {
         accumulator.add(wrap(DeletedColumn.instance(), Entity::isDeleted));
         accumulator.add(wrap(VersionColumn.instance(), Entity::version));
 
-        Columns<E> columns = new Columns<>(accumulator);
+        EntityColumns<E> columns = new EntityColumns<>(accumulator);
         return columns;
     }
 

--- a/server/src/main/java/io/spine/server/event/store/EventColumn.java
+++ b/server/src/main/java/io/spine/server/event/store/EventColumn.java
@@ -26,9 +26,9 @@
 
 package io.spine.server.event.store;
 
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Timestamp;
 import io.spine.core.Event;
+import io.spine.query.Columns;
 import io.spine.query.RecordColumn;
 import io.spine.query.RecordColumns;
 
@@ -74,7 +74,7 @@ final class EventColumn {
     /**
      * Returns all the column definitions.
      */
-    static ImmutableList<RecordColumn<Event, ?>> definitions() {
-        return ImmutableList.of(type, created);
+    static Columns<Event> definitions() {
+        return Columns.of(type, created);
     }
 }

--- a/server/src/test/java/io/spine/server/entity/storage/ScannerTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ScannerTest.java
@@ -53,7 +53,7 @@ class ScannerTest {
     void extractSystemColumns() {
         EntityClass<TaskViewProjection> entityClass = asEntityClass(TaskViewProjection.class);
         Scanner<TaskView, TaskViewProjection> scanner = new Scanner<>(entityClass);
-        Columns<TaskViewProjection> columns = scanner.columns();
+        EntityColumns<TaskViewProjection> columns = scanner.columns();
 
         ImmutableSet<ColumnName> names =
                 columns.stream()

--- a/server/src/test/java/io/spine/server/storage/given/StgColumn.java
+++ b/server/src/test/java/io/spine/server/storage/given/StgColumn.java
@@ -26,8 +26,8 @@
 
 package io.spine.server.storage.given;
 
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Timestamp;
+import io.spine.query.Columns;
 import io.spine.query.RecordColumn;
 import io.spine.query.RecordColumns;
 import io.spine.test.storage.StgProject;
@@ -64,7 +64,7 @@ public final class StgColumn {
     private StgColumn() {
     }
 
-    public static ImmutableList<RecordColumn<StgProject, ?>> definitions() {
-        return ImmutableList.of(project_version, due_date, status);
+    public static Columns<StgProject> definitions() {
+        return Columns.of(project_version, due_date, status);
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -40,18 +40,19 @@
 /**
  * Version of this library.
  */
-val coreJava = "2.0.0-SNAPSHOT.44"
+val coreJava = "2.0.0-SNAPSHOT.47"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.
  */
-val base = "2.0.0-SNAPSHOT.40"
+val base = "2.0.0-SNAPSHOT.47"
+val baseTypes = "2.0.0-SNAPSHOT.40"
 val time = "2.0.0-SNAPSHOT.40"
 
 project.extra.apply {
     this["versionToPublish"] = coreJava
     this["spineBaseVersion"] = base
-    this["spineBaseTypesVersion"] = base
+    this["spineBaseTypesVersion"] = baseTypes
     this["spineTimeVersion"] = time
     this["kotlinVersion"] = io.spine.internal.dependency.Kotlin.version
 }


### PR DESCRIPTION
This changeset addresses #1330.

See [the first part of this changeset](https://github.com/SpineEventEngine/base/pull/665) for description.

In addition, an existing `Columns` type was renamed to `EntityColumns` and made package-private.

The version of the library is set to `2.0.0-SNAPSHOT.47`.