### PR TITLE
[2.x] Perform clear-and-replace when applying entity `Migration`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.77`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.78`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -502,12 +502,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 12 16:46:53 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 16 17:34:34 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.77`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.78`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -969,12 +969,12 @@ This report was generated on **Fri Nov 12 16:46:53 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 12 16:46:54 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 16 17:34:35 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.77`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.78`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1476,12 +1476,12 @@ This report was generated on **Fri Nov 12 16:46:54 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 12 16:46:55 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 16 17:34:35 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.77`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.78`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -2079,12 +2079,12 @@ This report was generated on **Fri Nov 12 16:46:55 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 12 16:46:55 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 16 17:34:36 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.77`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.78`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2594,12 +2594,12 @@ This report was generated on **Fri Nov 12 16:46:55 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 12 16:46:56 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 16 17:34:37 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.77`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.78`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3153,12 +3153,12 @@ This report was generated on **Fri Nov 12 16:46:56 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 12 16:46:57 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 16 17:34:37 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.77`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.78`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3712,12 +3712,12 @@ This report was generated on **Fri Nov 12 16:46:57 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 12 16:46:57 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 16 17:34:38 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.77`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.78`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4315,4 +4315,4 @@ This report was generated on **Fri Nov 12 16:46:57 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 12 16:46:58 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 16 17:34:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.77</version>
+<version>2.0.0-SNAPSHOT.78</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/entity/Migration.java
+++ b/server/src/main/java/io/spine/server/entity/Migration.java
@@ -292,7 +292,8 @@ public abstract class Migration<I,
 
         private void updateState(S newState) {
             if (!entity.state().equals(newState)) {
-                tx.builder().mergeFrom(newState);
+                tx.builder().clear()
+                            .mergeFrom(newState);
                 Version version = increment(entity.version());
                 tx.setVersion(version);
             }

--- a/server/src/test/java/io/spine/server/procman/ProcessManagerRepositoryTest.java
+++ b/server/src/test/java/io/spine/server/procman/ProcessManagerRepositoryTest.java
@@ -721,18 +721,8 @@ class ProcessManagerRepositoryTest
         Iterator<TestProcessManager> foundAfterMigration = repository.find(query);
 
         ImmutableList<TestProcessManager> results = ImmutableList.copyOf(foundAfterMigration);
-        Project expectedState1 = pm1
-                .state()
-                .toBuilder()
-                .setName(NEW_NAME)
-                .setIdString(pm1.getIdString())
-                .build();
-        Project expectedState2 = pm2
-                .state()
-                .toBuilder()
-                .setName(NEW_NAME)
-                .setIdString(pm2.getIdString())
-                .build();
+        Project expectedState1 = expectedState(pm1, NEW_NAME);
+        Project expectedState2 = expectedState(pm2, NEW_NAME);
         assertThat(results).hasSize(2);
         assertThat(results)
                 .comparingElementsUsing(entityState())

--- a/server/src/test/java/io/spine/server/procman/given/repo/RandomFillProcess.java
+++ b/server/src/test/java/io/spine/server/procman/given/repo/RandomFillProcess.java
@@ -29,23 +29,41 @@ package io.spine.server.procman.given.repo;
 import io.spine.server.procman.ProcessManagerMigration;
 import io.spine.test.procman.Project;
 import io.spine.test.procman.ProjectId;
+import io.spine.test.procman.Task;
+import io.spine.test.procman.TaskId;
+
+import static io.spine.base.Identifier.newUuid;
+import static io.spine.test.procman.Project.Status.DONE;
 
 /**
- * Sets the process {@code name} to a predefined {@linkplain #NEW_NAME value}.
+ * Fills the state of the migrated {@code ProcessManager} with some random values.
  */
-public final class SetTestProcessName
+public final class RandomFillProcess
         extends ProcessManagerMigration<ProjectId, TestProcessManager, Project, Project.Builder> {
-
-    public static final String NEW_NAME = "Migrated process";
 
     @Override
     public Project apply(Project project) {
         Project newState = project
                 .toBuilder()
-                .clear()
-                .setId(id())
-                .setName(NEW_NAME)
-                .build();
+                .setId(project.getId())
+                .setName(newUuid())
+                .setStatus(DONE)
+                .addTask(task())
+                .vBuild();
         return newState;
+    }
+
+    private static Task task() {
+        return Task.newBuilder()
+                .setTaskId(taskId())
+                .setTitle(newUuid())
+                .setDescription(newUuid())
+                .vBuild();
+    }
+
+    private static TaskId taskId() {
+        return TaskId.newBuilder()
+                .setId(newUuid().hashCode())
+                .build();
     }
 }

--- a/server/src/test/java/io/spine/server/projection/given/RandomFillProjection.java
+++ b/server/src/test/java/io/spine/server/projection/given/RandomFillProjection.java
@@ -24,28 +24,47 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.server.procman.given.repo;
+package io.spine.server.projection.given;
 
-import io.spine.server.procman.ProcessManagerMigration;
-import io.spine.test.procman.Project;
-import io.spine.test.procman.ProjectId;
+import io.spine.server.projection.ProjectionMigration;
+import io.spine.test.projection.Project;
+import io.spine.test.projection.ProjectId;
+import io.spine.test.projection.Task;
+import io.spine.test.projection.TaskId;
+
+import static io.spine.base.Identifier.newUuid;
+import static io.spine.test.projection.Project.Status.CREATED;
 
 /**
- * Sets the process {@code name} to a predefined {@linkplain #NEW_NAME value}.
+ * Fills each field of the state of `TestProjection` with some random value.
  */
-public final class SetTestProcessName
-        extends ProcessManagerMigration<ProjectId, TestProcessManager, Project, Project.Builder> {
-
-    public static final String NEW_NAME = "Migrated process";
+public final class RandomFillProjection
+        extends ProjectionMigration<ProjectId, TestProjection, Project, Project.Builder> {
 
     @Override
     public Project apply(Project project) {
-        Project newState = project
+        Project result = project
                 .toBuilder()
-                .clear()
-                .setId(id())
-                .setName(NEW_NAME)
+                .setId(project.getId())
+                .setName(newUuid())
+                .setStatus(CREATED)
+                .addTask(task())
                 .vBuild();
-        return newState;
+        return result;
     }
+
+    private static Task task() {
+        return Task.newBuilder()
+                .setTaskId(taskId())
+                .setTitle(newUuid())
+                .setDescription(newUuid())
+                .vBuild();
+    }
+
+    private static TaskId taskId() {
+        return TaskId.newBuilder()
+                .setId(newUuid().hashCode())
+                .build();
+    }
+
 }

--- a/server/src/test/java/io/spine/server/projection/given/RandomFillProjection.java
+++ b/server/src/test/java/io/spine/server/projection/given/RandomFillProjection.java
@@ -66,5 +66,4 @@ public final class RandomFillProjection
                 .setId(newUuid().hashCode())
                 .build();
     }
-
 }

--- a/server/src/test/java/io/spine/server/projection/given/SetTestProjectionName.java
+++ b/server/src/test/java/io/spine/server/projection/given/SetTestProjectionName.java
@@ -42,8 +42,10 @@ public final class SetTestProjectionName
     public Project apply(Project project) {
         Project result = project
                 .toBuilder()
+                .clear()
+                .setId(id())
                 .setName(NEW_NAME)
-                .build();
+                .vBuild();
         return result;
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@ val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.74")
 val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.76")
 
 /** The version of this library. */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.77")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.78")


### PR DESCRIPTION
This changeset addresses #1403, now for 2.x `master` branch. In short, previously during the entity migration the old state was being merged with the new state returned by the `Migration` instance. That led to a number of unwanted side effects and bugs.

Now, the entity `Migration` routines fully replace the old state with the new state, as per its original API design.

([a similar PR](https://github.com/SpineEventEngine/core-java/pull/1405) has been merged into 1.x branch)

The library version has been set to `2.0.0-SNAPSHOT.78`.