### PR TITLE
[2.x] Improve Catch-up by caching `ProjectionRepository` instances

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -502,12 +502,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 16 17:34:34 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 16 20:32:59 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -969,12 +969,12 @@ This report was generated on **Tue Nov 16 17:34:34 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 16 17:34:35 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 16 20:33:00 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1476,12 +1476,12 @@ This report was generated on **Tue Nov 16 17:34:35 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 16 17:34:35 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 16 20:33:00 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -2079,12 +2079,12 @@ This report was generated on **Tue Nov 16 17:34:35 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 16 17:34:36 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 16 20:33:01 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2594,12 +2594,12 @@ This report was generated on **Tue Nov 16 17:34:36 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 16 17:34:37 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 16 20:33:01 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3153,12 +3153,12 @@ This report was generated on **Tue Nov 16 17:34:37 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 16 17:34:37 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 16 20:33:02 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3712,12 +3712,12 @@ This report was generated on **Tue Nov 16 17:34:37 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 16 17:34:38 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 16 20:33:02 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4315,4 +4315,4 @@ This report was generated on **Tue Nov 16 17:34:38 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 16 17:34:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 16 20:33:02 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.78</version>
+<version>2.0.0-SNAPSHOT.79</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/delivery/CatchUpProcess.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpProcess.java
@@ -287,7 +287,6 @@ public final class CatchUpProcess<I>
      */
     private static final Turbulence TURBULENCE = Turbulence.of(fromMillis(500));
 
-    private final ProjectionRepository<I, ?, ?> repository;
     private final DispatchCatchingUp<I> dispatchOperation;
     private final CatchUpStorage storage;
     private final CatchUpStarter.Builder<I> starterTemplate;
@@ -298,11 +297,10 @@ public final class CatchUpProcess<I>
 
     CatchUpProcess(CatchUpProcessBuilder<I> builder) {
         super(TYPE);
-        this.repository = builder.getRepository();
         this.dispatchOperation = builder.getDispatchOp();
         this.storage = builder.getStorage();
         this.queryLimit = limitOf(builder.getPageSize());
-        this.starterTemplate = CatchUpStarter.newBuilder(this.repository, this.storage);
+        this.starterTemplate = CatchUpStarter.newBuilder(builder.getRepository(), this.storage);
     }
 
     @Internal
@@ -607,7 +605,7 @@ public final class CatchUpProcess<I>
         Set<I> ids;
         List<Any> rawTargets = request.getTargetList();
         ids = rawTargets.isEmpty()
-              ? ImmutableSet.copyOf(repository.index())
+              ? ImmutableSet.copyOf(repository().index())
               : unpack(rawTargets);
         return ids;
     }
@@ -733,8 +731,23 @@ public final class CatchUpProcess<I>
 
     private Set<I> unpack(List<Any> packedIds) {
         return packedIds.stream()
-                        .map((any) -> Identifier.unpack(any, repository.idClass()))
+                        .map((any) -> Identifier.unpack(any, repository().idClass()))
                         .collect(toSet());
+    }
+
+    /**
+     * Loads the instance of corresponding {@link ProjectionRepository} from
+     * the {@link CatchUpRepositories} cache.
+     *
+     * <p>Such a mechanism ensures that this process always has both its ID and underlying
+     * repository matching each other.
+     */
+    private ProjectionRepository<I, ?, ?> repository() {
+        CatchUpId id = builder().getId();
+        TypeUrl projectionType = TypeUrl.parse(id.getProjectionType());
+        ProjectionRepository<I, ?, ?> result = CatchUpRepositories.cache()
+                                                                  .get(projectionType);
+        return result;
     }
 
     private EventStreamQuery toEventQuery(CatchUp.Request request,
@@ -762,22 +775,13 @@ public final class CatchUpProcess<I>
     /**
      * {@inheritDoc}
      *
-     * <p>If the passed envelope is a {@link CatchUpSignal}, it is verified that the projection type
-     * URL passed with the event matches the one of the projection repository configured
-     * for this instance.
+     * <p>Ensures that the passed signal is an instance of the supported types.
      */
     @Override
     public boolean canDispatch(EventEnvelope envelope) {
-        EventMessage raw = envelope.message();
-        if (raw instanceof CatchUpSignal) {
-            CatchUpSignal asSignal = (CatchUpSignal) raw;
-            String actualType = asSignal.getId()
-                                        .getProjectionType();
-            String expectedType = repository.entityStateType()
-                                            .value();
-            return expectedType.equals(actualType);
-        }
-        return true;
+        EventMessage message = envelope.message();
+        return message instanceof CatchUpSignal
+                || message instanceof ShardProcessed;
     }
 
     @SuppressWarnings("ChainOfInstanceofChecks")    // Handling two distinct cases.

--- a/server/src/main/java/io/spine/server/delivery/CatchUpProcess.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpProcess.java
@@ -38,6 +38,7 @@ import io.spine.base.Identifier;
 import io.spine.base.Time;
 import io.spine.core.Event;
 import io.spine.core.EventContext;
+import io.spine.core.Versions;
 import io.spine.grpc.MemoizingObserver;
 import io.spine.server.BoundedContext;
 import io.spine.server.ServerEnvironment;
@@ -611,10 +612,9 @@ public final class CatchUpProcess<I>
     }
 
     private Event wrapAsEvent(EventMessage event, EventContext context) {
-        Event firstEvent;
         EventFactory factory = EventFactory.forImport(context.actorContext(), producerId());
-        firstEvent = factory.createEvent(event, null);
-        return firstEvent;
+        Event result = factory.createEvent(event, Versions.zero());
+        return result;
     }
 
     private static List<Event> stripLastTimestamp(List<Event> events) {

--- a/server/src/main/java/io/spine/server/delivery/CatchUpRepositories.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpRepositories.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.delivery;
+
+import io.spine.server.projection.ProjectionRepository;
+import io.spine.type.TypeUrl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.spine.util.Exceptions.newIllegalStateException;
+import static java.util.Collections.synchronizedMap;
+
+/**
+ * A cache of {@link ProjectionRepository Projection repositories} which are used in
+ * the {@link CatchUpProcess}es across all known Bounded Contexts.
+ *
+ * <p>This type is a JVM-wide singleton.
+ */
+final class CatchUpRepositories {
+
+    private static final CatchUpRepositories instance = new CatchUpRepositories();
+
+    private final Map<TypeUrl, ProjectionRepository<?, ?, ?>> repos =
+            synchronizedMap(new HashMap<>());
+
+    private CatchUpRepositories() {
+    }
+
+    /**
+     * Returns the instance of this cache.
+     */
+    static CatchUpRepositories cache() {
+        return instance;
+    }
+
+    /**
+     * Registers the {@code ProjectionRepository} as such to be associated with
+     * the catch-up process that have already started, or may be started in the future.
+     *
+     * @param repository
+     *         a repository to cache
+     */
+    void put(ProjectionRepository<?, ?, ?> repository) {
+        repos.put(repository.entityStateType(), repository);
+    }
+
+    /**
+     * Obtains the previously registered {@code ProjectionRepository} by the type URL of the
+     * projection under-catch-up.
+     *
+     * <p>It is a responsibility of the caller to use a proper type when calling this method.
+     *
+     * <p>In case no repository was previously cached with the provided type URL,
+     * an {@link IllegalStateException} is thrown.
+     *
+     * @param projectionType
+     *         the type of the projection under-catch-up
+     * @param <I>
+     *         the type of the identifiers of projections managed by the repository.
+     * @return the instance of the repository
+     * @throws IllegalStateException
+     *         if no repository is registered for the passed type URL
+     */
+    @SuppressWarnings("unchecked")
+    <I> ProjectionRepository<I, ?, ?> get(TypeUrl projectionType) {
+        if (!repos.containsKey(projectionType)) {
+            throw newIllegalStateException("Cannot find a `ProjectionRepository` " +
+                                                   "for the catch-up process with type URL `%s`.",
+                                           projectionType);
+        }
+        return (ProjectionRepository<I, ?, ?>) repos.get(projectionType);
+    }
+}

--- a/server/src/main/java/io/spine/server/delivery/CatchUpStarter.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpStarter.java
@@ -89,9 +89,6 @@ final class CatchUpStarter<I> {
     /**
      * Starts the catch-up restricting it to the set of projection instances by certain identifiers.
      *
-     * <p>{@linkplain CatchUpRepositories Caches} the {@code ProjectionRepository}
-     * by the ID of the catch-up to improve the performance of the catch-up.
-     *
      * @param ids
      *         the IDs of the projection instances to catch-up, or {@code null} if all entities of
      *         this kind need to catch up.

--- a/server/src/main/java/io/spine/server/delivery/CatchUpStarter.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpStarter.java
@@ -66,9 +66,9 @@ final class CatchUpStarter<I> {
 
     private CatchUpStarter(Builder<I> builder) {
         this.context = builder.context;
-        this.projectionStateType = builder.projectionStateType;
         this.storage = builder.storage;
-        this.eventClasses = builder.eventClasses;
+        this.projectionStateType = builder.repository.entityStateType();
+        this.eventClasses = builder.repository.messageClasses();
     }
 
     /**
@@ -83,11 +83,14 @@ final class CatchUpStarter<I> {
      * @return the new instance of the builder
      */
     static <I> Builder<I> newBuilder(ProjectionRepository<I, ?, ?> repo, CatchUpStorage storage) {
-        return new Builder<>(repo.entityStateType(), repo.messageClasses(), storage);
+        return new Builder<>(repo, storage);
     }
 
     /**
      * Starts the catch-up restricting it to the set of projection instances by certain identifiers.
+     *
+     * <p>{@linkplain CatchUpRepositories Caches} the {@code ProjectionRepository}
+     * by the ID of the catch-up to improve the performance of the catch-up.
      *
      * @param ids
      *         the IDs of the projection instances to catch-up, or {@code null} if all entities of
@@ -183,18 +186,15 @@ final class CatchUpStarter<I> {
      */
     static final class Builder<I> {
 
-        private final TypeUrl projectionStateType;
+        private final ProjectionRepository<I, ?, ?> repository;
         private final CatchUpStorage storage;
-        private final ImmutableSet<EventClass> eventClasses;
 
         private BoundedContext context;
 
-        private Builder(TypeUrl stateType,
-                        ImmutableSet<EventClass> consumedEvents,
+        private Builder(ProjectionRepository<I, ?, ?> repository,
                         CatchUpStorage storage) {
-            this.projectionStateType = stateType;
+            this.repository = repository;
             this.storage = storage;
-            this.eventClasses = consumedEvents;
         }
 
         /**

--- a/server/src/main/java/io/spine/server/delivery/Delivery.java
+++ b/server/src/main/java/io/spine/server/delivery/Delivery.java
@@ -614,6 +614,7 @@ public final class Delivery implements Logging {
      */
     public <I> CatchUpProcessBuilder<I> newCatchUpProcess(ProjectionRepository<I, ?, ?> repo) {
         CatchUpProcessBuilder<I> builder = CatchUpProcess.newBuilder(repo);
+        CatchUpRepositories.cache().put(repo);
         return builder.setStorage(catchUpStorage)
                       .setPageSize(catchUpPageSize);
     }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@ val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.74")
 val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.76")
 
 /** The version of this library. */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.78")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.79")


### PR DESCRIPTION
This changeset is a port of #1406 to 2.x branch.

Previously, `CatchUpProcess` used a direct reference to the `ProjectionRepository` to dispatch the domain events to the `Projection` instances. However, as the catch-up itself could be distributed over different server nodes, the reference to the repository sometimes led to the repository mismatch.

This changeset addresses introduces caching of `ProjectionRepository` instances by the type URL of the `Projection` instances.

The library version is bumped to `2.0.0-SNAPSHOT.79`.