### PR TITLE
Bump base, extend publishing

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,9 +7,9 @@
 
 coverage:
   ignore:
-  - "**/generated/**/*"
-  - "**/examples/**/*"
-  - "**/test/**/*"
+    - "**/generated/**/*"
+    - "**/examples/**/*"
+    - "**/test/**/*"
   status:
     # https://docs.codecov.com/docs/github-checks#yaml-configuration-for-github-checks-and-codecov
     patch: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,9 +7,9 @@
 
 coverage:
   ignore:
-  - generated/*
-  - examples/*
-  - test/*
+  - "**/generated/**/*"
+  - "**/examples/**/*"
+  - "**/test/**/*"
   status:
     # https://docs.codecov.com/docs/github-checks#yaml-configuration-for-github-checks-and-codecov
     patch: false

--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -1,4 +1,4 @@
-name: Build under Unbuntu
+name: Build under Ubuntu
 
 on: pull_request
 

--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -15,11 +15,11 @@ name: Scan with Detekt
 on:
   # Triggers the workflow on push or pull request events but only for default and protected branches
   push:
-    branches: [ master, *master* ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
   schedule:
-     - cron: '21 2 * * 5'
+     - cron: '19 17 * * 4'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/ensure-reports.updated.yml
+++ b/.github/workflows/ensure-reports.updated.yml
@@ -1,0 +1,24 @@
+# Ensures that the license report files were modified in this PR.
+
+name: Ensure license reports updated
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Configure the checkout of all branches, so that it is possible to run the comparison.
+          fetch-depth: 0
+          # Check out the `config` submodule to fetch the required script file.
+          submodules: true
+
+      - name: Check that `pom.xml` and `license-report.md` are modified
+        shell: bash
+        run: chmod +x ./config/scripts/ensure-reports-updated.sh && ./config/scripts/ensure-reports-updated.sh

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,18 @@
+name: Validate Gradle Wrapper
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  validation:
+    name: Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v2
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,5 +47,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORMAL_GIT_HUB_PAGES_AUTHOR: developers@spine.io
-          REPO_SLUG: SpineEventEngine/core-java
+          # https://docs.github.com/en/actions/reference/environment-variables
+          REPO_SLUG: $GITHUB_REPOSITORY    # e.g. SpineEventEngine/core-java
           GOOGLE_APPLICATION_CREDENTIALS: ./maven-publisher.json

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,10 +86,14 @@ val spineBaseVersion: String by extra
 val spineTimeVersion: String by extra
 
 spinePublishing {
-    targetRepositories.addAll(setOf(
-        PublishingRepos.cloudRepo
-        //, PublishingRepos.gitHub("core-java")
-    ))
+    with(PublishingRepos) {
+        targetRepositories.addAll(setOf(
+            cloudRepo,
+            gitHub("core-java"),
+            cloudArtifactRegistry
+        ))
+    }
+
     projectsToPublish.addAll(
         "core",
         "client",

--- a/buildSrc/src/main/groovy/license-report-project.gradle
+++ b/buildSrc/src/main/groovy/license-report-project.gradle
@@ -102,7 +102,7 @@ class MarkdownReportRenderer implements ReportRenderer {
      * <p>If the {@code PublishExtension} has the property {@code spinePrefix} set to {@code true}
      * returns {@code "spine-"}, otherwise an empty string.
      */
-    private String prefixFor(final Project project) {
+    private static String prefixFor(final Project project) {
         final publishExtension = project.rootProject.extensions.findByType(PublishExtension.class)
         final prefix = (publishExtension?.spinePrefix?.getOrElse(false) ?: false)
                 ? "spine-"

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.57`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.59`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -476,12 +476,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 20 18:51:24 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 21 23:41:17 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.57`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.59`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -917,12 +917,12 @@ This report was generated on **Mon Sep 20 18:51:24 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 20 18:51:25 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 21 23:41:17 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.57`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.59`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1398,12 +1398,12 @@ This report was generated on **Mon Sep 20 18:51:25 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 20 18:51:25 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 21 23:41:18 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.57`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.59`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1935,12 +1935,12 @@ This report was generated on **Mon Sep 20 18:51:25 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 20 18:51:26 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 21 23:41:19 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.57`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.59`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2424,12 +2424,12 @@ This report was generated on **Mon Sep 20 18:51:26 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 20 18:51:26 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 21 23:41:19 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.57`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.59`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2960,12 +2960,12 @@ This report was generated on **Mon Sep 20 18:51:26 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 20 18:51:28 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 21 23:41:21 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.57`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.59`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3496,12 +3496,12 @@ This report was generated on **Mon Sep 20 18:51:28 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 20 18:51:29 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 21 23:41:22 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.57`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.59`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -4076,4 +4076,4 @@ This report was generated on **Mon Sep 20 18:51:29 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Sep 20 18:51:32 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 21 23:41:25 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.57</version>
+<version>2.0.0-SNAPSHOT.59</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -64,31 +64,31 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.57</version>
+    <version>2.0.0-SNAPSHOT.59</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base-types</artifactId>
-    <version>2.0.0-SNAPSHOT.57</version>
+    <version>2.0.0-SNAPSHOT.59</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-time</artifactId>
-    <version>2.0.0-SNAPSHOT.57</version>
+    <version>2.0.0-SNAPSHOT.59</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java</artifactId>
-    <version>2.0.0-SNAPSHOT.57</version>
+    <version>2.0.0-SNAPSHOT.59</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.57</version>
+    <version>2.0.0-SNAPSHOT.59</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -148,19 +148,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.57</version>
+    <version>2.0.0-SNAPSHOT.59</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.57</version>
+    <version>2.0.0-SNAPSHOT.59</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testutil-time</artifactId>
-    <version>2.0.0-SNAPSHOT.57</version>
+    <version>2.0.0-SNAPSHOT.59</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -192,12 +192,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>2.0.0-SNAPSHOT.57</version>
+    <version>2.0.0-SNAPSHOT.59</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mc-java-protoc</artifactId>
-    <version>2.0.0-SNAPSHOT.57</version>
+    <version>2.0.0-SNAPSHOT.59</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,35 +24,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/**
- * The versions of the libraries used.
- *
- * This file is used in both module `build.gradle.kts` scripts and in the integration tests,
- * as we want to manage the versions in a single source.
- *
- * This version file adheres to the contract of the
- * [publishing application](https://github.com/SpineEventEngine/publishing).
- *
- * When changing the version declarations or adding new ones, make sure to change
- * the publishing application accordingly.
- */
+/** The version of this library. */
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.59")
 
-/**
- * Version of this library.
- */
-val coreJava = "2.0.0-SNAPSHOT.58"
+/** Versions of the Spine libraries that `core-java` depends on. */
+val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.59")
+val spineBaseTypesVersion: String by extra("2.0.0-SNAPSHOT.59")
+val spineTimeVersion: String by extra("2.0.0-SNAPSHOT.59")
 
-/**
- * Versions of the Spine libraries that `core-java` depends on.
- */
-val base = "2.0.0-SNAPSHOT.57"
-val baseTypes = "2.0.0-SNAPSHOT.57"
-val time = "2.0.0-SNAPSHOT.57"
-
-project.extra.apply {
-    this["versionToPublish"] = coreJava
-    this["spineBaseVersion"] = base
-    this["spineBaseTypesVersion"] = baseTypes
-    this["spineTimeVersion"] = time
-    this["kotlinVersion"] = io.spine.internal.dependency.Kotlin.version
-}
+val kotlinVersion: String by extra(io.spine.internal.dependency.Kotlin.version)


### PR DESCRIPTION
This PR updates dependencies on `base`, `time`, and `base-types`. The latest `config` was also applied.

Also, this PR initiates publishing of `core-java` to GitHub and Cloud Artefact Registry.