### PR TITLE
[1.x] Lazy `ServerEnvironment.when(..).use(..)`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.7.7-SNAPSHOT.5`
+# Dependencies of `io.spine:spine-client:1.7.7-SNAPSHOT.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -399,12 +399,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 26 17:41:59 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 18 13:57:38 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.7.7-SNAPSHOT.5`
+# Dependencies of `io.spine:spine-core:1.7.7-SNAPSHOT.6`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -763,12 +763,12 @@ This report was generated on **Tue Oct 26 17:41:59 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 26 17:42:00 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 18 13:57:38 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.7.7-SNAPSHOT.5`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.7.7-SNAPSHOT.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1162,12 +1162,12 @@ This report was generated on **Tue Oct 26 17:42:00 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 26 17:42:00 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 18 13:57:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.7.7-SNAPSHOT.5`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.7.7-SNAPSHOT.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1627,12 +1627,12 @@ This report was generated on **Tue Oct 26 17:42:00 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 26 17:42:00 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 18 13:57:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.7.7-SNAPSHOT.5`
+# Dependencies of `io.spine:spine-server:1.7.7-SNAPSHOT.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2039,12 +2039,12 @@ This report was generated on **Tue Oct 26 17:42:00 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 26 17:42:01 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 18 13:57:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.7.7-SNAPSHOT.5`
+# Dependencies of `io.spine:spine-testutil-client:1.7.7-SNAPSHOT.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2493,12 +2493,12 @@ This report was generated on **Tue Oct 26 17:42:01 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 26 17:42:02 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 18 13:57:41 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.7.7-SNAPSHOT.5`
+# Dependencies of `io.spine:spine-testutil-core:1.7.7-SNAPSHOT.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2947,12 +2947,12 @@ This report was generated on **Tue Oct 26 17:42:02 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 26 17:42:03 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 18 13:57:42 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.7.7-SNAPSHOT.5`
+# Dependencies of `io.spine:spine-testutil-server:1.7.7-SNAPSHOT.6`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3445,4 +3445,4 @@ This report was generated on **Tue Oct 26 17:42:03 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Oct 26 17:42:05 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 18 13:57:44 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.7.7-SNAPSHOT.5</version>
+<version>1.7.7-SNAPSHOT.6</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/EnvSetting.java
+++ b/server/src/main/java/io/spine/server/EnvSetting.java
@@ -28,6 +28,7 @@ package io.spine.server;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.spine.base.EnvironmentType;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -93,7 +94,7 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  */
 final class EnvSetting<V> {
 
-    private final Map<Class<? extends EnvironmentType>, V> environmentValues =
+    private final Map<Class<? extends EnvironmentType>, Value<V>> environmentValues =
             new HashMap<>();
 
     private final Map<Class<? extends EnvironmentType>, Supplier<V>> fallbacks =
@@ -152,8 +153,11 @@ final class EnvSetting<V> {
      *        unnecessary value instantiation.
      */
     void apply(SettingOperation<V> operation) throws Exception {
-        for (V v : environmentValues.values()) {
-            operation.accept(v);
+        for (Value<V> v : environmentValues.values()) {
+            if(v.isResolved()) {
+                V value = v.get();
+                operation.accept(value);
+            }
         }
     }
 
@@ -193,13 +197,31 @@ final class EnvSetting<V> {
     void use(V value, Class<? extends EnvironmentType> type) {
         checkNotNull(value);
         checkNotNull(type);
-        this.environmentValues.put(type, value);
+        this.environmentValues.put(type, new Value<>(value));
+    }
+
+    /**
+     * Sets the value lazily provided via the passed {@code Supplier}
+     * for the specified environment type.
+     *
+     * <p>The supplier will not be invoked unless someone requests the value under the specified
+     * environment.
+     *
+     * @param value
+     *         supplier of the value to assign to one of environments
+     * @param type
+     *         the type of the environment
+     */
+    void lazyUse(Supplier<V> value, Class<? extends EnvironmentType> type) {
+        checkNotNull(value);
+        checkNotNull(type);
+        this.environmentValues.put(type, new Value<>(value));
     }
 
     private Optional<V> valueFor(Class<? extends EnvironmentType> type) {
         checkNotNull(type);
-        V result = this.environmentValues.get(type);
-        if (result == null) {
+        Value<V> value = this.environmentValues.get(type);
+        if (value == null) {
             Supplier<V> resultSupplier = this.fallbacks.get(type);
             if (resultSupplier == null) {
                 return Optional.empty();
@@ -209,6 +231,7 @@ final class EnvSetting<V> {
             this.use(newValue, type);
             return Optional.of(newValue);
         }
+        V result = value.get();
         return Optional.of(result);
     }
 
@@ -222,5 +245,52 @@ final class EnvSetting<V> {
 
         /** Performs this operation on the specified value. */
         void accept(V value) throws Exception;
+    }
+
+    /**
+     * The value configured for the setting.
+     *
+     * <p>Supports lazy initialization via the {@code Supplier}. In this case, once the value
+     * is {@linkplain #get() requested}, the supplier is invoked. The returned value is remembered
+     * for all future requests.
+     *
+     * @param <V>
+     *         type of the value
+     */
+    private static class Value<V> {
+
+        private final Supplier<V> supplier;
+        private @MonotonicNonNull V value;
+
+        /**
+         * Creates a value with the lazily resolving supplier.
+         *
+         * <p>The supplier is only invoked upon {@linkplain #get() request}.
+         */
+        private Value(Supplier<V> supplier) {
+            this.supplier = supplier;
+        }
+
+        /**
+         * Creates a new instance with the actual value already resolved.
+         */
+        private Value(V resolved) {
+            this.supplier = () -> resolved;
+            this.value = resolved;
+        }
+
+        /**
+         * Tells whether this instance already has the value provided by the supplier.
+         */
+        private synchronized boolean isResolved() {
+            return value != null;
+        }
+
+        private synchronized V get() {
+            if (value == null) {
+                value = supplier.get();
+            }
+            return value;
+        }
     }
 }

--- a/server/src/main/java/io/spine/server/EnvSetting.java
+++ b/server/src/main/java/io/spine/server/EnvSetting.java
@@ -204,8 +204,8 @@ final class EnvSetting<V> {
      * Sets the value lazily provided via the passed {@code Supplier}
      * for the specified environment type.
      *
-     * <p>The supplier will not be invoked unless someone requests the value under the specified
-     * environment.
+     * <p>The supplier will not be invoked unless someone requests the value under
+     * the matching environment.
      *
      * @param value
      *         supplier of the value to assign to one of environments

--- a/server/src/main/java/io/spine/server/ServerEnvironment.java
+++ b/server/src/main/java/io/spine/server/ServerEnvironment.java
@@ -471,7 +471,11 @@ public final class ServerEnvironment implements AutoCloseable {
         @CanIgnoreReturnValue
         public TypeConfigurator useStorageFactory(Fn<StorageFactory> fn) {
             checkNotNull(fn);
-            se.storageFactory.lazyUse(() -> fn.apply(type), type);
+            se.storageFactory.lazyUse(() -> {
+                StorageFactory factory = fn.apply(type);
+                SystemAwareStorageFactory wrapped = wrap(factory);
+                return wrapped;
+            }, type);
             return this;
         }
     }

--- a/server/src/main/java/io/spine/server/ServerEnvironment.java
+++ b/server/src/main/java/io/spine/server/ServerEnvironment.java
@@ -370,6 +370,9 @@ public final class ServerEnvironment implements AutoCloseable {
         /**
          * Assigns a {@code Delivery} obtained from the passed function.
          *
+         * <p>In case the {@code Delivery} is never requested for the current server
+         * environment type, the passed function will be not invoked.
+         *
          * @param fn
          *         the function to provide the {@code Delivery} in response to
          *         the currently configured server environment type
@@ -378,8 +381,8 @@ public final class ServerEnvironment implements AutoCloseable {
         @CanIgnoreReturnValue
         public TypeConfigurator useDelivery(Fn<Delivery> fn) {
             checkNotNull(fn);
-            Delivery delivery = fn.apply(type);
-            return use(delivery);
+            se.delivery.lazyUse(() -> fn.apply(type), type);
+            return this;
         }
 
         /**
@@ -395,7 +398,10 @@ public final class ServerEnvironment implements AutoCloseable {
         }
 
         /**
-         * Assigns a {@code TracerFactory} obtained from the passed function.
+         * Lazily uses the {@code TracerFactory} obtained from the passed function.
+         *
+         * <p>In case the {@code TracerFactory} is never requested for the current server
+         * environment type, the passed function will be not invoked.
          *
          * @param fn
          *         the function to provide the {@code TracerFactory} in response to
@@ -405,8 +411,8 @@ public final class ServerEnvironment implements AutoCloseable {
         @CanIgnoreReturnValue
         public TypeConfigurator useTracerFactory(Fn<TracerFactory> fn) {
             checkNotNull(fn);
-            TracerFactory factory = fn.apply(type);
-            return use(factory);
+            se.tracerFactory.lazyUse(() -> fn.apply(type), type);
+            return this;
         }
 
         /**
@@ -424,6 +430,9 @@ public final class ServerEnvironment implements AutoCloseable {
         /**
          * Assigns a {@code TransportFactory} obtained from the passed function.
          *
+         * <p>In case the {@code TransportFactory} is never requested for the current server
+         * environment type, the passed function will be not invoked.
+         *
          * @param fn
          *         the function to provide the {@code TransportFactory} in response to
          *         the currently configured server environment type
@@ -432,8 +441,8 @@ public final class ServerEnvironment implements AutoCloseable {
         @CanIgnoreReturnValue
         public TypeConfigurator useTransportFactory(Fn<TransportFactory> fn) {
             checkNotNull(fn);
-            TransportFactory factory = fn.apply(type);
-            return use(factory);
+            se.transportFactory.lazyUse(() -> fn.apply(type), type);
+            return this;
         }
 
         /**
@@ -451,6 +460,9 @@ public final class ServerEnvironment implements AutoCloseable {
         /**
          * Assigns a {@code StorageFactory} obtained from the passed function.
          *
+         * <p>In case the {@code StorageFactory} is never requested for the current server
+         * environment type, the passed function will be not invoked.
+         *
          * @param fn
          *         the function to provide the {@code StorageFactory} in response to
          *         the currently configured server environment type
@@ -459,8 +471,8 @@ public final class ServerEnvironment implements AutoCloseable {
         @CanIgnoreReturnValue
         public TypeConfigurator useStorageFactory(Fn<StorageFactory> fn) {
             checkNotNull(fn);
-            StorageFactory factory = fn.apply(type);
-            return use(factory);
+            se.storageFactory.lazyUse(() -> fn.apply(type), type);
+            return this;
         }
     }
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,7 +34,7 @@
 /**
  * Version of this library.
  */
-val coreJava = "1.7.7-SNAPSHOT.5"
+val coreJava = "1.7.7-SNAPSHOT.6"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.


### PR DESCRIPTION
Previously, `ServerEnvironment` provided two kinds of API calls for the conditional settings:

```java
    ServerEnvironment.when(Staging.class)
                     // This call is handy when `myStorageFactory` is already available.
                     .use(myStorageFactory)

    ServerEnvironment.when(PreProduction.class)
                     // And this one looks lazy, so that it is only executed when and _if_ requested.
                     .use((env) -> createMySqlStorage())
```

The "lazy" option looks as one allowing to postpone the initialization until it is requested. I.e., the `createMySqlStorage()` would only make sense if run in the pre-production environment, so the call may fail if executed when running, say, local tests.

However, in fact, there was no "lazy" behavior, which caused numerous workarounds to actually _postpone_ the initialization of environment-specific settings until they start to make sense.

This changeset addresses the issue by making the behavior truly "lazy".

Closes #1414.

The library version is set to `1.7.7-SNAPSHOT.6`.
