### PR TITLE
[1.7.6] Avoid clash between Catch-up Processes at runtime

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.7.5`
+# Dependencies of `io.spine:spine-client:1.7.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -399,12 +399,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jul 26 22:39:51 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Sep 26 19:28:36 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.7.5`
+# Dependencies of `io.spine:spine-core:1.7.6`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -763,12 +763,12 @@ This report was generated on **Mon Jul 26 22:39:51 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jul 26 22:39:51 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Sep 26 19:28:36 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.7.5`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.7.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1162,12 +1162,12 @@ This report was generated on **Mon Jul 26 22:39:51 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jul 26 22:39:51 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Sep 26 19:28:36 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.7.5`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.7.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1627,12 +1627,12 @@ This report was generated on **Mon Jul 26 22:39:51 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jul 26 22:39:52 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Sep 26 19:28:37 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.7.5`
+# Dependencies of `io.spine:spine-server:1.7.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2039,12 +2039,12 @@ This report was generated on **Mon Jul 26 22:39:52 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jul 26 22:39:52 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Sep 26 19:28:38 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.7.5`
+# Dependencies of `io.spine:spine-testutil-client:1.7.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2493,12 +2493,12 @@ This report was generated on **Mon Jul 26 22:39:52 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jul 26 22:39:54 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Sep 26 19:28:39 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.7.5`
+# Dependencies of `io.spine:spine-testutil-core:1.7.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2947,12 +2947,12 @@ This report was generated on **Mon Jul 26 22:39:54 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jul 26 22:39:55 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Sep 26 19:28:40 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.7.5`
+# Dependencies of `io.spine:spine-testutil-server:1.7.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3445,4 +3445,4 @@ This report was generated on **Mon Jul 26 22:39:55 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jul 26 22:39:57 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Sep 26 19:28:44 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.7.5</version>
+<version>1.7.6</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/BoundedContext.java
+++ b/server/src/main/java/io/spine/server/BoundedContext.java
@@ -55,6 +55,7 @@ import io.spine.system.server.SystemClient;
 import io.spine.system.server.SystemContext;
 import io.spine.system.server.SystemReadSide;
 import io.spine.type.TypeName;
+import io.spine.type.TypeUrl;
 
 import java.util.Optional;
 import java.util.Set;
@@ -515,13 +516,27 @@ public abstract class BoundedContext implements Closeable, Logging {
         }
 
         /**
-         * Obtains repositories of the context.
+         * Obtains the repository of the context by the type of the entity state.
          *
+         * @param stateClass
+         *         the state class of the entities managed by the repository
          * @throws IllegalStateException
-         *         if there is not repository entities of which have the passed state
+         *         if there is no repository entities of which have the passed state
          */
         public Repository<?, ?> getRepository(Class<? extends EntityState> stateClass) {
             return guard.get(stateClass);
+        }
+
+        /**
+         * Obtains the repository of the context by the type URL of the entity state..
+         *
+         * @param stateType
+         *         the state type URL of the entities managed by the repository
+         * @throws IllegalStateException
+         *         if there is no such repository
+         */
+        public Repository<?, ?> getRepository(TypeUrl stateType) {
+            return guard.get(stateType);
         }
 
         /**

--- a/server/src/main/java/io/spine/server/VisibilityGuard.java
+++ b/server/src/main/java/io/spine/server/VisibilityGuard.java
@@ -157,7 +157,7 @@ final class VisibilityGuard {
     private static Supplier<IllegalStateException> cannotFindByTypeUrl(TypeUrl repositoryState) {
         return () ->
                 newIllegalStateException(
-                        "A repository for the type URL `%s` is not registered.",
+                        "Cannot find a registered repository by `%s` type URL of its entity state.",
                         repositoryState);
     }
 

--- a/server/src/main/java/io/spine/server/delivery/CatchUpProcess.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpProcess.java
@@ -607,9 +607,9 @@ public final class CatchUpProcess<I>
     /**
      * {@inheritDoc}
      *
-     * <p>Tells if the passed envelope can be dispatched to this instance of the process
-     * by verifying that the projection type URL passed with the event matches the one of the
-     * projection repository configured for this instance.
+     * <p>Ensures that the passed signal is an instance of {@link CatchUpSignal} and hence
+     * is suitable for the upcoming {@linkplain #route(EventEnvelope) ID extraction
+     * at the routing stage}.
      */
     @Override
     public boolean canDispatch(EventEnvelope envelope) {

--- a/server/src/main/java/io/spine/server/delivery/CatchUpProcess.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpProcess.java
@@ -257,9 +257,9 @@ public final class CatchUpProcess<I>
      * @param ids
      *         identifiers of the projections to catch up, or {@code null} if all of the
      *         instances should be caught up
+     * @return identifier of the catch-up operation
      * @throws CatchUpAlreadyStartedException
      *         if at least one of the selected instances is already catching up at the moment
-     * @return identifier of the catch-up operation
      */
     @Internal
     public CatchUpId startCatchUp(Timestamp since, @Nullable Set<I> ids)
@@ -590,7 +590,7 @@ public final class CatchUpProcess<I>
         String type = builder().getId()
                                .getProjectionType();
         synchronized (repos) {
-            if(repos.containsKey(type)) {
+            if (repos.containsKey(type)) {
                 return repos.get(type);
             }
             TypeUrl typeUrl = TypeUrl.parse(type);
@@ -655,6 +655,8 @@ public final class CatchUpProcess<I>
          * <p>If no particular IDs are specified, the event will be dispatched according to the
          * repository routing rules.
          *
+         * @param repo
+         *         the projection repository which manages the entities involved into the catch-up
          * @param event
          *         event to dispatch
          * @param narrowDownToIds

--- a/server/src/main/java/io/spine/server/delivery/CatchUpProcessBuilder.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpProcessBuilder.java
@@ -28,6 +28,7 @@ package io.spine.server.delivery;
 
 import io.spine.server.delivery.CatchUpProcess.DispatchCatchingUp;
 import io.spine.server.projection.ProjectionRepository;
+import io.spine.type.TypeUrl;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -39,6 +40,8 @@ import static io.spine.util.Preconditions2.checkPositive;
 public final class CatchUpProcessBuilder<I> {
 
     private final ProjectionRepository<I, ?, ?> repository;
+    private final TypeUrl projectionType;
+    private @MonotonicNonNull RepositoryLookup<I> lookup;
     private @MonotonicNonNull CatchUpStorage storage;
     private @MonotonicNonNull DispatchCatchingUp<I> dispatchOp;
     private int pageSize;
@@ -51,6 +54,7 @@ public final class CatchUpProcessBuilder<I> {
      */
     CatchUpProcessBuilder(ProjectionRepository<I, ?, ?> repository) {
         this.repository = repository;
+        this.projectionType = repository.entityStateType();
     }
 
     /**
@@ -112,6 +116,31 @@ public final class CatchUpProcessBuilder<I> {
      */
     DispatchCatchingUp<I> getDispatchOp() {
         return checkNotNull(dispatchOp);
+    }
+
+    /**
+     * Sets the way to find the repository at the catch-up run-time.
+     */
+    public CatchUpProcessBuilder<I> setLookup(RepositoryLookup<I> lookup) {
+        this.lookup = checkNotNull(lookup);
+        return this;
+    }
+
+    /**
+     * Obtains the pre-configured way to dispatch the events during the catch-up.
+     *
+     * @throws NullPointerException
+     *         if the lookup has not been set
+     */
+    RepositoryLookup<I> getLookup() {
+        return checkNotNull(lookup);
+    }
+
+    /**
+     * Obtains the type URL of the state of the projection to catch up.
+     */
+    public TypeUrl getProjectionType() {
+        return projectionType;
     }
 
     /**

--- a/server/src/main/java/io/spine/server/delivery/CatchUpProcessBuilder.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpProcessBuilder.java
@@ -109,7 +109,7 @@ public final class CatchUpProcessBuilder<I> {
      * Obtains the pre-configured way to dispatch the events during the catch-up.
      *
      * @throws NullPointerException
-     *         if the storage has not been set
+     *         if the dispatch operation has not been set
      */
     DispatchCatchingUp<I> getDispatchOp() {
         return checkNotNull(dispatchOp);

--- a/server/src/main/java/io/spine/server/delivery/CatchUpProcessBuilder.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpProcessBuilder.java
@@ -28,7 +28,6 @@ package io.spine.server.delivery;
 
 import io.spine.server.delivery.CatchUpProcess.DispatchCatchingUp;
 import io.spine.server.projection.ProjectionRepository;
-import io.spine.type.TypeUrl;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -40,7 +39,6 @@ import static io.spine.util.Preconditions2.checkPositive;
 public final class CatchUpProcessBuilder<I> {
 
     private final ProjectionRepository<I, ?, ?> repository;
-    private final TypeUrl projectionType;
     private @MonotonicNonNull RepositoryLookup<I> lookup;
     private @MonotonicNonNull CatchUpStorage storage;
     private @MonotonicNonNull DispatchCatchingUp<I> dispatchOp;
@@ -54,7 +52,6 @@ public final class CatchUpProcessBuilder<I> {
      */
     CatchUpProcessBuilder(ProjectionRepository<I, ?, ?> repository) {
         this.repository = repository;
-        this.projectionType = repository.entityStateType();
     }
 
     /**
@@ -134,13 +131,6 @@ public final class CatchUpProcessBuilder<I> {
      */
     RepositoryLookup<I> getLookup() {
         return checkNotNull(lookup);
-    }
-
-    /**
-     * Obtains the type URL of the state of the projection to catch up.
-     */
-    public TypeUrl getProjectionType() {
-        return projectionType;
     }
 
     /**

--- a/server/src/main/java/io/spine/server/delivery/RepositoryLookup.java
+++ b/server/src/main/java/io/spine/server/delivery/RepositoryLookup.java
@@ -1,6 +1,12 @@
 /*
  * Copyright 2021, TeamDev. All rights reserved.
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
  * disclaimer.
@@ -18,32 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/**
- * The versions of the libraries used.
- *
- * This file is used in both module `build.gradle.kts` scripts and in the integration tests,
- * as we want to manage the versions in a single source.
- *
- * This version file adheres to the contract of the
- * [publishing application](https://github.com/SpineEventEngine/publishing).
- *
- * When changing the version declarations or adding new ones, make sure to change
- * the publishing application accordingly.
- */
+package io.spine.server.delivery;
+
+import io.spine.server.projection.ProjectionRepository;
+import io.spine.type.TypeUrl;
+
+import java.util.function.Function;
 
 /**
- * Version of this library.
+ * A function that searches for the {@link ProjectionRepository} instance by the type URL
+ * of the state of the managed projection.
  */
-val coreJava = "1.7.6"
-
-/**
- * Versions of the Spine libraries that `core-java` depends on.
- */
-val base = "1.7.4"
-val time = "1.7.1"
-
-project.extra.apply {
-    this["versionToPublish"] = coreJava
-    this["spineBaseVersion"] = base
-    this["spineTimeVersion"] = time
+@FunctionalInterface
+public interface RepositoryLookup<I> extends Function<TypeUrl, ProjectionRepository<I, ?, ?>> {
 }

--- a/server/src/main/java/io/spine/system/server/MirrorRepository.java
+++ b/server/src/main/java/io/spine/system/server/MirrorRepository.java
@@ -60,6 +60,8 @@ import static io.spine.system.server.MirrorProjection.buildFilters;
  * <p>The mirrored entity types are gathered at runtime and are usually
  * {@linkplain #registerMirroredType(Repository) registered} by the corresponding entity
  * repositories.
+ *
+ * <p>The catch-up is disabled for the instances of this repository.
  */
 @Internal
 public final class MirrorRepository
@@ -76,6 +78,12 @@ public final class MirrorRepository
         super.setupEventRouting(routing);
         routing.route(EntityLifecycleEvent.class,
                       (message, context) -> targetsFrom(message));
+    }
+
+    @Internal
+    @Override
+    protected boolean isCatchUpEnabled() {
+        return false;
     }
 
     private Set<MirrorId> targetsFrom(EntityLifecycleEvent event) {

--- a/server/src/test/java/io/spine/system/server/MirrorProjectionTest.java
+++ b/server/src/test/java/io/spine/system/server/MirrorProjectionTest.java
@@ -81,7 +81,8 @@ class MirrorProjectionTest {
         assertMirror.hasStateThat()
                     .comparingExpectedFieldsOnly()
                     .isEqualTo(Mirror.newBuilder()
-                                     .setLifecycle(LifecycleFlags.newBuilder().setArchived(true))
+                                     .setLifecycle(LifecycleFlags.newBuilder()
+                                                                 .setArchived(true))
                                      .buildPartial());
     }
 
@@ -101,7 +102,8 @@ class MirrorProjectionTest {
         assertMirror.hasStateThat()
                     .comparingExpectedFieldsOnly()
                     .isEqualTo(Mirror.newBuilder()
-                                     .setLifecycle(LifecycleFlags.newBuilder().setDeleted(true))
+                                     .setLifecycle(LifecycleFlags.newBuilder()
+                                                                 .setDeleted(true))
                                      .buildPartial());
     }
 
@@ -146,8 +148,7 @@ class MirrorProjectionTest {
     }
 
     private static void assertIse(Executable action) {
-        assertThrows(IllegalStateException.class,
-                     action);
+        assertThrows(IllegalStateException.class, action);
     }
 
     private static BlackBoxContext context() {

--- a/server/src/test/java/io/spine/system/server/MirrorProjectionTest.java
+++ b/server/src/test/java/io/spine/system/server/MirrorProjectionTest.java
@@ -26,7 +26,10 @@
 
 package io.spine.system.server;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.protobuf.Timestamp;
 import io.spine.base.EventMessage;
+import io.spine.base.Time;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.entity.LifecycleFlags;
 import io.spine.system.server.event.EntityStateChanged;
@@ -34,6 +37,7 @@ import io.spine.testing.server.blackbox.BlackBoxContext;
 import io.spine.testing.server.entity.EntitySubject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import static io.spine.system.server.given.mirror.MirrorProjectionTestEnv.AGGREGATE_TYPE_URL;
 import static io.spine.system.server.given.mirror.MirrorProjectionTestEnv.ID;
@@ -42,6 +46,8 @@ import static io.spine.system.server.given.mirror.MirrorProjectionTestEnv.entity
 import static io.spine.system.server.given.mirror.MirrorProjectionTestEnv.entityExtracted;
 import static io.spine.system.server.given.mirror.MirrorProjectionTestEnv.entityRestored;
 import static io.spine.system.server.given.mirror.MirrorProjectionTestEnv.entityStateChanged;
+import static io.spine.testdata.Sample.messageOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("`MirrorProjection` should")
 class MirrorProjectionTest {
@@ -127,6 +133,21 @@ class MirrorProjectionTest {
                     .isFalse();
         assertMirror.hasStateThat()
                     .isNotEqualToDefaultInstance();
+    }
+
+    @Test
+    @DisplayName("not allow to start the catch-up")
+    @SuppressWarnings("ResultOfMethodCallIgnored")  /* Expecting an exception. */
+    void haveNoCatchUp() {
+        MirrorRepository repo = new MirrorRepository();
+        Timestamp time = Time.currentTime();
+        assertIse(() -> repo.catchUp(time, ImmutableSet.of(messageOfType(MirrorId.class))));
+        assertIse(() -> repo.catchUpAll(time));
+    }
+
+    private static void assertIse(Executable action) {
+        assertThrows(IllegalStateException.class,
+                     action);
     }
 
     private static BlackBoxContext context() {


### PR DESCRIPTION
This PR addresses two issues discovered in production:

1. Catch-up processes may be incorrectly initialized with non-matching repository instances at run-time. To prevent that, now, a `CatchUpProcess` always loads the required `ProjectionRepository` from its `BoundedContext` according to the type URL of the projection state. That value is passed at run-time with each event, so it is guaranteed that the loaded repository will match the state of the catch-up process.

2. `MirrorProjection` could participate in catch-up. In fact, catching up mirrors makes very little sense, as they are not operating on top of domain events, but rather they subscribe to system events — which are not available for recall. This changeset prevents `MirrorProjection`s from registering their catch-up processes, and from starting the catch-up.

The library version is set to `1.7.6`.

NOTE: this PR is only made to illustrate the changes made to the codebase in relation to `1.7.5`. Actual merge will NOT happen, as for `1.x` versions we do not operate with `master` branch.