### PR TITLE
[2.x] Make `IntegrationBroker` safer. Adjust `SubscriptionService` for standalone event producers.

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.80`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.81`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -502,12 +502,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 18 14:51:56 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 17:49:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.80`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.81`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -969,12 +969,12 @@ This report was generated on **Thu Nov 18 14:51:56 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 18 14:51:56 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 17:49:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.80`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.81`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1476,12 +1476,12 @@ This report was generated on **Thu Nov 18 14:51:56 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 18 14:51:57 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 17:49:40 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.80`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.81`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -2079,12 +2079,12 @@ This report was generated on **Thu Nov 18 14:51:57 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 18 14:51:58 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 17:49:40 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.80`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.81`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2594,12 +2594,12 @@ This report was generated on **Thu Nov 18 14:51:58 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 18 14:51:58 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 17:49:41 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.80`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.81`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3153,12 +3153,12 @@ This report was generated on **Thu Nov 18 14:51:58 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 18 14:51:59 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 17:49:41 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.80`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.81`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3712,12 +3712,12 @@ This report was generated on **Thu Nov 18 14:51:59 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 18 14:51:59 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 17:49:42 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.80`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.81`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4315,4 +4315,4 @@ This report was generated on **Thu Nov 18 14:51:59 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 18 14:52:00 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 23 17:49:42 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.80</version>
+<version>2.0.0-SNAPSHOT.81</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/EventProducer.java
+++ b/server/src/main/java/io/spine/server/EventProducer.java
@@ -51,6 +51,11 @@ public interface EventProducer {
     Version version();
 
     /**
+     * Obtains classes of the events produced by this object.
+     */
+    ImmutableSet<EventClass> producedEvents();
+
+    /**
      * Obtains the {@link io.spine.server.model.Nothing} event message.
      *
      * <p>This event should be returned if there is no value for the domain to produce an actual
@@ -62,9 +67,4 @@ public interface EventProducer {
     default Nothing nothing() {
         return Nothing.getDefaultInstance();
     }
-
-    /**
-     * Obtains classes of the events produced by this object.
-     */
-    ImmutableSet<EventClass> producedEvents();
 }

--- a/server/src/main/java/io/spine/server/EventProducer.java
+++ b/server/src/main/java/io/spine/server/EventProducer.java
@@ -26,9 +26,11 @@
 
 package io.spine.server;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Any;
 import io.spine.core.Version;
 import io.spine.server.model.Nothing;
+import io.spine.server.type.EventClass;
 
 /**
  * An object with identity which produces events.
@@ -60,4 +62,9 @@ public interface EventProducer {
     default Nothing nothing() {
         return Nothing.getDefaultInstance();
     }
+
+    /**
+     * Obtains classes of the events produced by this object.
+     */
+    ImmutableSet<EventClass> producedEvents();
 }

--- a/server/src/main/java/io/spine/server/SubscriptionService.java
+++ b/server/src/main/java/io/spine/server/SubscriptionService.java
@@ -25,6 +25,7 @@
  */
 package io.spine.server;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -179,7 +180,16 @@ public final class SubscriptionService
         return result;
     }
 
-    private Optional<BoundedContext> findContextOf(Target target) {
+    /**
+     * Searches for the Bounded Context which provides the messages of the target type.
+     *
+     * @param target
+     *         the type which may be available through this subscription service
+     * @return the context which exposes the target type,
+     *         or {@code Optional.empty} if no known context does so
+     */
+    @VisibleForTesting  /* Otherwise should have been `private`. */
+    Optional<BoundedContext> findContextOf(Target target) {
         TypeUrl type = target.type();
         BoundedContext selected = typeToContextMap.get(type);
         Optional<BoundedContext> result = Optional.ofNullable(selected);

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -27,6 +27,7 @@ package io.spine.server.aggregate;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Any;
 import com.google.protobuf.Empty;
 import io.spine.annotation.Internal;
@@ -48,6 +49,7 @@ import io.spine.server.entity.RecentHistory;
 import io.spine.server.event.EventReactor;
 import io.spine.server.event.model.EventReactorMethod;
 import io.spine.server.type.CommandEnvelope;
+import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
 import io.spine.validate.ValidatingBuilder;
 
@@ -287,6 +289,12 @@ public abstract class Aggregate<I,
         return EventPlayer
                 .forTransactionOf(this)
                 .play(events);
+    }
+
+    @Override
+    @Internal
+    public ImmutableSet<EventClass> producedEvents() {
+        return modelClass().outgoingEvents();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/command/AbstractCommandHandler.java
+++ b/server/src/main/java/io/spine/server/command/AbstractCommandHandler.java
@@ -28,6 +28,7 @@ package io.spine.server.command;
 
 import com.google.common.collect.ImmutableSet;
 import io.spine.core.Version;
+import io.spine.server.BoundedContext;
 import io.spine.server.command.model.CommandHandlerClass;
 import io.spine.server.command.model.CommandHandlerMethod;
 import io.spine.server.commandbus.CommandDispatcher;
@@ -35,6 +36,7 @@ import io.spine.server.dispatch.DispatchOutcomeHandler;
 import io.spine.server.event.EventBus;
 import io.spine.server.type.CommandClass;
 import io.spine.server.type.CommandEnvelope;
+import io.spine.server.type.EventClass;
 
 import static io.spine.server.command.model.CommandHandlerClass.asCommandHandlerClass;
 
@@ -88,6 +90,17 @@ public abstract class AbstractCommandHandler
                 .onError(error -> onError(envelope, error))
                 .onRejection(rejection -> onRejection(envelope, rejection))
                 .handle();
+    }
+
+    @Override
+    public void registerWith(BoundedContext context) {
+        super.registerWith(context);
+        context.stand().registerTypeSupplier(this);
+    }
+
+    @Override
+    public ImmutableSet<EventClass> producedEvents() {
+        return thisClass.commandOutput();
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/command/AbstractCommander.java
+++ b/server/src/main/java/io/spine/server/command/AbstractCommander.java
@@ -129,6 +129,16 @@ public abstract class AbstractCommander
         return Versions.zero();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Always returns an empty set.
+     */
+    @Override
+    public ImmutableSet<EventClass> producedEvents() {
+        return ImmutableSet.of();
+    }
+
     private void postCommands(List<Command> commands) {
         commandBus().post(commands, noOpObserver());
     }

--- a/server/src/main/java/io/spine/server/delivery/CatchUpProcess.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpProcess.java
@@ -60,6 +60,7 @@ import io.spine.server.event.EventStreamQuery.Limit;
 import io.spine.server.event.React;
 import io.spine.server.model.Nothing;
 import io.spine.server.projection.ProjectionRepository;
+import io.spine.server.stand.Stand;
 import io.spine.server.tuple.EitherOf2;
 import io.spine.server.tuple.EitherOf3;
 import io.spine.server.type.EventEnvelope;
@@ -821,6 +822,16 @@ public final class CatchUpProcess<I>
     protected CatchUp.Builder newStateBuilderWith(CatchUpId id) {
         return CatchUp.newBuilder()
                       .setId(id);
+    }
+
+    /**
+     * Does NOT register this process in {@code Stand}, as the emitted events should
+     * not be available for subscribing.
+     */
+    @Internal
+    @Override
+    protected void registerIn(Stand stand) {
+        // Do nothing.
     }
 
     /**

--- a/server/src/main/java/io/spine/server/delivery/ShardMaintenanceProcess.java
+++ b/server/src/main/java/io/spine/server/delivery/ShardMaintenanceProcess.java
@@ -27,12 +27,14 @@
 package io.spine.server.delivery;
 
 import com.google.protobuf.Timestamp;
+import io.spine.annotation.Internal;
 import io.spine.base.Time;
 import io.spine.server.delivery.event.ShardProcessed;
 import io.spine.server.delivery.event.ShardProcessingRequested;
 import io.spine.server.entity.Repository;
 import io.spine.server.event.AbstractEventReactor;
 import io.spine.server.event.React;
+import io.spine.server.stand.Stand;
 import io.spine.server.type.EventEnvelope;
 import io.spine.type.TypeUrl;
 
@@ -84,6 +86,16 @@ final class ShardMaintenanceProcess extends AbstractEventReactor {
         ShardEvent message = (ShardEvent) event.message();
         inbox.send(event)
              .toReactor(message.getIndex());
+    }
+
+    /**
+     * Does NOT register this process in {@code Stand}, as the emitted events should
+     * not be available for subscribing.
+     */
+    @Internal
+    @Override
+    protected void registerIn(Stand stand) {
+        // do nothing.
     }
 
     /**

--- a/server/src/main/java/io/spine/server/delivery/ShardMaintenanceProcess.java
+++ b/server/src/main/java/io/spine/server/delivery/ShardMaintenanceProcess.java
@@ -95,7 +95,7 @@ final class ShardMaintenanceProcess extends AbstractEventReactor {
     @Internal
     @Override
     protected void registerIn(Stand stand) {
-        // do nothing.
+        // Do nothing.
     }
 
     /**

--- a/server/src/main/java/io/spine/server/event/AbstractEventReactor.java
+++ b/server/src/main/java/io/spine/server/event/AbstractEventReactor.java
@@ -29,6 +29,7 @@ package io.spine.server.event;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import com.google.protobuf.Any;
+import io.spine.annotation.Internal;
 import io.spine.base.Error;
 import io.spine.core.MessageId;
 import io.spine.core.Version;
@@ -41,6 +42,7 @@ import io.spine.server.Identity;
 import io.spine.server.dispatch.DispatchOutcomeHandler;
 import io.spine.server.event.model.EventReactorClass;
 import io.spine.server.event.model.EventReactorMethod;
+import io.spine.server.stand.Stand;
 import io.spine.server.tenant.TenantAwareRunner;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
@@ -87,6 +89,19 @@ public abstract class AbstractEventReactor
         checkNotRegistered();
         eventBus = context.eventBus();
         system = context.systemClient().writeSide();
+        registerIn(context.stand());
+    }
+
+    /**
+     * Registers this reactor in {@code Stand} as an event producer.
+     *
+     * <p>The descendants which emit system events may choose not to expose their signals
+     * via {@code Stand}, or expose them partially. In which case this method should be
+     * overridden respectively.
+     */
+    @Internal
+    protected void registerIn(Stand stand) {
+        stand.registerTypeSupplier(this);
     }
 
     @Override
@@ -153,5 +168,10 @@ public abstract class AbstractEventReactor
     @Override
     public ImmutableSet<EventClass> domesticEventClasses() {
         return thisClass.domesticEvents();
+    }
+
+    @Override
+    public ImmutableSet<EventClass> producedEvents() {
+        return thisClass.reactionOutput();
     }
 }

--- a/server/src/main/java/io/spine/server/integration/ObserveWantedEvents.java
+++ b/server/src/main/java/io/spine/server/integration/ObserveWantedEvents.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import static com.google.common.collect.Multimaps.synchronizedSetMultimap;
 import static io.spine.protobuf.AnyPacker.unpack;
 
 /**
@@ -53,9 +54,12 @@ final class ObserveWantedEvents extends AbstractChannelObserver implements AutoC
      * Current set of message type URLs, requested by other parties via sending the
      * {@linkplain ExternalEventsWanted configuration messages}, mapped to IDs of their origin
      * bounded contexts.
+     *
+     * <p>This instance is potentially accessed from different threads,
+     * therefore it's made concurrency-friendly.
      */
     private final Multimap<ExternalEventType, BoundedContextName> requestedTypes =
-            HashMultimap.create();
+            synchronizedSetMultimap(HashMultimap.create());
 
     ObserveWantedEvents(BoundedContextName context, BusAdapter bus) {
         super(context, ExternalEventsWanted.class);

--- a/server/src/main/java/io/spine/server/procman/ProcessManager.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManager.java
@@ -27,6 +27,7 @@
 package io.spine.server.procman;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import io.spine.annotation.Internal;
 import io.spine.base.EntityState;
 import io.spine.server.command.CommandHandlingEntity;
@@ -120,6 +121,11 @@ public abstract class ProcessManager<I,
     @Override
     protected ProcessManagerClass<?> thisClass() {
         return (ProcessManagerClass<?>) super.thisClass();
+    }
+
+    @Override
+    public ImmutableSet<EventClass> producedEvents() {
+        return thisClass().outgoingEvents();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/stand/EventRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/EventRegistry.java
@@ -27,6 +27,7 @@
 package io.spine.server.stand;
 
 import com.google.common.collect.ImmutableSet;
+import io.spine.server.EventProducer;
 import io.spine.server.entity.Repository;
 import io.spine.server.type.EventClass;
 import io.spine.type.TypeUrl;
@@ -40,6 +41,11 @@ interface EventRegistry extends AutoCloseable {
      * Registers the repository as an event producer in this registry.
      */
     void register(Repository<?, ?> repository);
+
+    /**
+     * Registers the event producer in this registry.
+     */
+    void register(EventProducer producer);
 
     /**
      * Retrieves all event {@linkplain TypeUrl types} stored in the registry.

--- a/server/src/main/java/io/spine/server/stand/EventRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/EventRegistry.java
@@ -38,12 +38,12 @@ import io.spine.type.TypeUrl;
 interface EventRegistry extends AutoCloseable {
 
     /**
-     * Registers the repository as an event producer in this registry.
+     * Registers the repository as an event producer.
      */
     void register(Repository<?, ?> repository);
 
     /**
-     * Registers the event producer in this registry.
+     * Registers the event producer.
      */
     void register(EventProducer producer);
 

--- a/server/src/main/java/io/spine/server/stand/InMemoryEventRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/InMemoryEventRegistry.java
@@ -27,6 +27,7 @@
 package io.spine.server.stand;
 
 import com.google.common.collect.ImmutableSet;
+import io.spine.server.EventProducer;
 import io.spine.server.entity.EventProducingRepository;
 import io.spine.server.entity.Repository;
 import io.spine.server.type.EventClass;
@@ -57,6 +58,12 @@ final class InMemoryEventRegistry implements EventRegistry {
             repo.outgoingEvents()
                 .forEach(this::putIntoMap);
         }
+    }
+
+    @Override
+    public void register(EventProducer producer) {
+        producer.producedEvents()
+                .forEach(this::putIntoMap);
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/stand/InMemoryTypeRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/InMemoryTypeRegistry.java
@@ -51,7 +51,7 @@ final class InMemoryTypeRegistry implements TypeRegistry {
      * The mapping between {@code TypeUrl} instances and repositories providing
      * the entities of this type.
      */
-    private final ConcurrentMap<TypeUrl, QueryableRepository> repositories =
+    private final ConcurrentMap<TypeUrl, QueryableRepository<?, ?>> repositories =
             new ConcurrentHashMap<>();
 
     private final Set<TypeUrl> aggregateTypes = synchronizedSet(new HashSet<>());
@@ -70,8 +70,9 @@ final class InMemoryTypeRegistry implements TypeRegistry {
         TypeUrl entityType = repository.entityStateType();
 
         if (repository instanceof QueryableRepository) {
-            QueryableRepository recordBasedRepository = (QueryableRepository) repository;
-            repositories.put(entityType, recordBasedRepository);
+            @SuppressWarnings("unchecked")  /* Guaranteed by the `QueryableRepository` contract. */
+            QueryableRepository<I, ?> recordRepo = (QueryableRepository<I, ?>) repository;
+            repositories.put(entityType, recordRepo);
         }
         if (repository instanceof AggregateRepository) {
             AggregateRepository<I, ?, ?> aggRepository = (AggregateRepository<I, ?, ?>) repository;
@@ -80,9 +81,9 @@ final class InMemoryTypeRegistry implements TypeRegistry {
     }
 
     @Override
-    public Optional<QueryableRepository> recordRepositoryOf(TypeUrl type) {
-        QueryableRepository repo = repositories.get(type);
-        Optional<QueryableRepository> result = ofNullable(repo);
+    public Optional<QueryableRepository<?, ?>> recordRepositoryOf(TypeUrl type) {
+        QueryableRepository<?, ?> repo = repositories.get(type);
+        Optional<QueryableRepository<?, ?>> result = ofNullable(repo);
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/stand/Stand.java
+++ b/server/src/main/java/io/spine/server/stand/Stand.java
@@ -43,6 +43,7 @@ import io.spine.core.Response;
 import io.spine.core.Responses;
 import io.spine.core.TenantId;
 import io.spine.protobuf.AnyPacker;
+import io.spine.server.EventProducer;
 import io.spine.server.Identity;
 import io.spine.server.bus.Listener;
 import io.spine.server.entity.Entity;
@@ -368,6 +369,13 @@ public class Stand implements AutoCloseable {
     public void registerTypeSupplier(Repository<?, ?> repository) {
         typeRegistry.register(repository);
         eventRegistry.register(repository);
+    }
+
+    /**
+     * Registers the passed {@code EventProducer} as the event type supplier.
+     */
+    public void registerTypeSupplier(EventProducer producer) {
+        eventRegistry.register(producer);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/stand/Stand.java
+++ b/server/src/main/java/io/spine/server/stand/Stand.java
@@ -401,9 +401,9 @@ public class Stand implements AutoCloseable {
      * @return suitable implementation of {@code QueryProcessor}
      */
     private QueryProcessor processorFor(TypeUrl type) {
-        Optional<QueryableRepository> maybeRepo = typeRegistry.recordRepositoryOf(type);
+        Optional<QueryableRepository<?, ?>> maybeRepo = typeRegistry.recordRepositoryOf(type);
         if (maybeRepo.isPresent()) {
-            QueryableRepository recordRepo = maybeRepo.get();
+            QueryableRepository<?, ?> recordRepo = maybeRepo.get();
             return new EntityQueryProcessor(recordRepo);
         }
         return NO_OP_PROCESSOR;

--- a/server/src/main/java/io/spine/server/stand/TypeRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/TypeRegistry.java
@@ -65,7 +65,7 @@ interface TypeRegistry extends AutoCloseable {
      * @return {@code RecordBasedRepository} managing the objects of the given {@code type},
      *         or {@code Optional.empty()} if no such repository has been registered
      */
-    Optional<QueryableRepository> recordRepositoryOf(TypeUrl type);
+    Optional<QueryableRepository<?, ?>> recordRepositoryOf(TypeUrl type);
 
     /**
      * Reads all {@link io.spine.server.aggregate.Aggregate Aggregate} entity state types

--- a/server/src/test/java/io/spine/server/Given.java
+++ b/server/src/test/java/io/spine/server/Given.java
@@ -44,6 +44,7 @@ import io.spine.people.PersonName;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.AggregateRepository;
 import io.spine.server.aggregate.Apply;
+import io.spine.server.command.AbstractCommandHandler;
 import io.spine.server.command.Assign;
 import io.spine.server.entity.EntityRecord;
 import io.spine.server.event.AbstractEventReactor;
@@ -66,6 +67,9 @@ import io.spine.test.commandservice.customer.Customer;
 import io.spine.test.commandservice.customer.CustomerId;
 import io.spine.test.commandservice.customer.command.CreateCustomer;
 import io.spine.test.commandservice.customer.event.CustomerCreated;
+import io.spine.test.subscriptionservice.ReportId;
+import io.spine.test.subscriptionservice.command.SendReport;
+import io.spine.test.subscriptionservice.event.ReportSent;
 import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.testing.core.given.GivenUserId;
 import io.spine.time.LocalDate;
@@ -115,9 +119,17 @@ public class Given {
         }
 
         public static AggCreateProject createProject(ProjectId id) {
-            return AggCreateProject.newBuilder()
-                                   .setProjectId(id)
-                                   .build();
+            return AggCreateProject
+                    .newBuilder()
+                    .setProjectId(id)
+                    .build();
+        }
+
+        public static SendReport sendReport() {
+            return SendReport
+                    .newBuilder()
+                    .setId(ReportId.generate())
+                    .vBuild();
         }
     }
 
@@ -269,13 +281,24 @@ public class Given {
         }
     }
 
-    public static class AggProjectCreatedReactor extends AbstractEventReactor {
+    static class AggProjectCreatedReactor extends AbstractEventReactor {
 
         @React
         AggOwnerNotified on(AggProjectCreated event, EventContext context) {
             return AggOwnerNotified
                     .newBuilder()
                     .setOwner(context.actor())
+                    .vBuild();
+        }
+    }
+
+    static class ReportSender extends AbstractCommandHandler {
+
+        @Assign
+        ReportSent on(SendReport command) {
+            return ReportSent
+                    .newBuilder()
+                    .setId(command.getId())
                     .vBuild();
         }
     }

--- a/server/src/test/java/io/spine/server/SubscriptionServiceTest.java
+++ b/server/src/test/java/io/spine/server/SubscriptionServiceTest.java
@@ -354,7 +354,9 @@ class SubscriptionServiceTest {
             Target target = Targets.allOf(targetType);
             Optional<BoundedContext> result = subscriptionService.findContextOf(target);
             assertThat(result).isPresent();
-            assertThat(result.get().name()).isEqualTo(context.name());
+            BoundedContext actual = result.get();
+            assertThat(actual.name())
+                    .isEqualTo(context.name());
         }
     }
 

--- a/server/src/test/java/io/spine/server/command/given/CommandHandlingEntityTestEnv.java
+++ b/server/src/test/java/io/spine/server/command/given/CommandHandlingEntityTestEnv.java
@@ -26,11 +26,13 @@
 
 package io.spine.server.command.given;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.StringValue;
 import io.spine.server.command.CommandHandlingEntity;
 import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.test.shared.EmptyEntity;
 import io.spine.server.type.CommandEnvelope;
+import io.spine.server.type.EventClass;
 
 import static io.spine.testing.TestValues.newUuidValue;
 
@@ -63,6 +65,11 @@ public class CommandHandlingEntityTestEnv {
         @Override
         protected DispatchOutcome dispatchCommand(CommandEnvelope cmd) {
             return DispatchOutcome.getDefaultInstance();
+        }
+
+        @Override
+        public ImmutableSet<EventClass> producedEvents() {
+            return ImmutableSet.of();
         }
     }
 }

--- a/server/src/test/java/io/spine/server/entity/RecordBasedRepositoryTest.java
+++ b/server/src/test/java/io/spine/server/entity/RecordBasedRepositoryTest.java
@@ -135,6 +135,7 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
     @AfterEach
     protected void tearDown() throws Exception {
         clearCurrentTenant();
+        ModelTests.dropAllModels();
     }
 
     /*

--- a/server/src/test/java/io/spine/server/event/model/given/classes/ConferenceSetup.java
+++ b/server/src/test/java/io/spine/server/event/model/given/classes/ConferenceSetup.java
@@ -26,6 +26,7 @@
 
 package io.spine.server.event.model.given.classes;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Any;
 import io.spine.base.Identifier;
 import io.spine.core.EventContext;
@@ -34,6 +35,7 @@ import io.spine.core.Version;
 import io.spine.core.Versions;
 import io.spine.server.event.EventReactor;
 import io.spine.server.event.React;
+import io.spine.server.type.EventClass;
 import io.spine.test.event.model.ConferenceAnnounced;
 import io.spine.test.event.model.SpeakerJoined;
 import io.spine.test.event.model.SpeakersInvited;
@@ -85,5 +87,10 @@ public class ConferenceSetup implements EventReactor {
     @Override
     public Version version() {
         return Versions.zero();
+    }
+
+    @Override
+    public ImmutableSet<EventClass> producedEvents() {
+        return ImmutableSet.of();
     }
 }

--- a/server/src/test/java/io/spine/server/event/model/given/reactor/TestEventReactor.java
+++ b/server/src/test/java/io/spine/server/event/model/given/reactor/TestEventReactor.java
@@ -26,10 +26,12 @@
 
 package io.spine.server.event.model.given.reactor;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Any;
 import io.spine.base.Identifier;
 import io.spine.core.Version;
 import io.spine.server.event.EventReactor;
+import io.spine.server.type.EventClass;
 import io.spine.testing.server.model.ModelTests;
 
 import java.lang.reflect.Method;
@@ -56,6 +58,10 @@ public class TestEventReactor implements EventReactor {
         return Version.getDefaultInstance();
     }
 
+    @Override
+    public ImmutableSet<EventClass> producedEvents() {
+        return ImmutableSet.of();
+    }
 
     public Method getMethod() {
         return ModelTests.getMethod(getClass(), REACTOR_METHOD_NAME);

--- a/server/src/test/java/io/spine/server/stand/given/AloneWaiter.java
+++ b/server/src/test/java/io/spine/server/stand/given/AloneWaiter.java
@@ -23,24 +23,37 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-syntax = "proto3";
 
-package spine.test.integration.event;
+package io.spine.server.stand.given;
 
-import "spine/options.proto";
+import io.spine.server.command.AbstractCommandHandler;
+import io.spine.server.command.Assign;
+import io.spine.test.integration.OrderId;
+import io.spine.test.integration.command.PlaceOrder;
+import io.spine.test.integration.event.OrderPlaced;
 
-option (type_url_prefix) = "type.spine.io";
-option java_package="io.spine.test.integration.event";
-option java_outer_classname = "IntegrationEventsProto";
-option java_multiple_files = true;
+/**
+ * A standalone command handler to use in {@link io.spine.server.stand.StandTest StandTest}s.
+ */
+public final class AloneWaiter extends AbstractCommandHandler {
 
-import "spine/test/integration/project.proto";
-import "spine/test/integration/identifiers.proto";
+    private int ordersPlaced = 0;
 
-message ItgProjectCreated {
-    ProjectId project_id = 1;
-}
+    @Assign
+    OrderPlaced handler(PlaceOrder command) {
+        OrderId id = command.getId();
+        OrderPlaced placed =
+                OrderPlaced.newBuilder()
+                           .setId(id)
+                           .vBuild();
+        ordersPlaced++;
+        return placed;
+    }
 
-message OrderPlaced {
-    OrderId id = 1;
+    /**
+     * Returns the number of orders placed by this waiter.
+     */
+    public int ordersPlaced() {
+        return ordersPlaced;
+    }
 }

--- a/server/src/test/java/io/spine/server/stand/given/StandTestEnv.java
+++ b/server/src/test/java/io/spine/server/stand/given/StandTestEnv.java
@@ -118,16 +118,18 @@ public final class StandTestEnv {
 
     public static Stand newStand(boolean multitenant, Repository<?, ?>... repositories) {
         BoundedContextBuilder builder = BoundedContextBuilder.assumingTests(multitenant);
-        Arrays.stream(repositories)
-              .forEach(builder::add);
+        for (Repository<?, ?> repository : repositories) {
+            builder.add(repository);
+        }
         BoundedContext context = builder.build();
         return context.stand();
     }
 
     public static Stand newStand(CommandDispatcher... dispatchers) {
         BoundedContextBuilder builder = BoundedContextBuilder.assumingTests();
-        Arrays.stream(dispatchers)
-              .forEach(builder::addCommandDispatcher);
+        for (CommandDispatcher dispatcher : dispatchers) {
+            builder.addCommandDispatcher(dispatcher);
+        }
         BoundedContext context = builder.build();
         return context.stand();
     }

--- a/server/src/test/java/io/spine/server/stand/given/StandTestEnv.java
+++ b/server/src/test/java/io/spine/server/stand/given/StandTestEnv.java
@@ -88,6 +88,7 @@ import static io.spine.grpc.StreamObservers.memoizingObserver;
 import static io.spine.grpc.StreamObservers.noOpObserver;
 import static io.spine.protobuf.AnyPacker.unpack;
 import static io.spine.server.entity.given.Given.projectionOfClass;
+import io.spine.server.commandbus.CommandDispatcher;
 import static io.spine.test.projection.Project.Status.STARTED;
 import static io.spine.testing.Assertions.assertMatchesMask;
 import static java.util.stream.Collectors.toList;
@@ -119,6 +120,14 @@ public final class StandTestEnv {
         BoundedContextBuilder builder = BoundedContextBuilder.assumingTests(multitenant);
         Arrays.stream(repositories)
               .forEach(builder::add);
+        BoundedContext context = builder.build();
+        return context.stand();
+    }
+
+    public static Stand newStand(CommandDispatcher... dispatchers) {
+        BoundedContextBuilder builder = BoundedContextBuilder.assumingTests();
+        Arrays.stream(dispatchers)
+              .forEach(builder::addCommandDispatcher);
         BoundedContext context = builder.build();
         return context.stand();
     }

--- a/server/src/test/proto/spine/test/aggregate/project.proto
+++ b/server/src/test/proto/spine/test/aggregate/project.proto
@@ -33,7 +33,6 @@ option (type_url_prefix) = "type.spine.io";
 option java_package = "io.spine.test.aggregate";
 option java_multiple_files = true;
 
-import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 
 message ProjectId {

--- a/server/src/test/proto/spine/test/integration/commands.proto
+++ b/server/src/test/proto/spine/test/integration/commands.proto
@@ -35,7 +35,12 @@ option java_outer_classname = "IntegrationCommandsProto";
 option java_multiple_files = true;
 
 import "spine/test/integration/project.proto";
+import "spine/test/integration/identifiers.proto";
 
 message ItgStartProject {
     ProjectId project_id = 1;
+}
+
+message PlaceOrder {
+    OrderId id = 1;
 }

--- a/server/src/test/proto/spine/test/integration/identifiers.proto
+++ b/server/src/test/proto/spine/test/integration/identifiers.proto
@@ -25,22 +25,15 @@
  */
 syntax = "proto3";
 
-package spine.test.integration.event;
+package spine.test.integration;
 
 import "spine/options.proto";
 
 option (type_url_prefix) = "type.spine.io";
-option java_package="io.spine.test.integration.event";
-option java_outer_classname = "IntegrationEventsProto";
+option java_package="io.spine.test.integration";
+option java_outer_classname = "IntegrationIdentifiersProto";
 option java_multiple_files = true;
 
-import "spine/test/integration/project.proto";
-import "spine/test/integration/identifiers.proto";
-
-message ItgProjectCreated {
-    ProjectId project_id = 1;
-}
-
-message OrderPlaced {
-    OrderId id = 1;
+message OrderId {
+    string uuid = 1;
 }

--- a/server/src/test/proto/spine/test/subscriptionservice/report.proto
+++ b/server/src/test/proto/spine/test/subscriptionservice/report.proto
@@ -25,22 +25,16 @@
  */
 syntax = "proto3";
 
-package spine.test.integration.event;
+package spine.test.subscriptionservice;
 
 import "spine/options.proto";
 
 option (type_url_prefix) = "type.spine.io";
-option java_package="io.spine.test.integration.event";
-option java_outer_classname = "IntegrationEventsProto";
+option java_package = "io.spine.test.subscriptionservice";
+option java_outer_classname = "ReportDefsProto";
 option java_multiple_files = true;
 
-import "spine/test/integration/project.proto";
-import "spine/test/integration/identifiers.proto";
 
-message ItgProjectCreated {
-    ProjectId project_id = 1;
-}
-
-message OrderPlaced {
-    OrderId id = 1;
+message ReportId {
+    string uuid = 1;
 }

--- a/server/src/test/proto/spine/test/subscriptionservice/report.proto
+++ b/server/src/test/proto/spine/test/subscriptionservice/report.proto
@@ -34,7 +34,6 @@ option java_package = "io.spine.test.subscriptionservice";
 option java_outer_classname = "ReportDefsProto";
 option java_multiple_files = true;
 
-
 message ReportId {
     string uuid = 1;
 }

--- a/server/src/test/proto/spine/test/subscriptionservice/report_commands.proto
+++ b/server/src/test/proto/spine/test/subscriptionservice/report_commands.proto
@@ -25,22 +25,17 @@
  */
 syntax = "proto3";
 
-package spine.test.integration.event;
+package spine.test.subscriptionservice;
 
 import "spine/options.proto";
 
 option (type_url_prefix) = "type.spine.io";
-option java_package="io.spine.test.integration.event";
-option java_outer_classname = "IntegrationEventsProto";
+option java_package = "io.spine.test.subscriptionservice.command";
+option java_outer_classname = "ReportCommandsProto";
 option java_multiple_files = true;
 
-import "spine/test/integration/project.proto";
-import "spine/test/integration/identifiers.proto";
+import "spine/test/subscriptionservice/report.proto";
 
-message ItgProjectCreated {
-    ProjectId project_id = 1;
-}
-
-message OrderPlaced {
-    OrderId id = 1;
+message SendReport {
+    ReportId id = 1;
 }

--- a/server/src/test/proto/spine/test/subscriptionservice/report_events.proto
+++ b/server/src/test/proto/spine/test/subscriptionservice/report_events.proto
@@ -25,22 +25,17 @@
  */
 syntax = "proto3";
 
-package spine.test.integration.event;
+package spine.test.subscriptionservice;
 
 import "spine/options.proto";
 
 option (type_url_prefix) = "type.spine.io";
-option java_package="io.spine.test.integration.event";
-option java_outer_classname = "IntegrationEventsProto";
+option java_package = "io.spine.test.subscriptionservice.event";
+option java_outer_classname = "ReportEventsProto";
 option java_multiple_files = true;
 
-import "spine/test/integration/project.proto";
-import "spine/test/integration/identifiers.proto";
+import "spine/test/subscriptionservice/report.proto";
 
-message ItgProjectCreated {
-    ProjectId project_id = 1;
-}
-
-message OrderPlaced {
-    OrderId id = 1;
+message ReportSent {
+    ReportId id = 1;
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@ val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.74")
 val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.76")
 
 /** The version of this library. */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.80")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.81")


### PR DESCRIPTION
This is a port of #1423 to the `master` branch.

This changeset addresses #1349 and #1370.

In particular, the internals of `IntegrationBroker` were made more thread-safe.

Also, `SubscriptionService` now properly locates the Bounded Context when subscribing to events produced by standalone producers, such as `AbstractCommandHandler` or `AbstractEventReactor` descendants. Previously, these dispatchers did not register themselves in `Stand`. Therefore, `SubscriptionService` was failing to find the target Bounded Context and always ended up creating a number of redundant event subscriptions in each known Bounded Context.

As a part of the updates, the event producers related to catch-up were hidden from `Stand` — as we don't want the events
emitted by them become available for subscribing.

Lastly, a minor change was made to the pieces which attempted to use a raw version of `QueryableRepository`. In order to avoid the erasure, they were supplied with the corresponding generic param values.

The version of the library was set to `2.0.0-SNAPSHOT.81`.