### PR TITLE
Add a workflow to ensure that the license report files are modified

### DIFF
--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -1,4 +1,4 @@
-name: Build under Unbuntu
+name: Build under Ubuntu
 
 on: pull_request
 

--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -15,11 +15,11 @@ name: Scan with Detekt
 on:
   # Triggers the workflow on push or pull request events but only for default and protected branches
   push:
-    branches: [ master, *master* ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
   schedule:
-     - cron: '21 2 * * 5'
+     - cron: '19 17 * * 4'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/ensure-license-reports-modified.yml
+++ b/.github/workflows/ensure-license-reports-modified.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: master
+          ref: ${{ secrets.GITHUB_HEAD_REF }}
 
       - name: Check that `pom.xml` and `license-report.md` are modified
         shell: bash

--- a/.github/workflows/ensure-license-reports-modified.yml
+++ b/.github/workflows/ensure-license-reports-modified.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: $GITHUB_HEAD_REF
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Check that `pom.xml` and `license-report.md` are modified
         shell: bash

--- a/.github/workflows/ensure-license-reports-modified.yml
+++ b/.github/workflows/ensure-license-reports-modified.yml
@@ -1,5 +1,4 @@
-# Ensures that the current lib version is not yet published but executing the Gradle
-# `checkVersionIncrement` task.
+# Ensures that the license report files were modified in this PR.
 
 name: Ensure license reports updated
 

--- a/.github/workflows/ensure-license-reports-modified.yml
+++ b/.github/workflows/ensure-license-reports-modified.yml
@@ -1,0 +1,20 @@
+# Ensures that the current lib version is not yet published but executing the Gradle
+# `checkVersionIncrement` task.
+
+name: Ensure license reports updated
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check version is not yet published
+        shell: bash
+        run: ./scripts/ensure-required-files-modified-in-PR.sh

--- a/.github/workflows/ensure-license-reports-modified.yml
+++ b/.github/workflows/ensure-license-reports-modified.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Check version is not yet published
+      - name: Check that `pom.xml` and `license-report.md` are modified
         shell: bash
-        run: ./scripts/ensure-required-files-modified-in-PR.sh
+        run: chmod +x ./scripts/ensure-required-files-modified-in-PR.sh && ./scripts/ensure-required-files-modified-in-PR.sh

--- a/.github/workflows/ensure-license-reports-modified.yml
+++ b/.github/workflows/ensure-license-reports-modified.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ secrets.GITHUB_HEAD_REF }}
+          fetch-depth: 0
 
       - name: Check that `pom.xml` and `license-report.md` are modified
         shell: bash

--- a/.github/workflows/ensure-license-reports-modified.yml
+++ b/.github/workflows/ensure-license-reports-modified.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          # Configure the checkout of all branches, so that it is possible to run comparison.
+          # Configure the checkout of all branches, so that it is possible to run the comparison.
           fetch-depth: 0
 
       - name: Check that `pom.xml` and `license-report.md` are modified

--- a/.github/workflows/ensure-license-reports-modified.yml
+++ b/.github/workflows/ensure-license-reports-modified.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: master
 
       - name: Check that `pom.xml` and `license-report.md` are modified
         shell: bash

--- a/.github/workflows/ensure-license-reports-modified.yml
+++ b/.github/workflows/ensure-license-reports-modified.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          # Configure the checkout of all branches, so that it is possible to run comparison.
           fetch-depth: 0
 
       - name: Check that `pom.xml` and `license-report.md` are modified

--- a/.github/workflows/ensure-license-reports-modified.yml
+++ b/.github/workflows/ensure-license-reports-modified.yml
@@ -4,7 +4,7 @@
 name: Ensure license reports updated
 
 on:
-  push:
+  pull_request:
     branches:
       - '**'
 

--- a/.github/workflows/ensure-license-reports-modified.yml
+++ b/.github/workflows/ensure-license-reports-modified.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: $GITHUB_HEAD_REF
 
       - name: Check that `pom.xml` and `license-report.md` are modified
         shell: bash

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,18 @@
+name: Validate Gradle Wrapper
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  validation:
+    name: Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v2
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,5 +47,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORMAL_GIT_HUB_PAGES_AUTHOR: developers@spine.io
-          REPO_SLUG: SpineEventEngine/core-java
+          # https://docs.github.com/en/actions/reference/environment-variables
+          REPO_SLUG: $GITHUB_REPOSITORY    # e.g. SpineEventEngine/core-java
           GOOGLE_APPLICATION_CREDENTIALS: ./maven-publisher.json

--- a/buildSrc/src/main/groovy/license-report-project.gradle
+++ b/buildSrc/src/main/groovy/license-report-project.gradle
@@ -102,7 +102,7 @@ class MarkdownReportRenderer implements ReportRenderer {
      * <p>If the {@code PublishExtension} has the property {@code spinePrefix} set to {@code true}
      * returns {@code "spine-"}, otherwise an empty string.
      */
-    private String prefixFor(final Project project) {
+    private static String prefixFor(final Project project) {
         final publishExtension = project.rootProject.extensions.findByType(PublishExtension.class)
         final prefix = (publishExtension?.spinePrefix?.getOrElse(false) ?: false)
                 ? "spine-"

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
-Modification.
+
     
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.57`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.59`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -476,12 +476,12 @@ Modification.
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 20 18:51:24 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 22 13:42:29 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.57`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.59`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -917,12 +917,12 @@ This report was generated on **Mon Sep 20 18:51:24 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 20 18:51:25 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 22 13:42:30 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.57`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.59`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1398,12 +1398,12 @@ This report was generated on **Mon Sep 20 18:51:25 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 20 18:51:25 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 22 13:42:31 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.57`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.59`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1935,12 +1935,12 @@ This report was generated on **Mon Sep 20 18:51:25 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 20 18:51:26 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 22 13:42:31 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.57`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.59`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2424,12 +2424,12 @@ This report was generated on **Mon Sep 20 18:51:26 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 20 18:51:26 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 22 13:42:32 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.57`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.59`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2960,12 +2960,12 @@ This report was generated on **Mon Sep 20 18:51:26 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 20 18:51:28 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 22 13:42:34 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.57`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.59`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3496,12 +3496,12 @@ This report was generated on **Mon Sep 20 18:51:28 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 20 18:51:29 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 22 13:42:35 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.57`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.59`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -4076,4 +4076,4 @@ This report was generated on **Mon Sep 20 18:51:29 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 20 18:51:32 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 22 13:42:37 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,4 +1,4 @@
-
+Modification.
     
 # Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.57`
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,12 @@ all modules and does not describe the project structure per-subproject.
     <scope>compile</scope>
   </dependency>
   <dependency>
+    <groupId>com.google.truth</groupId>
+    <artifactId>truth</artifactId>
+    <version>1.1.2</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
     <groupId>com.google.truth.extensions</groupId>
     <artifactId>truth-java8-extension</artifactId>
     <version>1.1.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.57</version>
+<version>2.0.0-SNAPSHOT.59</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -29,12 +29,6 @@ all modules and does not describe the project structure per-subproject.
     <groupId>com.google.truth</groupId>
     <artifactId>truth</artifactId>
     <version>1.1.3</version>
-    <scope>compile</scope>
-  </dependency>
-  <dependency>
-    <groupId>com.google.truth</groupId>
-    <artifactId>truth</artifactId>
-    <version>1.1.2</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/scripts/ensure-required-files-modified-in-PR.sh
+++ b/scripts/ensure-required-files-modified-in-PR.sh
@@ -39,7 +39,7 @@
 # Exists with the code 1, if such a file has NOT been modified.
 # Does nothing, if such a modification was found.
 function ensureChanged() {
-	modificationCount=$(git diff --name-only origin/$GITHUB_BASE_REF...$GITHUB_HEAD_REF | grep $1 | wc -l)
+	modificationCount=$(git diff --name-only origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF | grep $1 | wc -l)
 	if [ "$modificationCount" -eq "0" ];
 	then
 	   echo "ERROR: '$1' file has not been modified in this PR. Please re-check the changeset.";

--- a/scripts/ensure-required-files-modified-in-PR.sh
+++ b/scripts/ensure-required-files-modified-in-PR.sh
@@ -39,7 +39,7 @@
 # Exists with the code 1, if such a file has NOT been modified.
 # Does nothing, if such a modification was found.
 function ensureChanged() {
-	modificationCount=$(git diff --name-only $GITHUB_BASE_REF...$GITHUB_HEAD_REF | grep $1 | wc -l)
+	modificationCount=$(git diff --name-only remotes/origin/$GITHUB_BASE_REF...remotes/origin/$GITHUB_HEAD_REF | grep $1 | wc -l)
 	if [ "$modificationCount" -eq "0" ];
 	then
 	   echo "ERROR: '$1' file has not been modified in this PR. Please re-check the changeset.";
@@ -50,14 +50,11 @@ function ensureChanged() {
 }
 
 echo "Available branches:"
-
 git branch -a
 
 echo "Starting to check if all required files were modified within this PR..."
-echo "Comparing \"$GITHUB_HEAD_REF\" branch to \"$GITHUB_BASE_REF\" contents."
+echo "Comparing \"remotes/origin/$GITHUB_HEAD_REF\" branch to \"remotes/origin/$GITHUB_BASE_REF\" contents."
 
-git checkout --progress --force origin/$GITHUB_BASE_REF
-git checkout --progress --force origin/$GITHUB_HEAD_REF
 
 ensureChanged "pom.xml"
 ensureChanged "license-report.md"

--- a/scripts/ensure-required-files-modified-in-PR.sh
+++ b/scripts/ensure-required-files-modified-in-PR.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Copyright 2021, TeamDev. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Redistribution and use in source and/or binary forms, with or without
+# modification, must retain the above copyright notice and the following
+# disclaimer.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# This script is a part of a GitHub Actions workflow.
+#
+# Its purpose is to prevent PRs from leaving `pom.xml` and `license-report.md` from being untouched.
+# In case any of these files are not modified, it exits with an error code 1.
+# Otherwise, exits with a success code 0.
+#
+# In its implementation, the script relies into the environment variables set by GitHub Actions.
+# See https://docs.github.com/en/actions/reference/environment-variables.
+
+
+# Detects if the file with the passed name has been modified in this changeset.
+# Exists with the code 1, if such a file has NOT been modified.
+# Does nothing, if such a modification was found.
+function ensureChanged() {
+
+	modificationCount=$(git diff --name-only $GITHUB_HEAD_REF...$GITHUB_BASE_REF | grep $1 | wc -l)
+	if [ "$modificationCount" -eq "0" ];
+	then
+	   echo "ERROR: '$1' file has not been modified in this PR. Please re-check the changeset.";
+	   exit 1;
+	else
+		echo "Detected the modifications in '$1'."
+	fi
+}
+
+echo "Starting to check if all required files were modified within this PR..."
+echo "Comparing '$GITHUB_HEAD_REF' in relation to '$GITHUB_BASE_REF'."
+
+ensureChanged "pom.xml"
+ensureChanged "license-report.md"
+
+echo "All good."
+exit 0;

--- a/scripts/ensure-required-files-modified-in-PR.sh
+++ b/scripts/ensure-required-files-modified-in-PR.sh
@@ -39,7 +39,7 @@
 # Exists with the code 1, if such a file has NOT been modified.
 # Does nothing, if such a modification was found.
 function ensureChanged() {
-	modificationCount=$(git diff --name-only $GITHUB_BASE_REF...$GITHUB_HEAD_REF | grep $1 | wc -l)
+	modificationCount=$(git diff --name-only origin/$GITHUB_BASE_REF...$GITHUB_HEAD_REF | grep $1 | wc -l)
 	if [ "$modificationCount" -eq "0" ];
 	then
 	   echo "ERROR: '$1' file has not been modified in this PR. Please re-check the changeset.";

--- a/scripts/ensure-required-files-modified-in-PR.sh
+++ b/scripts/ensure-required-files-modified-in-PR.sh
@@ -49,9 +49,6 @@ function ensureChanged() {
 	fi
 }
 
-echo "Available branches:"
-git branch -a
-
 echo "Starting to check if all required files were modified within this PR..."
 echo "Comparing \"remotes/origin/$GITHUB_HEAD_REF\" branch to \"remotes/origin/$GITHUB_BASE_REF\" contents."
 

--- a/scripts/ensure-required-files-modified-in-PR.sh
+++ b/scripts/ensure-required-files-modified-in-PR.sh
@@ -39,7 +39,6 @@
 # Exists with the code 1, if such a file has NOT been modified.
 # Does nothing, if such a modification was found.
 function ensureChanged() {
-
 	modificationCount=$(git diff --name-only $GITHUB_BASE_REF...$GITHUB_HEAD_REF | grep $1 | wc -l)
 	if [ "$modificationCount" -eq "0" ];
 	then

--- a/scripts/ensure-required-files-modified-in-PR.sh
+++ b/scripts/ensure-required-files-modified-in-PR.sh
@@ -49,6 +49,10 @@ function ensureChanged() {
 	fi
 }
 
+echo "Available branches:"
+
+git branch -a
+
 echo "Starting to check if all required files were modified within this PR..."
 echo "Comparing \"$GITHUB_HEAD_REF\" branch to \"$GITHUB_BASE_REF\" contents."
 

--- a/scripts/ensure-required-files-modified-in-PR.sh
+++ b/scripts/ensure-required-files-modified-in-PR.sh
@@ -39,7 +39,7 @@
 # Exists with the code 1, if such a file has NOT been modified.
 # Does nothing, if such a modification was found.
 function ensureChanged() {
-	modificationCount=$(git diff --name-only origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF | grep $1 | wc -l)
+	modificationCount=$(git diff --name-only $GITHUB_BASE_REF...$GITHUB_HEAD_REF | grep $1 | wc -l)
 	if [ "$modificationCount" -eq "0" ];
 	then
 	   echo "ERROR: '$1' file has not been modified in this PR. Please re-check the changeset.";
@@ -51,6 +51,9 @@ function ensureChanged() {
 
 echo "Starting to check if all required files were modified within this PR..."
 echo "Comparing \"$GITHUB_HEAD_REF\" branch to \"$GITHUB_BASE_REF\" contents."
+
+git checkout --progress --force $GITHUB_BASE_REF
+git checkout --progress --force $GITHUB_HEAD_REF
 
 ensureChanged "pom.xml"
 ensureChanged "license-report.md"

--- a/scripts/ensure-required-files-modified-in-PR.sh
+++ b/scripts/ensure-required-files-modified-in-PR.sh
@@ -52,8 +52,8 @@ function ensureChanged() {
 echo "Starting to check if all required files were modified within this PR..."
 echo "Comparing \"$GITHUB_HEAD_REF\" branch to \"$GITHUB_BASE_REF\" contents."
 
-git checkout --progress --force $GITHUB_BASE_REF
-git checkout --progress --force $GITHUB_HEAD_REF
+git checkout --progress --force origin/$GITHUB_BASE_REF
+git checkout --progress --force origin/$GITHUB_HEAD_REF
 
 ensureChanged "pom.xml"
 ensureChanged "license-report.md"

--- a/scripts/ensure-required-files-modified-in-PR.sh
+++ b/scripts/ensure-required-files-modified-in-PR.sh
@@ -51,7 +51,7 @@ function ensureChanged() {
 }
 
 echo "Starting to check if all required files were modified within this PR..."
-echo "Comparing '$GITHUB_HEAD_REF' in relation to '$GITHUB_BASE_REF'."
+echo "Comparing \"$GITHUB_HEAD_REF\" branch to \"$GITHUB_BASE_REF\" contents."
 
 ensureChanged "pom.xml"
 ensureChanged "license-report.md"

--- a/scripts/ensure-required-files-modified-in-PR.sh
+++ b/scripts/ensure-required-files-modified-in-PR.sh
@@ -40,7 +40,7 @@
 # Does nothing, if such a modification was found.
 function ensureChanged() {
 
-	modificationCount=$(git diff --name-only $GITHUB_HEAD_REF...$GITHUB_BASE_REF | grep $1 | wc -l)
+	modificationCount=$(git diff --name-only $GITHUB_BASE_REF...$GITHUB_HEAD_REF | grep $1 | wc -l)
 	if [ "$modificationCount" -eq "0" ];
 	then
 	   echo "ERROR: '$1' file has not been modified in this PR. Please re-check the changeset.";

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -40,7 +40,7 @@
 /**
  * Version of this library.
  */
-val coreJava = "2.0.0-SNAPSHOT.58"
+val coreJava = "2.0.0-SNAPSHOT.59"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to ensure that the license report files are modified within the PR.

The version has been updated to `2.0.0-SNAPSHOT.59`. License report files were updated as well.

In future changesets, the workflow file will be added to `config`.