### PR TITLE
[1.x] Make `IntegrationBroker` safer. Adjust `SubscriptionService` for standalone event producers.

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.7.7-SNAPSHOT.6`
+# Dependencies of `io.spine:spine-client:1.7.7-SNAPSHOT.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -399,12 +399,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Nov 18 13:57:38 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 22 15:05:52 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.7.7-SNAPSHOT.6`
+# Dependencies of `io.spine:spine-core:1.7.7-SNAPSHOT.7`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -763,12 +763,12 @@ This report was generated on **Thu Nov 18 13:57:38 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Nov 18 13:57:38 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 22 15:05:52 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.7.7-SNAPSHOT.6`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.7.7-SNAPSHOT.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1162,12 +1162,12 @@ This report was generated on **Thu Nov 18 13:57:38 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Nov 18 13:57:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 22 15:05:52 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.7.7-SNAPSHOT.6`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.7.7-SNAPSHOT.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1627,12 +1627,12 @@ This report was generated on **Thu Nov 18 13:57:39 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Nov 18 13:57:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 22 15:05:53 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.7.7-SNAPSHOT.6`
+# Dependencies of `io.spine:spine-server:1.7.7-SNAPSHOT.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2039,12 +2039,12 @@ This report was generated on **Thu Nov 18 13:57:39 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Nov 18 13:57:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 22 15:05:53 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.7.7-SNAPSHOT.6`
+# Dependencies of `io.spine:spine-testutil-client:1.7.7-SNAPSHOT.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2493,12 +2493,12 @@ This report was generated on **Thu Nov 18 13:57:39 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Nov 18 13:57:41 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 22 15:05:55 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.7.7-SNAPSHOT.6`
+# Dependencies of `io.spine:spine-testutil-core:1.7.7-SNAPSHOT.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2947,12 +2947,12 @@ This report was generated on **Thu Nov 18 13:57:41 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Nov 18 13:57:42 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 22 15:05:56 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.7.7-SNAPSHOT.6`
+# Dependencies of `io.spine:spine-testutil-server:1.7.7-SNAPSHOT.7`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3445,4 +3445,4 @@ This report was generated on **Thu Nov 18 13:57:42 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Nov 18 13:57:44 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 22 15:05:58 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.7.7-SNAPSHOT.6</version>
+<version>1.7.7-SNAPSHOT.7</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/EventProducer.java
+++ b/server/src/main/java/io/spine/server/EventProducer.java
@@ -26,9 +26,11 @@
 
 package io.spine.server;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Any;
 import io.spine.core.Version;
 import io.spine.server.model.Nothing;
+import io.spine.server.type.EventClass;
 
 /**
  * An object with identity which produces events.
@@ -60,4 +62,9 @@ public interface EventProducer {
     default Nothing nothing() {
         return Nothing.getDefaultInstance();
     }
+
+    /**
+     * Obtains classes of the events produced by this object.
+     */
+    ImmutableSet<EventClass> producedEvents();
 }

--- a/server/src/main/java/io/spine/server/SubscriptionService.java
+++ b/server/src/main/java/io/spine/server/SubscriptionService.java
@@ -25,6 +25,7 @@
  */
 package io.spine.server;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -170,7 +171,16 @@ public final class SubscriptionService
         return result;
     }
 
-    private Optional<BoundedContext> findContextOf(Target target) {
+    /**
+     * Searches for the Bounded Context which provides the messages of the target type.
+     *
+     * @param target
+     *         the type which may be available through this subscription service
+     * @return the context which exposes the target type,
+     *         or {@code Optional.empty} if no known context does so
+     */
+    @VisibleForTesting  /* Otherwise should have been `private`. */
+    Optional<BoundedContext> findContextOf(Target target) {
         TypeUrl type = target.type();
         BoundedContext selected = typeToContextMap.get(type);
         Optional<BoundedContext> result = Optional.ofNullable(selected);

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -27,6 +27,7 @@ package io.spine.server.aggregate;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Any;
 import com.google.protobuf.Empty;
 import io.spine.annotation.Internal;
@@ -47,6 +48,7 @@ import io.spine.server.entity.RecentHistory;
 import io.spine.server.event.EventReactor;
 import io.spine.server.event.model.EventReactorMethod;
 import io.spine.server.type.CommandEnvelope;
+import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
 
 import java.util.Iterator;
@@ -295,6 +297,12 @@ public abstract class Aggregate<I,
         return EventPlayer
                 .forTransactionOf(this)
                 .play(events);
+    }
+
+    @Override
+    @Internal
+    public ImmutableSet<EventClass> producedEvents() {
+        return modelClass().outgoingEvents();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/command/AbstractCommandHandler.java
+++ b/server/src/main/java/io/spine/server/command/AbstractCommandHandler.java
@@ -28,6 +28,7 @@ package io.spine.server.command;
 
 import com.google.common.collect.ImmutableSet;
 import io.spine.core.Version;
+import io.spine.server.BoundedContext;
 import io.spine.server.command.model.CommandHandlerClass;
 import io.spine.server.command.model.CommandHandlerMethod;
 import io.spine.server.commandbus.CommandDispatcher;
@@ -35,6 +36,7 @@ import io.spine.server.dispatch.DispatchOutcomeHandler;
 import io.spine.server.event.EventBus;
 import io.spine.server.type.CommandClass;
 import io.spine.server.type.CommandEnvelope;
+import io.spine.server.type.EventClass;
 
 import static io.spine.server.command.model.CommandHandlerClass.asCommandHandlerClass;
 
@@ -88,6 +90,17 @@ public abstract class AbstractCommandHandler
                 .onError(error -> onError(envelope, error))
                 .onRejection(rejection -> onRejection(envelope, rejection))
                 .handle();
+    }
+
+    @Override
+    public void registerWith(BoundedContext context) {
+        super.registerWith(context);
+        context.stand().registerTypeSupplier(this);
+    }
+
+    @Override
+    public ImmutableSet<EventClass> producedEvents() {
+        return thisClass.commandOutput();
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/command/AbstractCommander.java
+++ b/server/src/main/java/io/spine/server/command/AbstractCommander.java
@@ -124,6 +124,16 @@ public abstract class AbstractCommander
         return Versions.zero();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Always returns an empty set.
+     */
+    @Override
+    public ImmutableSet<EventClass> producedEvents() {
+        return ImmutableSet.of();
+    }
+
     private void postCommands(List<Command> commands) {
         commandBus().post(commands, noOpObserver());
     }

--- a/server/src/main/java/io/spine/server/event/AbstractEventReactor.java
+++ b/server/src/main/java/io/spine/server/event/AbstractEventReactor.java
@@ -85,6 +85,7 @@ public abstract class AbstractEventReactor
         checkNotRegistered();
         eventBus = context.eventBus();
         system = context.systemClient().writeSide();
+        context.stand().registerTypeSupplier(this);
     }
 
     @Override
@@ -146,5 +147,10 @@ public abstract class AbstractEventReactor
     @Override
     public ImmutableSet<EventClass> domesticEventClasses() {
         return thisClass.domesticEvents();
+    }
+
+    @Override
+    public ImmutableSet<EventClass> producedEvents() {
+        return thisClass.reactionOutput();
     }
 }

--- a/server/src/main/java/io/spine/server/integration/ExternalNeedsObserver.java
+++ b/server/src/main/java/io/spine/server/integration/ExternalNeedsObserver.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import static com.google.common.collect.Multimaps.synchronizedSetMultimap;
 import static io.spine.protobuf.AnyPacker.unpack;
 
 /**
@@ -55,9 +56,12 @@ final class ExternalNeedsObserver
      * Current set of message type URLs, requested by other parties via sending the
      * {@linkplain RequestForExternalMessages configuration messages}, mapped to IDs of their origin
      * bounded contexts.
+     *
+     * <p>This instance is potentially accessed from different threads,
+     * therefore it's made concurrency-friendly.
      */
     private final Multimap<ExternalMessageType, BoundedContextName> requestedTypes =
-            HashMultimap.create();
+            synchronizedSetMultimap(HashMultimap.create());
 
     ExternalNeedsObserver(BoundedContextName context, BusAdapter bus) {
         super(context, RequestForExternalMessages.class);

--- a/server/src/main/java/io/spine/server/procman/ProcessManager.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManager.java
@@ -27,6 +27,7 @@
 package io.spine.server.procman;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import io.spine.annotation.Internal;
 import io.spine.base.EntityState;
 import io.spine.protobuf.ValidatingBuilder;
@@ -110,6 +111,11 @@ public abstract class ProcessManager<I,
     @Override
     protected ProcessManagerClass<?> thisClass() {
         return (ProcessManagerClass<?>) super.thisClass();
+    }
+
+    @Override
+    public ImmutableSet<EventClass> producedEvents() {
+        return thisClass().outgoingEvents();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/stand/EventRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/EventRegistry.java
@@ -45,7 +45,7 @@ interface EventRegistry extends AutoCloseable {
     /**
      * Registers the event producer in this registry.
      */
-    void register(EventProducer handler);
+    void register(EventProducer producer);
 
     /**
      * Retrieves all event {@linkplain TypeUrl types} stored in the registry.

--- a/server/src/main/java/io/spine/server/stand/EventRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/EventRegistry.java
@@ -27,6 +27,7 @@
 package io.spine.server.stand;
 
 import com.google.common.collect.ImmutableSet;
+import io.spine.server.EventProducer;
 import io.spine.server.entity.Repository;
 import io.spine.server.type.EventClass;
 import io.spine.type.TypeUrl;
@@ -40,6 +41,11 @@ interface EventRegistry extends AutoCloseable {
      * Registers the repository as an event producer in this registry.
      */
     void register(Repository<?, ?> repository);
+
+    /**
+     * Registers the event producer in this registry.
+     */
+    void register(EventProducer handler);
 
     /**
      * Retrieves all event {@linkplain TypeUrl types} stored in the registry.

--- a/server/src/main/java/io/spine/server/stand/InMemoryEventRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/InMemoryEventRegistry.java
@@ -27,6 +27,7 @@
 package io.spine.server.stand;
 
 import com.google.common.collect.ImmutableSet;
+import io.spine.server.EventProducer;
 import io.spine.server.entity.EventProducingRepository;
 import io.spine.server.entity.Repository;
 import io.spine.server.type.EventClass;
@@ -57,6 +58,12 @@ final class InMemoryEventRegistry implements EventRegistry {
             repo.outgoingEvents()
                 .forEach(this::putIntoMap);
         }
+    }
+
+    @Override
+    public void register(EventProducer handler) {
+        handler.producedEvents()
+               .forEach(this::putIntoMap);
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/stand/InMemoryEventRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/InMemoryEventRegistry.java
@@ -61,9 +61,9 @@ final class InMemoryEventRegistry implements EventRegistry {
     }
 
     @Override
-    public void register(EventProducer handler) {
-        handler.producedEvents()
-               .forEach(this::putIntoMap);
+    public void register(EventProducer producer) {
+        producer.producedEvents()
+                .forEach(this::putIntoMap);
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/stand/Stand.java
+++ b/server/src/main/java/io/spine/server/stand/Stand.java
@@ -43,6 +43,7 @@ import io.spine.core.Response;
 import io.spine.core.Responses;
 import io.spine.core.TenantId;
 import io.spine.protobuf.AnyPacker;
+import io.spine.server.EventProducer;
 import io.spine.server.Identity;
 import io.spine.server.bus.Listener;
 import io.spine.server.entity.Entity;
@@ -377,6 +378,13 @@ public class Stand implements AutoCloseable {
     }
 
     /**
+     * Registers the passed {@code EventProducer} as the event type supplier.
+     */
+    public void registerTypeSupplier(EventProducer producer) {
+        eventRegistry.register(producer);
+    }
+
+    /**
      * Closes the {@code Stand} performing necessary cleanups.
      */
     @Override
@@ -504,9 +512,7 @@ public class Stand implements AutoCloseable {
         @Internal
         public Stand build() {
             checkState(systemReadSide != null, "SystemWriteSide is not set.");
-            boolean multitenant = this.multitenant == null
-                                  ? false
-                                  : this.multitenant;
+            boolean multitenant = this.multitenant != null && this.multitenant;
             if (subscriptionRegistry == null) {
                 subscriptionRegistry = MultitenantSubscriptionRegistry.newInstance(multitenant);
             }

--- a/server/src/test/java/io/spine/server/Given.java
+++ b/server/src/test/java/io/spine/server/Given.java
@@ -43,6 +43,7 @@ import io.spine.people.PersonName;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.AggregateRepository;
 import io.spine.server.aggregate.Apply;
+import io.spine.server.command.AbstractCommandHandler;
 import io.spine.server.command.Assign;
 import io.spine.server.entity.EntityRecord;
 import io.spine.server.event.AbstractEventReactor;
@@ -65,6 +66,9 @@ import io.spine.test.commandservice.customer.CustomerId;
 import io.spine.test.commandservice.customer.command.CreateCustomer;
 import io.spine.test.commandservice.customer.event.CustomerCreated;
 import io.spine.test.storage.Task;
+import io.spine.test.subscriptionservice.ReportId;
+import io.spine.test.subscriptionservice.command.SendReport;
+import io.spine.test.subscriptionservice.event.ReportSent;
 import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.testing.core.given.GivenUserId;
 import io.spine.time.LocalDate;
@@ -112,9 +116,17 @@ public class Given {
         }
 
         public static AggCreateProject createProject(ProjectId id) {
-            return AggCreateProject.newBuilder()
-                                   .setProjectId(id)
-                                   .build();
+            return AggCreateProject
+                    .newBuilder()
+                    .setProjectId(id)
+                    .build();
+        }
+
+        public static SendReport sendReport() {
+            return SendReport
+                    .newBuilder()
+                    .setId(ReportId.generate())
+                    .vBuild();
         }
     }
 
@@ -269,13 +281,24 @@ public class Given {
         }
     }
 
-    public static class AggProjectCreatedReactor extends AbstractEventReactor {
+    static class AggProjectCreatedReactor extends AbstractEventReactor {
 
         @React
         AggOwnerNotified on(AggProjectCreated event, EventContext context) {
             return AggOwnerNotified
                     .newBuilder()
                     .setOwner(context.actor())
+                    .vBuild();
+        }
+    }
+
+    static class ReportSender extends AbstractCommandHandler {
+
+        @Assign
+        ReportSent on(SendReport command) {
+            return ReportSent
+                    .newBuilder()
+                    .setId(command.getId())
                     .vBuild();
         }
     }

--- a/server/src/test/java/io/spine/server/SubscriptionServiceTest.java
+++ b/server/src/test/java/io/spine/server/SubscriptionServiceTest.java
@@ -122,7 +122,7 @@ class SubscriptionServiceTest {
 
     private static BoundedContext randomCtx() {
         return BoundedContext.singleTenant(Identifier.newUuid())
-                                    .build();
+                             .build();
     }
 
     @AfterEach

--- a/server/src/test/java/io/spine/server/SubscriptionServiceTest.java
+++ b/server/src/test/java/io/spine/server/SubscriptionServiceTest.java
@@ -31,6 +31,7 @@ import com.google.common.truth.extensions.proto.ProtoTruth;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Message;
 import io.spine.base.EntityState;
+import io.spine.base.Identifier;
 import io.spine.client.EntityStateUpdate;
 import io.spine.client.EntityUpdates;
 import io.spine.client.EventUpdates;
@@ -47,13 +48,16 @@ import io.spine.grpc.MemoizingObserver;
 import io.spine.grpc.StreamObservers;
 import io.spine.server.Given.AggProjectCreatedReactor;
 import io.spine.server.Given.ProjectAggregateRepository;
+import io.spine.server.Given.ReportSender;
 import io.spine.server.stand.InvalidSubscriptionException;
 import io.spine.test.aggregate.Project;
 import io.spine.test.aggregate.ProjectId;
 import io.spine.test.aggregate.command.AggCreateProject;
 import io.spine.test.aggregate.event.AggOwnerNotified;
 import io.spine.test.aggregate.event.AggProjectCreated;
+import io.spine.test.aggregate.event.AggTaskAdded;
 import io.spine.test.commandservice.customer.Customer;
+import io.spine.test.subscriptionservice.event.ReportSent;
 import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.testing.logging.LoggingTest;
 import io.spine.testing.logging.MuteLogging;
@@ -65,18 +69,21 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.logging.Level;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.grpc.StreamObservers.noOpObserver;
 import static io.spine.protobuf.AnyPacker.unpack;
 import static io.spine.server.Given.CommandMessage.createProject;
+import static io.spine.server.Given.CommandMessage.sendReport;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("SubscriptionService should")
+@DisplayName("`SubscriptionService` should")
 class SubscriptionServiceTest {
 
     private final TestActorRequestFactory requestFactory =
@@ -100,14 +107,22 @@ class SubscriptionServiceTest {
                 .assumingTests()
                 .add(new ProjectAggregateRepository())
                 .addEventDispatcher(new AggProjectCreatedReactor())
+                .addCommandDispatcher(new ReportSender())
                 .build();
         subscriptionService = SubscriptionService
                 .newBuilder()
                 .add(context)
+                .add(randomCtx())
+                .add(randomCtx())
                 .build();
         observer = new MemoizingObserver<>();
         activationObserver = new MemoizingObserver<>();
         cancellationObserver = new MemoizingObserver<>();
+    }
+
+    private static BoundedContext randomCtx() {
+        return BoundedContext.singleTenant(Identifier.newUuid())
+                                    .build();
     }
 
     @AfterEach
@@ -245,9 +260,9 @@ class SubscriptionServiceTest {
             checkSubscribesTo(AggProjectCreated.class);
         }
 
-        @MuteLogging
         @Test
         @DisplayName("events from abstract reactors")
+        @MuteLogging
         void eventsFromReactors() {
             Subscription subscription = checkSubscribesTo(AggOwnerNotified.class);
             MemoizingObserver<SubscriptionUpdate> observer = StreamObservers.memoizingObserver();
@@ -269,6 +284,26 @@ class SubscriptionServiceTest {
                     .isInstanceOf(AggOwnerNotified.class);
         }
 
+        @Test
+        @DisplayName("events from standalone command handlers")
+        @MuteLogging
+        void eventsFromCommandHandlers() {
+            Subscription subscription = checkSubscribesTo(ReportSent.class);
+            MemoizingObserver<SubscriptionUpdate> observer = StreamObservers.memoizingObserver();
+            subscriptionService.activate(subscription, observer);
+            Command command = new TestActorRequestFactory(SubscriptionServiceTest.class)
+                    .createCommand(sendReport());
+            context.commandBus()
+                   .post(command, noOpObserver());
+            EventUpdates events = observer.firstResponse()
+                                          .getEventUpdates();
+            assertThat(events.getEventList())
+                    .hasSize(1);
+            Event event = events.getEvent(0);
+            assertThat(event.enclosedMessage())
+                    .isInstanceOf(ReportSent.class);
+        }
+
         @CanIgnoreReturnValue
         private Subscription checkSubscribesTo(Class<? extends Message> aClass) {
             Target target = Targets.allOf(aClass);
@@ -288,6 +323,42 @@ class SubscriptionServiceTest {
             assertThat(observer.isCompleted())
                     .isTrue();
             return response;
+        }
+    }
+
+    @Nested
+    @DisplayName("select proper `BoundedContext` by the type of the requested ")
+    class PickContextBy {
+
+        @Test
+        @DisplayName("events emitted by one of Context entities")
+        void eventsFromEntity() {
+            assertTargetFound(AggTaskAdded.class);
+        }
+
+        @Test
+        @DisplayName("events emitted by a standalone event reactor")
+        void eventsFromEventReactor() {
+            assertTargetFound(AggOwnerNotified.class);
+        }
+
+        @Test
+        @DisplayName("events emitted by a standalone command handler")
+        void eventsFromCommandHandler() {
+            assertTargetFound(ReportSent.class);
+        }
+
+        @Test
+        @DisplayName("state of entities that belong to Context")
+        void entityType() {
+            assertTargetFound(Project.class);
+        }
+
+        private void assertTargetFound(Class<? extends Message> targetType) {
+            Target target = Targets.allOf(targetType);
+            Optional<BoundedContext> result = subscriptionService.findContextOf(target);
+            assertThat(result).isPresent();
+            assertThat(result.get().name()).isEqualTo(context.name());
         }
     }
 

--- a/server/src/test/java/io/spine/server/command/given/CommandHandlingEntityTestEnv.java
+++ b/server/src/test/java/io/spine/server/command/given/CommandHandlingEntityTestEnv.java
@@ -26,11 +26,13 @@
 
 package io.spine.server.command.given;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.StringValue;
 import io.spine.server.command.CommandHandlingEntity;
 import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.test.shared.EmptyEntity;
 import io.spine.server.type.CommandEnvelope;
+import io.spine.server.type.EventClass;
 
 import static io.spine.testing.TestValues.newUuidValue;
 
@@ -63,6 +65,11 @@ public class CommandHandlingEntityTestEnv {
         @Override
         protected DispatchOutcome dispatchCommand(CommandEnvelope cmd) {
             return DispatchOutcome.getDefaultInstance();
+        }
+
+        @Override
+        public ImmutableSet<EventClass> producedEvents() {
+            return ImmutableSet.of();
         }
     }
 }

--- a/server/src/test/java/io/spine/server/entity/RecordBasedRepositoryTest.java
+++ b/server/src/test/java/io/spine/server/entity/RecordBasedRepositoryTest.java
@@ -135,6 +135,7 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
     @AfterEach
     protected void tearDown() throws Exception {
         clearCurrentTenant();
+        ModelTests.dropAllModels();
     }
 
     /*

--- a/server/src/test/java/io/spine/server/event/model/given/classes/ConferenceSetup.java
+++ b/server/src/test/java/io/spine/server/event/model/given/classes/ConferenceSetup.java
@@ -26,6 +26,7 @@
 
 package io.spine.server.event.model.given.classes;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Any;
 import io.spine.base.Identifier;
 import io.spine.core.EventContext;
@@ -34,6 +35,7 @@ import io.spine.core.Version;
 import io.spine.core.Versions;
 import io.spine.server.event.EventReactor;
 import io.spine.server.event.React;
+import io.spine.server.type.EventClass;
 import io.spine.test.event.model.ConferenceAnnounced;
 import io.spine.test.event.model.SpeakerJoined;
 import io.spine.test.event.model.SpeakersInvited;
@@ -87,5 +89,10 @@ public class ConferenceSetup implements EventReactor {
     @Override
     public Version version() {
         return Versions.zero();
+    }
+
+    @Override
+    public ImmutableSet<EventClass> producedEvents() {
+        return ImmutableSet.of();
     }
 }

--- a/server/src/test/java/io/spine/server/event/model/given/reactor/TestEventReactor.java
+++ b/server/src/test/java/io/spine/server/event/model/given/reactor/TestEventReactor.java
@@ -26,10 +26,12 @@
 
 package io.spine.server.event.model.given.reactor;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Any;
 import io.spine.base.Identifier;
 import io.spine.core.Version;
 import io.spine.server.event.EventReactor;
+import io.spine.server.type.EventClass;
 import io.spine.testing.server.model.ModelTests;
 
 import java.lang.reflect.Method;
@@ -56,6 +58,10 @@ public class TestEventReactor implements EventReactor {
         return Version.getDefaultInstance();
     }
 
+    @Override
+    public ImmutableSet<EventClass> producedEvents() {
+        return ImmutableSet.of();
+    }
 
     public Method getMethod() {
         return ModelTests.getMethod(getClass(), REACTOR_METHOD_NAME);

--- a/server/src/test/java/io/spine/server/procman/model/ProcessManagerClassTest.java
+++ b/server/src/test/java/io/spine/server/procman/model/ProcessManagerClassTest.java
@@ -48,6 +48,8 @@ import io.spine.test.procman.event.PmProjectStarted;
 import io.spine.test.procman.event.PmTaskAdded;
 import io.spine.test.procman.quiz.event.PmQuestionAnswered;
 import io.spine.test.procman.quiz.event.PmQuizStarted;
+import io.spine.testing.server.model.ModelTests;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -61,6 +63,11 @@ class ProcessManagerClassTest {
 
     private final ProcessManagerClass<?> processManagerClass =
             ProcessManagerClass.asProcessManagerClass(TestProcessManager.class);
+
+    @BeforeEach
+    void setUp() {
+        ModelTests.dropAllModels();
+    }
 
     @Nested
     @DisplayName("provide classes of")

--- a/server/src/test/java/io/spine/server/stand/StandTest.java
+++ b/server/src/test/java/io/spine/server/stand/StandTest.java
@@ -479,10 +479,10 @@ class StandTest extends TenantAwareTest {
         @Test
         @DisplayName("upon receiving the event of observed type, " +
                 "when event is produced by a standalone command handler")
-        void uponEventFromStandaloneAssignee() {
+        void uponEventFromStandaloneHandler() {
             AloneWaiter waiter = new AloneWaiter();
             BoundedContext context =
-                    BoundedContextBuilder.assumingTests()
+                    BoundedContextBuilder.assumingTests(isMultitenant())
                                          .addCommandDispatcher(waiter)
                                          .build();
             Stand stand = context.stand();

--- a/server/src/test/java/io/spine/server/stand/StandTest.java
+++ b/server/src/test/java/io/spine/server/stand/StandTest.java
@@ -64,6 +64,7 @@ import io.spine.server.Given.CustomerAggregateRepository;
 import io.spine.server.entity.EntityRecord;
 import io.spine.server.entity.Repository;
 import io.spine.server.projection.ProjectionRepository;
+import io.spine.server.stand.given.AloneWaiter;
 import io.spine.server.stand.given.Given.StandTestProjectionRepository;
 import io.spine.server.stand.given.StandTestEnv.MemoizeQueryResponseObserver;
 import io.spine.server.stand.given.StandTestEnv.MemoizeSubscriptionCallback;
@@ -74,6 +75,9 @@ import io.spine.test.commandservice.customer.Customer;
 import io.spine.test.commandservice.customer.CustomerId;
 import io.spine.test.commandservice.customer.command.CreateCustomer;
 import io.spine.test.commandservice.customer.event.CustomerCreated;
+import io.spine.test.integration.OrderId;
+import io.spine.test.integration.command.PlaceOrder;
+import io.spine.test.integration.event.OrderPlaced;
 import io.spine.test.projection.Project;
 import io.spine.test.projection.ProjectId;
 import io.spine.testing.core.given.GivenUserId;
@@ -425,10 +429,10 @@ class StandTest extends TenantAwareTest {
             assertThat(packedState).isEqualTo(callback.newEntityState());
         }
 
-        @SuppressWarnings("OverlyCoupledMethod") // Huge end-to-end test.
         @Test
-        @DisplayName("upon event of observed type received")
-        void uponEvent() {
+        @DisplayName("upon receiving the event of observed type, when event is produced by Entity")
+        @SuppressWarnings("OverlyCoupledMethod") // Huge end-to-end test.
+        void uponEventFromEntity() {
             // Subscribe to Customer aggregate updates.
             CustomerAggregateRepository repository = new CustomerAggregateRepository();
             Stand stand = createStand(repository);
@@ -470,6 +474,43 @@ class StandTest extends TenantAwareTest {
                     .isEqualTo(customerId);
             assertThat(eventMessage.getCustomer())
                     .isEqualTo(customer);
+        }
+
+        @Test
+        @DisplayName("upon receiving the event of observed type, " +
+                "when event is produced by a standalone command handler")
+        void uponEventFromStandaloneAssignee() {
+            AloneWaiter waiter = new AloneWaiter();
+            BoundedContext context =
+                    BoundedContextBuilder.assumingTests()
+                                         .addCommandDispatcher(waiter)
+                                         .build();
+            Stand stand = context.stand();
+            Topic topic = requestFactory.topic()
+                                        .allOf(OrderPlaced.class);
+
+            MemoizeSubscriptionCallback callback = new MemoizeSubscriptionCallback();
+            subscribeAndActivate(stand, topic, callback);
+
+            OrderId orderId = OrderId.generate();
+            PlaceOrder placeOrder =
+                    PlaceOrder.newBuilder()
+                              .setId(orderId)
+                              .vBuild();
+            Command command = requestFactory.command()
+                                            .create(placeOrder);
+
+            assertThat(waiter.ordersPlaced()).isEqualTo(0);
+            context.commandBus().post(command, noOpObserver());
+            assertThat(waiter.ordersPlaced()).isEqualTo(1);
+
+            @Nullable Event observed = callback.newEvent();
+            assertThat(observed).isNotNull();
+            OrderPlaced expected =
+                    OrderPlaced.newBuilder()
+                               .setId(orderId)
+                               .vBuild();
+            assertThat(observed.enclosedMessage()).isEqualTo(expected);
         }
     }
 

--- a/server/src/test/java/io/spine/server/stand/given/AloneWaiter.java
+++ b/server/src/test/java/io/spine/server/stand/given/AloneWaiter.java
@@ -23,24 +23,37 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-syntax = "proto3";
 
-package spine.test.integration.event;
+package io.spine.server.stand.given;
 
-import "spine/options.proto";
+import io.spine.server.command.AbstractCommandHandler;
+import io.spine.server.command.Assign;
+import io.spine.test.integration.OrderId;
+import io.spine.test.integration.command.PlaceOrder;
+import io.spine.test.integration.event.OrderPlaced;
 
-option (type_url_prefix) = "type.spine.io";
-option java_package="io.spine.test.integration.event";
-option java_outer_classname = "IntegrationEventsProto";
-option java_multiple_files = true;
+/**
+ * A standalone command handler to use in {@link io.spine.server.stand.StandTest StandTest}s.
+ */
+public final class AloneWaiter extends AbstractCommandHandler {
 
-import "spine/test/integration/project.proto";
-import "spine/test/integration/identifiers.proto";
+    private int ordersPlaced = 0;
 
-message ItgProjectCreated {
-    ProjectId project_id = 1;
-}
+    @Assign
+    OrderPlaced handler(PlaceOrder command) {
+        OrderId id = command.getId();
+        OrderPlaced placed =
+                OrderPlaced.newBuilder()
+                           .setId(id)
+                           .vBuild();
+        ordersPlaced++;
+        return placed;
+    }
 
-message OrderPlaced {
-    OrderId id = 1;
+    /**
+     * Returns the number of orders placed by this waiter.
+     */
+    public int ordersPlaced() {
+        return ordersPlaced;
+    }
 }

--- a/server/src/test/java/io/spine/server/stand/given/StandTestEnv.java
+++ b/server/src/test/java/io/spine/server/stand/given/StandTestEnv.java
@@ -36,6 +36,8 @@ import io.spine.core.Event;
 import io.spine.server.BoundedContext;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.Given.CustomerAggregateRepository;
+import io.spine.server.command.CommandHandler;
+import io.spine.server.commandbus.CommandDispatcher;
 import io.spine.server.entity.Repository;
 import io.spine.server.stand.Stand;
 import io.spine.server.stand.SubscriptionCallback;
@@ -57,10 +59,18 @@ public class StandTestEnv {
                         new CustomerAggregateRepository(), new StandTestProjectionRepository());
     }
 
-    public static Stand newStand(boolean multitenant, Repository... repositories) {
+    public static Stand newStand(boolean multitenant, Repository<?, ?>... repositories) {
         BoundedContextBuilder builder = BoundedContextBuilder.assumingTests(multitenant);
         Arrays.stream(repositories)
               .forEach(builder::add);
+        BoundedContext context = builder.build();
+        return context.stand();
+    }
+
+    public static Stand newStand(CommandDispatcher... dispatchers) {
+        BoundedContextBuilder builder = BoundedContextBuilder.assumingTests();
+        Arrays.stream(dispatchers)
+              .forEach(builder::addCommandDispatcher);
         BoundedContext context = builder.build();
         return context.stand();
     }

--- a/server/src/test/proto/spine/test/integration/commands.proto
+++ b/server/src/test/proto/spine/test/integration/commands.proto
@@ -35,7 +35,12 @@ option java_outer_classname = "IntegrationCommandsProto";
 option java_multiple_files = true;
 
 import "spine/test/integration/project.proto";
+import "spine/test/integration/identifiers.proto";
 
 message ItgStartProject {
     ProjectId project_id = 1;
+}
+
+message PlaceOrder {
+    OrderId id = 1;
 }

--- a/server/src/test/proto/spine/test/integration/identifiers.proto
+++ b/server/src/test/proto/spine/test/integration/identifiers.proto
@@ -25,22 +25,15 @@
  */
 syntax = "proto3";
 
-package spine.test.integration.event;
+package spine.test.integration;
 
 import "spine/options.proto";
 
 option (type_url_prefix) = "type.spine.io";
-option java_package="io.spine.test.integration.event";
-option java_outer_classname = "IntegrationEventsProto";
+option java_package="io.spine.test.integration";
+option java_outer_classname = "IntegrationIdentifiersProto";
 option java_multiple_files = true;
 
-import "spine/test/integration/project.proto";
-import "spine/test/integration/identifiers.proto";
-
-message ItgProjectCreated {
-    ProjectId project_id = 1;
-}
-
-message OrderPlaced {
-    OrderId id = 1;
+message OrderId {
+    string uuid = 1;
 }

--- a/server/src/test/proto/spine/test/subscriptionservice/report.proto
+++ b/server/src/test/proto/spine/test/subscriptionservice/report.proto
@@ -25,22 +25,16 @@
  */
 syntax = "proto3";
 
-package spine.test.integration.event;
+package spine.test.subscriptionservice;
 
 import "spine/options.proto";
 
 option (type_url_prefix) = "type.spine.io";
-option java_package="io.spine.test.integration.event";
-option java_outer_classname = "IntegrationEventsProto";
+option java_package = "io.spine.test.subscriptionservice";
+option java_outer_classname = "ReportDefsProto";
 option java_multiple_files = true;
 
-import "spine/test/integration/project.proto";
-import "spine/test/integration/identifiers.proto";
 
-message ItgProjectCreated {
-    ProjectId project_id = 1;
-}
-
-message OrderPlaced {
-    OrderId id = 1;
+message ReportId {
+    string uuid = 1;
 }

--- a/server/src/test/proto/spine/test/subscriptionservice/report_commands.proto
+++ b/server/src/test/proto/spine/test/subscriptionservice/report_commands.proto
@@ -25,22 +25,17 @@
  */
 syntax = "proto3";
 
-package spine.test.integration.event;
+package spine.test.subscriptionservice;
 
 import "spine/options.proto";
 
 option (type_url_prefix) = "type.spine.io";
-option java_package="io.spine.test.integration.event";
-option java_outer_classname = "IntegrationEventsProto";
+option java_package = "io.spine.test.subscriptionservice.command";
+option java_outer_classname = "ReportCommandsProto";
 option java_multiple_files = true;
 
-import "spine/test/integration/project.proto";
-import "spine/test/integration/identifiers.proto";
+import "spine/test/subscriptionservice/report.proto";
 
-message ItgProjectCreated {
-    ProjectId project_id = 1;
-}
-
-message OrderPlaced {
-    OrderId id = 1;
+message SendReport {
+    ReportId id = 1;
 }

--- a/server/src/test/proto/spine/test/subscriptionservice/report_events.proto
+++ b/server/src/test/proto/spine/test/subscriptionservice/report_events.proto
@@ -25,22 +25,17 @@
  */
 syntax = "proto3";
 
-package spine.test.integration.event;
+package spine.test.subscriptionservice;
 
 import "spine/options.proto";
 
 option (type_url_prefix) = "type.spine.io";
-option java_package="io.spine.test.integration.event";
-option java_outer_classname = "IntegrationEventsProto";
+option java_package = "io.spine.test.subscriptionservice.event";
+option java_outer_classname = "ReportEventsProto";
 option java_multiple_files = true;
 
-import "spine/test/integration/project.proto";
-import "spine/test/integration/identifiers.proto";
+import "spine/test/subscriptionservice/report.proto";
 
-message ItgProjectCreated {
-    ProjectId project_id = 1;
-}
-
-message OrderPlaced {
-    OrderId id = 1;
+message ReportSent {
+    ReportId id = 1;
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,7 +34,7 @@
 /**
  * Version of this library.
  */
-val coreJava = "1.7.7-SNAPSHOT.6"
+val coreJava = "1.7.7-SNAPSHOT.7"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.


### PR DESCRIPTION
This changeset addresses #1349 and #1370.

In particular, the internals of `IntegrationBroker` were made more thread-safe.

Also, `SubscriptionService` now properly locates the Bounded Context when subscribing to events produced by standalone producers, such as `AbstractCommandHandler` or `AbstractEventReactor` descendants. Previously, these dispatchers did not register themselves in `Stand`. Therefore, `SubscriptionService` was failing to find the target Bounded Context and always ended up creating a number of redundant event subscriptions in each known Bounded Context.