### PR TITLE
Migrate to JDK 11 and Java 11 syntax [part 2]

### DIFF
--- a/core/src/main/java/io/spine/change/BooleanMismatch.java
+++ b/core/src/main/java/io/spine/change/BooleanMismatch.java
@@ -75,16 +75,16 @@ public final class BooleanMismatch {
                                     boolean actual,
                                     boolean newValue,
                                     int version) {
-        ValueMismatch.Builder builder = ValueMismatch.newBuilder()
-                                                     .setExpected(toAny(expected))
-                                                     .setActual(toAny(actual))
-                                                     .setNewValue(toAny(newValue))
-                                                     .setVersion(version);
+        var builder = ValueMismatch.newBuilder()
+                .setExpected(toAny(expected))
+                .setActual(toAny(actual))
+                .setNewValue(toAny(newValue))
+                .setVersion(version);
         return builder.build();
     }
 
     private static boolean unpacked(Any any) {
-        BoolValue unpacked = unpack(any, BoolValue.class);
+        var unpacked = unpack(any, BoolValue.class);
         return unpacked.getValue();
     }
 
@@ -95,7 +95,7 @@ public final class BooleanMismatch {
      */
     public static boolean unpackExpected(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any expected = mismatch.getExpected();
+        var expected = mismatch.getExpected();
         return unpacked(expected);
     }
 
@@ -106,7 +106,7 @@ public final class BooleanMismatch {
      */
     public static boolean unpackActual(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any actual = mismatch.getActual();
+        var actual = mismatch.getActual();
         return unpacked(actual);
     }
 
@@ -117,7 +117,7 @@ public final class BooleanMismatch {
      */
     public static boolean unpackNewValue(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any newValue = mismatch.getNewValue();
+        var newValue = mismatch.getNewValue();
         return unpacked(newValue);
     }
 }

--- a/core/src/main/java/io/spine/change/Changes.java
+++ b/core/src/main/java/io/spine/change/Changes.java
@@ -55,8 +55,7 @@ public final class Changes {
         checkNewValueNotEmpty(newValue);
         checkNotEqual(previousValue, newValue);
 
-        StringChange result = StringChange
-                .newBuilder()
+        var result = StringChange.newBuilder()
                 .setPreviousValue(previousValue)
                 .setNewValue(newValue)
                 .vBuild();
@@ -73,8 +72,7 @@ public final class Changes {
         checkNotNull(newValue);
         checkNotEqual(previousValue, newValue);
 
-        TimestampChange result = TimestampChange
-                .newBuilder()
+        var result = TimestampChange.newBuilder()
                 .setPreviousValue(previousValue)
                 .setNewValue(newValue)
                 .vBuild();
@@ -89,8 +87,7 @@ public final class Changes {
     public static DoubleChange of(double previousValue, double newValue) {
         checkNotEqual(previousValue, newValue);
 
-        DoubleChange result = DoubleChange
-                .newBuilder()
+        var result = DoubleChange.newBuilder()
                 .setPreviousValue(previousValue)
                 .setNewValue(newValue)
                 .vBuild();
@@ -105,8 +102,7 @@ public final class Changes {
     public static FloatChange of(float previousValue, float newValue) {
         checkNotEqual(previousValue, newValue);
 
-        FloatChange result = FloatChange
-                .newBuilder()
+        var result = FloatChange.newBuilder()
                 .setPreviousValue(previousValue)
                 .setNewValue(newValue)
                 .vBuild();
@@ -121,8 +117,7 @@ public final class Changes {
     public static Int32Change ofInt32(int previousValue, int newValue) {
         checkNotEqual(previousValue, newValue);
 
-        Int32Change result = Int32Change
-                .newBuilder()
+        var result = Int32Change.newBuilder()
                 .setPreviousValue(previousValue)
                 .setNewValue(newValue)
                 .vBuild();
@@ -137,8 +132,7 @@ public final class Changes {
     public static Int64Change ofInt64(long previousValue, long newValue) {
         checkNotEqual(previousValue, newValue);
 
-        Int64Change result = Int64Change
-                .newBuilder()
+        var result = Int64Change.newBuilder()
                 .setPreviousValue(previousValue)
                 .setNewValue(newValue)
                 .vBuild();
@@ -153,8 +147,7 @@ public final class Changes {
     public static UInt32Change ofUInt32(int previousValue, int newValue) {
         checkNotEqual(previousValue, newValue);
 
-        UInt32Change result = UInt32Change
-                .newBuilder()
+        var result = UInt32Change.newBuilder()
                 .setPreviousValue(previousValue)
                 .setNewValue(newValue)
                 .vBuild();
@@ -169,8 +162,7 @@ public final class Changes {
     public static UInt64Change ofUInt64(long previousValue, long newValue) {
         checkNotEqual(previousValue, newValue);
 
-        UInt64Change result = UInt64Change
-                .newBuilder()
+        var result = UInt64Change.newBuilder()
                 .setPreviousValue(previousValue)
                 .setNewValue(newValue)
                 .vBuild();
@@ -185,8 +177,7 @@ public final class Changes {
     public static SInt32Change ofSInt32(int previousValue, int newValue) {
         checkNotEqual(previousValue, newValue);
 
-        SInt32Change result = SInt32Change
-                .newBuilder()
+        var result = SInt32Change.newBuilder()
                 .setPreviousValue(previousValue)
                 .setNewValue(newValue)
                 .vBuild();
@@ -201,8 +192,7 @@ public final class Changes {
     public static SInt64Change ofSInt64(long previousValue, long newValue) {
         checkNotEqual(previousValue, newValue);
 
-        SInt64Change result = SInt64Change
-                .newBuilder()
+        var result = SInt64Change.newBuilder()
                 .setPreviousValue(previousValue)
                 .setNewValue(newValue)
                 .vBuild();
@@ -217,8 +207,7 @@ public final class Changes {
     public static Fixed32Change ofFixed32(int previousValue, int newValue) {
         checkNotEqual(previousValue, newValue);
 
-        Fixed32Change result = Fixed32Change
-                .newBuilder()
+        var result = Fixed32Change.newBuilder()
                 .setPreviousValue(previousValue)
                 .setNewValue(newValue)
                 .vBuild();
@@ -233,8 +222,7 @@ public final class Changes {
     public static Fixed64Change ofFixed64(long previousValue, long newValue) {
         checkNotEqual(previousValue, newValue);
 
-        Fixed64Change result = Fixed64Change
-                .newBuilder()
+        var result = Fixed64Change.newBuilder()
                 .setPreviousValue(previousValue)
                 .setNewValue(newValue)
                 .vBuild();
@@ -249,8 +237,7 @@ public final class Changes {
     public static Sfixed32Change ofSfixed32(int previousValue, int newValue) {
         checkNotEqual(previousValue, newValue);
 
-        Sfixed32Change result = Sfixed32Change
-                .newBuilder()
+        var result = Sfixed32Change.newBuilder()
                 .setPreviousValue(previousValue)
                 .setNewValue(newValue)
                 .vBuild();
@@ -265,8 +252,7 @@ public final class Changes {
     public static Sfixed64Change ofSfixed64(long previousValue, long newValue) {
         checkNotEqual(previousValue, newValue);
 
-        Sfixed64Change result = Sfixed64Change
-                .newBuilder()
+        var result = Sfixed64Change.newBuilder()
                 .setPreviousValue(previousValue)
                 .setNewValue(newValue)
                 .vBuild();
@@ -283,8 +269,7 @@ public final class Changes {
         checkNotNull(newValue);
         checkNotEqual(previousValue, newValue);
 
-        BytesChange result = BytesChange
-                .newBuilder()
+        var result = BytesChange.newBuilder()
                 .setPreviousValue(previousValue)
                 .setNewValue(newValue)
                 .vBuild();
@@ -299,8 +284,7 @@ public final class Changes {
     public static BooleanChange of(boolean previousValue, boolean newValue) {
         checkNotEqual(previousValue, newValue);
 
-        BooleanChange result = BooleanChange
-                .newBuilder()
+        var result = BooleanChange.newBuilder()
                 .setPreviousValue(previousValue)
                 .setNewValue(newValue)
                 .vBuild();

--- a/core/src/main/java/io/spine/change/DoubleMismatch.java
+++ b/core/src/main/java/io/spine/change/DoubleMismatch.java
@@ -90,16 +90,16 @@ public final class DoubleMismatch {
      * for a double attribute.
      */
     public static ValueMismatch of(double expected, double actual, double newValue, int version) {
-        ValueMismatch.Builder builder = ValueMismatch.newBuilder()
-                                                     .setExpected(toAny(expected))
-                                                     .setActual(toAny(actual))
-                                                     .setNewValue(toAny(newValue))
-                                                     .setVersion(version);
+        var builder = ValueMismatch.newBuilder()
+                .setExpected(toAny(expected))
+                .setActual(toAny(actual))
+                .setNewValue(toAny(newValue))
+                .setVersion(version);
         return builder.build();
     }
 
     private static double unpacked(Any any) {
-        DoubleValue unpacked = unpack(any, DoubleValue.class);
+        var unpacked = unpack(any, DoubleValue.class);
         return unpacked.getValue();
     }
 
@@ -110,7 +110,7 @@ public final class DoubleMismatch {
      */
     public static double unpackExpected(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any expected = mismatch.getExpected();
+        var expected = mismatch.getExpected();
         return unpacked(expected);
     }
 
@@ -121,7 +121,7 @@ public final class DoubleMismatch {
      */
     public static double unpackActual(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any actual = mismatch.getActual();
+        var actual = mismatch.getActual();
         return unpacked(actual);
     }
 
@@ -132,7 +132,7 @@ public final class DoubleMismatch {
      */
     public static double unpackNewValue(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any newValue = mismatch.getNewValue();
+        var newValue = mismatch.getNewValue();
         return unpacked(newValue);
     }
 }

--- a/core/src/main/java/io/spine/change/FloatMismatch.java
+++ b/core/src/main/java/io/spine/change/FloatMismatch.java
@@ -89,16 +89,16 @@ public final class FloatMismatch {
      * Creates a new instance of {@code ValueMismatch} with the passed values for a float attribute.
      */
     public static ValueMismatch of(float expected, float actual, float newValue, int version) {
-        ValueMismatch.Builder builder = ValueMismatch.newBuilder()
-                                                     .setExpected(toAny(expected))
-                                                     .setActual(toAny(actual))
-                                                     .setNewValue(toAny(newValue))
-                                                     .setVersion(version);
+        var builder = ValueMismatch.newBuilder()
+                .setExpected(toAny(expected))
+                .setActual(toAny(actual))
+                .setNewValue(toAny(newValue))
+                .setVersion(version);
         return builder.build();
     }
 
     private static float unpacked(Any any) {
-        FloatValue unpacked = unpack(any, FloatValue.class);
+        var unpacked = unpack(any, FloatValue.class);
         return unpacked.getValue();
     }
 
@@ -109,7 +109,7 @@ public final class FloatMismatch {
      */
     public static float unpackExpected(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any expected = mismatch.getExpected();
+        var expected = mismatch.getExpected();
         return unpacked(expected);
     }
 
@@ -120,7 +120,7 @@ public final class FloatMismatch {
      */
     public static float unpackActual(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any actual = mismatch.getActual();
+        var actual = mismatch.getActual();
         return unpacked(actual);
     }
 
@@ -131,7 +131,7 @@ public final class FloatMismatch {
      */
     public static float unpackNewValue(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any newValue = mismatch.getNewValue();
+        var newValue = mismatch.getNewValue();
         return unpacked(newValue);
     }
 }

--- a/core/src/main/java/io/spine/change/IntMismatch.java
+++ b/core/src/main/java/io/spine/change/IntMismatch.java
@@ -90,16 +90,16 @@ public final class IntMismatch {
      * for an integer attribute.
      */
     public static ValueMismatch of(int expected, int actual, int newValue, int version) {
-        ValueMismatch.Builder builder = ValueMismatch.newBuilder()
-                                                     .setExpected(toAny(expected))
-                                                     .setActual(toAny(actual))
-                                                     .setNewValue(toAny(newValue))
-                                                     .setVersion(version);
+        var builder = ValueMismatch.newBuilder()
+                .setExpected(toAny(expected))
+                .setActual(toAny(actual))
+                .setNewValue(toAny(newValue))
+                .setVersion(version);
         return builder.build();
     }
 
     private static int unpacked(Any any) {
-        Int32Value unpacked = unpack(any, Int32Value.class);
+        var unpacked = unpack(any, Int32Value.class);
         return unpacked.getValue();
     }
 
@@ -110,7 +110,7 @@ public final class IntMismatch {
      */
     public static int unpackExpected(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any expected = mismatch.getExpected();
+        var expected = mismatch.getExpected();
         return unpacked(expected);
     }
 
@@ -121,7 +121,7 @@ public final class IntMismatch {
      */
     public static int unpackActual(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any actual = mismatch.getActual();
+        var actual = mismatch.getActual();
         return unpacked(actual);
     }
 
@@ -132,7 +132,7 @@ public final class IntMismatch {
      */
     public static int unpackNewValue(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any newValue = mismatch.getNewValue();
+        var newValue = mismatch.getNewValue();
         return unpacked(newValue);
     }
 }

--- a/core/src/main/java/io/spine/change/LongMismatch.java
+++ b/core/src/main/java/io/spine/change/LongMismatch.java
@@ -89,16 +89,16 @@ public final class LongMismatch {
      * Creates a new instance of {@code ValueMismatch} with the passed values for a long attribute.
      */
     public static ValueMismatch of(long expected, long actual, long newValue, int version) {
-        ValueMismatch.Builder builder = ValueMismatch.newBuilder()
-                                                     .setExpected(toAny(expected))
-                                                     .setActual(toAny(actual))
-                                                     .setNewValue(toAny(newValue))
-                                                     .setVersion(version);
+        var builder = ValueMismatch.newBuilder()
+                .setExpected(toAny(expected))
+                .setActual(toAny(actual))
+                .setNewValue(toAny(newValue))
+                .setVersion(version);
         return builder.build();
     }
 
     private static long unpacked(Any any) {
-        Int64Value unpacked = unpack(any, Int64Value.class);
+        var unpacked = unpack(any, Int64Value.class);
         return unpacked.getValue();
     }
 
@@ -109,7 +109,7 @@ public final class LongMismatch {
      */
     public static long unpackExpected(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any expected = mismatch.getExpected();
+        var expected = mismatch.getExpected();
         return unpacked(expected);
     }
 
@@ -120,7 +120,7 @@ public final class LongMismatch {
      */
     public static long unpackActual(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any actual = mismatch.getActual();
+        var actual = mismatch.getActual();
         return unpacked(actual);
     }
 
@@ -131,7 +131,7 @@ public final class LongMismatch {
      */
     public static long unpackNewValue(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any newValue = mismatch.getNewValue();
+        var newValue = mismatch.getNewValue();
         return unpacked(newValue);
     }
 }

--- a/core/src/main/java/io/spine/change/MessageMismatch.java
+++ b/core/src/main/java/io/spine/change/MessageMismatch.java
@@ -26,7 +26,6 @@
 
 package io.spine.change;
 
-import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -55,7 +54,7 @@ public final class MessageMismatch {
     public static ValueMismatch expectedDefault(Message actual, Message newValue, int version) {
         checkNotNull(actual);
         checkNotNull(newValue);
-        Message expectedDefault = actual.getDefaultInstanceForType();
+        var expectedDefault = actual.getDefaultInstanceForType();
         return of(expectedDefault, actual, newValue, version);
     }
 
@@ -69,7 +68,7 @@ public final class MessageMismatch {
      */
     public static ValueMismatch expectedNotDefault(Message expected, int version) {
         checkNotNull(expected);
-        Message defaultValue = expected.getDefaultInstanceForType();
+        var defaultValue = expected.getDefaultInstanceForType();
         return of(expected, defaultValue, defaultValue, version);
     }
 
@@ -87,7 +86,7 @@ public final class MessageMismatch {
                                                    int version) {
         checkNotNull(expected);
         checkNotNull(newValue);
-        Message defaultValue = expected.getDefaultInstanceForType();
+        var defaultValue = expected.getDefaultInstanceForType();
         return of(expected, defaultValue, newValue, version);
     }
 
@@ -116,8 +115,7 @@ public final class MessageMismatch {
      */
     private static ValueMismatch of(Message expected, Message actual,
                                     Message newValue, int version) {
-        ValueMismatch result = ValueMismatch
-                .newBuilder()
+        var result = ValueMismatch.newBuilder()
                 .setExpected(pack(expected))
                 .setActual(pack(actual))
                 .setNewValue(pack(newValue))
@@ -134,8 +132,8 @@ public final class MessageMismatch {
      */
     public static Message unpackExpected(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any any = mismatch.getExpected();
-        Message result = unpack(any);
+        var any = mismatch.getExpected();
+        var result = unpack(any);
         return result;
     }
 
@@ -147,8 +145,8 @@ public final class MessageMismatch {
      */
     public static Message unpackActual(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any any = mismatch.getActual();
-        Message result = unpack(any);
+        var any = mismatch.getActual();
+        var result = unpack(any);
         return result;
     }
 
@@ -160,8 +158,8 @@ public final class MessageMismatch {
      */
     public static Message unpackNewValue(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any any = mismatch.getNewValue();
-        Message result = unpack(any);
+        var any = mismatch.getNewValue();
+        var result = unpack(any);
         return result;
     }
 }

--- a/core/src/main/java/io/spine/change/StringMismatch.java
+++ b/core/src/main/java/io/spine/change/StringMismatch.java
@@ -95,16 +95,16 @@ public final class StringMismatch {
      * Creates a new instance of {@code ValueMismatch} with the passed values.
      */
     private static ValueMismatch of(String expected, String actual, String newValue, int version) {
-        ValueMismatch.Builder builder = ValueMismatch.newBuilder()
-                                                     .setExpected(toAny(expected))
-                                                     .setActual(toAny(actual))
-                                                     .setNewValue(toAny(newValue))
-                                                     .setVersion(version);
+        var builder = ValueMismatch.newBuilder()
+                .setExpected(toAny(expected))
+                .setActual(toAny(actual))
+                .setNewValue(toAny(newValue))
+                .setVersion(version);
         return builder.build();
     }
 
     private static String unpacked(Any any) {
-        StringValue unpacked = unpack(any, StringValue.class);
+        var unpacked = unpack(any, StringValue.class);
         return unpacked.getValue();
     }
 
@@ -115,7 +115,7 @@ public final class StringMismatch {
      */
     public static String unpackExpected(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any expected = mismatch.getExpected();
+        var expected = mismatch.getExpected();
         return unpacked(expected);
     }
 
@@ -126,7 +126,7 @@ public final class StringMismatch {
      */
     public static String unpackActual(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any actual = mismatch.getActual();
+        var actual = mismatch.getActual();
         return unpacked(actual);
     }
 
@@ -137,7 +137,7 @@ public final class StringMismatch {
      */
     public static String unpackNewValue(ValueMismatch mismatch) {
         checkNotNull(mismatch);
-        Any newValue = mismatch.getNewValue();
+        var newValue = mismatch.getNewValue();
         return unpacked(newValue);
     }
 }

--- a/core/src/main/java/io/spine/core/Acks.java
+++ b/core/src/main/java/io/spine/core/Acks.java
@@ -26,7 +26,6 @@
 
 package io.spine.core;
 
-import com.google.protobuf.Message;
 import io.spine.protobuf.AnyPacker;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -50,14 +49,14 @@ public final class Acks {
      */
     public static CommandId toCommandId(Ack ack) {
         checkNotNull(ack);
-        Message unpacked = AnyPacker.unpack(ack.getMessageId());
+        var unpacked = AnyPacker.unpack(ack.getMessageId());
         if (!(unpacked instanceof CommandId)) {
             throw newIllegalArgumentException(
                     "Unable to get a command ID from the acknowledgement: `%s`.",
                     shortDebugString(ack)
             );
         }
-        CommandId commandId = (CommandId) unpacked;
+        var commandId = (CommandId) unpacked;
         return commandId;
     }
 }

--- a/core/src/main/java/io/spine/core/BoundedContextNameMixin.java
+++ b/core/src/main/java/io/spine/core/BoundedContextNameMixin.java
@@ -53,9 +53,8 @@ interface BoundedContextNameMixin extends BoundedContextNameOrBuilder {
      */
     @Internal
     default BoundedContextName toSystem() {
-        String value = value() + "_System";
-        BoundedContextName result = BoundedContextName
-                .newBuilder()
+        var value = value() + "_System";
+        var result = BoundedContextName.newBuilder()
                 .setValue(value)
                 .build();
         return result;

--- a/core/src/main/java/io/spine/core/BoundedContextNames.java
+++ b/core/src/main/java/io/spine/core/BoundedContextNames.java
@@ -60,8 +60,7 @@ public final class BoundedContextNames {
      */
     public static BoundedContextName newName(String name) {
         checkNotEmptyOrBlank(name, "Empty context name is not allowed.");
-        BoundedContextName result = BoundedContextName
-                .newBuilder()
+        var result = BoundedContextName.newBuilder()
                 .setValue(name)
                 .build();
         checkValid(result);
@@ -78,7 +77,7 @@ public final class BoundedContextNames {
     @Internal
     public static void checkValid(BoundedContextName name) throws IllegalArgumentException {
         checkNotNull(name);
-        String value = name.getValue();
+        var value = name.getValue();
         checkValid(value);
     }
 

--- a/core/src/main/java/io/spine/core/CommandMixin.java
+++ b/core/src/main/java/io/spine/core/CommandMixin.java
@@ -28,7 +28,6 @@ package io.spine.core;
 
 import com.google.errorprone.annotations.Immutable;
 import com.google.protobuf.Descriptors;
-import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
 import io.spine.annotation.GeneratedMixin;
 import io.spine.annotation.Internal;
@@ -76,8 +75,7 @@ interface CommandMixin
 
     @Override
     default MessageId rootMessage() {
-        MessageId rootId = context().getOrigin()
-                                    .root();
+        var rootId = context().getOrigin().root();
         return isNotDefault(rootId)
                ? rootId
                : messageId();
@@ -85,7 +83,7 @@ interface CommandMixin
 
     @Override
     default Optional<Origin> origin() {
-        Origin parent = context().getOrigin();
+        var parent = context().getOrigin();
         return Optional.of(parent)
                        .filter(Messages::isNotDefault);
     }
@@ -97,8 +95,8 @@ interface CommandMixin
      *         {@code false} otherwise
      */
     default boolean isScheduled() {
-        CommandContext.Schedule schedule = context().getSchedule();
-        Duration delay = schedule.getDelay();
+        var schedule = context().getSchedule();
+        var delay = schedule.getDelay();
         if (isNotDefault(delay)) {
             checkState(delay.getSeconds() > 0,
                        "Command delay seconds must be a positive value.");

--- a/core/src/main/java/io/spine/core/Commands.java
+++ b/core/src/main/java/io/spine/core/Commands.java
@@ -64,7 +64,7 @@ public final class Commands {
         if (commandOrMessage instanceof Command) {
             return ((Command) commandOrMessage).enclosedMessage();
         }
-        CommandMessage unpacked = (CommandMessage) Messages.ensureMessage(commandOrMessage);
+        var unpacked = (CommandMessage) Messages.ensureMessage(commandOrMessage);
         return unpacked;
     }
 
@@ -91,13 +91,13 @@ public final class Commands {
     static class CommandIdStringifier extends Stringifier<CommandId> {
         @Override
         protected String toString(CommandId commandId) {
-            String result = commandId.getUuid();
+            var result = commandId.getUuid();
             return result;
         }
 
         @Override
         protected CommandId fromString(String str) {
-            CommandId result = CommandId.of(str);
+            var result = CommandId.of(str);
             return result;
         }
     }

--- a/core/src/main/java/io/spine/core/EnrichableMessageContext.java
+++ b/core/src/main/java/io/spine/core/EnrichableMessageContext.java
@@ -48,8 +48,8 @@ public interface EnrichableMessageContext extends MessageContext {
     Enrichment getEnrichment();
 
     default <E extends Message> Optional<E> find(Class<E> cls) {
-        Optional<Container> container = containerIn(this);
-        Optional<E> result = container.flatMap(c -> Enrichments.find(cls, c));
+        var container = containerIn(this);
+        var result = container.flatMap(c -> Enrichments.find(cls, c));
         return result;
     }
 
@@ -59,8 +59,8 @@ public interface EnrichableMessageContext extends MessageContext {
      * @throws IllegalStateException if the enrichment is not found
      */
     default <E extends Message> E get(Class<E> cls) {
-        Container container = containerIn(this).orElse(Container.getDefaultInstance());
-        E result = Enrichments.get(cls, container);
+        var container = containerIn(this).orElse(Container.getDefaultInstance());
+        var result = Enrichments.get(cls, container);
         return result;
     }
 }

--- a/core/src/main/java/io/spine/core/Enrichments.java
+++ b/core/src/main/java/io/spine/core/Enrichments.java
@@ -26,7 +26,6 @@
 
 package io.spine.core;
 
-import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import io.spine.core.Enrichment.Container;
 import io.spine.core.Enrichment.ModeCase;
@@ -55,7 +54,7 @@ final class Enrichments {
      * <p>Otherwise, empty {@code Optional} is returned.
      */
     static Optional<Container> containerIn(EnrichableMessageContext context) {
-        Enrichment enrichment = context.getEnrichment();
+        var enrichment = context.getEnrichment();
         if (enrichment.getModeCase() == ModeCase.CONTAINER) {
             return Optional.of(enrichment.getContainer());
         }
@@ -67,8 +66,8 @@ final class Enrichments {
      */
     static <E extends Message>
     Optional<E> find(Class<E> enrichmentClass, Container container) {
-        TypeName typeName = TypeName.of(enrichmentClass);
-        Optional<E> result = findType(typeName, enrichmentClass, container);
+        var typeName = TypeName.of(enrichmentClass);
+        var result = findType(typeName, enrichmentClass, container);
         return result;
     }
 
@@ -78,8 +77,8 @@ final class Enrichments {
      * @throws IllegalStateException if there is no enrichment of this class in the passed container
      */
     static <E extends Message> E get(Class<E> enrichmentClass, Container container) {
-        TypeName typeName = TypeName.of(enrichmentClass);
-        E result = findType(typeName, enrichmentClass, container)
+        var typeName = TypeName.of(enrichmentClass);
+        var result = findType(typeName, enrichmentClass, container)
                 .orElseThrow(() -> newIllegalStateException(
                         "Unable to get enrichment of the type `%s` from the container `%s`.",
                         typeName, container));
@@ -88,10 +87,10 @@ final class Enrichments {
 
     private static <E extends Message> Optional<E>
     findType(TypeName typeName, Class<E> enrichmentClass, Container container) {
-        Any any = container.getItemsMap()
+        var any = container.getItemsMap()
                            .get(typeName.value());
-        Optional<E> result = Optional.ofNullable(any)
-                                     .map(packed -> unpack(packed, enrichmentClass));
+        var result = Optional.ofNullable(any)
+                             .map(packed -> unpack(packed, enrichmentClass));
         return result;
     }
 
@@ -100,17 +99,16 @@ final class Enrichments {
      */
     @SuppressWarnings("deprecation") // Uses the deprecated field to be sure to clean up old data.
     static Event clear(Event event) {
-        EventContext context = event.getContext();
-        EventContext.OriginCase originCase = context.getOriginCase();
-        EventContext.Builder resultContext = context.toBuilder()
-                                                    .clearEnrichment();
+        var context = event.getContext();
+        var originCase = context.getOriginCase();
+        var resultContext = context.toBuilder().clearEnrichment();
         if (originCase == EventContext.OriginCase.EVENT_CONTEXT) {
             resultContext.setEventContext(context.getEventContext()
-                                                 .toBuilder()
-                                                 .clearEnrichment()
-                                                 .build());
+                                                  .toBuilder()
+                                                  .clearEnrichment()
+                                                  .build());
         }
-        Event result = event.toBuilder()
+        var result = event.toBuilder()
                             .setContext(resultContext.build())
                             .build();
         return result;
@@ -123,18 +121,18 @@ final class Enrichments {
             "deprecation" /* Uses the deprecated field to be sure to clean up old data. */,
             "ConstantConditions" /* Checked logically. */})
     static Event clearAll(Event event) {
-        EventContext.Builder eventContext = event.getContext()
-                                                 .toBuilder()
-                                                 .clearEnrichment();
-        Deque<EventContext.Builder> contexts = eventContextHierarchy(eventContext);
+        var eventContext = event.getContext()
+                .toBuilder()
+                .clearEnrichment();
+        var contexts = eventContextHierarchy(eventContext);
 
-        EventContext.Builder context = contexts.pollLast();
-        EventContext.Builder next = contexts.pollLast();
+        var context = contexts.pollLast();
+        var next = contexts.pollLast();
         while (next != null) {
             context = next.setEventContext(context);
             next = contexts.pollLast();
         }
-        Event result = event.toBuilder()
+        var result = event.toBuilder()
                             .setContext(context.build())
                             .build();
         return result;
@@ -150,14 +148,14 @@ final class Enrichments {
     private static Deque<EventContext.Builder>
     eventContextHierarchy(EventContext.Builder eventContext) {
 
-        EventContext.Builder child = eventContext;
-        EventContext.OriginCase originCase = child.getOriginCase();
+        var child = eventContext;
+        var originCase = child.getOriginCase();
         Deque<EventContext.Builder> contexts = newArrayDeque();
         contexts.add(child);
         while (originCase == EventContext.OriginCase.EVENT_CONTEXT) {
-            EventContext.Builder origin = child.getEventContext()
-                                               .toBuilder()
-                                               .clearEnrichment();
+            var origin = child.getEventContext()
+                    .toBuilder()
+                    .clearEnrichment();
             contexts.add(origin);
             child = origin;
             originCase = child.getOriginCase();

--- a/core/src/main/java/io/spine/core/EventContextMixin.java
+++ b/core/src/main/java/io/spine/core/EventContextMixin.java
@@ -73,7 +73,7 @@ interface EventContextMixin extends EventContextOrBuilder,
     })
     default ActorContext actorContext() {
         ActorContext actorContext = null;
-        EventContext ctx = (EventContext) this;
+        var ctx = (EventContext) this;
 
         while (actorContext == null) {
             switch (ctx.getOriginCase()) {
@@ -116,7 +116,7 @@ interface EventContextMixin extends EventContextOrBuilder,
      */
     @SuppressWarnings("deprecation") // For backward compatibility.
     default Optional<MessageId> rootMessage() {
-        EventContext.OriginCase origin = getOriginCase();
+        var origin = getOriginCase();
         switch (origin) {
             case PAST_MESSAGE:
                 return Optional.of(getPastMessage().root());
@@ -128,8 +128,7 @@ interface EventContextMixin extends EventContextOrBuilder,
             default:
                 if (hasRootCommandId()) {
                     @SuppressWarnings("DuplicateStringLiteralInspection") // Coincidence.
-                    MessageId id = MessageId
-                            .newBuilder()
+                    var id = MessageId.newBuilder()
                             .setId(Identifier.pack(getRootCommandId()))
                             .setTypeUrl("Unknown")
                             .vBuild();
@@ -146,7 +145,7 @@ interface EventContextMixin extends EventContextOrBuilder,
      */
     default Object producer() {
         @SuppressWarnings("ClassReferencesSubclass")  // which is the only impl.
-        EventContext thisContext = (EventContext) this;
+        var thisContext = (EventContext) this;
         return Identifier.unpack(thisContext.getProducerId());
     }
 

--- a/core/src/main/java/io/spine/core/EventMixin.java
+++ b/core/src/main/java/io/spine/core/EventMixin.java
@@ -77,7 +77,7 @@ interface EventMixin
 
     @Override
     default Optional<Origin> origin() {
-        Origin parent = context().getPastMessage();
+        var parent = context().getPastMessage();
         return Optional.of(parent)
                        .filter(Messages::isNotDefault);
     }
@@ -107,8 +107,8 @@ interface EventMixin
      * @return {@code true} if the given event is a rejection, {@code false} otherwise
      */
     default boolean isRejection() {
-        EventContext context = context();
-        boolean result = context.hasRejection() || !isDefault(context.getRejection());
+        var context = context();
+        var result = context.hasRejection() || !isDefault(context.getRejection());
         return result;
     }
 
@@ -177,8 +177,8 @@ interface EventMixin
     @Override
     @Internal
     default ActorContext actorContext() {
-        EventContext eventContext = context();
-        ActorContext result = eventContext.actorContext();
+        var eventContext = context();
+        var result = eventContext.actorContext();
         return result;
     }
 

--- a/core/src/main/java/io/spine/core/Events.java
+++ b/core/src/main/java/io/spine/core/Events.java
@@ -35,10 +35,10 @@ import io.spine.string.Stringifier;
 import io.spine.string.StringifierRegistry;
 
 import java.util.List;
-import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.spine.base.Identifier.newUuid;
 import static io.spine.util.Preconditions2.checkNotDefaultArg;
 
 /**
@@ -65,8 +65,7 @@ public final class Events {
      * @return new UUID-based event ID
      */
     public static EventId generateId() {
-        String value = UUID.randomUUID()
-                           .toString();
+        var value = newUuid();
         return EventId.newBuilder()
                       .setValue(value)
                       .build();
@@ -81,7 +80,7 @@ public final class Events {
         if (eventOrMessage instanceof Event) {
             return ((Event) eventOrMessage).enclosedMessage();
         }
-        Message unpacked = Messages.ensureMessage(eventOrMessage);
+        var unpacked = Messages.ensureMessage(eventOrMessage);
         return (EventMessage) unpacked;
     }
 
@@ -136,7 +135,7 @@ public final class Events {
      * Marks the given event as {@code external}.
      */
     public static Event toExternal(Event event) {
-        Event.Builder externalEvent = event.toBuilder();
+        var externalEvent = event.toBuilder();
         externalEvent.getContextBuilder().setExternal(true);
         return externalEvent.build();
     }
@@ -148,15 +147,15 @@ public final class Events {
 
         @Override
         protected String toString(EventId eventId) {
-            String result = eventId.getValue();
+            var result = eventId.getValue();
             return result;
         }
 
         @Override
         protected EventId fromString(String str) {
-            EventId result = EventId.newBuilder()
-                                    .setValue(str)
-                                    .build();
+            var result = EventId.newBuilder()
+                    .setValue(str)
+                    .build();
             return result;
         }
     }

--- a/core/src/main/java/io/spine/core/MessageIdMixin.java
+++ b/core/src/main/java/io/spine/core/MessageIdMixin.java
@@ -26,7 +26,6 @@
 
 package io.spine.core;
 
-import com.google.protobuf.Any;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import io.spine.annotation.GeneratedMixin;
@@ -59,7 +58,7 @@ interface MessageIdMixin extends MessageIdOrBuilder, FieldAwareMessage {
      * Checks if the associated message is an event.
      */
     default boolean isEvent() {
-        Any id = getId();
+        var id = getId();
         return EVENT_ID_TYPE_URL.equals(id.getTypeUrl());
     }
 
@@ -77,7 +76,7 @@ interface MessageIdMixin extends MessageIdOrBuilder, FieldAwareMessage {
      * Checks if the associated message is a command.
      */
     default boolean isCommand() {
-        Any id = getId();
+        var id = getId();
         return COMMAND_ID_TYPE_URL.equals(id.getTypeUrl());
     }
 

--- a/core/src/main/java/io/spine/core/OriginMixin.java
+++ b/core/src/main/java/io/spine/core/OriginMixin.java
@@ -49,7 +49,7 @@ interface OriginMixin extends OriginOrBuilder, FieldAwareMessage {
      * <p>The root message has no further origin, as it is produced by an actor.
      */
     default MessageId root() {
-        OriginMixin root = this;
+        var root = this;
         while (isNotDefault(root.getGrandOrigin())) {
             root = root.getGrandOrigin();
         }

--- a/core/src/main/java/io/spine/core/Responses.java
+++ b/core/src/main/java/io/spine/core/Responses.java
@@ -77,7 +77,7 @@ public final class Responses {
      */
     public static Status rejectedBecauseOf(Event rejection) {
         checkNotDefaultArg(rejection);
-        Status status = Status.newBuilder()
+        var status = Status.newBuilder()
                 .setRejection(rejection)
                 .build();
         return status;

--- a/core/src/main/java/io/spine/core/Signal.java
+++ b/core/src/main/java/io/spine/core/Signal.java
@@ -98,7 +98,7 @@ public interface Signal<I extends SignalId,
      */
     default Class<? extends M> type() {
         @SuppressWarnings("unchecked") // Safe as we obtain it from an instance of <M>.
-        Class<? extends M> type = (Class<? extends M>) enclosedMessage().getClass();
+        var type = (Class<? extends M>) enclosedMessage().getClass();
         return type;
     }
 
@@ -109,7 +109,7 @@ public interface Signal<I extends SignalId,
      */
     @SuppressWarnings("unchecked") // protected by generic params of extending interfaces
     default M enclosedMessage() {
-        Message enclosed = AnyPacker.unpack(getMessage());
+        var enclosed = AnyPacker.unpack(getMessage());
         return (M) enclosed;
     }
 
@@ -134,7 +134,7 @@ public interface Signal<I extends SignalId,
     default boolean is(Class<? extends Message> enclosedMessageClass) {
         checkNotNull(enclosedMessageClass);
         Message enclosed = enclosedMessage();
-        boolean result = enclosedMessageClass.isAssignableFrom(enclosed.getClass());
+        var result = enclosedMessageClass.isAssignableFrom(enclosed.getClass());
         return result;
     }
 
@@ -163,7 +163,7 @@ public interface Signal<I extends SignalId,
      * <p>This origin is assigned to any signal message produced as a reaction to this one.
      */
     default Origin asMessageOrigin() {
-        Origin.Builder originBuilder = Origin
+        var originBuilder = Origin
                 .newBuilder()
                 .setActorContext(actorContext())
                 .setMessage(messageId());

--- a/core/src/main/java/io/spine/core/Versions.java
+++ b/core/src/main/java/io/spine/core/Versions.java
@@ -69,7 +69,7 @@ public final class Versions {
      */
     public static Version increment(Version version) {
         checkNotNull(version);
-        Version result = create(version.getNumber() + 1, currentTime());
+        var result = create(version.getNumber() + 1, currentTime());
         return result;
     }
 
@@ -85,7 +85,7 @@ public final class Versions {
         checkNotNull(currentVersion);
         checkNotNull(newVersion);
         if (!newVersion.isIncrement(currentVersion)) {
-            String errMsg = format(
+            var errMsg = format(
                     "New version number (%d) cannot be less or equal to the current (%d).",
                     newVersion.getNumber(), currentVersion.getNumber());
             throw new IllegalArgumentException(errMsg);

--- a/core/src/main/java/io/spine/core/WithTime.java
+++ b/core/src/main/java/io/spine/core/WithTime.java
@@ -90,7 +90,7 @@ public interface WithTime {
      */
     default LocalDate localDate() {
         @SuppressWarnings("FromTemporalAccessor") // `Instant` does have date info.
-        LocalDate result = LocalDate.from(instant());
+        var result = LocalDate.from(instant());
         return result;
     }
 
@@ -99,7 +99,7 @@ public interface WithTime {
      */
     default LocalDateTime localDateTime() {
         @SuppressWarnings("FromTemporalAccessor") // `Instant` does have date/time info.
-        LocalDateTime result = LocalDateTime.from(instant());
+        var result = LocalDateTime.from(instant());
         return result;
     }
 }

--- a/core/src/test/java/io/spine/change/BooleanMismatchTest.java
+++ b/core/src/test/java/io/spine/change/BooleanMismatchTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings({"InnerClassMayBeStatic" /* JUnit nested classes cannot be static */,
                    "DuplicateStringLiteralInspection" /* A lot of similar test display names */})
-@DisplayName("BooleanMismatch should")
+@DisplayName("`BooleanMismatch` should")
 class BooleanMismatchTest extends UtilityClassTest<BooleanMismatch> {
 
     private static final int VERSION = 2;
@@ -51,16 +51,16 @@ class BooleanMismatchTest extends UtilityClassTest<BooleanMismatch> {
     }
 
     @Nested
-    @DisplayName("create ValueMismatch instance")
+    @DisplayName("create `ValueMismatch` instance")
     class Create {
 
         @Test
         @DisplayName("for `expectedFalse` case")
         void forExpectedFalse() {
-            boolean expected = false;
-            boolean actual = true;
-            boolean newValue = true;
-            ValueMismatch mismatch = expectedFalse(VERSION);
+            var expected = false;
+            var actual = true;
+            var newValue = true;
+            var mismatch = expectedFalse(VERSION);
 
             assertEquals(expected, unpackExpected(mismatch));
             assertEquals(actual, unpackActual(mismatch));
@@ -71,10 +71,10 @@ class BooleanMismatchTest extends UtilityClassTest<BooleanMismatch> {
         @Test
         @DisplayName("for `expectedTrue` case")
         void forExpectedTrue() {
-            boolean expected = true;
-            boolean actual = false;
-            boolean newValue = false;
-            ValueMismatch mismatch = expectedTrue(VERSION);
+            var expected = true;
+            var actual = false;
+            var newValue = false;
+            var mismatch = expectedTrue(VERSION);
 
             assertEquals(expected, unpackExpected(mismatch));
             assertEquals(actual, unpackActual(mismatch));
@@ -84,27 +84,27 @@ class BooleanMismatchTest extends UtilityClassTest<BooleanMismatch> {
     }
 
     @Nested
-    @DisplayName("if given non-boolean ValueMismatch, fail to unpack")
+    @DisplayName("if given non-boolean `ValueMismatch`, fail to unpack")
     class FailToUnpack {
 
         @Test
         @DisplayName("expected")
         void expectedWithWrongType() {
-            ValueMismatch mismatch = IntMismatch.of(1, 2, 3, VERSION);
+            var mismatch = IntMismatch.of(1, 2, 3, VERSION);
             assertThrows(RuntimeException.class, () -> BooleanMismatch.unpackExpected(mismatch));
         }
 
         @Test
         @DisplayName("actual boolean")
         void actualWithWrongType() {
-            ValueMismatch mismatch = IntMismatch.of(1, 2, 3, VERSION);
+            var mismatch = IntMismatch.of(1, 2, 3, VERSION);
             assertThrows(RuntimeException.class, () -> BooleanMismatch.unpackActual(mismatch));
         }
 
         @Test
         @DisplayName("new value")
         void newValueWithWrongType() {
-            ValueMismatch mismatch = IntMismatch.of(1, 2, 3, VERSION);
+            var mismatch = IntMismatch.of(1, 2, 3, VERSION);
             assertThrows(RuntimeException.class, () -> BooleanMismatch.unpackNewValue(mismatch));
         }
     }

--- a/core/src/test/java/io/spine/change/ChangePreconditionsTest.java
+++ b/core/src/test/java/io/spine/change/ChangePreconditionsTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 import static io.spine.change.ChangePreconditions.checkNewValueNotEmpty;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisplayName("ChangePreconditions utility should")
+@DisplayName("`ChangePreconditions` utility should")
 class ChangePreconditionsTest extends UtilityClassTest<ChangePreconditions> {
 
     ChangePreconditionsTest() {
@@ -42,16 +42,16 @@ class ChangePreconditionsTest extends UtilityClassTest<ChangePreconditions> {
     }
 
     @Test
-    @DisplayName("not accept empty ByteString value")
+    @DisplayName("not accept empty `ByteString` value")
     void failOnEmptyByteString() {
-        ByteString str = ByteString.EMPTY;
+        var str = ByteString.EMPTY;
         assertThrows(IllegalArgumentException.class, () -> checkNewValueNotEmpty(str));
     }
 
     @Test
     @DisplayName("not accept empty String value")
     void failOnEmptyString() {
-        String str = "";
+        var str = "";
         assertThrows(IllegalArgumentException.class, () -> checkNewValueNotEmpty(str));
     }
 }

--- a/core/src/test/java/io/spine/change/ChangesTest.java
+++ b/core/src/test/java/io/spine/change/ChangesTest.java
@@ -70,10 +70,10 @@ class ChangesTest extends UtilityClassTest<Changes> {
         @Test
         @DisplayName("`String`")
         void forStrings() {
-            String previousValue = randomUuid();
-            String newValue = randomUuid();
+            var previousValue = randomUuid();
+            var newValue = randomUuid();
 
-            StringChange result = Changes.of(previousValue, newValue);
+            var result = Changes.of(previousValue, newValue);
 
             assertEquals(previousValue, result.getPreviousValue());
             assertEquals(newValue, result.getNewValue());
@@ -82,10 +82,10 @@ class ChangesTest extends UtilityClassTest<Changes> {
         @Test
         @DisplayName("`ByteString`")
         void forByteStrings() {
-            ByteString previousValue = copyFromUtf8(randomUuid());
-            ByteString newValue = copyFromUtf8(randomUuid());
+            var previousValue = copyFromUtf8(randomUuid());
+            var newValue = copyFromUtf8(randomUuid());
 
-            BytesChange result = Changes.of(previousValue, newValue);
+            var result = Changes.of(previousValue, newValue);
 
             assertEquals(previousValue, result.getPreviousValue());
             assertEquals(newValue, result.getNewValue());
@@ -94,10 +94,10 @@ class ChangesTest extends UtilityClassTest<Changes> {
         @Test
         @DisplayName("`Timestamp`")
         void forTimestamps() {
-            Timestamp fiveMinutesAgo = Past.minutesAgo(5);
-            Timestamp now = currentTime();
+            var fiveMinutesAgo = Past.minutesAgo(5);
+            var now = currentTime();
 
-            TimestampChange result = Changes.of(fiveMinutesAgo, now);
+            var result = Changes.of(fiveMinutesAgo, now);
 
             assertEquals(fiveMinutesAgo, result.getPreviousValue());
             assertEquals(now, result.getNewValue());
@@ -106,10 +106,10 @@ class ChangesTest extends UtilityClassTest<Changes> {
         @Test
         @DisplayName("`boolean`")
         void forBooleans() {
-            boolean s1 = true;
-            boolean s2 = false;
+            var s1 = true;
+            var s2 = false;
 
-            BooleanChange result = Changes.of(s1, s2);
+            var result = Changes.of(s1, s2);
 
             assertEquals(s1, result.getPreviousValue());
             assertEquals(s2, result.getNewValue());
@@ -118,10 +118,10 @@ class ChangesTest extends UtilityClassTest<Changes> {
         @Test
         @DisplayName("`double`")
         void forDoubles() {
-            double s1 = 1957.1004;
-            double s2 = 1957.1103;
+            var s1 = 1957.1004;
+            var s2 = 1957.1103;
 
-            DoubleChange result = Changes.of(s1, s2);
+            var result = Changes.of(s1, s2);
 
             assertEquals(s1, result.getPreviousValue());
             assertEquals(s2, result.getNewValue());
@@ -130,10 +130,10 @@ class ChangesTest extends UtilityClassTest<Changes> {
         @Test
         @DisplayName("`int32`")
         void forInt32s() {
-            int s1 = 1550;
-            int s2 = 1616;
+            var s1 = 1550;
+            var s2 = 1616;
 
-            Int32Change result = Changes.ofInt32(s1, s2);
+            var result = Changes.ofInt32(s1, s2);
 
             assertEquals(s1, result.getPreviousValue());
             assertEquals(s2, result.getNewValue());
@@ -142,10 +142,10 @@ class ChangesTest extends UtilityClassTest<Changes> {
         @Test
         @DisplayName("`int64`")
         void forInt64s() {
-            long s1 = 16420225L;
-            long s2 = 17270320L;
+            var s1 = 16420225L;
+            var s2 = 17270320L;
 
-            Int64Change result = Changes.ofInt64(s1, s2);
+            var result = Changes.ofInt64(s1, s2);
 
             assertEquals(s1, result.getPreviousValue());
             assertEquals(s2, result.getNewValue());
@@ -154,10 +154,10 @@ class ChangesTest extends UtilityClassTest<Changes> {
         @Test
         @DisplayName("`float`")
         void forFloats() {
-            float s1 = 1473.0219f;
-            float s2 = 1543.0524f;
+            var s1 = 1473.0219f;
+            var s2 = 1543.0524f;
 
-            FloatChange result = Changes.of(s1, s2);
+            var result = Changes.of(s1, s2);
 
             assertEquals(s1, result.getPreviousValue());
             assertEquals(s2, result.getNewValue());
@@ -166,10 +166,10 @@ class ChangesTest extends UtilityClassTest<Changes> {
         @Test
         @DisplayName("`uint32`")
         void forUint32s() {
-            int s1 = 16440925;
-            int s2 = 17100919;
+            var s1 = 16440925;
+            var s2 = 17100919;
 
-            UInt32Change result = Changes.ofUInt32(s1, s2);
+            var result = Changes.ofUInt32(s1, s2);
 
             assertEquals(s1, result.getPreviousValue());
             assertEquals(s2, result.getNewValue());
@@ -178,10 +178,10 @@ class ChangesTest extends UtilityClassTest<Changes> {
         @Test
         @DisplayName("`uint64`")
         void forUint64s() {
-            long s1 = 16290414L;
-            long s2 = 16950708L;
+            var s1 = 16290414L;
+            var s2 = 16950708L;
 
-            UInt64Change result = Changes.ofUInt64(s1, s2);
+            var result = Changes.ofUInt64(s1, s2);
 
             assertEquals(s1, result.getPreviousValue());
             assertEquals(s2, result.getNewValue());
@@ -190,10 +190,10 @@ class ChangesTest extends UtilityClassTest<Changes> {
         @Test
         @DisplayName("`sint32`")
         void forSint32s() {
-            int s1 = 16550106;
-            int s2 = 17050816;
+            var s1 = 16550106;
+            var s2 = 17050816;
 
-            SInt32Change result = Changes.ofSInt32(s1, s2);
+            var result = Changes.ofSInt32(s1, s2);
 
             assertEquals(s1, result.getPreviousValue());
             assertEquals(s2, result.getNewValue());
@@ -202,10 +202,10 @@ class ChangesTest extends UtilityClassTest<Changes> {
         @Test
         @DisplayName("`sint64`")
         void forSint64s() {
-            long s1 = 1666L;
-            long s2 = 1736L;
+            var s1 = 1666L;
+            var s2 = 1736L;
 
-            SInt64Change result = Changes.ofSInt64(s1, s2);
+            var result = Changes.ofSInt64(s1, s2);
 
             assertEquals(s1, result.getPreviousValue());
             assertEquals(s2, result.getNewValue());
@@ -214,10 +214,10 @@ class ChangesTest extends UtilityClassTest<Changes> {
         @Test
         @DisplayName("`fixed32`")
         void forFixed32s() {
-            int s1 = 17070415;
-            int s2 = 17830918;
+            var s1 = 17070415;
+            var s2 = 17830918;
 
-            Fixed32Change result = Changes.ofFixed32(s1, s2);
+            var result = Changes.ofFixed32(s1, s2);
 
             assertEquals(s1, result.getPreviousValue());
             assertEquals(s2, result.getNewValue());
@@ -226,10 +226,10 @@ class ChangesTest extends UtilityClassTest<Changes> {
         @Test
         @DisplayName("`fixed64`")
         void forFixed64s() {
-            long s1 = 17240422L;
-            long s2 = 18040212L;
+            var s1 = 17240422L;
+            var s2 = 18040212L;
 
-            Fixed64Change result = Changes.ofFixed64(s1, s2);
+            var result = Changes.ofFixed64(s1, s2);
 
             assertEquals(s1, result.getPreviousValue());
             assertEquals(s2, result.getNewValue());
@@ -238,10 +238,10 @@ class ChangesTest extends UtilityClassTest<Changes> {
         @Test
         @DisplayName("`sfixed32`")
         void forSfixed32s() {
-            int s1 = 1550;
-            int s2 = 1616;
+            var s1 = 1550;
+            var s2 = 1616;
 
-            Sfixed32Change result = Changes.ofSfixed32(s1, s2);
+            var result = Changes.ofSfixed32(s1, s2);
 
             assertEquals(s1, result.getPreviousValue());
             assertEquals(s2, result.getNewValue());
@@ -250,10 +250,10 @@ class ChangesTest extends UtilityClassTest<Changes> {
         @Test
         @DisplayName("`sfixed64`")
         void forSfixed64s() {
-            long s1 = 16420225L;
-            long s2 = 17270320L;
+            var s1 = 16420225L;
+            var s2 = 17270320L;
 
-            Sfixed64Change result = Changes.ofSfixed64(s1, s2);
+            var result = Changes.ofSfixed64(s1, s2);
 
             assertEquals(s1, result.getPreviousValue());
             assertEquals(s2, result.getNewValue());
@@ -272,112 +272,112 @@ class ChangesTest extends UtilityClassTest<Changes> {
         @Test
         @DisplayName("`String`")
         void strings() {
-            String value = randomString();
+            var value = randomString();
             assertThrows(IllegalArgumentException.class, () -> Changes.of(value, value));
         }
 
         @Test
         @DisplayName("`ByteString`")
         void byteStrings() {
-            ByteString value = copyFromUtf8(randomString());
+            var value = copyFromUtf8(randomString());
             assertThrows(IllegalArgumentException.class, () -> Changes.of(value, value));
         }
 
         @Test
         @DisplayName("`Timestamp`")
         void timestamps() {
-            Timestamp now = currentTime();
+            var now = currentTime();
             assertThrows(IllegalArgumentException.class, () -> Changes.of(now, now));
         }
 
         @Test
         @DisplayName("`boolean`")
         void booleans() {
-            boolean value = true;
+            var value = true;
             assertThrows(IllegalArgumentException.class, () -> Changes.of(value, value));
         }
 
         @Test
         @DisplayName("`double`")
         void doubles() {
-            double value = 1961.0412;
+            var value = 1961.0412;
             assertThrows(IllegalArgumentException.class, () -> Changes.of(value, value));
         }
 
         @Test
         @DisplayName("`float`")
         void floats() {
-            float value = 1543.0f;
+            var value = 1543.0f;
             assertThrows(IllegalArgumentException.class, () -> Changes.of(value, value));
         }
 
         @Test
         @DisplayName("`int32`")
         void int32s() {
-            int value = 1614;
+            var value = 1614;
             assertThrows(IllegalArgumentException.class, () -> Changes.ofInt32(value, value));
         }
 
         @Test
         @DisplayName("`uint32`")
         void uint32s() {
-            int value = 1776;
+            var value = 1776;
             assertThrows(IllegalArgumentException.class, () -> Changes.ofUInt32(value, value));
         }
 
         @Test
         @DisplayName("`sint32`")
         void sint32s() {
-            int value = 1694;
+            var value = 1694;
             assertThrows(IllegalArgumentException.class, () -> Changes.ofSInt32(value, value));
         }
 
         @Test
         @DisplayName("`fixed32`")
         void fixed32s() {
-            int value = 1736;
+            var value = 1736;
             assertThrows(IllegalArgumentException.class, () -> Changes.ofFixed32(value, value));
         }
 
         @Test
         @DisplayName("`int64`")
         void int64s() {
-            long value = 1666L;
+            var value = 1666L;
             assertThrows(IllegalArgumentException.class, () -> Changes.ofInt64(value, value));
         }
 
         @Test
         @DisplayName("`uint64`")
         void uint64s() {
-            long value = 1690L;
+            var value = 1690L;
             assertThrows(IllegalArgumentException.class, () -> Changes.ofUInt64(value, value));
         }
 
         @Test
         @DisplayName("`sint64`")
         void sint64s() {
-            long value = 1729L;
+            var value = 1729L;
             assertThrows(IllegalArgumentException.class, () -> Changes.ofSInt64(value, value));
         }
 
         @Test
         @DisplayName("`fixed64`")
         void fixed64s() {
-            long value = 1755L;
+            var value = 1755L;
             assertThrows(IllegalArgumentException.class, () -> Changes.ofFixed64(value, value));
         }
 
         @Test
         @DisplayName("`sfixed32`")
         void sfixed32s() {
-            int value = 1614;
+            var value = 1614;
             assertThrows(IllegalArgumentException.class, () -> Changes.ofSfixed32(value, value));
         }
 
         @Test
         @DisplayName("`sfixed64`")
         void sfixed64s() {
-            long value = 1666L;
+            var value = 1666L;
             assertThrows(IllegalArgumentException.class, () -> Changes.ofSfixed64(value, value));
         }
     }

--- a/core/src/test/java/io/spine/change/DoubleMismatchTest.java
+++ b/core/src/test/java/io/spine/change/DoubleMismatchTest.java
@@ -41,7 +41,7 @@ import static io.spine.change.DoubleMismatch.unpackNewValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisplayName("DoubleMismatch should")
+@DisplayName("`DoubleMismatch` should")
 class DoubleMismatchTest extends UtilityClassTest<DoubleMismatch> {
 
     private static final int VERSION = 100;
@@ -55,13 +55,13 @@ class DoubleMismatchTest extends UtilityClassTest<DoubleMismatch> {
     }
 
     @Nested
-    @DisplayName("create ValueMismatch instance")
+    @DisplayName("create `ValueMismatch` instance")
     class Create {
 
         @Test
         @DisplayName("from given double values")
         void withDoubles() {
-            ValueMismatch mismatch = DoubleMismatch.of(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
+            var mismatch = DoubleMismatch.of(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
 
             assertEquals(EXPECTED, unpackExpected(mismatch), DELTA);
             assertEquals(ACTUAL, unpackActual(mismatch), DELTA);
@@ -72,8 +72,8 @@ class DoubleMismatchTest extends UtilityClassTest<DoubleMismatch> {
         @Test
         @DisplayName("for expected zero amount")
         void forExpectedZero() {
-            double expected = 0.0;
-            ValueMismatch mismatch = expectedZero(ACTUAL, NEW_VALUE, VERSION);
+            var expected = 0.0;
+            var mismatch = expectedZero(ACTUAL, NEW_VALUE, VERSION);
 
             assertEquals(expected, unpackExpected(mismatch), DELTA);
             assertEquals(ACTUAL, unpackActual(mismatch), DELTA);
@@ -82,10 +82,10 @@ class DoubleMismatchTest extends UtilityClassTest<DoubleMismatch> {
         }
 
         @Test
-        @DisplayName("for expected non zero amount")
+        @DisplayName("for expected non-zero amount")
         void forExpectedNonZero() {
-            double actual = 0.0;
-            ValueMismatch mismatch = expectedNonZero(EXPECTED, NEW_VALUE, VERSION);
+            var actual = 0.0;
+            var mismatch = expectedNonZero(EXPECTED, NEW_VALUE, VERSION);
 
             assertEquals(EXPECTED, unpackExpected(mismatch), DELTA);
             assertEquals(actual, unpackActual(mismatch), DELTA);
@@ -97,7 +97,7 @@ class DoubleMismatchTest extends UtilityClassTest<DoubleMismatch> {
         @Test
         @DisplayName("for unexpected double value")
         void forUnexpectedDouble() {
-            ValueMismatch mismatch = unexpectedValue(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
+            var mismatch = unexpectedValue(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
 
             assertEquals(EXPECTED, unpackExpected(mismatch), DELTA);
             assertEquals(ACTUAL, unpackActual(mismatch), DELTA);
@@ -109,7 +109,7 @@ class DoubleMismatchTest extends UtilityClassTest<DoubleMismatch> {
     @Test
     @DisplayName("not accept same expected and actual values")
     void notAcceptSameExpectedAndActual() {
-        double value = 19.19;
+        var value = 19.19;
         assertThrows(IllegalArgumentException.class,
                      () -> unexpectedValue(value, value, NEW_VALUE, VERSION));
     }
@@ -121,21 +121,21 @@ class DoubleMismatchTest extends UtilityClassTest<DoubleMismatch> {
         @Test
         @DisplayName("expected")
         void expectedWithWrongType() {
-            ValueMismatch mismatch = expectedTrue(VERSION);
+            var mismatch = expectedTrue(VERSION);
             assertThrows(RuntimeException.class, () -> unpackExpected(mismatch));
         }
 
         @Test
         @DisplayName("actual double")
         void actualWithWrongType() {
-            ValueMismatch mismatch = expectedTrue(VERSION);
+            var mismatch = expectedTrue(VERSION);
             assertThrows(RuntimeException.class, () -> unpackActual(mismatch));
         }
 
         @Test
         @DisplayName("new value")
         void newValueWithWrongType() {
-            ValueMismatch mismatch = expectedTrue(VERSION);
+            var mismatch = expectedTrue(VERSION);
             assertThrows(RuntimeException.class, () -> unpackNewValue(mismatch));
         }
     }

--- a/core/src/test/java/io/spine/change/FloatMismatchTest.java
+++ b/core/src/test/java/io/spine/change/FloatMismatchTest.java
@@ -41,7 +41,7 @@ import static io.spine.change.FloatMismatch.unpackNewValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisplayName("FloatMismatch should")
+@DisplayName("`FloatMismatch` should")
 class FloatMismatchTest extends UtilityClassTest<FloatMismatch> {
 
     private static final int VERSION = 100;
@@ -55,13 +55,13 @@ class FloatMismatchTest extends UtilityClassTest<FloatMismatch> {
     }
 
     @Nested
-    @DisplayName("create ValueMismatch instance")
+    @DisplayName("create `ValueMismatch` instance")
     class Create {
 
         @Test
         @DisplayName("from given float values")
         void withFloats() {
-            ValueMismatch mismatch = FloatMismatch.of(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
+            var mismatch = FloatMismatch.of(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
 
             assertEquals(EXPECTED, unpackExpected(mismatch), DELTA);
             assertEquals(ACTUAL, unpackActual(mismatch), DELTA);
@@ -73,7 +73,7 @@ class FloatMismatchTest extends UtilityClassTest<FloatMismatch> {
         @DisplayName("for expected zero amount")
         void forExpectedZero() {
             double expected = 0.0f;
-            ValueMismatch mismatch = expectedZero(ACTUAL, NEW_VALUE, VERSION);
+            var mismatch = expectedZero(ACTUAL, NEW_VALUE, VERSION);
 
             assertEquals(expected, unpackExpected(mismatch), DELTA);
             assertEquals(ACTUAL, unpackActual(mismatch), DELTA);
@@ -82,10 +82,10 @@ class FloatMismatchTest extends UtilityClassTest<FloatMismatch> {
         }
 
         @Test
-        @DisplayName("for expected non zero amount")
+        @DisplayName("for expected non-zero amount")
         void forExpectedNonZero() {
-            float actual = 0.0f;
-            ValueMismatch mismatch = expectedNonZero(EXPECTED, NEW_VALUE, VERSION);
+            var actual = 0.0f;
+            var mismatch = expectedNonZero(EXPECTED, NEW_VALUE, VERSION);
 
             assertEquals(EXPECTED, unpackExpected(mismatch), DELTA);
             assertEquals(actual, unpackActual(mismatch), DELTA);
@@ -96,7 +96,7 @@ class FloatMismatchTest extends UtilityClassTest<FloatMismatch> {
         @Test
         @DisplayName("for unexpected float value")
         void forUnexpectedFloat() {
-            ValueMismatch mismatch = unexpectedValue(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
+            var mismatch = unexpectedValue(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
 
             assertEquals(EXPECTED, unpackExpected(mismatch), DELTA);
             assertEquals(ACTUAL, unpackActual(mismatch), DELTA);
@@ -108,33 +108,33 @@ class FloatMismatchTest extends UtilityClassTest<FloatMismatch> {
     @Test
     @DisplayName("not accept same expected and actual values")
     void notAcceptSameExpectedAndActual() {
-        float value = 19.19f;
+        var value = 19.19f;
         assertThrows(IllegalArgumentException.class,
                      () -> unexpectedValue(value, value, NEW_VALUE, VERSION));
     }
 
     @Nested
-    @DisplayName("if given non-float ValueMismatch, fail to unpack")
+    @DisplayName("if given non-float `ValueMismatch`, fail to unpack")
     class FailToUnpack {
 
         @Test
         @DisplayName("expected")
         void expectedWithWrongType() {
-            ValueMismatch mismatch = expectedTrue(VERSION);
+            var mismatch = expectedTrue(VERSION);
             assertThrows(RuntimeException.class, () -> unpackExpected(mismatch));
         }
 
         @Test
         @DisplayName("actual float")
         void actualWithWrongType() {
-            ValueMismatch mismatch = expectedTrue(VERSION);
+            var mismatch = expectedTrue(VERSION);
             assertThrows(RuntimeException.class, () -> unpackActual(mismatch));
         }
 
         @Test
         @DisplayName("new value")
         void newValueWithWrongType() {
-            ValueMismatch mismatch = expectedTrue(VERSION);
+            var mismatch = expectedTrue(VERSION);
             assertThrows(RuntimeException.class, () -> unpackNewValue(mismatch));
         }
     }

--- a/core/src/test/java/io/spine/change/IntMismatchTest.java
+++ b/core/src/test/java/io/spine/change/IntMismatchTest.java
@@ -95,8 +95,7 @@ class IntMismatchTest extends UtilityClassTest<IntMismatch> {
         @Test
         @DisplayName("for unexpected int value")
         void forUnexpectedInt() {
-            var mismatch = unexpectedValue(EXPECTED, ACTUAL, NEW_VALUE,
-                                           VERSION);
+            var mismatch = unexpectedValue(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
 
             assertEquals(EXPECTED, unpackExpected(mismatch));
             assertEquals(ACTUAL, unpackActual(mismatch));

--- a/core/src/test/java/io/spine/change/IntMismatchTest.java
+++ b/core/src/test/java/io/spine/change/IntMismatchTest.java
@@ -41,7 +41,7 @@ import static io.spine.change.IntMismatch.unpackNewValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisplayName("IntMismatch should")
+@DisplayName("`IntMismatch` should")
 class IntMismatchTest extends UtilityClassTest<IntMismatch> {
 
     private static final int EXPECTED = 1986;
@@ -54,13 +54,13 @@ class IntMismatchTest extends UtilityClassTest<IntMismatch> {
     }
 
     @Nested
-    @DisplayName("create ValueMismatch instance")
+    @DisplayName("create `ValueMismatch` instance")
     class Create {
 
         @Test
         @DisplayName("from given int values")
         void withInts() {
-            ValueMismatch mismatch = IntMismatch.of(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
+            var mismatch = IntMismatch.of(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
 
             assertEquals(EXPECTED, unpackExpected(mismatch));
             assertEquals(ACTUAL, unpackActual(mismatch));
@@ -71,8 +71,8 @@ class IntMismatchTest extends UtilityClassTest<IntMismatch> {
         @Test
         @DisplayName("for expected zero amount")
         void forExpectedZero() {
-            int expected = 0;
-            ValueMismatch mismatch = expectedZero(ACTUAL, NEW_VALUE, VERSION);
+            var expected = 0;
+            var mismatch = expectedZero(ACTUAL, NEW_VALUE, VERSION);
 
             assertEquals(expected, unpackExpected(mismatch));
             assertEquals(ACTUAL, unpackActual(mismatch));
@@ -81,10 +81,10 @@ class IntMismatchTest extends UtilityClassTest<IntMismatch> {
         }
 
         @Test
-        @DisplayName("for expected non zero amount")
+        @DisplayName("for expected non-zero amount")
         void forExpectedNonZero() {
-            int actual = 0;
-            ValueMismatch mismatch = expectedNonZero(EXPECTED, NEW_VALUE, VERSION);
+            var actual = 0;
+            var mismatch = expectedNonZero(EXPECTED, NEW_VALUE, VERSION);
 
             assertEquals(EXPECTED, unpackExpected(mismatch));
             assertEquals(actual, unpackActual(mismatch));
@@ -95,8 +95,8 @@ class IntMismatchTest extends UtilityClassTest<IntMismatch> {
         @Test
         @DisplayName("for unexpected int value")
         void forUnexpectedInt() {
-            ValueMismatch mismatch = unexpectedValue(EXPECTED, ACTUAL, NEW_VALUE,
-                                                     VERSION);
+            var mismatch = unexpectedValue(EXPECTED, ACTUAL, NEW_VALUE,
+                                           VERSION);
 
             assertEquals(EXPECTED, unpackExpected(mismatch));
             assertEquals(ACTUAL, unpackActual(mismatch));
@@ -108,33 +108,33 @@ class IntMismatchTest extends UtilityClassTest<IntMismatch> {
     @Test
     @DisplayName("not accept same expected and actual values")
     void notAcceptSameExpectedAndActual() {
-        int value = 5;
+        var value = 5;
         assertThrows(IllegalArgumentException.class,
                      () -> unexpectedValue(value, value, NEW_VALUE, VERSION));
     }
 
     @Nested
-    @DisplayName("if given non-int ValueMismatch, fail to unpack")
+    @DisplayName("if given non-int `ValueMismatch`, fail to unpack")
     class FailToUnpack {
 
         @Test
         @DisplayName("expected")
         void expectedWithWrongType() {
-            ValueMismatch mismatch = expectedTrue(VERSION);
+            var mismatch = expectedTrue(VERSION);
             assertThrows(RuntimeException.class, () -> unpackExpected(mismatch));
         }
 
         @Test
         @DisplayName("actual int")
         void actualWithWrongType() {
-            ValueMismatch mismatch = expectedTrue(VERSION);
+            var mismatch = expectedTrue(VERSION);
             assertThrows(RuntimeException.class, () -> unpackActual(mismatch));
         }
 
         @Test
         @DisplayName("new value")
         void newValueWithWrongType() {
-            ValueMismatch mismatch = expectedTrue(VERSION);
+            var mismatch = expectedTrue(VERSION);
             assertThrows(RuntimeException.class, () -> unpackNewValue(mismatch));
         }
     }

--- a/core/src/test/java/io/spine/change/LongMismatchTest.java
+++ b/core/src/test/java/io/spine/change/LongMismatchTest.java
@@ -41,7 +41,7 @@ import static io.spine.change.LongMismatch.unpackNewValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisplayName("LongMismatch should")
+@DisplayName("`LongMismatch` should")
 class LongMismatchTest extends UtilityClassTest<LongMismatch> {
 
     private static final long EXPECTED = 1839L;
@@ -54,13 +54,13 @@ class LongMismatchTest extends UtilityClassTest<LongMismatch> {
     }
 
     @Nested
-    @DisplayName("create ValueMismatch instance")
+    @DisplayName("create `ValueMismatch` instance")
     class Create {
 
         @Test
         @DisplayName("from given long values")
         void withLongs() {
-            ValueMismatch mismatch = LongMismatch.of(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
+            var mismatch = LongMismatch.of(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
 
             assertEquals(EXPECTED, unpackExpected(mismatch));
             assertEquals(ACTUAL, unpackActual(mismatch));
@@ -71,8 +71,8 @@ class LongMismatchTest extends UtilityClassTest<LongMismatch> {
         @Test
         @DisplayName("for expected zero amount")
         void forExpectedZero() {
-            long expected = 0L;
-            ValueMismatch mismatch = expectedZero(ACTUAL, NEW_VALUE, VERSION);
+            var expected = 0L;
+            var mismatch = expectedZero(ACTUAL, NEW_VALUE, VERSION);
 
             assertEquals(expected, unpackExpected(mismatch));
             assertEquals(ACTUAL, unpackActual(mismatch));
@@ -81,10 +81,10 @@ class LongMismatchTest extends UtilityClassTest<LongMismatch> {
         }
 
         @Test
-        @DisplayName("for expected non zero amount")
+        @DisplayName("for expected non-zero amount")
         void forExpectedNonZero() {
-            long actual = 0L;
-            ValueMismatch mismatch = expectedNonZero(EXPECTED, NEW_VALUE, VERSION);
+            var actual = 0L;
+            var mismatch = expectedNonZero(EXPECTED, NEW_VALUE, VERSION);
 
             assertEquals(EXPECTED, unpackExpected(mismatch));
             assertEquals(actual, unpackActual(mismatch));
@@ -95,7 +95,7 @@ class LongMismatchTest extends UtilityClassTest<LongMismatch> {
         @Test
         @DisplayName("for unexpected long value")
         void forUnexpectedLong() {
-            ValueMismatch mismatch = unexpectedValue(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
+            var mismatch = unexpectedValue(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
 
             assertEquals(EXPECTED, unpackExpected(mismatch));
             assertEquals(ACTUAL, unpackActual(mismatch));
@@ -107,33 +107,33 @@ class LongMismatchTest extends UtilityClassTest<LongMismatch> {
     @Test
     @DisplayName("not accept same expected and actual values")
     void notAcceptSameExpectedAndActual() {
-        long value = 1919L;
+        var value = 1919L;
         assertThrows(IllegalArgumentException.class,
                      () -> unexpectedValue(value, value, NEW_VALUE, VERSION));
     }
 
     @Nested
-    @DisplayName("if given non-long ValueMismatch, fail to unpack")
+    @DisplayName("if given non-long `ValueMismatch`, fail to unpack")
     class FailToUnpack {
 
         @Test
         @DisplayName("expected")
         void expectedWithWrongType() {
-            ValueMismatch mismatch = expectedTrue(VERSION);
+            var mismatch = expectedTrue(VERSION);
             assertThrows(RuntimeException.class, () -> unpackExpected(mismatch));
         }
 
         @Test
         @DisplayName("actual long")
         void actualWithWrongType() {
-            ValueMismatch mismatch = expectedTrue(VERSION);
+            var mismatch = expectedTrue(VERSION);
             assertThrows(RuntimeException.class, () -> unpackActual(mismatch));
         }
 
         @Test
         @DisplayName("new value")
         void newValueWithWrongType() {
-            ValueMismatch mismatch = expectedTrue(VERSION);
+            var mismatch = expectedTrue(VERSION);
             assertThrows(RuntimeException.class, () -> unpackNewValue(mismatch));
         }
     }

--- a/core/src/test/java/io/spine/change/MessageMismatchTest.java
+++ b/core/src/test/java/io/spine/change/MessageMismatchTest.java
@@ -40,7 +40,7 @@ import static io.spine.change.MessageMismatch.unpackExpected;
 import static io.spine.change.MessageMismatch.unpackNewValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@DisplayName("MessageMismatch should")
+@DisplayName("`MessageMismatch` should")
 class MessageMismatchTest extends UtilityClassTest<MessageMismatch> {
 
     private static final StringValue EXPECTED = StringValue.of("expected_value");
@@ -54,13 +54,13 @@ class MessageMismatchTest extends UtilityClassTest<MessageMismatch> {
     }
 
     @Nested
-    @DisplayName("create ValueMismatch instance")
+    @DisplayName("create `ValueMismatch` instance")
     class Create {
 
         @Test
         @DisplayName("for expected default value")
         void forExpectedDefault() {
-            ValueMismatch mismatch = expectedDefault(ACTUAL, NEW_VALUE, VERSION);
+            var mismatch = expectedDefault(ACTUAL, NEW_VALUE, VERSION);
 
             assertEquals(DEFAULT_VALUE, unpackExpected(mismatch));
             assertEquals(ACTUAL, unpackActual(mismatch));
@@ -71,7 +71,7 @@ class MessageMismatchTest extends UtilityClassTest<MessageMismatch> {
         @Test
         @DisplayName("for unexpected default when clearing")
         void forUnexpectedDefaultWhenClearing() {
-            ValueMismatch mismatch = expectedNotDefault(EXPECTED, VERSION);
+            var mismatch = expectedNotDefault(EXPECTED, VERSION);
 
             assertEquals(EXPECTED, unpackExpected(mismatch));
 
@@ -87,7 +87,7 @@ class MessageMismatchTest extends UtilityClassTest<MessageMismatch> {
         @Test
         @DisplayName("for unexpected default when changing")
         void forUnexpectedDefaultWhenChanging() {
-            ValueMismatch mismatch = expectedNotDefault(EXPECTED, NEW_VALUE, VERSION);
+            var mismatch = expectedNotDefault(EXPECTED, NEW_VALUE, VERSION);
 
             assertEquals(EXPECTED, unpackExpected(mismatch));
 
@@ -101,7 +101,7 @@ class MessageMismatchTest extends UtilityClassTest<MessageMismatch> {
         @Test
         @DisplayName("for unexpected value")
         void forUnexpectedValue() {
-            ValueMismatch mismatch = unexpectedValue(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
+            var mismatch = unexpectedValue(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
 
             assertEquals(EXPECTED, unpackExpected(mismatch));
             assertEquals(ACTUAL, unpackActual(mismatch));

--- a/core/src/test/java/io/spine/change/StringMismatchTest.java
+++ b/core/src/test/java/io/spine/change/StringMismatchTest.java
@@ -41,7 +41,7 @@ import static io.spine.change.StringMismatch.unpackNewValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisplayName("StringMismatch should")
+@DisplayName("`StringMismatch` should")
 class StringMismatchTest extends UtilityClassTest<StringMismatch> {
 
     private static final String EXPECTED = "expected string";
@@ -54,13 +54,13 @@ class StringMismatchTest extends UtilityClassTest<StringMismatch> {
     }
 
     @Nested
-    @DisplayName("create ValueMismatch instance")
+    @DisplayName("create `ValueMismatch` instance")
     class Create {
 
         @Test
         @DisplayName("for expected empty string")
         void forExpectedEmptyString() {
-            ValueMismatch mismatch = expectedEmpty(ACTUAL, NEW_VALUE, VERSION);
+            var mismatch = expectedEmpty(ACTUAL, NEW_VALUE, VERSION);
 
             assertEquals("", unpackExpected(mismatch));
             assertEquals(ACTUAL, unpackActual(mismatch));
@@ -71,7 +71,7 @@ class StringMismatchTest extends UtilityClassTest<StringMismatch> {
         @Test
         @DisplayName("for unexpected empty string")
         void forUnexpectedEmptyString() {
-            ValueMismatch mismatch = expectedNotEmpty(EXPECTED, VERSION);
+            var mismatch = expectedNotEmpty(EXPECTED, VERSION);
 
             assertEquals(EXPECTED, unpackExpected(mismatch));
 
@@ -88,7 +88,7 @@ class StringMismatchTest extends UtilityClassTest<StringMismatch> {
         @Test
         @DisplayName("for unexpected value")
         void forUnexpectedValue() {
-            ValueMismatch mismatch = unexpectedValue(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
+            var mismatch = unexpectedValue(EXPECTED, ACTUAL, NEW_VALUE, VERSION);
 
             assertEquals(EXPECTED, unpackExpected(mismatch));
             assertEquals(ACTUAL, unpackActual(mismatch));
@@ -100,33 +100,33 @@ class StringMismatchTest extends UtilityClassTest<StringMismatch> {
     @Test
     @DisplayName("not accept same expected and actual values")
     void notAcceptSameExpectedAndActual() {
-        String value = "same-same";
+        var value = "same-same";
         assertThrows(IllegalArgumentException.class,
                      () -> unexpectedValue(value, value, NEW_VALUE, VERSION));
     }
 
     @Nested
-    @DisplayName("if given non-string ValueMismatch, fail to unpack")
+    @DisplayName("if given non-string `ValueMismatch`, fail to unpack")
     class FailToUnpack {
 
         @Test
         @DisplayName("expected")
         void expectedWithWrongType() {
-            ValueMismatch mismatch = expectedTrue(VERSION);
+            var mismatch = expectedTrue(VERSION);
             assertThrows(RuntimeException.class, () -> unpackExpected(mismatch));
         }
 
         @Test
         @DisplayName("actual String")
         void actualWithWrongType() {
-            ValueMismatch mismatch = expectedTrue(VERSION);
+            var mismatch = expectedTrue(VERSION);
             assertThrows(RuntimeException.class, () -> unpackActual(mismatch));
         }
 
         @Test
         @DisplayName("new value")
         void newValueWithWrongType() {
-            ValueMismatch mismatch = expectedTrue(VERSION);
+            var mismatch = expectedTrue(VERSION);
             assertThrows(RuntimeException.class, () -> unpackNewValue(mismatch));
         }
     }

--- a/core/src/test/java/io/spine/core/AcksTest.java
+++ b/core/src/test/java/io/spine/core/AcksTest.java
@@ -52,8 +52,8 @@ class AcksTest extends UtilityClassTest<Acks> {
         @Test
         @DisplayName("returning ID value")
         void value() {
-            CommandId commandId = CommandId.generate();
-            Ack ack = newAck(commandId);
+            var commandId = CommandId.generate();
+            var ack = newAck(commandId);
             assertThat(toCommandId(ack))
                     .isEqualTo(commandId);
         }

--- a/core/src/test/java/io/spine/core/ResponsesTest.java
+++ b/core/src/test/java/io/spine/core/ResponsesTest.java
@@ -60,11 +60,11 @@ class ResponsesTest extends UtilityClassTest<Responses> {
     @DisplayName("recognize not OK response")
     void recognizeNotOkResponse() {
         var status = Status.newBuilder()
-                              .setError(Error.getDefaultInstance())
-                              .build();
+                .setError(Error.getDefaultInstance())
+                .build();
         var error = Response.newBuilder()
-                                 .setStatus(status)
-                                 .build();
+                .setStatus(status)
+                .build();
         assertFalse(error.isOk());
         assertTrue(error.isError());
     }

--- a/core/src/test/java/io/spine/core/ResponsesTest.java
+++ b/core/src/test/java/io/spine/core/ResponsesTest.java
@@ -51,7 +51,7 @@ class ResponsesTest extends UtilityClassTest<Responses> {
     @Test
     @DisplayName("recognize OK response")
     void recognizeOkResponse() {
-        Response ok = Responses.ok();
+        var ok = Responses.ok();
         assertTrue(ok.isOk());
         assertFalse(ok.isError());
     }
@@ -59,10 +59,10 @@ class ResponsesTest extends UtilityClassTest<Responses> {
     @Test
     @DisplayName("recognize not OK response")
     void recognizeNotOkResponse() {
-        Status status = Status.newBuilder()
+        var status = Status.newBuilder()
                               .setError(Error.getDefaultInstance())
                               .build();
-        Response error = Response.newBuilder()
+        var error = Response.newBuilder()
                                  .setStatus(status)
                                  .build();
         assertFalse(error.isOk());

--- a/core/src/test/java/io/spine/core/SignalTest.java
+++ b/core/src/test/java/io/spine/core/SignalTest.java
@@ -42,7 +42,7 @@ class SignalTest {
     @Test
     @DisplayName("verify type of the enclosed message")
     void checkType() {
-        Event event = stubEvent();
+        var event = stubEvent();
 
         assertThat(event.is(ProjectCreated.class))
                 .isTrue();
@@ -56,16 +56,13 @@ class SignalTest {
      * Creates a stub instance of {@code Event} with the type {@link ProjectCreated}.
      */
     private Event stubEvent() {
-        ProjectId project = ProjectId
-                .newBuilder()
+        var project = ProjectId.newBuilder()
                 .setId(getClass().getName())
                 .build();
-        ProjectCreated message = ProjectCreated
-                .newBuilder()
+        var message = ProjectCreated.newBuilder()
                 .setProjectId(project)
                 .build();
-        Event event = Event
-                .newBuilder()
+        var event = Event.newBuilder()
                 .setMessage(AnyPacker.pack(message))
                 .build();
         return event;

--- a/core/src/test/java/io/spine/core/VersionsTest.java
+++ b/core/src/test/java/io/spine/core/VersionsTest.java
@@ -63,7 +63,7 @@ class VersionsTest extends UtilityClassTest<Versions> {
     @Test
     @DisplayName("increment `Version`")
     void incr() {
-        Version v1 = GivenVersion.withNumber(1);
+        var v1 = GivenVersion.withNumber(1);
         assertThat(increment(v1).getNumber())
                 .isEqualTo(v1.getNumber() + 1);
     }

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.82`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.83`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -505,12 +505,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 26 19:09:16 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 27 19:57:25 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.82`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.83`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -975,12 +975,12 @@ This report was generated on **Fri Nov 26 19:09:16 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 26 19:09:18 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 27 19:57:26 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.82`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.83`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1485,12 +1485,12 @@ This report was generated on **Fri Nov 26 19:09:18 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 26 19:09:19 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 27 19:57:26 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.82`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.83`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -2095,12 +2095,12 @@ This report was generated on **Fri Nov 26 19:09:19 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 26 19:09:20 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 27 19:57:27 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.82`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.83`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2613,12 +2613,12 @@ This report was generated on **Fri Nov 26 19:09:20 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 26 19:09:21 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 27 19:57:27 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.82`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.83`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3175,12 +3175,12 @@ This report was generated on **Fri Nov 26 19:09:21 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 26 19:09:22 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 27 19:57:28 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.82`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.83`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3737,12 +3737,12 @@ This report was generated on **Fri Nov 26 19:09:22 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 26 19:09:23 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 27 19:57:28 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.82`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.83`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4343,4 +4343,4 @@ This report was generated on **Fri Nov 26 19:09:23 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 26 19:09:24 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 27 19:57:29 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.82</version>
+<version>2.0.0-SNAPSHOT.83</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/BoundedContext.java
+++ b/server/src/main/java/io/spine/server/BoundedContext.java
@@ -54,7 +54,6 @@ import io.spine.server.tenant.TenantIndex;
 import io.spine.server.trace.TracerFactory;
 import io.spine.system.server.SystemClient;
 import io.spine.system.server.SystemContext;
-import io.spine.system.server.SystemReadSide;
 import io.spine.type.TypeName;
 
 import java.util.Optional;
@@ -160,7 +159,7 @@ public abstract class BoundedContext implements Closeable, Logging {
      */
     @SuppressWarnings("ClassReferencesSubclass")
     private void checkInheritance() {
-        Class<? extends BoundedContext> thisClass = getClass();
+        var thisClass = getClass();
         checkState(
                 DomainContext.class.equals(thisClass) ||
                         SystemContext.class.equals(thisClass),
@@ -170,8 +169,7 @@ public abstract class BoundedContext implements Closeable, Logging {
     }
 
     private static ImportBus buildImportBus(TenantIndex tenantIndex) {
-        ImportBus.Builder result = ImportBus
-                .newBuilder()
+        var result = ImportBus.newBuilder()
                 .injectTenantIndex(tenantIndex);
         return result.build();
     }
@@ -185,7 +183,7 @@ public abstract class BoundedContext implements Closeable, Logging {
      */
     public static BoundedContextBuilder singleTenant(String name) {
         checkNotNull(name);
-        ContextSpec spec = ContextSpec.singleTenant(name);
+        var spec = ContextSpec.singleTenant(name);
         return new BoundedContextBuilder(spec);
     }
 
@@ -198,7 +196,7 @@ public abstract class BoundedContext implements Closeable, Logging {
      */
     public static BoundedContextBuilder multitenant(String name) {
         checkNotNull(name);
-        ContextSpec spec = ContextSpec.multitenant(name);
+        var spec = ContextSpec.multitenant(name);
         return new BoundedContextBuilder(spec);
     }
 
@@ -237,7 +235,7 @@ public abstract class BoundedContext implements Closeable, Logging {
             commandBus().register(dispatcher);
         }
         if (dispatcher instanceof EventDispatcherDelegate) {
-            EventDispatcherDelegate eventDispatcher = (EventDispatcherDelegate) dispatcher;
+            var eventDispatcher = (EventDispatcherDelegate) dispatcher;
             registerEventDispatcher(eventDispatcher);
         }
     }
@@ -268,16 +266,16 @@ public abstract class BoundedContext implements Closeable, Logging {
         Security.allowOnlyFrameworkServer();
         registerIfAware(dispatcher);
         if (dispatcher.dispatchesEvents()) {
-            EventBus eventBus = eventBus();
+            var eventBus = eventBus();
             eventBus.register(dispatcher);
-            SystemReadSide systemReadSide = systemClient().readSide();
+            var systemReadSide = systemClient().readSide();
             systemReadSide.register(dispatcher);
         }
         if (dispatcher.dispatchesExternalEvents()) {
             broker.register(dispatcher);
         }
         if (dispatcher instanceof CommandDispatcherDelegate) {
-            CommandDispatcherDelegate commandDispatcher = (CommandDispatcherDelegate) dispatcher;
+            var commandDispatcher = (CommandDispatcherDelegate) dispatcher;
             registerCommandDispatcher(commandDispatcher);
         }
     }
@@ -289,7 +287,7 @@ public abstract class BoundedContext implements Closeable, Logging {
      */
     private void registerEventDispatcher(EventDispatcherDelegate dispatcher) {
         checkNotNull(dispatcher);
-        DelegatingEventDispatcher delegate = DelegatingEventDispatcher.of(dispatcher);
+        var delegate = DelegatingEventDispatcher.of(dispatcher);
         registerEventDispatcher(delegate);
     }
 
@@ -299,7 +297,7 @@ public abstract class BoundedContext implements Closeable, Logging {
      */
     private void registerIfAware(Object contextPart) {
         if (contextPart instanceof ContextAware) {
-            ContextAware contextAware = (ContextAware) contextPart;
+            var contextAware = (ContextAware) contextPart;
             if (!contextAware.isRegistered()) {
                 contextAware.registerWith(this);
             }
@@ -310,7 +308,7 @@ public abstract class BoundedContext implements Closeable, Logging {
      * Obtains a set of entity type names by their visibility.
      */
     public Set<TypeName> stateTypes(Visibility visibility) {
-        Set<TypeName> result = guard.entityStateTypes(visibility);
+        var result = guard.entityStateTypes(visibility);
         return result;
     }
 
@@ -318,7 +316,7 @@ public abstract class BoundedContext implements Closeable, Logging {
      * Obtains the set of all entity type names.
      */
     public Set<TypeName> stateTypes() {
-        Set<TypeName> result = guard.allEntityTypes();
+        var result = guard.allEntityTypes();
         return result;
     }
 
@@ -328,8 +326,8 @@ public abstract class BoundedContext implements Closeable, Logging {
      * <p>This method does not take into account visibility of entity states.
      */
     public boolean hasEntitiesOfType(Class<? extends Entity<?, ?>> entityClass) {
-        EntityClass<? extends Entity<?, ?>> cls = EntityClass.asEntityClass(entityClass);
-        boolean result = guard.hasRepository(cls.stateClass());
+        var cls = EntityClass.asEntityClass(entityClass);
+        var result = guard.hasRepository(cls.stateClass());
         return result;
     }
 
@@ -339,7 +337,7 @@ public abstract class BoundedContext implements Closeable, Logging {
      * <p>This method does not take into account visibility of entity states.
      */
     public boolean hasEntitiesWithState(Class<? extends EntityState<?>> stateClass) {
-        boolean result = guard.hasRepository(stateClass);
+        var result = guard.hasRepository(stateClass);
         return result;
     }
 
@@ -558,7 +556,7 @@ public abstract class BoundedContext implements Closeable, Logging {
                         stateCls.getName()
                 );
             }
-            Optional<Repository<?, ?>> repository = guard.repositoryFor(stateCls);
+            var repository = guard.repositoryFor(stateCls);
             return repository;
         }
 

--- a/server/src/main/java/io/spine/server/BoundedContextBuilder.java
+++ b/server/src/main/java/io/spine/server/BoundedContextBuilder.java
@@ -136,9 +136,9 @@ public final class BoundedContextBuilder implements Logging {
     @Internal
     @VisibleForTesting
     public static BoundedContextBuilder assumingTests(boolean multitenant) {
-        ContextSpec spec = multitenant
-                           ? multitenant(assumingTestsValue())
-                           : singleTenant(assumingTestsValue());
+        var spec = multitenant
+                   ? multitenant(assumingTestsValue())
+                   : singleTenant(assumingTestsValue());
         return new BoundedContextBuilder(spec);
     }
 
@@ -198,9 +198,9 @@ public final class BoundedContextBuilder implements Logging {
      * the {@code BoundedContext}.
      */
     TenantIndex buildTenantIndex() {
-        TenantIndex result = isMultitenant()
-                             ? checkNotNull(tenantIndex)
-                             : TenantIndex.singleTenant();
+        var result = isMultitenant()
+                     ? checkNotNull(tenantIndex)
+                     : TenantIndex.singleTenant();
         return result;
     }
 
@@ -416,7 +416,7 @@ public final class BoundedContextBuilder implements Logging {
         if (commandDispatcher instanceof Repository) {
             return hasRepository((Repository<?, ?>) commandDispatcher);
         }
-        boolean result = commandDispatchers.contains(commandDispatcher);
+        var result = commandDispatchers.contains(commandDispatcher);
         return result;
     }
 
@@ -430,7 +430,7 @@ public final class BoundedContextBuilder implements Logging {
         if (eventDispatcher instanceof Repository) {
             return hasRepository((Repository<?, ?>) eventDispatcher);
         }
-        boolean result = eventDispatchers.contains(eventDispatcher);
+        var result = eventDispatchers.contains(eventDispatcher);
         return result;
     }
 
@@ -441,7 +441,7 @@ public final class BoundedContextBuilder implements Logging {
     @VisibleForTesting
     <I, E extends Entity<I, ?>> boolean hasRepository(Class<E> entityClass) {
         checkNotNull(entityClass);
-        boolean result =
+        var result =
                 repositories.stream()
                             .anyMatch(repository -> repository.entityClass()
                                                               .equals(entityClass));
@@ -455,7 +455,7 @@ public final class BoundedContextBuilder implements Logging {
     @VisibleForTesting
     boolean hasRepository(Repository<?, ?> repository) {
         checkNotNull(repository);
-        boolean result = repositories.contains(repository);
+        var result = repositories.contains(repository);
         return result;
     }
 
@@ -548,8 +548,8 @@ public final class BoundedContextBuilder implements Logging {
      * @return new {@code BoundedContext}
      */
     public BoundedContext build() {
-        SystemContext system = buildSystem();
-        BoundedContext result = buildDomain(system);
+        var system = buildSystem();
+        var result = buildDomain(system);
         _debug().log("%s created.", result.nameForLogging());
 
         registerRepositories(result);
@@ -572,7 +572,7 @@ public final class BoundedContextBuilder implements Logging {
     }
 
     private void registerRepositories(BoundedContext result) {
-        for (Repository<?, ?> repository : repositories) {
+        for (var repository : repositories) {
             result.register(repository);
             _debug().log("`%s` registered.", repository);
         }
@@ -584,7 +584,7 @@ public final class BoundedContextBuilder implements Logging {
     }
 
     private BoundedContext buildDomain(SystemContext system) {
-        SystemClient systemClient = system.createClient();
+        var systemClient = system.createClient();
         Function<BoundedContextBuilder, DomainContext> instanceFactory =
                 builder -> DomainContext.newInstance(builder, systemClient);
         BoundedContext result = buildPartial(instanceFactory, systemClient, system.stand());
@@ -592,16 +592,15 @@ public final class BoundedContextBuilder implements Logging {
     }
 
     private SystemContext buildSystem() {
-        BoundedContextBuilder system = new BoundedContextBuilder(systemSpec(), systemSettings);
-        Optional<? extends TenantIndex> tenantIndex = tenantIndex();
+        var system = new BoundedContextBuilder(systemSpec(), systemSettings);
+        var tenantIndex = tenantIndex();
         tenantIndex.ifPresent(system::setTenantIndex);
-        SystemContext result =
-                system.buildPartial(SystemContext::newInstance, NoOpSystemClient.INSTANCE);
+        var result = system.buildPartial(SystemContext::newInstance, NoOpSystemClient.INSTANCE);
         return result;
     }
 
     private ContextSpec systemSpec() {
-        ContextSpec systemSpec = this.spec.toSystem();
+        var systemSpec = this.spec.toSystem();
         if (!systemSettings.includePersistentEvents()) {
             systemSpec = systemSpec.notStoringEvents();
         }
@@ -620,7 +619,7 @@ public final class BoundedContextBuilder implements Logging {
         initTenantIndex();
         initCommandBus(client.writeSide());
         this.stand = createStand(systemStand);
-        B result = instanceFactory.apply(this);
+        var result = instanceFactory.apply(this);
         return result;
     }
 
@@ -639,8 +638,7 @@ public final class BoundedContextBuilder implements Logging {
     }
 
     private Stand createStand(@Nullable Stand systemStand) {
-        Stand.Builder result = Stand
-                .newBuilder()
+        var result = Stand.newBuilder()
                 .setMultitenant(isMultitenant());
         if (systemStand != null) {
             result.withSubscriptionRegistryFrom(systemStand);
@@ -654,11 +652,10 @@ public final class BoundedContextBuilder implements Logging {
     @Internal
     @VisibleForTesting
     public BoundedContextBuilder testingCopy() {
-        String name = name().getValue();
-        EventEnricher enricher =
-                eventEnricher().orElseGet(() -> EventEnricher.newBuilder()
-                                                             .build());
-        BoundedContextBuilder copy =
+        var name = name().getValue();
+        var enricher = eventEnricher().orElseGet(() ->
+                                                         EventEnricher.newBuilder().build());
+        var copy =
                 isMultitenant()
                 ? BoundedContext.multitenant(name)
                 : BoundedContext.singleTenant(name);

--- a/server/src/main/java/io/spine/server/CommandService.java
+++ b/server/src/main/java/io/spine/server/CommandService.java
@@ -30,14 +30,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.grpc.stub.StreamObserver;
-import io.spine.base.Error;
 import io.spine.client.grpc.CommandServiceGrpc;
 import io.spine.core.Ack;
 import io.spine.core.Command;
-import io.spine.core.CommandId;
 import io.spine.logging.Logging;
 import io.spine.server.bus.MessageIdExtensions;
-import io.spine.server.commandbus.CommandBus;
 import io.spine.server.commandbus.UnsupportedCommandException;
 import io.spine.server.type.CommandClass;
 
@@ -77,31 +74,29 @@ public final class CommandService
      */
     public static CommandService withSingle(BoundedContext context) {
         checkNotNull(context);
-        CommandService result = newBuilder()
-                .add(context)
-                .build();
+        var result = newBuilder().add(context).build();
         return result;
     }
 
     @Override
     public void post(Command request, StreamObserver<Ack> responseObserver) {
-        CommandClass commandClass = CommandClass.of(request);
-        BoundedContext context = commandToContext.get(commandClass);
+        var commandClass = CommandClass.of(request);
+        var context = commandToContext.get(commandClass);
         if (context == null) {
             handleUnsupported(request, responseObserver);
         } else {
-            CommandBus commandBus = context.commandBus();
+            var commandBus = context.commandBus();
             commandBus.post(request, responseObserver);
         }
     }
 
     private void handleUnsupported(Command command, StreamObserver<Ack> responseObserver) {
-        UnsupportedCommandException unsupported = new UnsupportedCommandException(command);
+        var unsupported = new UnsupportedCommandException(command);
         _error().withCause(unsupported)
                 .log("Unsupported command posted to `CommandService`.");
-        Error error = unsupported.asError();
-        CommandId id = command.getId();
-        Ack response = MessageIdExtensions.causedError(id, error);
+        var error = unsupported.asError();
+        var id = command.getId();
+        var response = MessageIdExtensions.causedError(id, error);
         responseObserver.onNext(response);
         responseObserver.onCompleted();
     }
@@ -139,7 +134,7 @@ public final class CommandService
          * @return {@code true} if the instance was added to the builder, {@code false} otherwise
          */
         public boolean contains(BoundedContext context) {
-            boolean contains = contexts.contains(context);
+            var contains = contexts.contains(context);
             return contains;
         }
 
@@ -147,8 +142,8 @@ public final class CommandService
          * Builds a new {@link CommandService}.
          */
         public CommandService build() {
-            ImmutableMap<CommandClass, BoundedContext> map = createMap();
-            CommandService result = new CommandService(map);
+            var map = createMap();
+            var result = new CommandService(map);
             return result;
         }
 
@@ -158,7 +153,7 @@ public final class CommandService
          */
         private ImmutableMap<CommandClass, BoundedContext> createMap() {
             ImmutableMap.Builder<CommandClass, BoundedContext> builder = ImmutableMap.builder();
-            for (BoundedContext boundedContext : contexts) {
+            for (var boundedContext : contexts) {
                 putIntoMap(boundedContext, builder);
             }
             return builder.build();
@@ -170,9 +165,9 @@ public final class CommandService
          */
         private static void putIntoMap(BoundedContext context,
                                        ImmutableMap.Builder<CommandClass, BoundedContext> builder) {
-            CommandBus commandBus = context.commandBus();
-            Set<CommandClass> cmdClasses = commandBus.registeredCommandClasses();
-            for (CommandClass commandClass : cmdClasses) {
+            var commandBus = context.commandBus();
+            var cmdClasses = commandBus.registeredCommandClasses();
+            for (var commandClass : cmdClasses) {
                 builder.put(commandClass, context);
             }
         }

--- a/server/src/main/java/io/spine/server/ContextSpec.java
+++ b/server/src/main/java/io/spine/server/ContextSpec.java
@@ -71,7 +71,7 @@ public final class ContextSpec {
 
     private static ContextSpec createDomain(String name, boolean multitenant) {
         checkNotNull(name);
-        BoundedContextName contextName = newName(name);
+        var contextName = newName(name);
         return new ContextSpec(contextName, multitenant, true);
     }
 
@@ -123,7 +123,7 @@ public final class ContextSpec {
      */
     public ContextSpec toSingleTenant() {
         if (isMultitenant()) {
-            ContextSpec result = singleTenant(name.getValue());
+            var result = singleTenant(name.getValue());
             return result;
         }
         return this;
@@ -137,7 +137,7 @@ public final class ContextSpec {
         if (!(o instanceof ContextSpec)) {
             return false;
         }
-        ContextSpec spec = (ContextSpec) o;
+        var spec = (ContextSpec) o;
         return isMultitenant() == spec.isMultitenant() &&
                 storeEvents == spec.storeEvents &&
                 Objects.equal(name, spec.name);
@@ -150,9 +150,9 @@ public final class ContextSpec {
 
     @Override
     public String toString() {
-        String tenancy = multitenant
-                         ? "Multitenant"
-                         : "Single tenant";
+        var tenancy = multitenant
+                      ? "Multitenant"
+                      : "Single tenant";
         return String.format("%s context %s", tenancy, name.getValue());
     }
 }

--- a/server/src/main/java/io/spine/server/DeploymentDetector.java
+++ b/server/src/main/java/io/spine/server/DeploymentDetector.java
@@ -75,7 +75,7 @@ final class DeploymentDetector implements Supplier<DeploymentType> {
     }
 
     private static DeploymentType detect() {
-        Optional<String> gaeEnvironment = getProperty(APP_ENGINE_ENVIRONMENT_PATH);
+        var gaeEnvironment = getProperty(APP_ENGINE_ENVIRONMENT_PATH);
         if (gaeEnvironment.isPresent()) {
             if (APP_ENGINE_ENVIRONMENT_DEVELOPMENT_VALUE.equals(gaeEnvironment.get())) {
                 return APPENGINE_EMULATOR;

--- a/server/src/main/java/io/spine/server/DomainContext.java
+++ b/server/src/main/java/io/spine/server/DomainContext.java
@@ -63,7 +63,7 @@ final class DomainContext extends BoundedContext {
         checkNotNull(builder);
         checkNotNull(system);
 
-        DomainContext result = new DomainContext(builder, system);
+        var result = new DomainContext(builder, system);
         result.init();
         return result;
     }

--- a/server/src/main/java/io/spine/server/EnvSetting.java
+++ b/server/src/main/java/io/spine/server/EnvSetting.java
@@ -121,7 +121,7 @@ final class EnvSetting<V> {
      * empty {@code Optional} otherwise.
      */
     Optional<V> optionalValue(Class<? extends EnvironmentType> type) {
-        Optional<V> result = valueFor(type);
+        var result = valueFor(type);
         return result;
     }
 
@@ -137,7 +137,7 @@ final class EnvSetting<V> {
      */
     void ifPresentForEnvironment(Class<? extends EnvironmentType> type,
                                  SettingOperation<V> operation) throws Exception {
-        Optional<V> value = valueFor(type);
+        var value = valueFor(type);
         if (value.isPresent()) {
             operation.accept(value.get());
         }
@@ -153,9 +153,9 @@ final class EnvSetting<V> {
      *        unnecessary value instantiation.
      */
     void apply(SettingOperation<V> operation) throws Exception {
-        for (Value<V> v : environmentValues.values()) {
+        for (var v : environmentValues.values()) {
             if(v.isResolved()) {
-                V value = v.get();
+                var value = v.get();
                 operation.accept(value);
             }
         }
@@ -169,7 +169,7 @@ final class EnvSetting<V> {
      */
     V value(Class<? extends EnvironmentType> type) {
         checkNotNull(type);
-        Optional<V> result = valueFor(type);
+        var result = valueFor(type);
         return result.orElseThrow(
                 () -> newIllegalStateException("Env setting for environment `%s` is unset.",
                                                type));
@@ -220,18 +220,18 @@ final class EnvSetting<V> {
 
     private Optional<V> valueFor(Class<? extends EnvironmentType> type) {
         checkNotNull(type);
-        Value<V> value = this.environmentValues.get(type);
+        var value = this.environmentValues.get(type);
         if (value == null) {
-            Supplier<V> resultSupplier = this.fallbacks.get(type);
+            var resultSupplier = this.fallbacks.get(type);
             if (resultSupplier == null) {
                 return Optional.empty();
             }
-            V newValue = resultSupplier.get();
+            var newValue = resultSupplier.get();
             checkNotNull(newValue);
             this.use(newValue, type);
             return Optional.of(newValue);
         }
-        V result = value.get();
+        var result = value.get();
         return Optional.of(result);
     }
 

--- a/server/src/main/java/io/spine/server/GrpcContainer.java
+++ b/server/src/main/java/io/spine/server/GrpcContainer.java
@@ -166,7 +166,7 @@ public final class GrpcContainer {
      * @see GrpcContainer#shutdown()
      */
     public boolean isShutdown() {
-        boolean isShutdown = grpcServer == null;
+        var isShutdown = grpcServer == null;
         return isShutdown;
     }
 
@@ -218,13 +218,13 @@ public final class GrpcContainer {
      * @return {@code true}, if the given gRPC service for deployment and {@code false} otherwise
      */
     public boolean isScheduledForDeployment(BindableService service) {
-        String nameOfInterest = service.bindService()
-                                       .getServiceDescriptor()
-                                       .getName();
-        boolean serviceIsPresent = false;
-        for (ServerServiceDefinition serverServiceDefinition : services) {
-            String scheduledServiceName = serverServiceDefinition.getServiceDescriptor()
-                                                                 .getName();
+        var nameOfInterest = service.bindService()
+                                    .getServiceDescriptor()
+                                    .getName();
+        var serviceIsPresent = false;
+        for (var serverServiceDefinition : services) {
+            var scheduledServiceName = serverServiceDefinition.getServiceDescriptor()
+                                                              .getName();
             serviceIsPresent = serviceIsPresent || scheduledServiceName.equals(nameOfInterest);
         }
         return serviceIsPresent;
@@ -244,9 +244,9 @@ public final class GrpcContainer {
      *         {@code false} otherwise
      */
     public boolean isLive(BindableService service) {
-        boolean inShutdownState = isShutdown();
-        boolean scheduledForDeployment = isScheduledForDeployment(service);
-        boolean result = !inShutdownState && scheduledForDeployment;
+        var inShutdownState = isShutdown();
+        var scheduledForDeployment = isScheduledForDeployment(service);
+        var result = !inShutdownState && scheduledForDeployment;
         return result;
     }
 
@@ -273,8 +273,8 @@ public final class GrpcContainer {
         if (injectedServer != null) {
             return injectedServer;
         }
-        ServerBuilder<?> builder = createServerBuilder(executor);
-        for (ServerServiceDefinition service : services) {
+        var builder = createServerBuilder(executor);
+        for (var service : services) {
             builder.addService(service);
         }
         return builder.build();
@@ -290,17 +290,16 @@ public final class GrpcContainer {
      *         executor to configure for the created builder
      */
     private ServerBuilder<?> createServerBuilder(@Nullable Executor executor) {
-        boolean serverNameGiven = serverName != null;
+        var serverNameGiven = serverName != null;
         @Nullable Integer port = serverNameGiven ? null : requireNonNull(this.port);
-        ServerBuilder<?> result =
-                serverNameGiven
-                ? inProcessBuilder(serverName, executor)
-                : builderAtPort(requireNonNull(port), executor);
+        var result = serverNameGiven
+                     ? inProcessBuilder(serverName, executor)
+                     : builderAtPort(requireNonNull(port), executor);
         return result;
     }
 
     private static ServerBuilder<?> inProcessBuilder(String name, @Nullable Executor executor) {
-        InProcessServerBuilder builder = InProcessServerBuilder.forName(name);
+        var builder = InProcessServerBuilder.forName(name);
         builder = executor == null
                   ? builder.directExecutor()
                   : builder.executor(executor);
@@ -308,7 +307,7 @@ public final class GrpcContainer {
     }
 
     private static ServerBuilder<?> builderAtPort(Integer port, @Nullable Executor executor) {
-        ServerBuilder<?> builder = ServerBuilder.forPort(port);
+        var builder = ServerBuilder.forPort(port);
         builder = executor == null
                   ? builder
                   : builder.executor(executor);
@@ -363,7 +362,7 @@ public final class GrpcContainer {
 
         @FormatMethod
         private void println(@FormatString String msgFormat, Object... arg) {
-            String msg = format(msgFormat, arg);
+            var msg = format(msgFormat, arg);
             System.err.println(msg);
         }
     }

--- a/server/src/main/java/io/spine/server/Identity.java
+++ b/server/src/main/java/io/spine/server/Identity.java
@@ -55,7 +55,7 @@ public final class Identity {
      */
     public static MessageId byString(String value) {
         checkNotEmptyOrBlank(value);
-        Any producer = Identifier.pack(value);
+        var producer = Identifier.pack(value);
         return ofProducer(producer);
     }
 

--- a/server/src/main/java/io/spine/server/Ignored.java
+++ b/server/src/main/java/io/spine/server/Ignored.java
@@ -62,7 +62,7 @@ public final class Ignored {
     public static DispatchOutcome ignored(ModelClass<?> handler, EventEnvelope event) {
         checkNotNull(handler);
         checkNotNull(event);
-        String reason = format(
+        var reason = format(
                 "`@%s` filters in `%s` rejected event %s[%s]",
                 Where.class.getSimpleName(), handler, event.messageTypeName(), event.id().value()
         );

--- a/server/src/main/java/io/spine/server/QueryService.java
+++ b/server/src/main/java/io/spine/server/QueryService.java
@@ -26,10 +26,8 @@
 package io.spine.server;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import io.spine.client.Query;
 import io.spine.client.QueryResponse;
@@ -37,7 +35,6 @@ import io.spine.client.grpc.QueryServiceGrpc;
 import io.spine.logging.Logging;
 import io.spine.server.model.UnknownEntityTypeException;
 import io.spine.server.stand.InvalidRequestException;
-import io.spine.server.stand.Stand;
 import io.spine.type.TypeUrl;
 
 import java.util.Map;
@@ -76,9 +73,7 @@ public final class QueryService
      */
     public static QueryService withSingle(BoundedContext context) {
         checkNotNull(context);
-        QueryService result = newBuilder()
-                .add(context)
-                .build();
+        var result = newBuilder().add(context).build();
         return result;
     }
 
@@ -89,8 +84,8 @@ public final class QueryService
     public void read(Query query, StreamObserver<QueryResponse> responseObserver) {
         _debug().log("Incoming query: `%s`.", lazy(() -> shortDebugString(query)));
 
-        TypeUrl type = query.targetType();
-        BoundedContext context = typeToContextMap.get(type);
+        var type = query.targetType();
+        var context = typeToContextMap.get(type);
         if (context == null) {
             handleUnsupported(type, responseObserver);
         } else {
@@ -101,12 +96,12 @@ public final class QueryService
     private void handleQuery(BoundedContext context,
                              Query query,
                              StreamObserver<QueryResponse> responseObserver) {
-        Stand stand = context.stand();
+        var stand = context.stand();
         try {
             stand.execute(query, responseObserver);
         } catch (InvalidRequestException e) {
             _error().log("Invalid request. `%s`", e.asError());
-            StatusRuntimeException exception = invalidArgumentWithCause(e);
+            var exception = invalidArgumentWithCause(e);
             responseObserver.onError(exception);
         } catch (@SuppressWarnings("OverlyBroadCatchBlock") Exception e) {
             _error().withCause(e)
@@ -116,7 +111,7 @@ public final class QueryService
     }
 
     private void handleUnsupported(TypeUrl type, StreamObserver<QueryResponse> observer) {
-        UnknownEntityTypeException exception = new UnknownEntityTypeException(type);
+        var exception = new UnknownEntityTypeException(type);
         _error().withCause(exception)
                 .log("Unknown type encountered.");
         observer.onError(exception);
@@ -161,17 +156,17 @@ public final class QueryService
          */
         public QueryService build() throws IllegalStateException {
             if (contexts.isEmpty()) {
-                String message = "Query service must have at least one `BoundedContext`.";
+                var message = "Query service must have at least one `BoundedContext`.";
                 throw new IllegalStateException(message);
             }
-            ImmutableMap<TypeUrl, BoundedContext> map = createMap();
-            QueryService result = new QueryService(map);
+            var map = createMap();
+            var result = new QueryService(map);
             return result;
         }
 
         private ImmutableMap<TypeUrl, BoundedContext> createMap() {
             ImmutableMap.Builder<TypeUrl, BoundedContext> map = ImmutableMap.builder();
-            for (BoundedContext context : contexts) {
+            for (var context : contexts) {
                 putExposedTypes(context, map);
             }
             return map.build();
@@ -179,9 +174,9 @@ public final class QueryService
 
         private static void putExposedTypes(BoundedContext context,
                                             ImmutableMap.Builder<TypeUrl, BoundedContext> map) {
-            Stand stand = context.stand();
-            ImmutableSet<TypeUrl> exposedTypes = stand.exposedTypes();
-            for (TypeUrl type : exposedTypes) {
+            var stand = context.stand();
+            var exposedTypes = stand.exposedTypes();
+            for (var type : exposedTypes) {
                 map.put(type, context);
             }
         }

--- a/server/src/main/java/io/spine/server/Server.java
+++ b/server/src/main/java/io/spine/server/Server.java
@@ -28,7 +28,6 @@ package io.spine.server;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.flogger.FluentLogger;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.spine.logging.Logging;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -90,7 +89,7 @@ public final class Server implements Logging {
     public void start() throws IOException {
         grpcContainer.start();
         grpcContainer.addShutdownHook();
-        FluentLogger.Api info = _info();
+        var info = _info();
         grpcContainer
                 .port()
                 .ifPresent(p -> info.log("Server started, listening to the port %d.", p));
@@ -111,15 +110,15 @@ public final class Server implements Logging {
      * Initiates an orderly shutdown in which existing calls continue but new calls are rejected.
      */
     public void shutdown() {
-        FluentLogger.Api info = _info();
+        var info = _info();
         info.log("Shutting down the server...");
         grpcContainer.shutdown();
         contexts.forEach(context -> {
             try {
                 context.close();
             } catch (Exception e) {
-                String contextName = context.name()
-                                            .getValue();
+                var contextName = context.name()
+                                         .getValue();
                 _error().withCause(e)
                         .log("Unable to close the `%s` Context.", contextName);
             }
@@ -165,7 +164,7 @@ public final class Server implements Logging {
          * Creates a new instance of the server.
          */
         public Server build() {
-            Server result = new Server(this);
+            var result = new Server(this);
             return result;
         }
 
@@ -182,21 +181,20 @@ public final class Server implements Logging {
          * Creates a container for the passed Bounded Contexts.
          */
         private GrpcContainer createContainer() {
-            CommandService.Builder commandService = CommandService.newBuilder();
-            QueryService.Builder queryService = QueryService.newBuilder();
-            SubscriptionService.Builder subscriptionService = SubscriptionService.newBuilder();
+            var commandService = CommandService.newBuilder();
+            var queryService = QueryService.newBuilder();
+            var subscriptionService = SubscriptionService.newBuilder();
 
             contexts().forEach(context -> {
                 commandService.add(context);
                 queryService.add(context);
                 subscriptionService.add(context);
             });
-            GrpcContainer.Builder builder = createContainerBuilder();
-            GrpcContainer result = builder
-                    .addService(commandService.build())
-                    .addService(queryService.build())
-                    .addService(subscriptionService.build())
-                    .build();
+            var builder = createContainerBuilder();
+            var result = builder.addService(commandService.build())
+                                .addService(queryService.build())
+                                .addService(subscriptionService.build())
+                                .build();
             return result;
         }
 

--- a/server/src/main/java/io/spine/server/ServerEnvironment.java
+++ b/server/src/main/java/io/spine/server/ServerEnvironment.java
@@ -40,7 +40,6 @@ import io.spine.server.commandbus.ExecutorCommandScheduler;
 import io.spine.server.delivery.Delivery;
 import io.spine.server.storage.StorageFactory;
 import io.spine.server.storage.memory.InMemoryStorageFactory;
-import io.spine.server.storage.system.SystemAwareStorageFactory;
 import io.spine.server.trace.TracerFactory;
 import io.spine.server.transport.TransportFactory;
 import io.spine.server.transport.memory.InMemoryTransportFactory;
@@ -192,12 +191,12 @@ public final class ServerEnvironment implements AutoCloseable {
      * a {@linkplain Delivery#local() local implementation} of {@code Delivery}.
      */
     public synchronized Delivery delivery() {
-        Class<? extends EnvironmentType> currentEnv = environment().type();
-        Optional<Delivery> currentDelivery = this.delivery.optionalValue(currentEnv);
+        var currentEnv = environment().type();
+        var currentDelivery = this.delivery.optionalValue(currentEnv);
         if (currentDelivery.isPresent()) {
             return currentDelivery.get();
         }
-        Delivery localDelivery = Delivery.local();
+        var localDelivery = Delivery.local();
         this.delivery.use(localDelivery, currentEnv);
         return localDelivery;
     }
@@ -235,7 +234,7 @@ public final class ServerEnvironment implements AutoCloseable {
      * {@linkplain Supplier supplier} which utilizes system properties.
      */
     private void resetDeploymentType() {
-        Supplier<DeploymentType> supplier = DeploymentDetector.newInstance();
+        var supplier = DeploymentDetector.newInstance();
         configureDeployment(supplier);
     }
 
@@ -255,7 +254,7 @@ public final class ServerEnvironment implements AutoCloseable {
      * Obtains the {@link TracerFactory} associated with the current environment, if it was set.
      */
     public Optional<TracerFactory> tracing() {
-        Class<? extends EnvironmentType> currentType = environment().type();
+        var currentType = environment().type();
         return this.tracerFactory.optionalValue(currentType);
     }
 
@@ -272,9 +271,9 @@ public final class ServerEnvironment implements AutoCloseable {
      *         {@linkplain TypeConfigurator#use(StorageFactory) configured} prior to the call
      */
     public StorageFactory storageFactory() {
-        Class<? extends EnvironmentType> type = environment().type();
-        StorageFactory result = storageFactory.optionalValue(type)
-                .orElseThrow(() -> SuggestConfiguring.storageFactory(type));
+        var type = environment().type();
+        var result = storageFactory.optionalValue(type)
+                                   .orElseThrow(() -> SuggestConfiguring.storageFactory(type));
         return result;
     }
 
@@ -284,7 +283,7 @@ public final class ServerEnvironment implements AutoCloseable {
      */
     @Internal
     public Optional<StorageFactory> optionalStorageFactory() {
-        Class<? extends EnvironmentType> type = environment().type();
+        var type = environment().type();
         return storageFactory.optionalValue(type);
     }
 
@@ -300,9 +299,9 @@ public final class ServerEnvironment implements AutoCloseable {
      * {@link InMemoryTransportFactory} and returns it.
      */
     public TransportFactory transportFactory() {
-        Class<? extends EnvironmentType> type = environment().type();
-        TransportFactory result = transportFactory.optionalValue(type)
-                .orElseThrow(() -> SuggestConfiguring.transportFactory(type));
+        var type = environment().type();
+        var result = transportFactory.optionalValue(type)
+                                     .orElseThrow(() -> SuggestConfiguring.transportFactory(type));
 
         return result;
     }
@@ -320,7 +319,7 @@ public final class ServerEnvironment implements AutoCloseable {
         tracerFactory.reset();
         storageFactory.reset();
         delivery.reset();
-        Class<? extends EnvironmentType> currentEnv = environment().type();
+        var currentEnv = environment().type();
         delivery.use(Delivery.local(), currentEnv);
         resetDeploymentType();
     }
@@ -361,7 +360,7 @@ public final class ServerEnvironment implements AutoCloseable {
 
         private static void registerCustomType(Class<? extends EnvironmentType> type) {
             @SuppressWarnings("unchecked") // checked by calling site.
-            Class<? extends CustomEnvironmentType> customType =
+            var customType =
                     (Class<? extends CustomEnvironmentType>) type;
             Environment.instance()
                        .register(customType);
@@ -472,7 +471,7 @@ public final class ServerEnvironment implements AutoCloseable {
          */
         @CanIgnoreReturnValue
         public TypeConfigurator use(StorageFactory factory) {
-            SystemAwareStorageFactory wrapped = wrap(factory);
+            var wrapped = wrap(factory);
             se.storageFactory.use(wrapped, type);
             return this;
         }
@@ -492,8 +491,8 @@ public final class ServerEnvironment implements AutoCloseable {
         public TypeConfigurator useStorageFactory(Fn<StorageFactory> fn) {
             checkNotNull(fn);
             se.storageFactory.lazyUse(() -> {
-                StorageFactory factory = fn.apply(type);
-                SystemAwareStorageFactory wrapped = wrap(factory);
+                var factory = fn.apply(type);
+                var wrapped = wrap(factory);
                 return wrapped;
             }, type);
             return this;
@@ -551,8 +550,8 @@ public final class ServerEnvironment implements AutoCloseable {
          */
         private static IllegalStateException
         raise(String prefixFmt, Class<? extends EnvironmentType> type, String featureParamName) {
-            String typeName = type.getSimpleName();
-            String fmt = prefixFmt + " Please call `ServerEnvironment.when(%s.class).use(%s);`.";
+            var typeName = type.getSimpleName();
+            var fmt = prefixFmt + " Please call `ServerEnvironment.when(%s.class).use(%s);`.";
             return newIllegalStateException(fmt, typeName, typeName, featureParamName);
         }
     }

--- a/server/src/main/java/io/spine/server/VisibilityGuard.java
+++ b/server/src/main/java/io/spine/server/VisibilityGuard.java
@@ -32,7 +32,6 @@ import io.spine.base.EntityState;
 import io.spine.option.EntityOption.Visibility;
 import io.spine.server.entity.EntityVisibility;
 import io.spine.server.entity.Repository;
-import io.spine.server.entity.model.EntityClass;
 import io.spine.type.TypeName;
 
 import java.util.HashMap;
@@ -70,14 +69,14 @@ final class VisibilityGuard {
      */
     void register(Repository<?, ?> repository) {
         checkNotNull(repository);
-        EntityClass<?> entityClass = repository.entityModelClass();
-        Class<? extends EntityState<?>> stateClass = entityClass.stateClass();
+        var entityClass = repository.entityModelClass();
+        var stateClass = entityClass.stateClass();
         checkNotAlreadyRegistered(stateClass);
         repositories.put(stateClass, new RepositoryAccess(repository));
     }
 
     private void checkNotAlreadyRegistered(Class<? extends EntityState<?>> stateClass) {
-        RepositoryAccess alreadyRegistered = repositories.get(stateClass);
+        var alreadyRegistered = repositories.get(stateClass);
         if (alreadyRegistered != null) {
             throw newIllegalStateException(
                     "A repository for the state class %s already registered: `%s`.",
@@ -92,7 +91,7 @@ final class VisibilityGuard {
      */
     boolean hasRepository(Class<? extends EntityState<?>> stateClass) {
         checkNotNull(stateClass);
-        boolean result = repositories.containsKey(stateClass);
+        var result = repositories.containsKey(stateClass);
         return result;
     }
 
@@ -111,12 +110,12 @@ final class VisibilityGuard {
      */
     Optional<Repository<?, ?>> repositoryFor(Class<? extends EntityState<?>> stateClass) {
         checkNotNull(stateClass);
-        RepositoryAccess repositoryAccess = findOrThrow(stateClass);
+        var repositoryAccess = findOrThrow(stateClass);
         return repositoryAccess.get();
     }
 
     private RepositoryAccess findOrThrow(Class<? extends EntityState<?>> stateClass) {
-        RepositoryAccess repository = repositories.get(stateClass);
+        var repository = repositories.get(stateClass);
         if (repository == null) {
             throw newIllegalStateException(
                     "A repository for the state class `%s` is not registered.",
@@ -133,7 +132,7 @@ final class VisibilityGuard {
      *         if there is not repository entities of which have the passed state
      */
     Repository<?, ?> get(Class<? extends EntityState<?>> stateClass) {
-        RepositoryAccess access = findOrThrow(stateClass);
+        var access = findOrThrow(stateClass);
         return access.repository;
     }
 
@@ -191,7 +190,7 @@ final class VisibilityGuard {
 
         private RepositoryAccess(Repository<?, ?> repository) {
             this.repository = repository;
-            EntityClass<?> entityClass = repository.entityModelClass();
+            var entityClass = repository.entityModelClass();
             this.visibility = entityClass.visibility();
         }
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateCommandEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateCommandEndpoint.java
@@ -26,11 +26,8 @@
 
 package io.spine.server.aggregate;
 
-import io.spine.server.command.DispatchCommand;
 import io.spine.server.delivery.CommandEndpoint;
 import io.spine.server.dispatch.DispatchOutcome;
-import io.spine.server.entity.EntityLifecycle;
-import io.spine.server.type.CommandClass;
 import io.spine.server.type.CommandEnvelope;
 
 import static io.spine.server.command.DispatchCommand.operationFor;
@@ -52,8 +49,8 @@ final class AggregateCommandEndpoint<I, A extends Aggregate<I, ?, ?>>
 
     @Override
     protected DispatchOutcome invokeDispatcher(A aggregate) {
-        EntityLifecycle lifecycle = repository().lifecycleOf(aggregate.id());
-        DispatchCommand<I> dispatch = operationFor(lifecycle, aggregate, envelope());
+        var lifecycle = repository().lifecycleOf(aggregate.id());
+        var dispatch = operationFor(lifecycle, aggregate, envelope());
         return dispatch.perform();
     }
 
@@ -71,12 +68,11 @@ final class AggregateCommandEndpoint<I, A extends Aggregate<I, ?, ?>>
      */
     @Override
     protected void onEmptyResult(A aggregate) throws IllegalStateException {
-        CommandEnvelope cmd = envelope();
-        String entityId = aggregate.idAsString();
-        String entityClass = aggregate.getClass()
-                                      .getName();
-        String commandId = cmd.id().value();
-        CommandClass commandClass = cmd.messageClass();
+        var cmd = envelope();
+        var entityId = aggregate.idAsString();
+        var entityClass = aggregate.getClass().getName();
+        var commandId = cmd.id().value();
+        var commandClass = cmd.messageClass();
         throw newIllegalStateException(
                 "The aggregate (class: %s, ID: %s) produced empty response for " +
                         "the command (class: %s, ID: %s).",

--- a/server/src/main/java/io/spine/server/aggregate/AggregatePart.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregatePart.java
@@ -109,7 +109,7 @@ public abstract class AggregatePart<I,
      *                               the ID type of the {@code root}
      */
     protected <P extends EntityState<I>> P partState(Class<P> partStateClass) {
-        P partState = root.partState(partStateClass);
+        var partState = root.partState(partStateClass);
         return partState;
     }
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregatePartRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregatePartRepository.java
@@ -77,8 +77,8 @@ public abstract class AggregatePartRepository<I,
 
     @Override
     public A create(I id) {
-        AggregateRoot<I> root = createAggregateRoot(id);
-        A result = createAggregatePart(root);
+        var root = createAggregateRoot(id);
+        var result = createAggregatePart(root);
         return result;
     }
 
@@ -93,7 +93,7 @@ public abstract class AggregatePartRepository<I,
     }
 
     private AggregateRoot<I> createAggregateRoot(I id) {
-        AggregateRoot<I> result = aggregatePartClass().createRoot(context(), id);
+        var result = aggregatePartClass().createRoot(context(), id);
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRecords.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRecords.java
@@ -26,17 +26,11 @@
 
 package io.spine.server.aggregate;
 
-import com.google.protobuf.Any;
-import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
-import io.spine.base.EntityState;
 import io.spine.base.Identifier;
 import io.spine.core.Event;
-import io.spine.core.EventContext;
-import io.spine.core.Version;
 import io.spine.protobuf.AnyPacker;
 import io.spine.server.entity.EntityRecord;
-import io.spine.server.entity.LifecycleFlags;
 import io.spine.string.Stringifiers;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -73,22 +67,20 @@ final class AggregateRecords {
         checkArgument(event.hasContext(), "Event context must be set.");
         checkArgument(event.hasMessage(), "Event message must be set.");
 
-        String eventIdStr = Identifier.toString(event.getId());
+        var eventIdStr = Identifier.toString(event.getId());
         checkNotEmptyOrBlank(eventIdStr, "Event ID cannot be empty or blank.");
 
-        EventContext context = event.context();
-        Timestamp timestamp = checkValid(context.getTimestamp());
-        Any packedId = Identifier.pack(aggregateId);
+        var context = event.context();
+        var timestamp = checkValid(context.getTimestamp());
+        var packedId = Identifier.pack(aggregateId);
 
-        AggregateEventRecordId recordId = eventRecordId(eventIdStr);
-        AggregateEventRecord result =
-                AggregateEventRecord
-                        .newBuilder()
-                        .setId(recordId)
-                        .setAggregateId(packedId)
-                        .setTimestamp(timestamp)
-                        .setEvent(event)
-                        .vBuild();
+        var recordId = eventRecordId(eventIdStr);
+        var result = AggregateEventRecord.newBuilder()
+                .setId(recordId)
+                .setAggregateId(packedId)
+                .setTimestamp(timestamp)
+                .setEvent(event)
+                .vBuild();
         return result;
     }
 
@@ -106,22 +98,19 @@ final class AggregateRecords {
     static <I> AggregateEventRecord newEventRecord(I aggregateId, Snapshot snapshot) {
         checkNotNull(aggregateId);
         checkNotNull(snapshot);
-        Timestamp value = checkValid(snapshot.getTimestamp());
+        var value = checkValid(snapshot.getTimestamp());
 
-        String stringId = Stringifiers.toString(aggregateId);
-        String snapshotTimestamp = Timestamps.toString(snapshot.getTimestamp());
-        String snapshotColumnName = AggregateEventRecordColumn.snapshot.name()
-                                                                       .value();
-        String snapshotId = format("%s_%s_%s", snapshotColumnName, stringId, snapshotTimestamp);
-        AggregateEventRecordId recordId = eventRecordId(snapshotId);
-        AggregateEventRecord result =
-                AggregateEventRecord
-                        .newBuilder()
-                        .setId(recordId)
-                        .setAggregateId(Identifier.pack(aggregateId))
-                        .setTimestamp(value)
-                        .setSnapshot(snapshot)
-                        .vBuild();
+        var stringId = Stringifiers.toString(aggregateId);
+        var snapshotTimestamp = Timestamps.toString(snapshot.getTimestamp());
+        var snapshotColumnName = AggregateEventRecordColumn.snapshot.name().value();
+        var snapshotId = format("%s_%s_%s", snapshotColumnName, stringId, snapshotTimestamp);
+        var recordId = eventRecordId(snapshotId);
+        var result = AggregateEventRecord.newBuilder()
+                .setId(recordId)
+                .setAggregateId(Identifier.pack(aggregateId))
+                .setTimestamp(value)
+                .setSnapshot(snapshot)
+                .vBuild();
         return result;
     }
 
@@ -140,17 +129,16 @@ final class AggregateRecords {
     static <I> EntityRecord newStateRecord(Aggregate<I, ?, ?> aggregate, boolean includeState) {
         checkNotNull(aggregate);
 
-        LifecycleFlags flags = aggregate.lifecycleFlags();
-        I id = aggregate.id();
-        Version version = aggregate.version();
+        var flags = aggregate.lifecycleFlags();
+        var id = aggregate.id();
+        var version = aggregate.version();
 
-        EntityRecord.Builder builder =
-                EntityRecord.newBuilder()
-                            .setEntityId(Identifier.pack(id))
-                            .setLifecycleFlags(flags)
-                            .setVersion(version);
+        var builder = EntityRecord.newBuilder()
+                .setEntityId(Identifier.pack(id))
+                .setLifecycleFlags(flags)
+                .setVersion(version);
         if (includeState) {
-            EntityState<I> state = aggregate.state();
+            var state = aggregate.state();
             builder.setState(AnyPacker.pack(state));
         }
         return builder.vBuild();

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRoot.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRoot.java
@@ -106,8 +106,7 @@ public class AggregateRoot<I> {
                 () -> newIllegalStateException("Could not find repository for aggregate part `%s`.",
                                                stateClass.getName())
         );
-        var result =
-                (AggregatePartRepository<I, A, S, ?>) repository;
+        var result = (AggregatePartRepository<I, A, S, ?>) repository;
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRoot.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRoot.java
@@ -83,7 +83,7 @@ public class AggregateRoot<I> {
     S partState(Class<S> partStateClass) {
         AggregatePartRepository<I, A, S, ?> repo = repositoryOf(partStateClass);
         AggregatePart<I, S, ?, ?> aggregatePart = repo.loadOrCreate(id());
-        S partState = aggregatePart.state();
+        var partState = aggregatePart.state();
         return partState;
     }
 
@@ -97,7 +97,7 @@ public class AggregateRoot<I> {
     @SuppressWarnings("unchecked") // We ensure ID type when adding to the map.
     private <S extends EntityState<I>, A extends AggregatePart<I, S, ?, ?>>
     AggregatePartRepository<I, A, S, ?> repositoryOf(Class<S> stateClass) {
-        Class<? extends AggregateRoot<?>> thisType = (Class<? extends AggregateRoot<?>>) getClass();
+        var thisType = (Class<? extends AggregateRoot<?>>) getClass();
         Optional<? extends AggregatePartRepository<?, ?, ?, ?>> partRepository =
                 context.internalAccess()
                        .aggregateRootDirectory()
@@ -106,7 +106,7 @@ public class AggregateRoot<I> {
                 () -> newIllegalStateException("Could not find repository for aggregate part `%s`.",
                                                stateClass.getName())
         );
-        AggregatePartRepository<I, A, S, ?> result =
+        var result =
                 (AggregatePartRepository<I, A, S, ?>) repository;
         return result;
     }

--- a/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
@@ -37,7 +37,6 @@ import io.spine.client.TargetFilters;
 import io.spine.core.Event;
 import io.spine.core.Version;
 import io.spine.query.EntityQuery;
-import io.spine.query.RecordQuery;
 import io.spine.server.ContextSpec;
 import io.spine.server.entity.EntityRecord;
 import io.spine.server.entity.storage.EntityRecordStorage;
@@ -49,7 +48,6 @@ import io.spine.server.storage.StorageFactory;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Iterator;
-import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -223,7 +221,7 @@ public class AggregateStorage<I, S extends EntityState<I>>
      */
     @SuppressWarnings("CheckReturnValue") // calling builder method
     public Optional<AggregateHistory> read(I id, int batchSize) {
-        ReadOperation<I, S> op = new ReadOperation<>(this, id, batchSize);
+        var op = new ReadOperation<>(this, id, batchSize);
         return op.perform();
     }
 
@@ -247,11 +245,11 @@ public class AggregateStorage<I, S extends EntityState<I>>
     public void write(I id, AggregateHistory events) {
         checkNotClosedAndArguments(id, events);
 
-        List<Event> eventList = events.getEventList();
+        var eventList = events.getEventList();
         checkArgument(!eventList.isEmpty(), "Event list must not be empty.");
 
-        for (Event event : eventList) {
-            AggregateEventRecord record = newEventRecord(id, event);
+        for (var event : eventList) {
+            var record = newEventRecord(id, event);
             writeEventRecord(id, record);
         }
         if (events.hasSnapshot()) {
@@ -273,8 +271,8 @@ public class AggregateStorage<I, S extends EntityState<I>>
     void writeEvent(I id, Event event) {
         checkNotClosedAndArguments(id, event);
 
-        Event eventWithoutEnrichments = event.clearEnrichments();
-        AggregateEventRecord record = newEventRecord(id, eventWithoutEnrichments);
+        var eventWithoutEnrichments = event.clearEnrichments();
+        var record = newEventRecord(id, eventWithoutEnrichments);
         writeEventRecord(id, record);
     }
 
@@ -289,7 +287,7 @@ public class AggregateStorage<I, S extends EntityState<I>>
     void writeSnapshot(I aggregateId, Snapshot snapshot) {
         checkNotClosedAndArguments(aggregateId, snapshot);
 
-        AggregateEventRecord record = newEventRecord(aggregateId, snapshot);
+        var record = newEventRecord(aggregateId, snapshot);
         writeEventRecord(aggregateId, record);
     }
 
@@ -323,8 +321,8 @@ public class AggregateStorage<I, S extends EntityState<I>>
      */
     protected Iterator<EntityRecord> readStates(TargetFilters filters, ResponseFormat format) {
         ensureStatesQueryable();
-        RecordQuery<I, EntityRecord> query = convert(filters, format, stateStorage.recordSpec());
-        Iterator<EntityRecord> result = stateStorage.readAll(query);
+        var query = convert(filters, format, stateStorage.recordSpec());
+        var result = stateStorage.readAll(query);
         return result;
     }
 
@@ -340,9 +338,8 @@ public class AggregateStorage<I, S extends EntityState<I>>
      */
     protected Iterator<EntityRecord> readStates(ResponseFormat format) {
         ensureStatesQueryable();
-        RecordQuery<I, EntityRecord> query =
-                QueryConverter.newQuery(stateStorage.recordSpec(), format);
-        Iterator<EntityRecord> result = stateStorage.readAll(query);
+        var query = QueryConverter.newQuery(stateStorage.recordSpec(), format);
+        var result = stateStorage.readAll(query);
         return result;
     }
 
@@ -355,8 +352,8 @@ public class AggregateStorage<I, S extends EntityState<I>>
      */
     protected Iterator<EntityRecord> readStates(EntityQuery<I, S, ?> query) {
         ensureStatesQueryable();
-        RecordQuery<I, EntityRecord> recordQuery = ToEntityRecordQuery.transform(query);
-        Iterator<EntityRecord> result = stateStorage.readAll(recordQuery);
+        var recordQuery = ToEntityRecordQuery.transform(query);
+        var result = stateStorage.readAll(recordQuery);
         return result;
     }
 
@@ -377,15 +374,14 @@ public class AggregateStorage<I, S extends EntityState<I>>
     }
 
     protected void writeState(Aggregate<I, ?, ?> aggregate) {
-        EntityRecord record = AggregateRecords.newStateRecord(aggregate, queryingEnabled);
-        EntityRecordWithColumns<I> result =
-                EntityRecordWithColumns.create(aggregate, record);
+        var record = AggregateRecords.newStateRecord(aggregate, queryingEnabled);
+        var result = EntityRecordWithColumns.create(aggregate, record);
         stateStorage.write(result);
     }
 
     protected void writeAll(Aggregate<I, ?, ?> aggregate,
                             ImmutableList<AggregateHistory> historySegments) {
-        for (AggregateHistory history : historySegments) {
+        for (var history : historySegments) {
             write(aggregate.id(), history);
         }
         writeState(aggregate);

--- a/server/src/main/java/io/spine/server/aggregate/AggregateTransaction.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateTransaction.java
@@ -66,6 +66,7 @@ public class AggregateTransaction<I,
      * @return the new transaction instance
      */
     static <I> AggregateTransaction<I, ?, ?> start(Aggregate<I, ?, ?> aggregate) {
+        @SuppressWarnings("RedundantExplicitVariableType")  /* To enable wildcard instantiation. */
         AggregateTransaction<I, ?, ?> tx = new AggregateTransaction<>(aggregate);
         return tx;
     }
@@ -82,7 +83,7 @@ public class AggregateTransaction<I,
      */
     @Override
     public DispatchOutcome play(EventEnvelope event) {
-        DispatchOutcome outcome = super.play(event);
+        var outcome = super.play(event);
         entity().onAfterEventPlayed(event);
         return outcome;
     }

--- a/server/src/main/java/io/spine/server/aggregate/EventImportEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/EventImportEndpoint.java
@@ -63,12 +63,11 @@ final class EventImportEndpoint<I, A extends Aggregate<I, ?, ?>>
      */
     @Override
     protected DispatchOutcome invokeDispatcher(A aggregate) {
-        Event event = envelope().outerObject();
-        Success.Builder success = Success.newBuilder();
+        var event = envelope().outerObject();
+        var success = Success.newBuilder();
         success.getProducedEventsBuilder()
                .addEvent(event);
-        DispatchOutcome outcome = DispatchOutcome
-                .newBuilder()
+        var outcome = DispatchOutcome.newBuilder()
                 .setPropagatedSignal(event.messageId())
                 .setSuccess(success)
                 .vBuild();

--- a/server/src/main/java/io/spine/server/aggregate/HistoryBackwardOperation.java
+++ b/server/src/main/java/io/spine/server/aggregate/HistoryBackwardOperation.java
@@ -26,10 +26,8 @@
 
 package io.spine.server.aggregate;
 
-import com.google.protobuf.Any;
 import io.spine.base.Identifier;
 import io.spine.core.Version;
-import io.spine.query.RecordQuery;
 import io.spine.query.RecordQueryBuilder;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -71,21 +69,19 @@ final class HistoryBackwardOperation<I> {
      */
     Iterator<AggregateEventRecord>
     read(I aggregateId, int batchSize, @Nullable Version startingFrom) {
-        RecordQueryBuilder<AggregateEventRecordId, AggregateEventRecord> builder =
-                historyBackwardQuery(aggregateId);
+        var builder = historyBackwardQuery(aggregateId);
         if (startingFrom != null) {
             builder.where(version)
                    .isLessThan(startingFrom.getNumber());
         }
-        RecordQuery<AggregateEventRecordId, AggregateEventRecord> query =
-                inChronologicalOrder(builder, batchSize).build();
-        Iterator<AggregateEventRecord> iterator = eventStorage.readAll(query);
+        var query = inChronologicalOrder(builder, batchSize).build();
+        var iterator = eventStorage.readAll(query);
         return iterator;
     }
 
     private RecordQueryBuilder<AggregateEventRecordId, AggregateEventRecord>
     historyBackwardQuery(I id) {
-        Any packedId = Identifier.pack(id);
+        var packedId = Identifier.pack(id);
         return eventStorage.queryBuilder()
                            .where(aggregate_id)
                            .is(packedId);

--- a/server/src/main/java/io/spine/server/aggregate/IdempotencyGuard.java
+++ b/server/src/main/java/io/spine/server/aggregate/IdempotencyGuard.java
@@ -27,10 +27,8 @@
 package io.spine.server.aggregate;
 
 import io.spine.base.Error;
-import io.spine.core.CommandId;
 import io.spine.core.CommandValidationError;
 import io.spine.core.Event;
-import io.spine.core.EventId;
 import io.spine.core.EventValidationError;
 import io.spine.server.type.CommandEnvelope;
 import io.spine.server.type.EventEnvelope;
@@ -63,12 +61,12 @@ final class IdempotencyGuard {
      */
     Optional<Error> check(CommandEnvelope command) {
         if (didHandleRecently(command)) {
-            String errorMessage = format(
+            var errorMessage = format(
                     "Command %s[%s] is a duplicate.",
                     command.messageClass(),
                     command.id().value()
             );
-            Error error = Error.newBuilder()
+            var error = Error.newBuilder()
                     .setType(CommandValidationError.class.getSimpleName())
                     .setCode(DUPLICATE_COMMAND_VALUE)
                     .setMessage(errorMessage)
@@ -89,12 +87,12 @@ final class IdempotencyGuard {
      */
     Optional<Error> check(EventEnvelope event) {
         if (didHandleRecently(event)) {
-            String errorMessage = format(
+            var errorMessage = format(
                     "Event %s[%s] is a duplicate.",
                     event.messageClass(),
                     event.id().value()
             );
-            Error error = Error.newBuilder()
+            var error = Error.newBuilder()
                     .setType(EventValidationError.class.getSimpleName())
                     .setCode(DUPLICATE_EVENT_VALUE)
                     .setMessage(errorMessage)
@@ -119,7 +117,7 @@ final class IdempotencyGuard {
      * @return {@code true} if the event was handled since last snapshot, {@code false} otherwise
      */
     private boolean didHandleRecently(EventEnvelope event) {
-        EventId eventId = event.id();
+        var eventId = event.id();
         Predicate<Event> causedByEvent = e -> e.context()
                                                .getPastMessage()
                                                .messageId()
@@ -129,7 +127,7 @@ final class IdempotencyGuard {
                                                   .messageId()
                                                   .asEventId()
                                                   .equals(eventId);
-        boolean found = aggregate.historyContains(causedByEvent.and(originHasGivenId));
+        var found = aggregate.historyContains(causedByEvent.and(originHasGivenId));
         return found;
     }
 
@@ -147,7 +145,7 @@ final class IdempotencyGuard {
      * @return {@code true} if the command was handled since last snapshot, {@code false} otherwise
      */
     private boolean didHandleRecently(CommandEnvelope command) {
-        CommandId commandId = command.id();
+        var commandId = command.id();
         Predicate<Event> causedByCommand = e -> e.context()
                                                  .getPastMessage()
                                                  .messageId()
@@ -157,7 +155,7 @@ final class IdempotencyGuard {
                                                   .messageId()
                                                   .asCommandId()
                                                   .equals(commandId);
-        boolean found = aggregate.historyContains(causedByCommand.and(originHasGivenId));
+        var found = aggregate.historyContains(causedByCommand.and(originHasGivenId));
         return found;
     }
 }

--- a/server/src/main/java/io/spine/server/aggregate/ImportBus.java
+++ b/server/src/main/java/io/spine/server/aggregate/ImportBus.java
@@ -131,7 +131,7 @@ public final class ImportBus
      */
     @Override
     protected void store(Iterable<Event> events) {
-        TenantId tenantId = tenantOf(events);
+        var tenantId = tenantOf(events);
         tenantIndex.keep(tenantId);
     }
 

--- a/server/src/main/java/io/spine/server/aggregate/ImportValidator.java
+++ b/server/src/main/java/io/spine/server/aggregate/ImportValidator.java
@@ -26,14 +26,11 @@
 
 package io.spine.server.aggregate;
 
-import io.spine.base.EventMessage;
 import io.spine.server.MessageInvalid;
 import io.spine.server.bus.EnvelopeValidator;
 import io.spine.server.type.EventEnvelope;
-import io.spine.validate.ConstraintViolation;
 import io.spine.validate.Validate;
 
-import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -47,8 +44,8 @@ final class ImportValidator implements EnvelopeValidator<EventEnvelope> {
     @Override
     public Optional<MessageInvalid> validate(EventEnvelope event) {
         checkNotNull(event);
-        EventMessage eventMessage = event.message();
-        List<ConstraintViolation> violations = Validate.violationsOf(eventMessage);
+        var eventMessage = event.message();
+        var violations = Validate.violationsOf(eventMessage);
         if (violations.isEmpty()) {
             return Optional.empty();
         }

--- a/server/src/main/java/io/spine/server/aggregate/InMemoryRootDirectory.java
+++ b/server/src/main/java/io/spine/server/aggregate/InMemoryRootDirectory.java
@@ -33,7 +33,6 @@ import io.spine.base.EntityState;
 import io.spine.type.TypeUrl;
 
 import java.util.Optional;
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Multimaps.synchronizedSetMultimap;
@@ -52,7 +51,7 @@ public final class InMemoryRootDirectory implements AggregateRootDirectory {
     public void register(AggregatePartRepository<?, ?, ?, ?> repository) {
         checkNotNull(repository);
 
-        Class<? extends AggregateRoot<?>> rootClass = repository.aggregatePartClass().rootClass();
+        var rootClass = repository.aggregatePartClass().rootClass();
         repositories.put(rootClass, repository);
     }
 
@@ -60,13 +59,12 @@ public final class InMemoryRootDirectory implements AggregateRootDirectory {
     public Optional<? extends AggregatePartRepository<?, ?, ?, ?>>
     findPart(Class<? extends AggregateRoot<?>> rootClass,
              Class<? extends EntityState<?>> partStateClass) {
-        Set<AggregatePartRepository<?, ?, ?, ?>> parts = repositories.get(rootClass);
+        var parts = repositories.get(rootClass);
         if (parts.isEmpty()) {
             return Optional.empty();
         } else {
-            TypeUrl targetType = TypeUrl.of(partStateClass);
-            Optional<AggregatePartRepository<?, ?, ?, ?>> repository = parts
-                    .stream()
+            var targetType = TypeUrl.of(partStateClass);
+            var repository = parts.stream()
                     .filter(repo -> repo.entityStateType().equals(targetType))
                     .findAny();
             return repository;

--- a/server/src/main/java/io/spine/server/aggregate/ReadOperation.java
+++ b/server/src/main/java/io/spine/server/aggregate/ReadOperation.java
@@ -44,8 +44,10 @@ import static io.spine.util.Preconditions2.checkPositive;
 /**
  * Method object for reading {@link AggregateHistory}s.
  *
- * @param <I> the type of aggregate IDs
- * @param <S> the type of aggregate state
+ * @param <I>
+ *         the type of aggregate IDs
+ * @param <S>
+ *         the type of aggregate state
  */
 final class ReadOperation<I, S extends EntityState<I>> {
 
@@ -92,16 +94,16 @@ final class ReadOperation<I, S extends EntityState<I>> {
      *         or {@code Optional.empty()} if this {@code Aggregate} has no history
      */
     Optional<AggregateHistory> perform() {
-        Iterator<AggregateEventRecord> historyBackward = storage.historyBackward(id, batchSize);
+        var historyBackward = storage.historyBackward(id, batchSize);
         if (!historyBackward.hasNext()) {
             return Optional.empty();
         }
 
-        boolean historyBottomReached = false;
+        var historyBottomReached = false;
         while(snapshot == null && !historyBottomReached) {
-            Optional<Version> lastVersion = process(historyBackward);
+            var lastVersion = process(historyBackward);
             if(snapshot == null) {
-                if(!lastVersion.isPresent()) {
+                if(lastVersion.isEmpty()) {
                     historyBottomReached = true;
                 } else {
                     historyBackward = storage.historyBackward(id, batchSize, lastVersion.get());
@@ -109,7 +111,7 @@ final class ReadOperation<I, S extends EntityState<I>> {
             }
         }
 
-        AggregateHistory result = buildRecord();
+        var result = buildRecord();
         return Optional.of(result);
     }
 
@@ -123,7 +125,7 @@ final class ReadOperation<I, S extends EntityState<I>> {
     private Optional<Version> process(Iterator<AggregateEventRecord> historyBackward) {
         Version lastHandledVersion = null;
         while(historyBackward.hasNext() && snapshot == null) {
-            AggregateEventRecord record = historyBackward.next();
+            var record = historyBackward.next();
             lastHandledVersion = handleRecord(record);
         }
         return Optional.ofNullable(lastHandledVersion);
@@ -147,13 +149,13 @@ final class ReadOperation<I, S extends EntityState<I>> {
 
     @SuppressWarnings("ResultOfMethodCallIgnored") // calling builder
     private AggregateHistory buildRecord() {
-        AggregateHistory.Builder builder = AggregateHistory.newBuilder();
+        var builder = AggregateHistory.newBuilder();
         if (snapshot != null) {
             builder.setSnapshot(snapshot);
         }
         builder.addAllEvent(history);
 
-        AggregateHistory result = builder.build();
+        var result = builder.build();
         checkRecord(result);
         return result;
     }
@@ -171,9 +173,8 @@ final class ReadOperation<I, S extends EntityState<I>> {
      * @throws IllegalStateException if the {@link AggregateHistory} is not valid
      */
     private static void checkRecord(AggregateHistory record) throws IllegalStateException {
-        boolean snapshotIsNotSet = !record.hasSnapshot();
-        boolean noEvents = record.getEventList()
-                                 .isEmpty();
+        var snapshotIsNotSet = !record.hasSnapshot();
+        var noEvents = record.getEventList().isEmpty();
         if (noEvents && snapshotIsNotSet) {
             throw new IllegalStateException("AggregateStateRecord instance should have either "
                                                     + "snapshot or non-empty event list.");

--- a/server/src/main/java/io/spine/server/aggregate/TruncateOperation.java
+++ b/server/src/main/java/io/spine/server/aggregate/TruncateOperation.java
@@ -31,7 +31,6 @@ import io.spine.query.RecordQuery;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -79,13 +78,13 @@ final class TruncateOperation {
      *         the currently examined history record
      */
     void performWith(int snapshotIndex, Predicate<AggregateEventRecord> predicate) {
-        Iterator<AggregateEventRecord> eventRecords = eventStorage.readAll(chronologically());
+        var eventRecords = eventStorage.readAll(chronologically());
         Map<Any, Integer> snapshotHitsByAggregateId = new HashMap<>();
         Set<AggregateEventRecordId> toDelete = new HashSet<>();
         while (eventRecords.hasNext()) {
-            AggregateEventRecord eventRecord = eventRecords.next();
-            Any packedId = eventRecord.getAggregateId();
-            int snapshotsHit = snapshotHitsByAggregateId.get(packedId) != null
+            var eventRecord = eventRecords.next();
+            var packedId = eventRecord.getAggregateId();
+            var snapshotsHit = snapshotHitsByAggregateId.get(packedId) != null
                                ? snapshotHitsByAggregateId.get(packedId)
                                : 0;
             if (snapshotsHit > snapshotIndex && predicate.test(eventRecord)) {
@@ -99,7 +98,7 @@ final class TruncateOperation {
     }
 
     private RecordQuery<AggregateEventRecordId, AggregateEventRecord> chronologically() {
-        RecordQuery<AggregateEventRecordId, AggregateEventRecord> orderChronologically =
+        var orderChronologically =
                 inChronologicalOrder(eventStorage.queryBuilder(), null).build();
         return orderChronologically;
     }

--- a/server/src/main/java/io/spine/server/aggregate/UncommittedEvents.java
+++ b/server/src/main/java/io/spine/server/aggregate/UncommittedEvents.java
@@ -80,8 +80,7 @@ final class UncommittedEvents {
      * @return new {@code UncommittedEvents} instance
      */
     UncommittedEvents append(Iterable<Event> newEvents) {
-        ImmutableList<Event> newList = ImmutableList
-                .<Event>builder()
+        var newList = ImmutableList.<Event>builder()
                 .addAll(events)
                 .addAll(newEvents)
                 .build();

--- a/server/src/main/java/io/spine/server/aggregate/UncommittedHistory.java
+++ b/server/src/main/java/io/spine/server/aggregate/UncommittedHistory.java
@@ -35,7 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -125,19 +125,19 @@ final class UncommittedHistory {
         if (!enabled) {
             return;
         }
-        checkNotNull(snapshotTrigger,
-                     "The snapshot trigger must be set" +
-                             " to track the events applied to an `Aggregate`.");
+        requireNonNull(snapshotTrigger,
+                       "The snapshot trigger must be set" +
+                               " to track the events applied to an `Aggregate`.");
 
-        Event event = envelope.outerObject();
+        var event = envelope.outerObject();
         if (event.isRejection()) {
             return;
         }
         currentSegment.add(event);
-        int eventsInSegment = currentSegment.size();
+        var eventsInSegment = currentSegment.size();
         if (eventCountAfterLastSnapshot + eventsInSegment >= snapshotTrigger) {
-            Snapshot snapshot = makeSnapshot.get();
-            AggregateHistory completedSegment = historyFrom(currentSegment, snapshot);
+            var snapshot = makeSnapshot.get();
+            var completedSegment = historyFrom(currentSegment, snapshot);
             historySegments.add(completedSegment);
             currentSegment.clear();
             eventCountAfterLastSnapshot = 0;
@@ -154,7 +154,7 @@ final class UncommittedHistory {
         ImmutableList.Builder<AggregateHistory> builder = ImmutableList.builder();
         builder.addAll(historySegments);
         if (currentSegment.size() > 0) {
-            AggregateHistory lastSegment = historyFrom(currentSegment);
+            var lastSegment = historyFrom(currentSegment);
             builder.add(lastSegment);
         }
         return builder.build();
@@ -164,7 +164,7 @@ final class UncommittedHistory {
      * Returns all tracked uncommitted events.
      */
     UncommittedEvents events() {
-        List<Event> events = get().stream()
+        var events = get().stream()
                                   .flatMap(segment -> segment.getEventList()
                                                              .stream())
                                   .collect(toList());

--- a/server/src/main/java/io/spine/server/aggregate/UnsupportedImportEventException.java
+++ b/server/src/main/java/io/spine/server/aggregate/UnsupportedImportEventException.java
@@ -29,9 +29,7 @@ package io.spine.server.aggregate;
 import com.google.protobuf.Message;
 import io.spine.base.Error;
 import io.spine.server.bus.MessageUnhandled;
-import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
-import io.spine.type.TypeName;
 
 import static io.spine.core.EventValidationError.UNSUPPORTED_EVENT_VALUE;
 import static io.spine.server.event.EventException.eventTypeAttribute;
@@ -54,9 +52,9 @@ public final class UnsupportedImportEventException
     }
 
     private static String messageFormat(EventEnvelope event) {
-        EventClass eventClass = event.messageClass();
-        TypeName typeName = eventClass.typeName();
-        String result = format(
+        var eventClass = event.messageClass();
+        var typeName = eventClass.typeName();
+        var result = format(
             "None of the aggregates declare importing appliers for " +
                     "the event of the class: `%s` (proto type: `%s`).",
             eventClass, typeName
@@ -75,8 +73,7 @@ public final class UnsupportedImportEventException
     }
 
     private static Error unsupportedImportEvent(Message eventMessage, String errorMessage) {
-        Error result = Error
-                .newBuilder()
+        var result = Error.newBuilder()
                 .setType(UnsupportedImportEventException.class.getName())
                 .setCode(UNSUPPORTED_EVENT_VALUE)
                 .setMessage(errorMessage)

--- a/server/src/main/java/io/spine/server/aggregate/VersionSequence.java
+++ b/server/src/main/java/io/spine/server/aggregate/VersionSequence.java
@@ -29,7 +29,6 @@ package io.spine.server.aggregate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import io.spine.core.Event;
-import io.spine.core.EventContext;
 import io.spine.core.Version;
 import io.spine.core.Versions;
 
@@ -59,14 +58,13 @@ final class VersionSequence {
      * @see Aggregate#apply(List, int)
      */
     ImmutableList<Event> update(Collection<Event> originalEvents) {
-        Stream<Version> versions =
+        var versions =
                 Stream.iterate(start, Versions::increment)
                       .skip(1) // Skip current version
                       .limit(originalEvents.size());
-        Stream<Event> events = originalEvents.stream();
-        ImmutableList<Event> eventsToApply =
-                Streams.zip(events, versions,
-                            VersionSequence::substituteVersion)
+        var events = originalEvents.stream();
+        var eventsToApply =
+                Streams.zip(events, versions, VersionSequence::substituteVersion)
                        .collect(toImmutableList());
         return eventsToApply;
     }
@@ -81,15 +79,13 @@ final class VersionSequence {
      * @return the copy of the original event but with the new version
      */
     private static Event substituteVersion(Event event, Version newVersion) {
-        EventContext newContext =
-                event.context()
-                     .toBuilder()
-                     .setVersion(newVersion)
-                     .build();
-        Event result =
-                event.toBuilder()
-                     .setContext(newContext)
-                     .build();
+        var newContext = event.context()
+                .toBuilder()
+                .setVersion(newVersion)
+                .build();
+        var result = event.toBuilder()
+                .setContext(newContext)
+                .build();
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/aggregate/model/AggregateClass.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/AggregateClass.java
@@ -27,7 +27,6 @@
 package io.spine.server.aggregate.model;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets.SetView;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.entity.model.CommandHandlingEntityClass;
 import io.spine.server.event.model.EventReactorMethod;
@@ -73,7 +72,7 @@ public class AggregateClass<A extends Aggregate<?, ?, ?>>
     public static <A extends Aggregate<?, ?, ?>> AggregateClass<A> asAggregateClass(Class<A> cls) {
         checkNotNull(cls);
         @SuppressWarnings("unchecked")
-        AggregateClass<A> result = (AggregateClass<A>)
+        var result = (AggregateClass<A>)
                 get(cls, AggregateClass.class, () -> new AggregateClass<>(cls));
         return result;
     }
@@ -116,9 +115,9 @@ public class AggregateClass<A extends Aggregate<?, ?, ?>>
      * emitted by the aggregates.
      */
     public ImmutableSet<EventClass> outgoingEvents() {
-        SetView<EventClass> methodResults = union(commandOutput(), reactionOutput());
-        SetView<EventClass> generatedEvents = union(methodResults, rejections());
-        SetView<EventClass> result = union(generatedEvents, importableEvents());
+        var methodResults = union(commandOutput(), reactionOutput());
+        var generatedEvents = union(methodResults, rejections());
+        var result = union(generatedEvents, importableEvents());
         return result.immutableCopy();
     }
 

--- a/server/src/main/java/io/spine/server/aggregate/model/AggregatePartClass.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/AggregatePartClass.java
@@ -33,7 +33,6 @@ import io.spine.server.aggregate.AggregateRoot;
 import io.spine.server.entity.EntityFactory;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
-import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -65,7 +64,7 @@ public final class AggregatePartClass<A extends AggregatePart<?, ?, ?, ?>>
     AggregatePartClass<A> asAggregatePartClass(Class<A> cls) {
         checkNotNull(cls);
         @SuppressWarnings("unchecked")
-        AggregatePartClass<A> result = (AggregatePartClass<A>)
+        var result = (AggregatePartClass<A>)
                 get(cls, AggregatePartClass.class, () -> new AggregatePartClass<>(cls));
         return result;
     }
@@ -98,11 +97,11 @@ public final class AggregatePartClass<A extends AggregatePart<?, ?, ?, ?>>
         checkNotNull(bc);
         checkNotNull(aggregateId);
         @SuppressWarnings("unchecked") // Protected by generic parameters of the calling code.
-        Class<R> rootClass = (Class<R>) rootClass();
+        var rootClass = (Class<R>) rootClass();
         R result;
         try {
-            Constructor<R> ctor = rootClass.getDeclaredConstructor(BoundedContext.class,
-                                                                   aggregateId.getClass());
+            var ctor = rootClass.getDeclaredConstructor(BoundedContext.class,
+                                                        aggregateId.getClass());
             ctor.setAccessible(true);
             result = ctor.newInstance(bc, aggregateId);
         } catch (NoSuchMethodException | InvocationTargetException |

--- a/server/src/main/java/io/spine/server/aggregate/model/AllowImportAttribute.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/AllowImportAttribute.java
@@ -78,11 +78,11 @@ public enum AllowImportAttribute implements Attribute<Boolean> {
      */
     public static AllowImportAttribute of(Method method) {
         checkNotNull(method);
-        Apply annotation = method.getAnnotation(Apply.class);
+        var annotation = method.getAnnotation(Apply.class);
         checkArgument(annotation != null,
                       "The method `%s` is not annotated with `@Apply`.",
                       method);
-        AllowImportAttribute result = annotation.allowImport() ? ALLOW : DO_NOT_ALLOW;
+        var result = annotation.allowImport() ? ALLOW : DO_NOT_ALLOW;
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/aggregate/model/PartFactory.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/PartFactory.java
@@ -60,9 +60,9 @@ final class PartFactory<A extends AggregatePart<?, ?, ?, ?>> extends AbstractEnt
      */
     @Override
     public A create(Object root) {
-        Constructor<A> ctor = constructor();
+        var ctor = constructor();
         try {
-            A aggregatePart = ctor.newInstance(root);
+            var aggregatePart = ctor.newInstance(root);
             return aggregatePart;
         } catch (InvocationTargetException | InstantiationException | IllegalAccessException e) {
             throw new IllegalStateException(e);
@@ -104,16 +104,16 @@ final class PartFactory<A extends AggregatePart<?, ?, ?, ?>> extends AbstractEnt
             throw noSuchConstructor(cls, rootClass);
         }
         @SuppressWarnings("unchecked") // The cast is protected by generic params.
-                Constructor<A> result = (Constructor<A>) ctor;
+        var result = (Constructor<A>) ctor;
         return result;
     }
 
     private static ModelError noSuchConstructor(Class<?> partClass, Class<?> rootClass) {
-        String errMsg =
+        var errMsg =
                 format("`%s` class must declare a constructor with one parameter of the `%s` type.",
                        partClass.getName(),
                        rootClass.getName());
-        NoSuchMethodException cause = new NoSuchMethodException(errMsg);
+        var cause = new NoSuchMethodException(errMsg);
         throw new ModelError(cause);
     }
 

--- a/server/src/main/java/io/spine/server/aggregate/model/PartFactory.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/PartFactory.java
@@ -109,10 +109,10 @@ final class PartFactory<A extends AggregatePart<?, ?, ?, ?>> extends AbstractEnt
     }
 
     private static ModelError noSuchConstructor(Class<?> partClass, Class<?> rootClass) {
-        var errMsg =
-                format("`%s` class must declare a constructor with one parameter of the `%s` type.",
-                       partClass.getName(),
-                       rootClass.getName());
+        var errMsg = format(
+                "`%s` class must declare a constructor with one parameter of the `%s` type.",
+                partClass.getName(),
+                rootClass.getName());
         var cause = new NoSuchMethodException(errMsg);
         throw new ModelError(cause);
     }

--- a/server/src/main/java/io/spine/server/bus/Bus.java
+++ b/server/src/main/java/io/spine/server/bus/Bus.java
@@ -148,12 +148,12 @@ public abstract class Bus<T extends Signal<?, ?, ?>,
         checkNotNull(messages);
         checkNotNull(observer);
         messages.forEach(message -> listeners.accept(toEnvelope(message)));
-        StreamObserver<Ack> wrappedObserver = prepareObserver(messages, observer);
+        var wrappedObserver = prepareObserver(messages, observer);
         filterAndPost(messages, wrappedObserver);
     }
 
     private void filterAndPost(Iterable<T> messages, StreamObserver<Ack> observer) {
-        Map<T, E> filteredMessages = filter(messages, observer);
+        var filteredMessages = filter(messages, observer);
         if (!filteredMessages.isEmpty()) {
             store(filteredMessages.keySet());
             Iterable<E> envelopes = filteredMessages.values();
@@ -273,9 +273,9 @@ public abstract class Bus<T extends Signal<?, ?, ?>,
         checkNotNull(messages);
         checkNotNull(observer);
         Map<T, E> result = new LinkedHashMap<>();
-        for (T message : messages) {
-            E envelope = toEnvelope(message);
-            Optional<Ack> response = filter(envelope);
+        for (var message : messages) {
+            var envelope = toEnvelope(message);
+            var response = filter(envelope);
             if (response.isPresent()) {
                 observer.onNext(response.get());
             } else {
@@ -299,7 +299,7 @@ public abstract class Bus<T extends Signal<?, ?, ?>,
      * {@link Optional#empty()} otherwise
      */
     private Optional<Ack> filter(E message) {
-        Optional<Ack> filterOutput = filterChain().filter(message);
+        var filterOutput = filterChain().filter(message);
         return filterOutput;
     }
 
@@ -332,9 +332,9 @@ public abstract class Bus<T extends Signal<?, ?, ?>,
      */
     @SuppressWarnings("ProhibitedExceptionThrown") // Rethrow a caught exception.
     private void doPost(Iterable<E> envelopes, StreamObserver<Ack> observer) {
-        for (E envelope : envelopes) {
-            SignalId signalId = envelope.id();
-            Ack ack = acknowledge(signalId);
+        for (var envelope : envelopes) {
+            var signalId = envelope.id();
+            var ack = acknowledge(signalId);
             observer.onNext(ack);
             onDispatchingStarted(signalId);
             try {
@@ -412,8 +412,8 @@ public abstract class Bus<T extends Signal<?, ?, ?>,
     }
 
     private FilterChain<E> createFilterChain(Iterable<BusFilter<E>> filters) {
-        Iterable<BusFilter<E>> possiblyModifiedFilters = setupFilters(filters);
-        FilterChain<E> result = new FilterChain<>(possiblyModifiedFilters);
+        var possiblyModifiedFilters = setupFilters(filters);
+        var result = new FilterChain<>(possiblyModifiedFilters);
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/bus/BusBuilder.java
+++ b/server/src/main/java/io/spine/server/bus/BusBuilder.java
@@ -231,7 +231,7 @@ public abstract class BusBuilder<B extends BusBuilder<B, T, E, C, D>,
         private FieldCheck() {
         }
 
-        private static void check(BusBuilder builder) {
+        private static void check(BusBuilder<?, ?, ?, ?, ?> builder) {
             checkSet(builder.systemWriteSide, SystemWriteSide.class, SYSTEM_METHOD);
             checkSet(builder.tenantIndex, TenantIndex.class, TENANT_INDEX_METHOD);
         }
@@ -251,7 +251,7 @@ public abstract class BusBuilder<B extends BusBuilder<B, T, E, C, D>,
         }
 
         private static IllegalStateException newException(Class<?> fieldClass, String setterName) {
-            String errorMessage = format(ERROR_FORMAT, fieldClass.getSimpleName(), setterName);
+            var errorMessage = format(ERROR_FORMAT, fieldClass.getSimpleName(), setterName);
             return new IllegalStateException(errorMessage);
         }
     }

--- a/server/src/main/java/io/spine/server/bus/BusFilter.java
+++ b/server/src/main/java/io/spine/server/bus/BusFilter.java
@@ -93,7 +93,7 @@ public interface BusFilter<E extends MessageEnvelope<?, ?, ?>> extends AutoClose
      */
     default Optional<Ack> reject(E envelope) {
         checkNotNull(envelope);
-        Ack ack = acknowledge(envelope.id());
+        var ack = acknowledge(envelope.id());
         return Optional.of(ack);
     }
 
@@ -113,7 +113,7 @@ public interface BusFilter<E extends MessageEnvelope<?, ?, ?>> extends AutoClose
     default Optional<Ack> reject(E envelope, Error cause) {
         checkNotNull(envelope);
         checkNotNull(cause);
-        Ack ack = causedError(envelope.id(), cause);
+        var ack = causedError(envelope.id(), cause);
         return Optional.of(ack);
     }
 

--- a/server/src/main/java/io/spine/server/bus/DeadMessageFilter.java
+++ b/server/src/main/java/io/spine/server/bus/DeadMessageFilter.java
@@ -27,7 +27,6 @@
 package io.spine.server.bus;
 
 import com.google.protobuf.Message;
-import io.spine.base.Error;
 import io.spine.core.Ack;
 import io.spine.server.type.MessageEnvelope;
 import io.spine.type.MessageClass;
@@ -70,8 +69,8 @@ final class DeadMessageFilter<T extends Message,
     public Optional<Ack> filter(E envelope) {
         Collection<D> dispatchers = registry.dispatchersOf(envelope);
         if (dispatchers.isEmpty()) {
-            MessageUnhandled report = deadMessageHandler.handle(envelope);
-            Error error = report.asError();
+            var report = deadMessageHandler.handle(envelope);
+            var error = report.asError();
             return reject(envelope, error);
         } else {
             return letPass();

--- a/server/src/main/java/io/spine/server/bus/DispatcherRegistry.java
+++ b/server/src/main/java/io/spine/server/bus/DispatcherRegistry.java
@@ -169,8 +169,7 @@ DispatcherRegistry<C extends MessageClass<? extends Message>,
     protected Optional<? extends D> getDispatcherForType(C messageClass) {
         var dispatchersOfClass = dispatchers.get(messageClass);
         checkNotMoreThanOne(dispatchersOfClass, messageClass);
-        var dispatcher = dispatchersOfClass.stream()
-                                                   .findFirst();
+        var dispatcher = dispatchersOfClass.stream().findFirst();
         return dispatcher;
     }
 

--- a/server/src/main/java/io/spine/server/bus/DispatcherRegistry.java
+++ b/server/src/main/java/io/spine/server/bus/DispatcherRegistry.java
@@ -71,7 +71,7 @@ DispatcherRegistry<C extends MessageClass<? extends Message>,
     public void register(D dispatcher) {
         checkDispatcher(dispatcher);
         Set<C> messageClasses = dispatcher.messageClasses();
-        for (C messageClass : messageClasses) {
+        for (var messageClass : messageClasses) {
             dispatchers.put(messageClass, dispatcher);
         }
     }
@@ -81,7 +81,7 @@ DispatcherRegistry<C extends MessageClass<? extends Message>,
         checkNotEmpty(dispatcher);
 
         Set<C> messageClasses = dispatcher.messageClasses();
-        for (C messageClass : messageClasses) {
+        for (var messageClass : messageClasses) {
             dispatchers.remove(messageClass, dispatcher);
         }
     }
@@ -109,7 +109,7 @@ DispatcherRegistry<C extends MessageClass<? extends Message>,
      */
     final Set<D> dispatchersOf(E envelope) {
         checkNotNull(envelope);
-        C messageClass = classOf(envelope);
+        var messageClass = classOf(envelope);
         Set<D> dispatchers = this.dispatchers
                 .get(messageClass)
                 .stream()
@@ -138,9 +138,9 @@ DispatcherRegistry<C extends MessageClass<? extends Message>,
      */
     protected Optional<D> dispatcherOf(E envelope) {
         checkNotNull(envelope);
-        Set<D> dispatchers = dispatchersOf(envelope);
+        var dispatchers = dispatchersOf(envelope);
         checkNotMoreThanOne(dispatchers, classOf(envelope));
-        Optional<D> result = dispatchers.stream()
+        var result = dispatchers.stream()
                                         .findFirst();
         return result;
     }
@@ -154,7 +154,7 @@ DispatcherRegistry<C extends MessageClass<? extends Message>,
      */
     protected Set<D> dispatchersOf(C messageClass) {
         checkNotNull(messageClass);
-        Collection<D> dispatchersForType = dispatchers.get(messageClass);
+        var dispatchersForType = dispatchers.get(messageClass);
         return ImmutableSet.copyOf(dispatchersForType);
     }
 
@@ -167,15 +167,15 @@ DispatcherRegistry<C extends MessageClass<? extends Message>,
      *         if more than one dispatcher is found
      */
     protected Optional<? extends D> getDispatcherForType(C messageClass) {
-        Collection<D> dispatchersOfClass = dispatchers.get(messageClass);
+        var dispatchersOfClass = dispatchers.get(messageClass);
         checkNotMoreThanOne(dispatchersOfClass, messageClass);
-        Optional<D> dispatcher = dispatchersOfClass.stream()
+        var dispatcher = dispatchersOfClass.stream()
                                                    .findFirst();
         return dispatcher;
     }
 
     private void checkNotMoreThanOne(Collection<D> dispatchers, C messageClass) {
-        int size = dispatchers.size();
+        var size = dispatchers.size();
         checkState(size <= 1,
                    "More than one (%s) dispatchers found for the message class `%s`.",
                    size, messageClass);
@@ -183,7 +183,7 @@ DispatcherRegistry<C extends MessageClass<? extends Message>,
 
     private C classOf(E envelope) {
         @SuppressWarnings("unchecked") // Logically valid.
-        C messageClass = (C) envelope.messageClass();
+        var messageClass = (C) envelope.messageClass();
         return messageClass;
     }
 
@@ -203,7 +203,7 @@ DispatcherRegistry<C extends MessageClass<? extends Message>,
         checkNotEmpty(dispatcher);
     }
 
-    private static <D extends MessageDispatcher> void checkNotEmpty(D dispatcher) {
+    private static <D extends MessageDispatcher<?, ?>> void checkNotEmpty(D dispatcher) {
         Set<?> messageClasses = dispatcher.messageClasses();
         checkArgument(!messageClasses.isEmpty(),
                       "The dispatcher (%s) has empty message class set.",

--- a/server/src/main/java/io/spine/server/bus/DispatcherRegistry.java
+++ b/server/src/main/java/io/spine/server/bus/DispatcherRegistry.java
@@ -140,8 +140,7 @@ DispatcherRegistry<C extends MessageClass<? extends Message>,
         checkNotNull(envelope);
         var dispatchers = dispatchersOf(envelope);
         checkNotMoreThanOne(dispatchers, classOf(envelope));
-        var result = dispatchers.stream()
-                                        .findFirst();
+        var result = dispatchers.stream().findFirst();
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/bus/FilterChain.java
+++ b/server/src/main/java/io/spine/server/bus/FilterChain.java
@@ -62,8 +62,8 @@ final class FilterChain<E extends MessageEnvelope<?, ?, ?>> implements BusFilter
     public Optional<Ack> filter(E envelope) {
         checkNotNull(envelope);
         checkOpen();
-        for (BusFilter<E> filter : chain) {
-            Optional<Ack> output = filter.filter(envelope);
+        for (var filter : chain) {
+            var output = filter.filter(envelope);
             if (output.isPresent()) {
                 return output;
             }
@@ -107,10 +107,10 @@ final class FilterChain<E extends MessageEnvelope<?, ?, ?>> implements BusFilter
 
     @Override
     public String toString() {
-        String filters = chain.stream()
-                              .map(BusFilter::getClass)
-                              .map(Class::getSimpleName)
-                              .collect(joining(", "));
+        var filters = chain.stream()
+                .map(BusFilter::getClass)
+                .map(Class::getSimpleName)
+                .collect(joining(", "));
         return format("%s[%s]", FilterChain.class.getName(), filters);
     }
 }

--- a/server/src/main/java/io/spine/server/bus/MulticastBus.java
+++ b/server/src/main/java/io/spine/server/bus/MulticastBus.java
@@ -65,7 +65,7 @@ public abstract class MulticastBus<M extends Signal<?, ?, ?>,
      */
     protected int callDispatchers(E messageEnvelope) {
         Collection<D> dispatchers = registry().dispatchersOf(messageEnvelope);
-        for (D dispatcher : dispatchers) {
+        for (var dispatcher : dispatchers) {
             dispatcher.dispatch(messageEnvelope);
         }
         return dispatchers.size();

--- a/server/src/main/java/io/spine/server/bus/UnicastBus.java
+++ b/server/src/main/java/io/spine/server/bus/UnicastBus.java
@@ -66,7 +66,7 @@ public abstract class UnicastBus<T extends Signal<?, ?, ?>,
     }
 
     private static IllegalStateException noDispatcherFound(MessageEnvelope<?, ?, ?> envelope) {
-        String id = Identifier.toString(envelope.id());
+        var id = Identifier.toString(envelope.id());
         throw newIllegalStateException(
                 "No dispatcher found for the command (class: `%s` id: `%s`).",
                 envelope.messageClass(), id

--- a/server/src/main/java/io/spine/server/bus/ValidatingFilter.java
+++ b/server/src/main/java/io/spine/server/bus/ValidatingFilter.java
@@ -27,9 +27,7 @@
 package io.spine.server.bus;
 
 import com.google.protobuf.Message;
-import io.spine.base.Error;
 import io.spine.core.Ack;
-import io.spine.server.MessageInvalid;
 import io.spine.server.type.MessageEnvelope;
 
 import java.util.Optional;
@@ -58,10 +56,9 @@ final class ValidatingFilter<E extends MessageEnvelope<?, T, ?>, T extends Messa
     @Override
     public Optional<Ack> filter(E envelope) {
         checkNotNull(envelope);
-        Optional<MessageInvalid> violation = validator.validate(envelope);
+        var violation = validator.validate(envelope);
         if (violation.isPresent()) {
-            Error error = violation.get()
-                                   .asError();
+            var error = violation.get().asError();
             return reject(envelope, error);
         } else {
             return letPass();

--- a/server/src/main/java/io/spine/server/command/AbstractCommandDispatcher.java
+++ b/server/src/main/java/io/spine/server/command/AbstractCommandDispatcher.java
@@ -31,7 +31,6 @@ import com.google.protobuf.Any;
 import io.spine.base.Error;
 import io.spine.core.Event;
 import io.spine.core.MessageId;
-import io.spine.core.Origin;
 import io.spine.protobuf.TypeConverter;
 import io.spine.server.BoundedContext;
 import io.spine.server.ContextAware;
@@ -117,24 +116,22 @@ public abstract class AbstractCommandDispatcher implements CommandDispatcher, Co
     }
 
     private void postHandlerFailedUnexpectedly(SignalEnvelope<?, ?, ?> signal, Error error) {
-        HandlerFailedUnexpectedly systemEvent = HandlerFailedUnexpectedly
-                .newBuilder()
+        var systemEvent = HandlerFailedUnexpectedly.newBuilder()
                 .setEntity(eventAnchor.get())
                 .setHandledSignal(signal.messageId())
                 .setError(error)
                 .vBuild();
-        Origin origin = signal.asMessageOrigin();
+        var origin = signal.asMessageOrigin();
         system.postEvent(systemEvent, origin);
     }
 
     private void postSignalRejected(SignalEnvelope<?, ?, ?> signal, Event rejection) {
-        CommandRejected commandRejected = CommandRejected
-                .newBuilder()
+        var commandRejected = CommandRejected.newBuilder()
                 .setId(signal.messageId()
                              .asCommandId())
                 .setRejectionEvent(rejection)
                 .vBuild();
-        Origin origin = rejection.asMessageOrigin();
+        var origin = rejection.asMessageOrigin();
         system.postEvent(commandRejected, origin);
     }
 
@@ -154,8 +151,8 @@ public abstract class AbstractCommandDispatcher implements CommandDispatcher, Co
         if (!(o instanceof AbstractCommandDispatcher)) {
             return false;
         }
-        AbstractCommandDispatcher otherHandler = (AbstractCommandDispatcher) o;
-        boolean equals = id().equals(otherHandler.id());
+        var otherHandler = (AbstractCommandDispatcher) o;
+        var equals = id().equals(otherHandler.id());
         return equals;
     }
 

--- a/server/src/main/java/io/spine/server/command/AbstractCommandHandler.java
+++ b/server/src/main/java/io/spine/server/command/AbstractCommandHandler.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableSet;
 import io.spine.core.Version;
 import io.spine.server.BoundedContext;
 import io.spine.server.command.model.CommandHandlerClass;
-import io.spine.server.command.model.CommandHandlerMethod;
 import io.spine.server.commandbus.CommandDispatcher;
 import io.spine.server.dispatch.DispatchOutcomeHandler;
 import io.spine.server.event.EventBus;
@@ -83,7 +82,7 @@ public abstract class AbstractCommandHandler
      */
     @Override
     public void dispatch(CommandEnvelope envelope) {
-        CommandHandlerMethod method = thisClass.handlerOf(envelope);
+        var method = thisClass.handlerOf(envelope);
         DispatchOutcomeHandler
                 .from(method.invoke(this, envelope))
                 .onEvents(this::postEvents)

--- a/server/src/main/java/io/spine/server/command/AbstractCommander.java
+++ b/server/src/main/java/io/spine/server/command/AbstractCommander.java
@@ -35,8 +35,6 @@ import io.spine.core.Version;
 import io.spine.core.Versions;
 import io.spine.logging.Logging;
 import io.spine.server.BoundedContext;
-import io.spine.server.command.model.CommandReactionMethod;
-import io.spine.server.command.model.CommandSubstituteMethod;
 import io.spine.server.command.model.CommanderClass;
 import io.spine.server.commandbus.CommandBus;
 import io.spine.server.dispatch.DispatchOutcomeHandler;
@@ -48,7 +46,6 @@ import io.spine.server.type.EventEnvelope;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.grpc.StreamObservers.noOpObserver;
@@ -82,7 +79,7 @@ public abstract class AbstractCommander
 
     @Override
     public void dispatch(CommandEnvelope command) {
-        CommandSubstituteMethod method = thisClass.handlerOf(command);
+        var method = thisClass.handlerOf(command);
         DispatchOutcomeHandler
                 .from(method.invoke(this, command))
                 .onCommands(this::postCommands)
@@ -107,7 +104,7 @@ public abstract class AbstractCommander
 
     @Override
     public void dispatchEvent(EventEnvelope event) {
-        Optional<CommandReactionMethod> method = thisClass.commanderOn(event);
+        var method = thisClass.commanderOn(event);
         if (method.isPresent()) {
             DispatchOutcomeHandler
                     .from(method.get().invoke(this, event))
@@ -144,7 +141,7 @@ public abstract class AbstractCommander
     }
 
     private void postRejection(Event rejectionEvent) {
-        ImmutableList<Event> events = ImmutableList.of(rejectionEvent);
+        var events = ImmutableList.of(rejectionEvent);
         postEvents(events);
     }
 }

--- a/server/src/main/java/io/spine/server/command/model/AbstractCommandHandlingClass.java
+++ b/server/src/main/java/io/spine/server/command/model/AbstractCommandHandlingClass.java
@@ -76,12 +76,11 @@ public abstract class AbstractCommandHandlingClass<C,
 
     @Override
     public ImmutableSet<EventClass> rejections() {
-        ImmutableSet<EventClass> result =
-                commands.methods()
-                        .stream()
-                        .map(CommandAcceptingMethod::rejections)
-                        .flatMap(ImmutableSet::stream)
-                        .collect(toImmutableSet());
+        var result = commands.methods()
+                .stream()
+                .map(CommandAcceptingMethod::rejections)
+                .flatMap(ImmutableSet::stream)
+                .collect(toImmutableSet());
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/command/model/CommandAcceptingMethod.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandAcceptingMethod.java
@@ -30,8 +30,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
 import io.spine.base.CommandMessage;
 import io.spine.base.RejectionThrowable;
-import io.spine.core.Command;
-import io.spine.core.Event;
 import io.spine.server.EventProducer;
 import io.spine.server.dispatch.Success;
 import io.spine.server.model.AbstractHandlerMethod;
@@ -76,26 +74,25 @@ public abstract class CommandAcceptingMethod<T extends EventProducer,
      * if no rejections are thrown.
      */
     public ImmutableSet<EventClass> rejections() {
-        Class<?>[] exceptionTypes = rawMethod().getExceptionTypes();
+        var exceptionTypes = rawMethod().getExceptionTypes();
         @SuppressWarnings("unchecked") // The cast is safe as we filter before.
-        ImmutableSet<EventClass> result =
-                Arrays.stream(exceptionTypes)
-                      .filter(RejectionThrowable.class::isAssignableFrom)
-                      .map(c -> (Class<RejectionThrowable>) c)
-                      .map(EventClass::fromThrowable)
-                      .collect(toImmutableSet());
+        var result = Arrays.stream(exceptionTypes)
+                .filter(RejectionThrowable.class::isAssignableFrom)
+                .map(c -> (Class<RejectionThrowable>) c)
+                .map(EventClass::fromThrowable)
+                .collect(toImmutableSet());
         return result;
     }
 
     @Override
     protected final Optional<Success>
     handleRejection(T target, CommandEnvelope origin, RejectionThrowable throwable) {
-        Command command = origin.outerObject();
+        var command = origin.outerObject();
         throwable.initProducer(target.producerId());
-        Event rejection = reject(command, throwable);
-        Success success = Success.newBuilder()
-                                 .setRejection(rejection)
-                                 .vBuild();
+        var rejection = reject(command, throwable);
+        var success = Success.newBuilder()
+                .setRejection(rejection)
+                .vBuild();
         return Optional.of(success);
     }
 

--- a/server/src/main/java/io/spine/server/command/model/CommandHandlerClass.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandHandlerClass.java
@@ -53,7 +53,7 @@ public final class CommandHandlerClass<C extends AbstractCommandHandler>
     CommandHandlerClass<C> asCommandHandlerClass(Class<C> cls) {
         checkNotNull(cls);
         @SuppressWarnings("unchecked")
-        CommandHandlerClass<C> result = (CommandHandlerClass<C>)
+        var result = (CommandHandlerClass<C>)
                 get(cls, CommandHandlerClass.class, () -> new CommandHandlerClass<>(cls));
         return result;
     }

--- a/server/src/main/java/io/spine/server/command/model/CommandHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandHandlerMethod.java
@@ -64,7 +64,7 @@ public final class CommandHandlerMethod
         Success outcome =
                 EventProducingMethod.super.toSuccessfulOutcome(rawResult, target, handledSignal);
         if (outcome.getProducedEvents().getEventCount() == 0) {
-            String errorMessage = format(
+            var errorMessage = format(
                     "Command handler %s did not produce any events when processing command %s",
                     this,
                     handledSignal.id()

--- a/server/src/main/java/io/spine/server/command/model/CommandReactionMethod.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandReactionMethod.java
@@ -76,8 +76,7 @@ public final class CommandReactionMethod
     @Override
     protected void checkAttributesMatch(EventEnvelope envelope) {
         super.checkAttributesMatch(envelope);
-        boolean expected = envelope.context()
-                                   .getExternal();
+        var expected = envelope.context().getExternal();
         ensureExternalMatch(expected);
     }
 }

--- a/server/src/main/java/io/spine/server/command/model/CommandReactionSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandReactionSignature.java
@@ -100,7 +100,7 @@ public class CommandReactionSignature
      */
     @Override
     protected boolean skipMethod(Method method) {
-        boolean parentResult = !super.skipMethod(method);
+        var parentResult = !super.skipMethod(method);
         if (parentResult) {
             return MethodParams.firstIsCommand(method);
         }
@@ -133,14 +133,12 @@ public class CommandReactionSignature
 
         REJECTION_AND_COMMAND_CONTEXT(classImplementing(RejectionMessage.class),
                                       exactly(CommandContext.class)) {
-
             @Override
             public ExtractedArguments extractArguments(EventEnvelope event) {
-                CommandContext originContext =
-                        event.context()
-                             .getRejection()
-                             .getCommand()
-                             .getContext();
+                var originContext = event.context()
+                                         .getRejection()
+                                         .getCommand()
+                                         .getContext();
                 return ExtractedArguments.ofTwo(event.message(), originContext);
             }
         };

--- a/server/src/main/java/io/spine/server/command/model/CommandSubstituteMethod.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandSubstituteMethod.java
@@ -57,7 +57,7 @@ public final class CommandSubstituteMethod
      */
     @Override
     public Success fromEmpty(CommandEnvelope handledSignal) {
-        String errorMessage = format(
+        var errorMessage = format(
                 "Commander method `%s` did not produce any result for command with ID `%s`.",
                 this,
                 handledSignal.id()

--- a/server/src/main/java/io/spine/server/command/model/CommandSubstituteSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandSubstituteSignature.java
@@ -72,7 +72,7 @@ public class CommandSubstituteSignature extends CommandAcceptingSignature<Comman
     @SuppressWarnings("UnnecessaryInheritDoc") // IDEA bug.
     @Override
     protected boolean skipMethod(Method method) {
-        boolean parentResult = !super.skipMethod(method);
+        var parentResult = !super.skipMethod(method);
         if (parentResult) {
             return !MethodParams.firstIsCommand(method);
         }

--- a/server/src/main/java/io/spine/server/command/model/CommanderClass.java
+++ b/server/src/main/java/io/spine/server/command/model/CommanderClass.java
@@ -27,7 +27,6 @@
 package io.spine.server.command.model;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets.SetView;
 import io.spine.server.command.AbstractCommander;
 import io.spine.server.command.Commander;
 import io.spine.server.event.model.EventReceiverClass;
@@ -39,7 +38,6 @@ import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
 
 import java.util.Optional;
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Sets.union;
@@ -66,7 +64,7 @@ public final class CommanderClass<C extends Commander>
 
     public static <C extends Commander> CommanderClass<C> delegateFor(Class<C> cls) {
         checkNotNull(cls);
-        CommanderClass<C> result = new CommanderClass<>(cls);
+        var result = new CommanderClass<>(cls);
         return result;
     }
 
@@ -74,7 +72,7 @@ public final class CommanderClass<C extends Commander>
     CommanderClass<C> asCommanderClass(Class<C> cls) {
         checkNotNull(cls);
         @SuppressWarnings("unchecked")
-        CommanderClass<C> result = (CommanderClass<C>)
+        var result = (CommanderClass<C>)
                 get(cls, CommanderClass.class, () -> new CommanderClass<>(cls));
         return result;
     }
@@ -118,7 +116,7 @@ public final class CommanderClass<C extends Commander>
 
     @Override
     public ImmutableSet<CommandClass> outgoingCommands() {
-        SetView<CommandClass> result = union(commandOutput(), delegate.producedTypes());
+        var result = union(commandOutput(), delegate.producedTypes());
         return result.immutableCopy();
     }
 
@@ -134,11 +132,10 @@ public final class CommanderClass<C extends Commander>
      *         in case external command substitution methods are found within the class
      */
     private void validateExternalMethods() {
-        Set<CommandSubstituteMethod> methods = commands()
-                         .stream()
-                         .flatMap(type -> handlersForType(type).stream())
-                         .filter(HandlerMethod::isExternal)
-                         .collect(toSet());
+        var methods = commands().stream()
+                .flatMap(type -> handlersForType(type).stream())
+                .filter(HandlerMethod::isExternal)
+                .collect(toSet());
         if (!methods.isEmpty()) {
             throw new ExternalCommandReceiverMethodError(this, methods);
         }

--- a/server/src/main/java/io/spine/server/command/model/DuplicateHandlerCheck.java
+++ b/server/src/main/java/io/spine/server/command/model/DuplicateHandlerCheck.java
@@ -27,7 +27,6 @@
 package io.spine.server.command.model;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.flogger.FluentLogger;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.spine.logging.Logging;
 import io.spine.server.aggregate.Aggregate;
@@ -58,6 +57,7 @@ public final class DuplicateHandlerCheck implements Logging {
             "unchecked", // The cast is preserved by correct key-value pairs.
             "CheckReturnValue" /* Returned values for asXxxClass() are ignored because we use
                                   these methods only for verification of the classes. */
+            , "rawtypes" /* For code brevity. */
     })
     private final ImmutableMap<Class<?>, Appender> appenders =
             ImmutableMap.<Class<?>, Appender>builder()
@@ -88,7 +88,7 @@ public final class DuplicateHandlerCheck implements Logging {
     public void check(Iterable<Class<?>> classes) {
         _debug().log("Dropping models...");
         Model.dropAllModels();
-        for (Class<?> cls : classes) {
+        for (var cls : classes) {
             add(cls);
         }
     }
@@ -101,10 +101,10 @@ public final class DuplicateHandlerCheck implements Logging {
      * known to the Model.
      */
     public void add(Class<?> cls) {
-        FluentLogger.Api debug = _debug();
-        for (Class<?> keyClass : appenders.keySet()) {
+        var debug = _debug();
+        for (var keyClass : appenders.keySet()) {
             if (keyClass.isAssignableFrom(cls)) {
-                Appender appender = appenders.get(keyClass);
+                var appender = appenders.get(keyClass);
                 appender.apply(cls);
                 debug.log("`%s` has been added to the Model.", cls);
                 return;

--- a/server/src/main/java/io/spine/server/commandbus/AckRejectionPublisher.java
+++ b/server/src/main/java/io/spine/server/commandbus/AckRejectionPublisher.java
@@ -28,7 +28,6 @@ package io.spine.server.commandbus;
 
 import io.grpc.stub.StreamObserver;
 import io.spine.core.Ack;
-import io.spine.core.Status;
 import io.spine.server.event.EventBus;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -56,7 +55,7 @@ final class AckRejectionPublisher implements StreamObserver<Ack> {
     @Override
     public void onNext(Ack value) {
         checkNotNull(value);
-        Status status = value.getStatus();
+        var status = value.getStatus();
         if (status.getStatusCase() == REJECTION) {
             eventBus.post(status.getRejection());
         }

--- a/server/src/main/java/io/spine/server/commandbus/CommandAckMonitor.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandAckMonitor.java
@@ -33,7 +33,6 @@ import io.spine.base.EventMessage;
 import io.spine.core.Ack;
 import io.spine.core.Command;
 import io.spine.core.CommandId;
-import io.spine.core.Origin;
 import io.spine.core.Status;
 import io.spine.core.TenantId;
 import io.spine.server.type.CommandEnvelope;
@@ -90,13 +89,12 @@ final class CommandAckMonitor implements StreamObserver<Ack> {
     }
 
     private void postSystemEvent(Ack ack) {
-        Status status = ack.getStatus();
-        CommandId commandId = toCommandId(ack);
-        EventMessage systemEvent = systemEventFor(status, commandId);
-        Command command = commands.get(commandId);
+        var status = ack.getStatus();
+        var commandId = toCommandId(ack);
+        var systemEvent = systemEventFor(status, commandId);
+        var command = commands.get(commandId);
         checkState(command != null, "Unknown command ID encountered: `%s`.", commandId.value());
-        Origin systemEventOrigin = CommandEnvelope.of(command)
-                                                  .asMessageOrigin();
+        var systemEventOrigin = CommandEnvelope.of(command).asMessageOrigin();
         writeSide.postEvent(systemEvent, systemEventOrigin);
     }
 

--- a/server/src/main/java/io/spine/server/commandbus/CommandBus.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandBus.java
@@ -47,14 +47,12 @@ import io.spine.server.bus.DeadMessageHandler;
 import io.spine.server.bus.EnvelopeValidator;
 import io.spine.server.bus.UnicastBus;
 import io.spine.server.event.EventBus;
-import io.spine.server.tenant.TenantIndex;
 import io.spine.server.type.CommandClass;
 import io.spine.server.type.CommandEnvelope;
 import io.spine.system.server.SystemWriteSide;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.util.Iterator;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -164,9 +162,8 @@ public final class CommandBus
     @OverridingMethodsMustInvokeSuper
     protected Iterable<BusFilter<CommandEnvelope>>
     setupFilters(Iterable<BusFilter<CommandEnvelope>> filters) {
-        Iterable<BusFilter<CommandEnvelope>> fromSuper = super.setupFilters(filters);
-        return ImmutableList
-                .<BusFilter<CommandEnvelope>>builder()
+        var fromSuper = super.setupFilters(filters);
+        return ImmutableList.<BusFilter<CommandEnvelope>>builder()
                 .add(new CommandReceivedTap(this::systemFor))
                 .addAll(fromSuper)
                 .add(scheduler)
@@ -188,8 +185,8 @@ public final class CommandBus
     @Override
     protected StreamObserver<Ack> prepareObserver(Iterable<Command> commands,
                                                   StreamObserver<Ack> source) {
-        StreamObserver<Ack> wrappedSource = super.prepareObserver(commands, source);
-        TenantId tenant = tenantOf(commands);
+        var wrappedSource = super.prepareObserver(commands, source);
+        var tenant = tenantOf(commands);
         StreamObserver<Ack> commandAckMonitor = CommandAckMonitor
                 .newBuilder()
                 .setTenantId(tenant)
@@ -205,7 +202,7 @@ public final class CommandBus
     }
 
     private static TenantId tenantOf(Iterable<Command> commands) {
-        Iterator<Command> iterator = commands.iterator();
+        var iterator = commands.iterator();
         return iterator.hasNext()
                ? iterator.next().tenant()
                : TenantId.getDefaultInstance();
@@ -213,13 +210,13 @@ public final class CommandBus
 
     final SystemWriteSide systemFor(TenantId tenantId) {
         checkNotNull(tenantId);
-        SystemWriteSide result = delegatingTo(systemWriteSide).get(tenantId);
+        var result = delegatingTo(systemWriteSide).get(tenantId);
         return result;
     }
 
     @Override
     protected void dispatch(CommandEnvelope command) {
-        CommandDispatcher dispatcher = dispatcherOf(command);
+        var dispatcher = dispatcherOf(command);
         watcher.onDispatchCommand(command);
         dispatcher.dispatch(command);
     }
@@ -253,13 +250,13 @@ public final class CommandBus
      * Passes a previously scheduled command to the corresponding dispatcher.
      */
     void postPreviouslyScheduled(Command command) {
-        CommandEnvelope commandEnvelope = CommandEnvelope.of(command);
+        var commandEnvelope = CommandEnvelope.of(command);
         dispatch(commandEnvelope);
     }
 
     @Override
     protected void store(Iterable<Command> commands) {
-        TenantId tenantId = tenantOf(commands);
+        var tenantId = tenantOf(commands);
         tenantConsumer.accept(tenantId);
     }
 
@@ -334,7 +331,7 @@ public final class CommandBus
                     ServerEnvironment.instance()
                                      .newCommandScheduler();
             @SuppressWarnings("OptionalGetWithoutIsPresent") // ensured by checkFieldsSet()
-            SystemWriteSide writeSide = system().get();
+            var writeSide = system().get();
 
             if (watcher == null) {
                 watcher = new FlightRecorder(
@@ -343,10 +340,10 @@ public final class CommandBus
             }
             commandScheduler.setWatcher(watcher);
 
-            TenantIndex tenantIndex = tenantIndex().orElseThrow(tenantIndexNotSet());
+            var tenantIndex = tenantIndex().orElseThrow(tenantIndexNotSet());
             tenantConsumer = tenantIndex::keep;
 
-            CommandBus commandBus = createCommandBus();
+            var commandBus = createCommandBus();
 
             commandScheduler.setCommandBus(commandBus);
 
@@ -362,7 +359,7 @@ public final class CommandBus
         @CheckReturnValue
         @SuppressWarnings("CheckReturnValue")
         private CommandBus createCommandBus() {
-            CommandBus commandBus = new CommandBus(this);
+            var commandBus = new CommandBus(this);
             return commandBus;
         }
     }

--- a/server/src/main/java/io/spine/server/commandbus/CommandDispatcherRegistry.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandDispatcherRegistry.java
@@ -32,7 +32,6 @@ import io.spine.server.type.CommandEnvelope;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import static io.spine.util.Exceptions.newIllegalArgumentException;
@@ -95,9 +94,8 @@ class CommandDispatcherRegistry
         Set<CommandClass> commandClasses = dispatcher.messageClasses();
         Map<CommandClass, CommandDispatcher> alreadyRegistered = new HashMap<>();
         // Gather command classes from this dispatcher that are registered.
-        for (CommandClass commandClass : commandClasses) {
-            Optional<? extends CommandDispatcher> registeredDispatcher =
-                    getDispatcherForType(commandClass);
+        for (var commandClass : commandClasses) {
+            var registeredDispatcher  = getDispatcherForType(commandClass);
             registeredDispatcher.ifPresent(d -> alreadyRegistered.put(commandClass, d));
         }
 

--- a/server/src/main/java/io/spine/server/commandbus/CommandException.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandException.java
@@ -78,11 +78,10 @@ public abstract class CommandException extends RuntimeException implements Messa
      * @param commandMessage a command message to get the type from
      */
     public static Map<String, Value> commandTypeAttribute(Message commandMessage) {
-        String commandType = TypeName.of(commandMessage)
-                                     .value();
-        Value value = Value.newBuilder()
-                           .setStringValue(commandType)
-                           .build();
+        var commandType = TypeName.of(commandMessage).value();
+        var value = Value.newBuilder()
+                .setStringValue(commandType)
+                .build();
         return ImmutableMap.of(ATTR_COMMAND_TYPE_NAME, value);
     }
 
@@ -92,17 +91,16 @@ public abstract class CommandException extends RuntimeException implements Messa
         Message commandMessage = CommandEnvelope.of(command)
                                                 .message();
 
-        String commandType = commandMessage.getDescriptorForType()
-                                           .getFullName();
-        String errMsg = format(format, commandType);
-        String descriptorName = CommandValidationError.getDescriptor()
-                                                      .getFullName();
-        Error.Builder error =
-                Error.newBuilder()
-                     .setType(descriptorName)
-                     .setMessage(errMsg)
-                     .setCode(errorCode.getNumber())
-                     .putAllAttributes(commandTypeAttribute(commandMessage));
+        var commandType = commandMessage.getDescriptorForType()
+                                        .getFullName();
+        var errMsg = format(format, commandType);
+        var descriptorName = CommandValidationError.getDescriptor()
+                                                   .getFullName();
+        var error = Error.newBuilder()
+                .setType(descriptorName)
+                .setMessage(errMsg)
+                .setCode(errorCode.getNumber())
+                .putAllAttributes(commandTypeAttribute(commandMessage));
         return error.build();
     }
 
@@ -129,12 +127,11 @@ public abstract class CommandException extends RuntimeException implements Messa
      * <p>The second parameter is a {@link TypeName} of the command message.
      */
     protected static String messageFormat(String format, Command command) {
-        CommandEnvelope envelope = CommandEnvelope.of(command);
-        Class<? extends Message> commandClass = envelope.messageClass()
-                                                        .value();
-        ClassName commandClassName = ClassName.of(commandClass);
-        TypeName typeName = envelope.messageTypeName();
-        String result = format(format, commandClassName, typeName);
+        var envelope = CommandEnvelope.of(command);
+        Class<? extends Message> commandClass = envelope.messageClass().value();
+        var commandClassName = ClassName.of(commandClass);
+        var typeName = envelope.messageTypeName();
+        var result = format(format, commandClassName, typeName);
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/commandbus/CommandFilter.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandFilter.java
@@ -28,7 +28,6 @@ package io.spine.server.commandbus;
 
 import io.spine.base.RejectionThrowable;
 import io.spine.core.Ack;
-import io.spine.core.Command;
 import io.spine.server.bus.BusFilter;
 import io.spine.server.bus.MessageIdExtensions;
 import io.spine.server.type.CommandEnvelope;
@@ -62,8 +61,8 @@ public interface CommandFilter extends BusFilter<CommandEnvelope> {
     default Optional<Ack> reject(CommandEnvelope command, RejectionThrowable cause) {
         checkNotNull(command);
         checkNotNull(cause);
-        Command cmd = command.command();
-        Ack ack = MessageIdExtensions.reject(cmd, cause);
+        var cmd = command.command();
+        var ack = MessageIdExtensions.reject(cmd, cause);
         return Optional.of(ack);
     }
 }

--- a/server/src/main/java/io/spine/server/commandbus/CommandReceivedTap.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandReceivedTap.java
@@ -28,9 +28,7 @@ package io.spine.server.commandbus;
 
 import io.spine.core.Ack;
 import io.spine.core.Command;
-import io.spine.core.TenantId;
 import io.spine.server.type.CommandEnvelope;
-import io.spine.system.server.SystemWriteSide;
 import io.spine.system.server.WriteSideFunction;
 import io.spine.system.server.event.CommandReceived;
 
@@ -57,16 +55,15 @@ final class CommandReceivedTap implements CommandFilter {
 
     @Override
     public Optional<Ack> filter(CommandEnvelope envelope) {
-        CommandReceived systemEvent = systemEvent(envelope.command());
-        TenantId tenantId = envelope.tenantId();
-        SystemWriteSide writeSide = writeSideFunction.get(tenantId);
+        var systemEvent = systemEvent(envelope.command());
+        var tenantId = envelope.tenantId();
+        var writeSide = writeSideFunction.get(tenantId);
         writeSide.postEvent(systemEvent, envelope.asMessageOrigin());
         return letPass();
     }
 
     private static CommandReceived systemEvent(Command domainCommand) {
-        CommandReceived result = CommandReceived
-                .newBuilder()
+        var result = CommandReceived.newBuilder()
                 .setId(domainCommand.getId())
                 .setPayload(domainCommand)
                 .build();

--- a/server/src/main/java/io/spine/server/commandbus/CommandScheduler.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandScheduler.java
@@ -80,7 +80,7 @@ public abstract class CommandScheduler implements BusFilter<CommandEnvelope>, Cl
 
     @Override
     public Optional<Ack> filter(CommandEnvelope envelope) {
-        Command command = envelope.command();
+        var command = envelope.command();
         if (!command.isScheduled()) {
             return letPass();
         }
@@ -113,11 +113,11 @@ public abstract class CommandScheduler implements BusFilter<CommandEnvelope>, Cl
         if (isScheduledAlready(command)) {
             return;
         }
-        Command commandUpdated = setSchedulingTime(command, currentTime());
+        var commandUpdated = setSchedulingTime(command, currentTime());
         doSchedule(commandUpdated);
         rememberAsScheduled(commandUpdated);
 
-        CommandEnvelope updatedCommandEnvelope = CommandEnvelope.of(commandUpdated);
+        var updatedCommandEnvelope = CommandEnvelope.of(commandUpdated);
         watcher().onScheduled(updatedCommandEnvelope);
     }
 
@@ -163,13 +163,13 @@ public abstract class CommandScheduler implements BusFilter<CommandEnvelope>, Cl
     }
 
     private static boolean isScheduledAlready(Command command) {
-        CommandId id = command.getId();
-        boolean isScheduledAlready = scheduledCommandIds.contains(id);
+        var id = command.getId();
+        var isScheduledAlready = scheduledCommandIds.contains(id);
         return isScheduledAlready;
     }
 
     private static void rememberAsScheduled(Command command) {
-        CommandId id = command.getId();
+        var id = command.getId();
         scheduledCommandIds.add(id);
     }
 
@@ -197,10 +197,10 @@ public abstract class CommandScheduler implements BusFilter<CommandEnvelope>, Cl
         checkNotNull(command);
         checkNotNull(schedulingTime);
 
-        Duration delay = command.getContext()
-                                .getSchedule()
-                                .getDelay();
-        Command result = setSchedule(command, delay, schedulingTime);
+        var delay = command.getContext()
+                           .getSchedule()
+                           .getDelay();
+        var result = setSchedule(command, delay, schedulingTime);
         return result;
     }
 
@@ -221,23 +221,23 @@ public abstract class CommandScheduler implements BusFilter<CommandEnvelope>, Cl
         checkNotNull(schedulingTime);
         checkValid(schedulingTime);
 
-        CommandContext context = command.getContext();
-        CommandContext.Schedule scheduleUpdated = context.getSchedule()
-                                                         .toBuilder()
-                                                         .setDelay(delay)
-                                                         .build();
-        CommandContext contextUpdated = context.toBuilder()
-                                               .setSchedule(scheduleUpdated)
-                                               .build();
+        var context = command.getContext();
+        var scheduleUpdated = context.getSchedule()
+                .toBuilder()
+                .setDelay(delay)
+                .build();
+        var contextUpdated = context.toBuilder()
+                .setSchedule(scheduleUpdated)
+                .build();
 
-        Command.SystemProperties sysProps = command.getSystemProperties()
-                                                   .toBuilder()
-                                                   .setSchedulingTime(schedulingTime)
-                                                   .build();
-        Command result = command.toBuilder()
-                                .setContext(contextUpdated)
-                                .setSystemProperties(sysProps)
-                                .build();
+        var sysProps = command.getSystemProperties()
+                .toBuilder()
+                .setSchedulingTime(schedulingTime)
+                .build();
+        var result = command.toBuilder()
+                .setContext(contextUpdated)
+                .setSystemProperties(sysProps)
+                .build();
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/commandbus/CommandValidator.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandValidator.java
@@ -29,10 +29,7 @@ package io.spine.server.commandbus;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.spine.annotation.Internal;
-import io.spine.base.CommandMessage;
-import io.spine.core.Command;
 import io.spine.core.CommandId;
-import io.spine.core.TenantId;
 import io.spine.server.MessageInvalid;
 import io.spine.server.bus.EnvelopeValidator;
 import io.spine.server.type.CommandEnvelope;
@@ -70,18 +67,18 @@ final class CommandValidator implements EnvelopeValidator<CommandEnvelope> {
 
     @Override
     public Optional<MessageInvalid> validate(CommandEnvelope envelope) {
-        Optional<MessageInvalid> tenantCheckResult = isTenantIdValid(envelope);
+        var tenantCheckResult = isTenantIdValid(envelope);
         if (tenantCheckResult.isPresent()) {
             return tenantCheckResult;
         }
-        Optional<MessageInvalid> commandValid = isCommandValid(envelope);
+        var commandValid = isCommandValid(envelope);
         return commandValid;
     }
 
     private Optional<MessageInvalid> isTenantIdValid(CommandEnvelope envelope) {
-        TenantId tenantId = envelope.tenantId();
-        boolean tenantSpecified = !isDefault(tenantId);
-        Command command = envelope.command();
+        var tenantId = envelope.tenantId();
+        var tenantSpecified = !isDefault(tenantId);
+        var command = envelope.command();
         if (commandBus.isMultitenant()) {
             if (!tenantSpecified) {
                 MessageInvalid report = missingTenantId(command);
@@ -97,8 +94,8 @@ final class CommandValidator implements EnvelopeValidator<CommandEnvelope> {
     }
 
     private static Optional<MessageInvalid> isCommandValid(CommandEnvelope envelope) {
-        Command command = envelope.command();
-        List<ConstraintViolation> violations = inspect(envelope);
+        var command = envelope.command();
+        var violations = inspect(envelope);
         InvalidCommandException exception = null;
         if (!violations.isEmpty()) {
             exception = onConstraintViolations(command, violations);
@@ -115,7 +112,7 @@ final class CommandValidator implements EnvelopeValidator<CommandEnvelope> {
      */
     @VisibleForTesting
     static List<ConstraintViolation> inspect(CommandEnvelope envelope) {
-        ViolationCheck result = new ViolationCheck(envelope);
+        var result = new ViolationCheck(envelope);
         return result.build();
     }
 
@@ -138,7 +135,7 @@ final class CommandValidator implements EnvelopeValidator<CommandEnvelope> {
          */
         @Internal
         private static List<ConstraintViolation> validateId(CommandId id) {
-            List<ConstraintViolation> violations = Validate.violationsOf(id);
+            var violations = Validate.violationsOf(id);
             if (id.getUuid().isEmpty()) {
                 return ImmutableList.<ConstraintViolation>builder()
                         .addAll(violations)
@@ -158,18 +155,18 @@ final class CommandValidator implements EnvelopeValidator<CommandEnvelope> {
         }
 
         private void validateId() {
-            List<ConstraintViolation> violations = validateId(command.id());
+            var violations = validateId(command.id());
             if (!violations.isEmpty()) {
                 result.addAll(violations);
             }
         }
 
         private void validateMessage() {
-            CommandMessage message = command.message();
+            var message = command.message();
             if (isDefault(message)) {
                 addViolation("Non-default command message must be set.");
             }
-            List<ConstraintViolation> messageViolations = Validate.violationsOf(message);
+            var messageViolations = Validate.violationsOf(message);
             result.addAll(messageViolations);
         }
 

--- a/server/src/main/java/io/spine/server/commandbus/DeadCommandHandler.java
+++ b/server/src/main/java/io/spine/server/commandbus/DeadCommandHandler.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.commandbus;
 
-import io.spine.core.Command;
 import io.spine.server.bus.DeadMessageHandler;
 import io.spine.server.type.CommandEnvelope;
 
@@ -37,8 +36,8 @@ final class DeadCommandHandler implements DeadMessageHandler<CommandEnvelope> {
 
     @Override
     public UnsupportedCommandException handle(CommandEnvelope message) {
-        Command command = message.command();
-        UnsupportedCommandException exception = new UnsupportedCommandException(command);
+        var command = message.command();
+        var exception = new UnsupportedCommandException(command);
         return exception;
     }
 }

--- a/server/src/main/java/io/spine/server/commandbus/ExecutorCommandScheduler.java
+++ b/server/src/main/java/io/spine/server/commandbus/ExecutorCommandScheduler.java
@@ -34,7 +34,6 @@ import io.spine.logging.Logging;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
-import static io.spine.core.CommandContext.Schedule;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
@@ -66,7 +65,7 @@ public class ExecutorCommandScheduler extends CommandScheduler implements Loggin
     @SuppressWarnings("FutureReturnValueIgnored") // Error handling is done manually.
     @Override
     protected void doSchedule(Command command) {
-        final long delayMillis = delayMillisecondsOf(command);
+        final var delayMillis = delayMillisecondsOf(command);
         executorService.schedule(() -> safePost(command),
                                  delayMillis, MILLISECONDS);
     }
@@ -93,10 +92,9 @@ public class ExecutorCommandScheduler extends CommandScheduler implements Loggin
     }
 
     private static long delayMillisecondsOf(Command command) {
-        Schedule schedule = command.getContext()
-                                   .getSchedule();
-        Duration delay = schedule.getDelay();
-        long delaySec = delay.getSeconds();
+        var schedule = command.getContext().getSchedule();
+        var delay = schedule.getDelay();
+        var delaySec = delay.getSeconds();
         long delayMillisFraction = delay.getNanos() / NANOS_IN_MILLISECOND;
 
         /**
@@ -106,7 +104,7 @@ public class ExecutorCommandScheduler extends CommandScheduler implements Loggin
          * {@link Long.MAX_VALUE} is +9,223,372,036,854,775,807. That's why it is safe to multiply
          * {@code delaySec * MILLIS_IN_SECOND}.
          */
-        long absoluteMillis = delaySec * MILLIS_IN_SECOND + delayMillisFraction;
+        var absoluteMillis = delaySec * MILLIS_IN_SECOND + delayMillisFraction;
         return absoluteMillis;
     }
 

--- a/server/src/main/java/io/spine/server/commandbus/FlightRecorder.java
+++ b/server/src/main/java/io/spine/server/commandbus/FlightRecorder.java
@@ -27,9 +27,7 @@
 package io.spine.server.commandbus;
 
 import io.spine.base.EventMessage;
-import io.spine.core.CommandContext;
 import io.spine.server.type.CommandEnvelope;
-import io.spine.system.server.SystemWriteSide;
 import io.spine.system.server.WriteSideFunction;
 import io.spine.system.server.event.CommandDispatched;
 import io.spine.system.server.event.CommandScheduled;
@@ -55,8 +53,7 @@ final class FlightRecorder implements CommandFlowWatcher {
      */
     @Override
     public void onDispatchCommand(CommandEnvelope command) {
-        CommandDispatched systemEvent = CommandDispatched
-                .newBuilder()
+        var systemEvent = CommandDispatched.newBuilder()
                 .setId(command.id())
                 .build();
         postSystemEvent(systemEvent, command);
@@ -69,10 +66,9 @@ final class FlightRecorder implements CommandFlowWatcher {
      */
     @Override
     public void onScheduled(CommandEnvelope command) {
-        CommandContext context = command.context();
-        CommandContext.Schedule schedule = context.getSchedule();
-        CommandScheduled systemEvent = CommandScheduled
-                .newBuilder()
+        var context = command.context();
+        var schedule = context.getSchedule();
+        var systemEvent = CommandScheduled.newBuilder()
                 .setId(command.id())
                 .setSchedule(schedule)
                 .build();
@@ -80,7 +76,7 @@ final class FlightRecorder implements CommandFlowWatcher {
     }
 
     private void postSystemEvent(EventMessage systemEvent, CommandEnvelope cmd) {
-        SystemWriteSide writeSide = function.get(cmd.tenantId());
+        var writeSide = function.get(cmd.tenantId());
         writeSide.postEvent(systemEvent, cmd.asMessageOrigin());
     }
 }

--- a/server/src/main/java/io/spine/server/commandbus/InvalidCommandException.java
+++ b/server/src/main/java/io/spine/server/commandbus/InvalidCommandException.java
@@ -72,8 +72,7 @@ public class InvalidCommandException extends CommandException implements Message
     public static InvalidCommandException onConstraintViolations(
             Command command, Iterable<ConstraintViolation> violations) {
 
-        Factory helper =
-                new Factory(command, violations);
+        var helper = new Factory(command, violations);
         return helper.newException();
     }
 
@@ -82,9 +81,9 @@ public class InvalidCommandException extends CommandException implements Message
      * the {@code CommandContext} which is required in a multitenant application.
      */
     public static InvalidCommandException missingTenantId(Command command) {
-        CommandEnvelope envelope = CommandEnvelope.of(command);
+        var envelope = CommandEnvelope.of(command);
         Message commandMessage = envelope.message();
-        String errMsg = format(
+        var errMsg = format(
                 "The command (class: `%s`, type: `%s`, id: `%s`) is posted to " +
                 "multi-tenant Bounded Context, but has no `tenant_id` attribute in the context.",
                 CommandClass.of(commandMessage)
@@ -92,7 +91,7 @@ public class InvalidCommandException extends CommandException implements Message
                             .getName(),
                 TypeName.of(commandMessage),
                 Identifier.toString(envelope.id()));
-        Error error = unknownTenantError(commandMessage, errMsg);
+        var error = unknownTenantError(commandMessage, errMsg);
         return new InvalidCommandException(errMsg, command, error);
     }
 
@@ -101,8 +100,7 @@ public class InvalidCommandException extends CommandException implements Message
      * attribute in the {@code CommandContext} which is required in a multitenant application.
      */
     public static Error unknownTenantError(Message commandMessage, String errorText) {
-        Error error = Error
-                .newBuilder()
+        var error = Error.newBuilder()
                 .setType(InvalidCommandException.class.getCanonicalName())
                 .setCode(CommandValidationError.TENANT_UNKNOWN.getNumber())
                 .setMessage(errorText)
@@ -115,22 +113,21 @@ public class InvalidCommandException extends CommandException implements Message
      * Creates an exception for the command which specifies a tenant in a single-tenant context.
      */
     public static InvalidCommandException inapplicableTenantId(Command command) {
-        CommandEnvelope cmd = CommandEnvelope.of(command);
-        TypeName typeName = TypeName.of(cmd.message());
-        String errMsg = format(
+        var cmd = CommandEnvelope.of(command);
+        var typeName = TypeName.of(cmd.message());
+        var errMsg = format(
                 "The command (class: `%s`, type: `%s`, id: `%s`) was posted to a single-tenant " +
                 "Bounded Context, but has `tenant_id` (`%s`) attribute set in the command context.",
                 cmd.messageClass(),
                 typeName,
                 shortDebugString(cmd.id()),
                 shortDebugString(cmd.tenantId()));
-        Error error = inapplicableTenantError(cmd.message(), errMsg);
+        var error = inapplicableTenantError(cmd.message(), errMsg);
         return new InvalidCommandException(errMsg, command, error);
     }
 
     private static Error inapplicableTenantError(CommandMessage commandMessage, String errMsg) {
-        Error error = Error
-                .newBuilder()
+        var error = Error.newBuilder()
                 .setType(InvalidCommandException.class.getCanonicalName())
                 .setCode(CommandValidationError.TENANT_INAPPLICABLE.getNumber())
                 .setMessage(errMsg)
@@ -138,6 +135,7 @@ public class InvalidCommandException extends CommandException implements Message
                 .build();
         return error;
     }
+
     /**
      * A helper utility aimed to create an {@code InvalidCommandException} to report the
      * command which field values violate validation constraint(s).

--- a/server/src/main/java/io/spine/server/commandbus/UnsupportedCommandException.java
+++ b/server/src/main/java/io/spine/server/commandbus/UnsupportedCommandException.java
@@ -48,8 +48,8 @@ public class UnsupportedCommandException extends CommandException implements Mes
 
     /** Creates an instance of unsupported command error. */
     private static Error unsupportedCommand(Command command) {
-        String format = "Commands of the type `%s` are not supported.";
-        CommandValidationError errorCode = CommandValidationError.UNSUPPORTED_COMMAND;
+        var format = "Commands of the type `%s` are not supported.";
+        var errorCode = CommandValidationError.UNSUPPORTED_COMMAND;
         return createError(format, command, errorCode);
     }
 }

--- a/server/src/main/java/io/spine/server/delivery/AbstractWorkRegistry.java
+++ b/server/src/main/java/io/spine/server/delivery/AbstractWorkRegistry.java
@@ -28,7 +28,6 @@ package io.spine.server.delivery;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Duration;
-import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Durations;
 import io.spine.annotation.SPI;
 import io.spine.server.NodeId;
@@ -55,17 +54,17 @@ public abstract class AbstractWorkRegistry implements ShardedWorkRegistry {
         checkNotNull(index);
         checkNotNull(nodeId);
 
-        Optional<ShardSessionRecord> record = find(index);
+        var record = find(index);
         if (record.isPresent()) {
-            ShardSessionRecord existingRecord = record.get();
+            var existingRecord = record.get();
             if (hasPickedBy(existingRecord)) {
                 return Optional.empty();
             } else {
-                ShardSessionRecord updatedRecord = updateNode(existingRecord, nodeId);
+                var updatedRecord = updateNode(existingRecord, nodeId);
                 return Optional.of(asSession(updatedRecord));
             }
         } else {
-            ShardSessionRecord newRecord = createRecord(index, nodeId);
+            var newRecord = createRecord(index, nodeId);
             return Optional.of(asSession(newRecord));
         }
     }
@@ -75,8 +74,7 @@ public abstract class AbstractWorkRegistry implements ShardedWorkRegistry {
     }
 
     private ShardSessionRecord createRecord(ShardIndex index, NodeId nodeId) {
-        ShardSessionRecord newRecord = ShardSessionRecord
-                .newBuilder()
+        var newRecord = ShardSessionRecord.newBuilder()
                 .setIndex(index)
                 .setPickedBy(nodeId)
                 .setWhenLastPicked(currentTime())
@@ -86,8 +84,7 @@ public abstract class AbstractWorkRegistry implements ShardedWorkRegistry {
     }
 
     private ShardSessionRecord updateNode(ShardSessionRecord record, NodeId nodeId) {
-        ShardSessionRecord updatedRecord = record
-                .toBuilder()
+        var updatedRecord = record.toBuilder()
                 .setPickedBy(nodeId)
                 .setWhenLastPicked(currentTime())
                 .build();
@@ -101,10 +98,10 @@ public abstract class AbstractWorkRegistry implements ShardedWorkRegistry {
         ImmutableSet.Builder<ShardIndex> resultBuilder = ImmutableSet.builder();
         allRecords().forEachRemaining(record -> {
             if (record.hasPickedBy()) {
-                Timestamp whenPicked = record.getWhenLastPicked();
-                Duration elapsed = between(whenPicked, currentTime());
+                var whenPicked = record.getWhenLastPicked();
+                var elapsed = between(whenPicked, currentTime());
 
-                int comparison = Durations.compare(elapsed, inactivityPeriod);
+                var comparison = Durations.compare(elapsed, inactivityPeriod);
                 if (comparison >= 0) {
                     clearNode(record);
                     resultBuilder.add(record.getIndex());
@@ -118,9 +115,9 @@ public abstract class AbstractWorkRegistry implements ShardedWorkRegistry {
      * Clears the value of {@code ShardSessionRecord.when_last_picked} and stores the session.
      */
     protected void clearNode(ShardSessionRecord session) {
-        ShardSessionRecord record = session.toBuilder()
-                                           .clearPickedBy()
-                                           .build();
+        var record = session.toBuilder()
+                .clearPickedBy()
+                .build();
         write(record);
     }
 

--- a/server/src/main/java/io/spine/server/delivery/CatchUpAlreadyStartedException.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpAlreadyStartedException.java
@@ -52,7 +52,7 @@ public final class CatchUpAlreadyStartedException extends IllegalStateException 
 
     @Override
     public String getMessage() {
-        String message = String.format(
+        var message = String.format(
                 "Cannot start the catch-up for the `%s` Projection, `%s`. " +
                         "Another catch-up is already in progress.",
                 projectionStateType, targetsAsString());

--- a/server/src/main/java/io/spine/server/delivery/CatchUpAlreadyStartedException.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpAlreadyStartedException.java
@@ -33,6 +33,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Set;
 
+import static java.lang.String.format;
+
 /**
  * An exception telling that the projection catch-up cannot be started, since some of the requested
  * entities are already catching up.
@@ -52,7 +54,7 @@ public final class CatchUpAlreadyStartedException extends IllegalStateException 
 
     @Override
     public String getMessage() {
-        var message = String.format(
+        var message = format(
                 "Cannot start the catch-up for the `%s` Projection, `%s`. " +
                         "Another catch-up is already in progress.",
                 projectionStateType, targetsAsString());

--- a/server/src/main/java/io/spine/server/delivery/CatchUpEventFactory.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpEventFactory.java
@@ -26,13 +26,12 @@
 
 package io.spine.server.delivery;
 
-import com.google.protobuf.Any;
 import io.spine.base.EventMessage;
 import io.spine.client.ActorRequestFactory;
-import io.spine.core.ActorContext;
 import io.spine.core.Event;
 import io.spine.core.TenantId;
 import io.spine.core.UserId;
+import io.spine.core.Versions;
 import io.spine.protobuf.AnyPacker;
 import io.spine.server.event.EventFactory;
 import io.spine.server.tenant.TenantFunction;
@@ -59,29 +58,30 @@ final class CatchUpEventFactory {
      * one of the options on how to do that.
      */
     Event createEvent(EventMessage message) {
-        return factory.createEvent(message, null);
+        return factory.createEvent(message, Versions.zero());
     }
 
     private static EventFactory newEventFactory(TypeUrl stateType, boolean multitenant) {
-        String userIdValue = format("`CatchUpEventFactory` for `%s`", stateType.value());
-        UserId onBehalfOf = UserId.newBuilder()
-                                  .setValue(userIdValue)
-                                  .build();
-        ActorRequestFactory requestFactory = requestFactory(onBehalfOf, multitenant);
-        Any producerId = AnyPacker.pack(onBehalfOf);
-        ActorContext actorContext = requestFactory.newActorContext();
+        var userIdValue = format("`CatchUpEventFactory` for `%s`", stateType.value());
+        var onBehalfOf = UserId.newBuilder()
+                .setValue(userIdValue)
+                .build();
+        var requestFactory = requestFactory(onBehalfOf, multitenant);
+        var producerId = AnyPacker.pack(onBehalfOf);
+        var actorContext = requestFactory.newActorContext();
         return EventFactory.forImport(actorContext, producerId);
     }
 
+    @SuppressWarnings("ConstantConditions") /* The method never returns `null`. */
     private static ActorRequestFactory requestFactory(UserId actor, boolean multitenant) {
-        TenantFunction<ActorRequestFactory> function =
+        var function =
                 new TenantFunction<ActorRequestFactory>(multitenant) {
                     @Override
                     public ActorRequestFactory apply(TenantId id) {
                         return ActorRequestFactory.newBuilder()
-                                                  .setActor(actor)
-                                                  .setTenantId(id)
-                                                  .build();
+                                .setActor(actor)
+                                .setTenantId(id)
+                                .build();
                     }
                 };
         return function.execute();

--- a/server/src/main/java/io/spine/server/delivery/CatchUpMessageComparator.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpMessageComparator.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.delivery;
 
-import io.spine.core.Event;
 import io.spine.server.delivery.event.CatchUpStarted;
 import io.spine.server.event.EventComparator;
 import io.spine.type.TypeUrl;
@@ -48,15 +47,13 @@ final class CatchUpMessageComparator
     @Override
     public int compare(InboxMessage m1, InboxMessage m2) {
         if (m1.hasEvent() && m2.hasEvent()) {
-            Event e1 = m1.getEvent();
-            String typeOfFirst = e1.getMessage()
-                                   .getTypeUrl();
+            var e1 = m1.getEvent();
+            var typeOfFirst = e1.getMessage().getTypeUrl();
             if (typeOfFirst.equals(CATCH_UP_STARTED.toString())) {
                 return -1;
             }
-            Event e2 = m2.getEvent();
-            String typeOfSecond = e2.getMessage()
-                                    .getTypeUrl();
+            var e2 = m2.getEvent();
+            var typeOfSecond = e2.getMessage().getTypeUrl();
             if (typeOfSecond.equals(CATCH_UP_STARTED.toString())) {
                 return 1;
             }

--- a/server/src/main/java/io/spine/server/delivery/CatchUpMixin.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpMixin.java
@@ -26,11 +26,8 @@
 
 package io.spine.server.delivery;
 
-import com.google.protobuf.Any;
 import io.spine.annotation.GeneratedMixin;
 import io.spine.annotation.Internal;
-
-import java.util.List;
 
 /**
  * A mixin for the state of the {@linkplain CatchUpProcess catch-up process job}.
@@ -56,18 +53,17 @@ interface CatchUpMixin extends CatchUpOrBuilder {
      * @return {@code true} if the message matches the job, {@code false} otherwise
      */
     default boolean matches(InboxMessage message) {
-        String expectedProjectionType = getId().getProjectionType();
-        InboxId targetInbox = message.getInboxId();
-        String actualTargetType = targetInbox.getTypeUrl();
+        var expectedProjectionType = getId().getProjectionType();
+        var targetInbox = message.getInboxId();
+        var actualTargetType = targetInbox.getTypeUrl();
         if (!expectedProjectionType.equals(actualTargetType)) {
             return false;
         }
-        List<Any> targets = getRequest().getTargetList();
+        var targets = getRequest().getTargetList();
         if (targets.isEmpty()) {
             return true;
         }
-        Any rawEntityId = targetInbox.getEntityId()
-                                     .getId();
+        var rawEntityId = targetInbox.getEntityId().getId();
         return targets.stream()
                       .anyMatch((t) -> t.equals(rawEntityId));
     }

--- a/server/src/main/java/io/spine/server/delivery/CatchUpStation.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpStation.java
@@ -29,8 +29,6 @@ package io.spine.server.delivery;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Duration;
 import com.google.protobuf.util.Durations;
-import io.spine.base.EventMessage;
-import io.spine.core.Event;
 import io.spine.server.delivery.event.CatchUpStarted;
 
 import java.util.ArrayList;
@@ -85,8 +83,8 @@ final class CatchUpStation extends Station {
      */
     @Override
     public final Result process(Conveyor conveyor) {
-        JobFilter jobFilter = new JobFilter(jobs, conveyor);
-        Collection<InboxMessage> toDispatch = jobFilter.messagesToDispatch();
+        var jobFilter = new JobFilter(jobs, conveyor);
+        var toDispatch = jobFilter.messagesToDispatch();
         return dispatch(toDispatch, conveyor);
     }
 
@@ -113,9 +111,9 @@ final class CatchUpStation extends Station {
         List<InboxMessage> ordered = new ArrayList<>(messages);
         ordered.sort(COMPARATOR);
 
-        DeliveryErrors errors = action.executeFor(ordered);
+        var errors = action.executeFor(ordered);
         conveyor.markDelivered(ordered);
-        Result result = new Result(ordered.size(), errors);
+        var result = new Result(ordered.size(), errors);
         return result;
     }
 
@@ -155,7 +153,7 @@ final class CatchUpStation extends Station {
          * all the stages and are ready for the dispatching.
          */
         private Collection<InboxMessage> messagesToDispatch() {
-            for (InboxMessage message : conveyor) {
+            for (var message : conveyor) {
                 accept(message);
             }
             return dispatchToCatchUp.values();
@@ -175,7 +173,7 @@ final class CatchUpStation extends Station {
          *         the message to process
          */
         private void started(InboxMessage message) {
-            boolean dispatched = dispatchAsCatchUpSignal(message, CatchUpStarted.class);
+            var dispatched = dispatchAsCatchUpSignal(message, CatchUpStarted.class);
             if(dispatched) {
                 return;
             }
@@ -187,11 +185,10 @@ final class CatchUpStation extends Station {
         private boolean dispatchAsCatchUpSignal(InboxMessage message,
                                                 Class<? extends CatchUpSignal> signalType) {
             if(message.hasEvent()) {
-                Event event = message.getEvent();
-                Class<? extends EventMessage> eventType = event.enclosedMessage()
-                                                               .getClass();
+                var event = message.getEvent();
+                var eventType = event.enclosedMessage().getClass();
                 if (eventType.equals(signalType)) {
-                    DispatchingId dispatchingId = new DispatchingId(message);
+                    var dispatchingId = new DispatchingId(message);
                     dispatchToCatchUp.put(dispatchingId, message);
                     return true;
                 }
@@ -212,7 +209,7 @@ final class CatchUpStation extends Station {
          *         the message to process
          */
         private void inProgress(InboxMessage message) {
-            DispatchingId dispatchingId = new DispatchingId(message);
+            var dispatchingId = new DispatchingId(message);
             if (message.getStatus() == TO_CATCH_UP) {
                 if (dispatchToCatchUp.containsKey(dispatchingId)) {
                     conveyor.remove(message);
@@ -269,7 +266,7 @@ final class CatchUpStation extends Station {
          *         the message to process
          */
         private void completedWith(InboxMessage message) {
-            DispatchingId dispatchingId = new DispatchingId(message);
+            var dispatchingId = new DispatchingId(message);
             if (message.getStatus() == TO_CATCH_UP) {
                 if (!dispatchToCatchUp.containsKey(dispatchingId)) {
                     dispatchToCatchUp.put(dispatchingId, message);
@@ -290,11 +287,11 @@ final class CatchUpStation extends Station {
          *         the message to run through the filter
          */
         private void accept(InboxMessage message) {
-            for (CatchUp job : jobs) {
+            for (var job : jobs) {
                 if (!job.matches(message)) {
                     continue;
                 }
-                CatchUpStatus jobStatus = job.getStatus();
+                var jobStatus = job.getStatus();
 
                 switch (jobStatus) {
                     case STARTED:

--- a/server/src/main/java/io/spine/server/delivery/CatchUpStorage.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpStorage.java
@@ -29,7 +29,6 @@ package io.spine.server.delivery;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.spine.annotation.SPI;
-import io.spine.query.RecordQuery;
 import io.spine.server.storage.MessageRecordSpec;
 import io.spine.server.storage.MessageStorage;
 import io.spine.server.storage.StorageFactory;
@@ -65,11 +64,10 @@ public class CatchUpStorage extends MessageStorage<CatchUpId, CatchUp> {
      *         the type of the projection state to use for filtering
      */
     public Iterator<CatchUp> readByType(TypeUrl projectionType) {
-        RecordQuery<CatchUpId, CatchUp> query =
-                queryBuilder().where(projection_type)
-                              .is(projectionType.value())
-                              .build();
-        Iterator<CatchUp> result = readAll(query);
+        var query = queryBuilder()
+                .where(projection_type).is(projectionType.value())
+                .build();
+        var result = readAll(query);
         return result;
     }
 
@@ -98,8 +96,8 @@ public class CatchUpStorage extends MessageStorage<CatchUpId, CatchUp> {
      */
     @VisibleForTesting
     void clear() {
-        Iterator<CatchUpId> iterator = index();
-        ImmutableList<CatchUpId> allIds = ImmutableList.copyOf(iterator);
+        var iterator = index();
+        var allIds = ImmutableList.copyOf(iterator);
         deleteAll(allIds);
     }
 }

--- a/server/src/main/java/io/spine/server/delivery/CleanupStation.java
+++ b/server/src/main/java/io/spine/server/delivery/CleanupStation.java
@@ -49,9 +49,9 @@ final class CleanupStation extends Station {
      */
     @Override
     public final Result process(Conveyor conveyor) {
-        for (InboxMessage message : conveyor) {
+        for (var message : conveyor) {
             if (message.getStatus() == InboxMessageStatus.DELIVERED) {
-                Timestamp keepUntil = message.getKeepUntil();
+                var keepUntil = message.getKeepUntil();
                 if (keepUntil.equals(Timestamp.getDefaultInstance()) || isInPast(keepUntil)) {
                     conveyor.remove(message);
                 }

--- a/server/src/main/java/io/spine/server/delivery/Conveyor.java
+++ b/server/src/main/java/io/spine/server/delivery/Conveyor.java
@@ -238,13 +238,13 @@ final class Conveyor implements Iterable<InboxMessage> {
      * Writes all the pending changes to the passed {@code InboxStorage}.
      */
     void flushTo(InboxStorage storage) {
-        var dirtyMessages = messages.values()
+        var toWrite = messages.values()
                 .stream()
-                .filter(message -> this.dirtyMessages.contains(message.getId()))
+                .filter(message -> dirtyMessages.contains(message.getId()))
                 .collect(toList());
-        storage.writeBatch(dirtyMessages);
+        storage.writeBatch(toWrite);
         storage.removeBatch(removals);
-        dirtyMessages.clear();
+        toWrite.clear();
         removals.clear();
         duplicates.clear();
     }

--- a/server/src/main/java/io/spine/server/delivery/DeliveredMessages.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveredMessages.java
@@ -60,7 +60,7 @@ final class DeliveredMessages {
      * Records the delivery of the message.
      */
     void recordDelivered(InboxMessage message) {
-        DispatchingId id = new DispatchingId(message);
+        var id = new DispatchingId(message);
         cache.put(id, Time.currentTime());
     }
 }

--- a/server/src/main/java/io/spine/server/delivery/DeliveryBuilder.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryBuilder.java
@@ -287,7 +287,7 @@ public final class DeliveryBuilder {
             deduplicationWindow = Duration.getDefaultInstance();
         }
 
-        StorageFactory factory = storageFactory();
+        var factory = storageFactory();
         if (this.inboxStorage == null) {
             this.inboxStorage = factory.createInboxStorage(false);
         }
@@ -312,13 +312,13 @@ public final class DeliveryBuilder {
             catchUpPageSize = DEFAULT_CATCH_UP_PAGE_SIZE;
         }
 
-        Delivery delivery = new Delivery(this);
+        var delivery = new Delivery(this);
         return delivery;
     }
 
     private static StorageFactory storageFactory() {
-        ServerEnvironment serverEnvironment = ServerEnvironment.instance();
-        Optional<StorageFactory> currentStorageFactory = serverEnvironment.optionalStorageFactory();
+        var serverEnvironment = ServerEnvironment.instance();
+        var currentStorageFactory = serverEnvironment.optionalStorageFactory();
         return currentStorageFactory.orElseGet(InMemoryStorageFactory::newInstance);
     }
 }

--- a/server/src/main/java/io/spine/server/delivery/DeliveryDispatchListener.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryDispatchListener.java
@@ -29,11 +29,9 @@ package io.spine.server.delivery;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
 import io.spine.core.SignalId;
-import io.spine.core.TenantId;
 import io.spine.server.bus.MulticastDispatchListener;
 import io.spine.server.tenant.TenantAwareRunner;
 
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -68,10 +66,10 @@ final class DeliveryDispatchListener implements MulticastDispatchListener {
 
     @Override
     public void onCompleted(SignalId signal) {
-        boolean removed = currentlyDispatching.remove(signal);
+        var removed = currentlyDispatching.remove(signal);
         if (removed) {
-            Collection<InboxMessage> messages = pending.removeAll(signal);
-            for (InboxMessage message : messages) {
+            var messages = pending.removeAll(signal);
+            for (var message : messages) {
                 propagateMessage(message);
             }
         }
@@ -97,11 +95,9 @@ final class DeliveryDispatchListener implements MulticastDispatchListener {
     }
 
     private void propagateMessage(InboxMessage message) {
-        TenantId tenant =
-                message.hasEvent() ? message.getEvent()
-                                            .tenant()
-                                   : message.getCommand()
-                                            .tenant();
+        var tenant = message.hasEvent()
+                     ? message.getEvent().tenant()
+                     : message.getCommand().tenant();
         TenantAwareRunner
                 .with(tenant)
                 .run(() -> onNewMessage.accept(message));

--- a/server/src/main/java/io/spine/server/delivery/DeliveryErrors.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryErrors.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Throwables observed during signal delivery.
@@ -66,8 +67,8 @@ final class DeliveryErrors {
      */
     void throwIfAny() {
         if (hasErrors()) {
-            DeliveryError first = errors.get(0);
-            ImmutableList<DeliveryError> other = this.errors.subList(1, this.errors.size());
+            var first = errors.get(0);
+            var other = this.errors.subList(1, this.errors.size());
             other.forEach(first::addSuppressed);
             first.rethrow();
         }
@@ -101,7 +102,7 @@ final class DeliveryErrors {
         }
 
         private Throwable asThrowable() {
-            return exception != null ? exception : checkNotNull(error);
+            return exception != null ? exception : requireNonNull(error);
         }
 
         private void addSuppressed(DeliveryError error) {
@@ -112,7 +113,7 @@ final class DeliveryErrors {
             if (exception != null) {
                 throw exception;
             } else {
-                throw checkNotNull(error);
+                throw requireNonNull(error);
             }
         }
     }

--- a/server/src/main/java/io/spine/server/delivery/DeliveryStrategy.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryStrategy.java
@@ -86,8 +86,7 @@ public abstract class DeliveryStrategy {
                       "The index of the shard `%s` must be less" +
                               " than the total number of shards `%s`.",
                       indexValue, ofTotal);
-        ShardIndex result = ShardIndex
-                .newBuilder()
+        var result = ShardIndex.newBuilder()
                 .setIndex(indexValue)
                 .setOfTotal(ofTotal)
                 .vBuild();

--- a/server/src/main/java/io/spine/server/delivery/DispatchingId.java
+++ b/server/src/main/java/io/spine/server/delivery/DispatchingId.java
@@ -54,7 +54,7 @@ final class DispatchingId {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        DispatchingId id = (DispatchingId) o;
+        var id = (DispatchingId) o;
         return Objects.equals(signal, id.signal) &&
                 Objects.equals(inbox, id.inbox);
     }

--- a/server/src/main/java/io/spine/server/delivery/GroupByTargetAndDeliver.java
+++ b/server/src/main/java/io/spine/server/delivery/GroupByTargetAndDeliver.java
@@ -61,9 +61,9 @@ final class GroupByTargetAndDeliver implements DeliveryAction {
     @Override
     public DeliveryErrors executeFor(List<InboxMessage> messages) {
         List<Segment> segments = Segment.groupByTargetType(messages);
-        DeliveryErrors.Builder errors = DeliveryErrors.newBuilder();
-        for (Segment segment : segments) {
-            ShardedMessageDelivery<InboxMessage> delivery = inboxDeliveries.get(segment.typeUrl());
+        var errors = DeliveryErrors.newBuilder();
+        for (var segment : segments) {
+            var delivery = inboxDeliveries.get(segment.typeUrl());
             List<InboxMessage> deliveryPackage = segment.messages();
             try {
                 delivery.deliver(deliveryPackage);

--- a/server/src/main/java/io/spine/server/delivery/Inbox.java
+++ b/server/src/main/java/io/spine/server/delivery/Inbox.java
@@ -197,12 +197,12 @@ public final class Inbox<I> {
          * server-wide {@code Delivery}.
          */
         public Inbox<I> build() {
-            Delivery delivery = ServerEnvironment.instance()
-                                                 .delivery();
+            var delivery = ServerEnvironment.instance()
+                                            .delivery();
             checkNotNull(entityStateType, "Entity state type must be set.");
             checkArgument(!eventEndpoints.isEmpty() || !commandEndpoints.isEmpty(),
                           "There must be at least one event or command endpoint.");
-            Inbox<I> inbox = new Inbox<>(this, delivery);
+            var inbox = new Inbox<>(this, delivery);
             delivery.register(inbox);
             return inbox;
         }

--- a/server/src/main/java/io/spine/server/delivery/InboxDeliveries.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxDeliveries.java
@@ -26,8 +26,6 @@
 
 package io.spine.server.delivery;
 
-import io.spine.type.TypeUrl;
-
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -48,7 +46,7 @@ final class InboxDeliveries {
      *         if there is no delivery found
      */
     ShardedMessageDelivery<InboxMessage> get(String typeUrl) {
-        ShardedMessageDelivery<InboxMessage> result = contents.get(typeUrl);
+        var result = contents.get(typeUrl);
         checkState(result != null,
                    "Cannot find the registered Inbox for the type URL `%s`.", typeUrl);
         return result;
@@ -61,8 +59,8 @@ final class InboxDeliveries {
      *         if there is no delivery found
      */
     ShardedMessageDelivery<InboxMessage> get(InboxMessage message) {
-        String typeUrl = message.getInboxId()
-                                .getTypeUrl();
+        var typeUrl = message.getInboxId()
+                             .getTypeUrl();
         return get(typeUrl);
     }
 
@@ -70,7 +68,7 @@ final class InboxDeliveries {
      * Registers the given {@code Inbox}.
      */
     void register(Inbox<?> inbox) {
-        TypeUrl entityType = inbox.entityStateType();
+        var entityType = inbox.entityStateType();
         contents.put(entityType.value(), inbox.delivery());
     }
 
@@ -80,7 +78,7 @@ final class InboxDeliveries {
      * <p>If there was no such {@code Inbox} registered, does nothing.
      */
     void unregister(Inbox<?> inbox) {
-        TypeUrl entityType = inbox.entityStateType();
+        var entityType = inbox.entityStateType();
         contents.remove(entityType.value());
     }
 }

--- a/server/src/main/java/io/spine/server/delivery/InboxIds.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxIds.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.delivery;
 
-import com.google.protobuf.Any;
 import io.spine.base.Identifier;
 import io.spine.client.EntityId;
 import io.spine.string.Stringifiers;
@@ -59,12 +58,10 @@ final class InboxIds {
         checkNotNull(id);
         checkNotNull(entityType);
 
-        EntityId entityId = EntityId
-                .newBuilder()
+        var entityId = EntityId.newBuilder()
                 .setId(pack(id))
                 .vBuild();
-        InboxId inboxId = InboxId
-                .newBuilder()
+        var inboxId = InboxId.newBuilder()
                 .setEntityId(entityId)
                 .setTypeUrl(entityType.value())
                 .vBuild();
@@ -80,9 +77,8 @@ final class InboxIds {
      */
     static Object unwrap(InboxId inboxId) {
         checkNotNull(inboxId);
-        Any idValue = inboxId.getEntityId()
-                             .getId();
-        Object unpackedId = Identifier.unpack(idValue);
+        var idValue = inboxId.getEntityId().getId();
+        var unpackedId = Identifier.unpack(idValue);
         return unpackedId;
     }
 
@@ -99,10 +95,10 @@ final class InboxIds {
         checkNotNull(targetId);
         checkNotNull(uuid);
 
-        String rawValue = uuid + '@' + Stringifiers.toString(targetId);
-        InboxSignalId result = InboxSignalId.newBuilder()
-                                            .setValue(rawValue)
-                                            .build();
+        var rawValue = uuid + '@' + Stringifiers.toString(targetId);
+        var result = InboxSignalId.newBuilder()
+                .setValue(rawValue)
+                .build();
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/delivery/InboxMessageComparator.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxMessageComparator.java
@@ -53,7 +53,7 @@ public final class InboxMessageComparator implements Comparator<InboxMessage>, S
 
     @Override
     public int compare(InboxMessage m1, InboxMessage m2) {
-        int result = Comparator
+        var result = Comparator
                 .comparing(InboxMessage::getWhenReceived, Timestamps.comparator())
                 .thenComparing(InboxMessage::getVersion)
                 .thenComparing((m) -> m.getId()

--- a/server/src/main/java/io/spine/server/delivery/InboxOfCommands.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxOfCommands.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.delivery;
 
-import io.spine.core.Command;
 import io.spine.server.type.CommandEnvelope;
 
 /**
@@ -44,7 +43,7 @@ final class InboxOfCommands<I> extends InboxPart<I, CommandEnvelope> {
 
     @Override
     protected void setRecordPayload(CommandEnvelope envelope, InboxMessage.Builder builder) {
-        Command command = envelope.outerObject();
+        var command = envelope.outerObject();
         builder.setCommand(command);
     }
 

--- a/server/src/main/java/io/spine/server/delivery/InboxOfEvents.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxOfEvents.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.delivery;
 
-import io.spine.core.Event;
 import io.spine.server.type.EventEnvelope;
 
 /**
@@ -44,7 +43,7 @@ final class InboxOfEvents<I> extends InboxPart<I, EventEnvelope> {
 
     @Override
     protected void setRecordPayload(EventEnvelope envelope, InboxMessage.Builder builder) {
-        Event event = envelope.outerObject();
+        var event = envelope.outerObject();
         builder.setEvent(event);
     }
 

--- a/server/src/main/java/io/spine/server/delivery/InboxPage.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxPage.java
@@ -69,7 +69,7 @@ public final class InboxPage implements Page<InboxMessage> {
     }
 
     private ImmutableList<InboxMessage> readNext() {
-        ImmutableList<InboxMessage> contents = lookup.readAll(whenLastRead);
+        var contents = lookup.readAll(whenLastRead);
         if (!contents.isEmpty()) {
             this.whenLastRead = contents.get(contents.size() - 1)
                                         .getWhenReceived();
@@ -95,11 +95,11 @@ public final class InboxPage implements Page<InboxMessage> {
      */
     @Override
     public Optional<Page<InboxMessage>> next() {
-        ImmutableList<InboxMessage> moreContent = readNext();
+        var moreContent = readNext();
         if (moreContent.isEmpty()) {
             return Optional.empty();
         }
-        InboxPage nextPage = new InboxPage(this, moreContent);
+        var nextPage = new InboxPage(this, moreContent);
         return Optional.of(nextPage);
     }
 

--- a/server/src/main/java/io/spine/server/delivery/InboxPart.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxPart.java
@@ -84,13 +84,12 @@ abstract class InboxPart<I, M extends SignalEnvelope<?, ?, ?>> {
     }
 
     void store(M envelope, I entityId, InboxLabel label) {
-        InboxId inboxId = InboxIds.wrap(entityId, entityStateType);
-        Delivery delivery = ServerEnvironment.instance()
-                                             .delivery();
-        ShardIndex shardIndex = delivery.whichShardFor(entityId, entityStateType);
-        InboxMessageId id = InboxMessageMixin.generateIdWith(shardIndex);
-        InboxMessage.Builder builder = InboxMessage
-                .newBuilder()
+        var inboxId = InboxIds.wrap(entityId, entityStateType);
+        var delivery = ServerEnvironment.instance()
+                                        .delivery();
+        var shardIndex = delivery.whichShardFor(entityId, entityStateType);
+        var id = InboxMessageMixin.generateIdWith(shardIndex);
+        var builder = InboxMessage.newBuilder()
                 .setId(id)
                 .setSignalId(signalIdFrom(envelope, entityId))
                 .setInboxId(inboxId)
@@ -99,7 +98,7 @@ abstract class InboxPart<I, M extends SignalEnvelope<?, ?, ?>> {
                 .setStatus(determineStatus(envelope, label))
                 .setVersion(VersionCounter.next());
         setRecordPayload(envelope, builder);
-        InboxMessage message = builder.vBuild();
+        var message = builder.vBuild();
 
         TenantAwareRunner
                 .with(envelope.tenantId())
@@ -107,7 +106,7 @@ abstract class InboxPart<I, M extends SignalEnvelope<?, ?, ?>> {
     }
 
     private InboxSignalId signalIdFrom(M envelope, I targetId) {
-        String uuid = extractUuidFrom(envelope);
+        var uuid = extractUuidFrom(envelope);
         return InboxIds.newSignalId(targetId, uuid);
     }
 
@@ -126,15 +125,14 @@ abstract class InboxPart<I, M extends SignalEnvelope<?, ?, ?>> {
     }
 
     private void callEndpoint(InboxMessage message, EndpointCall<I, M> call) {
-        M envelope = asEnvelope(message);
-        InboxLabel label = message.getLabel();
-        InboxId inboxId = message.getInboxId();
-        MessageEndpoint<I, M> endpoint =
-                endpoints.get(label, envelope)
-                         .orElseThrow(() -> new LabelNotFoundException(inboxId, label));
+        var envelope = asEnvelope(message);
+        var label = message.getLabel();
+        var inboxId = message.getInboxId();
+        var endpoint = endpoints.get(label, envelope)
+                                .orElseThrow(() -> new LabelNotFoundException(inboxId, label));
 
         @SuppressWarnings("unchecked")    // Only IDs of type `I` are stored.
-                I unpackedId = (I) InboxIds.unwrap(message.getInboxId());
+        var unpackedId = (I) InboxIds.unwrap(message.getInboxId());
         TenantAwareRunner
                 .with(envelope.tenantId())
                 .run(() -> call.invoke(endpoint, unpackedId, envelope));

--- a/server/src/main/java/io/spine/server/delivery/LiveDeliveryStation.java
+++ b/server/src/main/java/io/spine/server/delivery/LiveDeliveryStation.java
@@ -34,7 +34,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A station that delivers those messages which are incoming in a live mode.
@@ -97,15 +96,15 @@ final class LiveDeliveryStation extends Station {
      */
     @Override
     public final Result process(Conveyor conveyor) {
-        FilterToDeliver filter = new FilterToDeliver(conveyor);
-        Collection<InboxMessage> filtered = filter.messagesToDispatch();
+        var filter = new FilterToDeliver(conveyor);
+        var filtered = filter.messagesToDispatch();
         if (filtered.isEmpty()) {
             return emptyResult();
         }
-        List<InboxMessage> toDispatch = deduplicateAndSort(filtered, conveyor);
-        DeliveryErrors errors = action.executeFor(toDispatch);
+        var toDispatch = deduplicateAndSort(filtered, conveyor);
+        var errors = action.executeFor(toDispatch);
         conveyor.markDelivered(toDispatch);
-        Result result = new Result(toDispatch.size(), errors);
+        var result = new Result(toDispatch.size(), errors);
         return result;
     }
 
@@ -126,7 +125,7 @@ final class LiveDeliveryStation extends Station {
          * Returns the messages considered to ready for further dispatching.
          */
         private Collection<InboxMessage> messagesToDispatch() {
-            for (InboxMessage message : conveyor) {
+            for (var message : conveyor) {
                 accept(message);
             }
             return seen.values();
@@ -150,9 +149,9 @@ final class LiveDeliveryStation extends Station {
          *         the message to run through the filter
          */
         private void accept(InboxMessage message) {
-            InboxMessageStatus status = message.getStatus();
+            var status = message.getStatus();
             if (status == InboxMessageStatus.TO_DELIVER) {
-                DispatchingId dispatchingId = new DispatchingId(message);
+                var dispatchingId = new DispatchingId(message);
                 if (seen.containsKey(dispatchingId)) {
                     conveyor.markDuplicateAndRemove(message);
                 } else {
@@ -184,10 +183,10 @@ final class LiveDeliveryStation extends Station {
      */
     private static List<InboxMessage> deduplicateAndSort(Collection<InboxMessage> messages,
                                                          Conveyor conveyor) {
-        Set<DispatchingId> previouslyDelivered = conveyor.allDelivered();
+        var previouslyDelivered = conveyor.allDelivered();
         List<InboxMessage> result = new ArrayList<>();
-        for (InboxMessage message : messages) {
-            DispatchingId id = new DispatchingId(message);
+        for (var message : messages) {
+            var id = new DispatchingId(message);
             if (previouslyDelivered.contains(id)) {
                 conveyor.markDuplicateAndRemove(message);
             } else {

--- a/server/src/main/java/io/spine/server/delivery/LocalDispatchingObserver.java
+++ b/server/src/main/java/io/spine/server/delivery/LocalDispatchingObserver.java
@@ -27,7 +27,6 @@
 package io.spine.server.delivery;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.spine.core.TenantId;
 import io.spine.server.ServerEnvironment;
 import io.spine.server.tenant.TenantAwareRunner;
 
@@ -65,9 +64,9 @@ public final class LocalDispatchingObserver implements ShardObserver {
 
     @Override
     public void onMessage(InboxMessage update) {
-        Delivery delivery = ServerEnvironment.instance()
-                                             .delivery();
-        ShardIndex index = update.shardIndex();
+        var delivery = ServerEnvironment.instance()
+                                        .delivery();
+        var index = update.shardIndex();
         if (async) {
             new Thread(() -> runDelivery(update, delivery, index)).start();
         } else {
@@ -76,7 +75,7 @@ public final class LocalDispatchingObserver implements ShardObserver {
     }
 
     private static void runDelivery(InboxMessage message, Delivery delivery, ShardIndex index) {
-        TenantId tenant = message.tenant();
+        var tenant = message.tenant();
         TenantAwareRunner.with(tenant)
                          .run(() -> delivery.deliverMessagesFrom(index));
     }

--- a/server/src/main/java/io/spine/server/delivery/MaintenanceStation.java
+++ b/server/src/main/java/io/spine/server/delivery/MaintenanceStation.java
@@ -28,8 +28,6 @@ package io.spine.server.delivery;
 
 import com.google.common.collect.ImmutableList;
 
-import java.util.List;
-
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 /**
@@ -73,11 +71,10 @@ final class MaintenanceStation extends Station {
     }
 
     private static ImmutableList<CatchUp> findFinalizingCatchUps(DeliveryRunInfo runInfo) {
-        List<CatchUp> jobs = runInfo.getCatchUpJobList();
-        ImmutableList<CatchUp> finalizingJobs =
-                jobs.stream()
-                    .filter((job) -> job.getStatus() == CatchUpStatus.FINALIZING)
-                    .collect(toImmutableList());
+        var jobs = runInfo.getCatchUpJobList();
+        var finalizingJobs = jobs.stream()
+                .filter((job) -> job.getStatus() == CatchUpStatus.FINALIZING)
+                .collect(toImmutableList());
         return finalizingJobs;
     }
 }

--- a/server/src/main/java/io/spine/server/delivery/Segment.java
+++ b/server/src/main/java/io/spine/server/delivery/Segment.java
@@ -65,9 +65,9 @@ final class Segment {
             return ImmutableList.of();
         }
         Segment segment = null;
-        for (InboxMessage message : source) {
-            String typeUrl = message.getInboxId()
-                                    .getTypeUrl();
+        for (var message : source) {
+            var typeUrl = message.getInboxId()
+                                 .getTypeUrl();
             if (segment == null) {
                 segment = new Segment(typeUrl);
             } else {
@@ -81,7 +81,7 @@ final class Segment {
         if (segment.hasMessages()) {
             builder.add(segment);
         }
-        ImmutableList<Segment> result = builder.build();
+        var result = builder.build();
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/delivery/ShardMaintenanceProcess.java
+++ b/server/src/main/java/io/spine/server/delivery/ShardMaintenanceProcess.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.delivery;
 
-import com.google.protobuf.Timestamp;
 import io.spine.annotation.Internal;
 import io.spine.base.Time;
 import io.spine.server.delivery.event.ShardProcessed;
@@ -71,9 +70,8 @@ final class ShardMaintenanceProcess extends AbstractEventReactor {
     @SuppressWarnings("unused")     // see the Javadoc.
     @React
     ShardProcessed on(ShardProcessingRequested event) {
-        Timestamp now = Time.currentTime();
-        ShardProcessed processed = ShardProcessed
-                .newBuilder()
+        var now = Time.currentTime();
+        var processed = ShardProcessed.newBuilder()
                 .setIndex(event.getIndex())
                 .setProcess(event.getProcess())
                 .setRunInfo(event.getRunInfo())
@@ -83,7 +81,7 @@ final class ShardMaintenanceProcess extends AbstractEventReactor {
 
     @Override
     public void dispatch(EventEnvelope event) {
-        ShardEvent message = (ShardEvent) event.message();
+        var message = (ShardEvent) event.message();
         inbox.send(event)
              .toReactor(message.getIndex());
     }

--- a/server/src/main/java/io/spine/server/delivery/TargetDelivery.java
+++ b/server/src/main/java/io/spine/server/delivery/TargetDelivery.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.delivery;
 
-import com.google.protobuf.Any;
 import io.spine.base.Identifier;
 import io.spine.core.TenantId;
 import io.spine.server.tenant.IdInTenant;
@@ -69,7 +68,7 @@ final class TargetDelivery<I> implements ShardedMessageDelivery<InboxMessage> {
     public void deliver(List<InboxMessage> incoming) {
 
         if (batchListener == null) {
-            for (InboxMessage incomingMessage : incoming) {
+            for (var incomingMessage : incoming) {
                 doDeliver(inboxOfCmds, inboxOfEvents, incomingMessage);
             }
         } else {
@@ -100,8 +99,8 @@ final class TargetDelivery<I> implements ShardedMessageDelivery<InboxMessage> {
                                 BatchDeliveryListener<I> batchDispatcher) {
         List<Batch<I>> batches = Batch.byInboxId(incoming, this::asEnvelope);
 
-        for (Batch<I> batch : batches) {
-            TenantId tenant = batch.inboxId.tenant();
+        for (var batch : batches) {
+            var tenant = batch.inboxId.tenant();
             TenantAwareRunner.with(tenant).run(
                     () -> batch.deliverVia(batchDispatcher, inboxOfCmds, inboxOfEvents)
             );
@@ -140,11 +139,11 @@ final class TargetDelivery<I> implements ShardedMessageDelivery<InboxMessage> {
         byInboxId(List<InboxMessage> messages, Function<InboxMessage, SignalEnvelope<?, ?, ?>> fn) {
             List<Batch<I>> batches = new ArrayList<>();
             Batch<I> currentBatch = null;
-            for (InboxMessage message : messages) {
+            for (var message : messages) {
 
-                InboxId msgInboxId = message.getInboxId();
-                SignalEnvelope<?, ?, ?> envelope = fn.apply(message);
-                TenantId tenantId = envelope.tenantId();
+                var msgInboxId = message.getInboxId();
+                var envelope = fn.apply(message);
+                var tenantId = envelope.tenantId();
                 if (currentBatch == null) {
                     currentBatch = new Batch<>(msgInboxId, tenantId);
                 } else {
@@ -178,14 +177,14 @@ final class TargetDelivery<I> implements ShardedMessageDelivery<InboxMessage> {
                                 InboxOfCommands<I> cmdDispatcher,
                                 InboxOfEvents<I> eventDispatcher) {
             if (messages.size() > 1) {
-                Any packedId = inboxId.value()
+                var packedId = inboxId.value()
                                       .getEntityId()
                                       .getId();
                 @SuppressWarnings("unchecked")      // Only IDs of type `I` are stored.
-                        I id = (I) Identifier.unpack(packedId);
+                var id = (I) Identifier.unpack(packedId);
                 dispatcher.onStart(id);
                 try {
-                    for (InboxMessage message : messages) {
+                    for (var message : messages) {
                         doDeliver(cmdDispatcher, eventDispatcher, message);
                     }
                 } finally {

--- a/server/src/main/java/io/spine/server/delivery/UniformAcrossAllShards.java
+++ b/server/src/main/java/io/spine/server/delivery/UniformAcrossAllShards.java
@@ -83,7 +83,7 @@ public final class UniformAcrossAllShards extends DeliveryStrategy implements Se
      * @return a uniform distribution strategy instance for a given shard number
      */
     public static DeliveryStrategy forNumber(int totalShards) {
-        UniformAcrossAllShards result = new UniformAcrossAllShards(totalShards);
+        var result = new UniformAcrossAllShards(totalShards);
         return result;
     }
 
@@ -92,10 +92,10 @@ public final class UniformAcrossAllShards extends DeliveryStrategy implements Se
         if (1 == numberOfShards) {
             return newIndex(0);
         }
-        int hashValue = hash(entityId);
-        int totalShards = shardCount();
-        int indexValue = abs(hashValue % totalShards);
-        ShardIndex result = newIndex(indexValue);
+        var hashValue = hash(entityId);
+        var totalShards = shardCount();
+        var indexValue = abs(hashValue % totalShards);
+        var result = newIndex(indexValue);
         return result;
     }
 
@@ -107,7 +107,7 @@ public final class UniformAcrossAllShards extends DeliveryStrategy implements Se
             bytes = entityId.toString()
                             .getBytes(Charset.defaultCharset());
         }
-        int value = HASHER.hashBytes(bytes)
+        var value = HASHER.hashBytes(bytes)
                           .asInt();
         return value;
     }

--- a/server/src/main/java/io/spine/server/delivery/UpdateShardProcessingEvents.java
+++ b/server/src/main/java/io/spine/server/delivery/UpdateShardProcessingEvents.java
@@ -27,7 +27,6 @@
 package io.spine.server.delivery;
 
 import io.spine.base.EventMessage;
-import io.spine.core.Event;
 import io.spine.server.delivery.event.ShardProcessingRequested;
 
 import java.util.Optional;
@@ -52,12 +51,12 @@ final class UpdateShardProcessingEvents implements ConveyorJob {
     @Override
     public Optional<InboxMessage> modify(InboxMessage message) {
         if (message.hasEvent()) {
-            Event event = message.getEvent();
-            EventMessage eventMessage = event.enclosedMessage();
+            var event = message.getEvent();
+            var eventMessage = event.enclosedMessage();
             if (eventMessage instanceof ShardProcessingRequested) {
-                ShardProcessingRequested cast = (ShardProcessingRequested) eventMessage;
-                ShardProcessingRequested updatedSignal = updateWithRunInfo(cast);
-                InboxMessage modified = inject(updatedSignal, message);
+                var cast = (ShardProcessingRequested) eventMessage;
+                var updatedSignal = updateWithRunInfo(cast);
+                var modified = inject(updatedSignal, message);
                 return Optional.of(modified);
             }
         }
@@ -76,23 +75,20 @@ final class UpdateShardProcessingEvents implements ConveyorJob {
      * @return a copy of the passed {@code InboxMessage} with the passed event message injected
      */
     private static InboxMessage inject(EventMessage what, InboxMessage destination) {
-        Event event = destination.getEvent();
-        Event modifiedEvent =
-                event.toBuilder()
-                     .setMessage(pack(what))
-                     .vBuild();
-        InboxMessage modifiedMessage =
-                destination.toBuilder()
-                           .setEvent(modifiedEvent)
-                           .vBuild();
+        var event = destination.getEvent();
+        var modifiedEvent = event.toBuilder()
+                .setMessage(pack(what))
+                .vBuild();
+        var modifiedMessage = destination.toBuilder()
+                .setEvent(modifiedEvent)
+                .vBuild();
         return modifiedMessage;
     }
 
     private ShardProcessingRequested updateWithRunInfo(ShardProcessingRequested signal) {
-        ShardProcessingRequested modifiedSignal =
-                signal.toBuilder()
-                      .setRunInfo(runInfo)
-                      .vBuild();
+        var modifiedSignal = signal.toBuilder()
+                .setRunInfo(runInfo)
+                .vBuild();
         return modifiedSignal;
     }
 }

--- a/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
+++ b/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
@@ -97,7 +97,7 @@ public final class InMemoryShardedWorkRegistry extends AbstractWorkRegistry {
 
         @Override
         protected void complete() {
-            ShardSessionRecord record = workByNode.get(shardIndex());
+            var record = workByNode.get(shardIndex());
             // Clear the node ID value and release the session.
             clearNode(record);
         }

--- a/server/src/main/java/io/spine/server/enrich/CompositeFn.java
+++ b/server/src/main/java/io/spine/server/enrich/CompositeFn.java
@@ -50,8 +50,8 @@ final class CompositeFn<M extends Message, C extends EnrichableMessageContext>
     CompositeFn(Iterable<EnrichmentFn<M, C, ? extends Message>> functions) {
         super();
         checkNotNull(functions);
-        ImmutableSet<EnrichmentFn<M, C, ?>> fns = ImmutableSet.copyOf(functions);
-        int size = fns.size();
+        var fns = ImmutableSet.copyOf(functions);
+        var size = fns.size();
         checkArgument(
                 size >= 2,
                 "Composite enrichment function must have at least two items. Passed: %s.",
@@ -62,8 +62,8 @@ final class CompositeFn<M extends Message, C extends EnrichableMessageContext>
 
     @Override
     protected void applyAndPut(Container.Builder container, M m, C c) {
-        for (EnrichmentFn<M, C, ?> function : functions) {
-            Message enrichment = function.apply(m, c);
+        for (var function : functions) {
+            var enrichment = function.apply(m, c);
             checkResult(enrichment, m, c, function);
             put(container, enrichment);
         }

--- a/server/src/main/java/io/spine/server/enrich/Enricher.java
+++ b/server/src/main/java/io/spine/server/enrich/Enricher.java
@@ -70,21 +70,21 @@ public abstract class Enricher<M extends Message, C extends EnrichableMessageCon
         if (schema.isEmpty()) {
             return source;
         }
-        E result = source.toEnriched(this);
+        var result = source.toEnriched(this);
         return  result;
     }
 
     @Override
     public Optional<Enrichment> createEnrichment(M message, C context) {
         @SuppressWarnings("unchecked") // correct type is ensured by a Bus which uses the Enricher.
-        Class<? extends M> cls = (Class<? extends M>) message.getClass();
-        @Nullable SchemaFn fn = schema.enrichmentOf(cls);
+        var cls = (Class<? extends M>) message.getClass();
+        @SuppressWarnings("unchecked")  /* Expected according to the `fn` setup. */
+        @Nullable SchemaFn<M, C> fn = (SchemaFn<M, C>) schema.enrichmentOf(cls);
         if (fn == null) {
             return Optional.empty();
         }
 
-        @SuppressWarnings("unchecked")
-        Enrichment enrichment = fn.apply(message, context);
+        var enrichment = fn.apply(message, context);
         return Optional.of(enrichment);
     }
 }

--- a/server/src/main/java/io/spine/server/enrich/EnricherBuilder.java
+++ b/server/src/main/java/io/spine/server/enrich/EnricherBuilder.java
@@ -204,8 +204,10 @@ public abstract class EnricherBuilder<M extends Message,
                 return false;
             }
             final var other = (Key) obj;
-            return Objects.equals(this.sourceClass, other.sourceClass)
-                    && Objects.equals(this.enrichmentClass, other.enrichmentClass);
+            return Objects.equals(this.sourceClass.getName(),
+                                  other.sourceClass.getName())
+                    && Objects.equals(this.enrichmentClass.getName(),
+                                      other.enrichmentClass.getName());
         }
     }
 }

--- a/server/src/main/java/io/spine/server/enrich/EnricherBuilder.java
+++ b/server/src/main/java/io/spine/server/enrich/EnricherBuilder.java
@@ -27,7 +27,6 @@
 package io.spine.server.enrich;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
 import com.google.protobuf.Message;
 import io.spine.core.EnrichableMessageContext;
@@ -85,7 +84,7 @@ public abstract class EnricherBuilder<M extends Message,
                       " implements this interface.",
                       enrichmentClass.getCanonicalName());
         checkNotNull(func);
-        Key key = new Key(messageClassOrInterface, enrichmentClass);
+        var key = new Key(messageClassOrInterface, enrichmentClass);
         checkDirectDuplication(key);
         checkInterfaceDuplication(key);
         checkImplDuplication(key);
@@ -108,11 +107,11 @@ public abstract class EnricherBuilder<M extends Message,
     }
 
     private void checkInterfaceDuplication(Key key) {
-        Class<? extends Message> sourceClass = key.sourceClass();
-        Class<? extends Message> enrichmentClass = key.enrichmentClass();
-        ImmutableSet<Class<? extends Message>> interfaces = interfacesOf(sourceClass);
+        var sourceClass = key.sourceClass();
+        var enrichmentClass = key.enrichmentClass();
+        var interfaces = interfacesOf(sourceClass);
         interfaces.forEach(i -> {
-            Key keyByInterface = new Key(i, enrichmentClass);
+            var keyByInterface = new Key(i, enrichmentClass);
             checkArgument(
                     !functions.containsKey(keyByInterface),
                     "The builder already has the function which creates enrichments of the class" +
@@ -126,11 +125,11 @@ public abstract class EnricherBuilder<M extends Message,
     }
 
     private void checkImplDuplication(Key key) {
-        Class<? extends Message> sourceInterface = key.sourceClass();
-        Class<? extends Message> enrichmentClass = key.enrichmentClass();
+        var sourceInterface = key.sourceClass();
+        var enrichmentClass = key.enrichmentClass();
         functions.forEach((k, v) -> {
-            Class<? extends Message> entrySourceCls = k.sourceClass();
-            Class<? extends Message> entryEnrichmentCls = k.enrichmentClass();
+            var entrySourceCls = k.sourceClass();
+            var entryEnrichmentCls = k.enrichmentClass();
             checkArgument(
                     !sourceInterface.isAssignableFrom(entrySourceCls)
                     || !enrichmentClass.equals(entryEnrichmentCls),
@@ -157,7 +156,7 @@ public abstract class EnricherBuilder<M extends Message,
     }
 
     /** Creates a new {@code Enricher}. */
-    public abstract Enricher build();
+    public abstract Enricher<M, C> build();
 
     /**
      * Obtains functions added to the builder by the time of the call.
@@ -204,7 +203,7 @@ public abstract class EnricherBuilder<M extends Message,
             if (!(obj instanceof Key)) {
                 return false;
             }
-            final Key other = (Key) obj;
+            final var other = (Key) obj;
             return Objects.equals(this.sourceClass, other.sourceClass)
                     && Objects.equals(this.enrichmentClass, other.enrichmentClass);
         }

--- a/server/src/main/java/io/spine/server/enrich/Schema.java
+++ b/server/src/main/java/io/spine/server/enrich/Schema.java
@@ -55,8 +55,8 @@ final class Schema<M extends Message, C extends EnrichableMessageContext> implem
 
     static <M extends Message, C extends EnrichableMessageContext>
     Schema<M, C> newInstance(EnricherBuilder<? extends M, C, ?> eBuilder) {
-        Factory<M, C> factory = new Factory<>(eBuilder);
-        Schema<M, C> result = factory.create();
+        var factory = new Factory<M, C>(eBuilder);
+        var result = factory.create();
         return result;
     }
 
@@ -71,7 +71,7 @@ final class Schema<M extends Message, C extends EnrichableMessageContext> implem
     }
 
     @Nullable SchemaFn<? extends M, C> enrichmentOf(Class<? extends M> cls) {
-        SchemaFn<? extends M, C> fn = map.get(cls);
+        var fn = map.get(cls);
         return fn;
     }
 
@@ -111,8 +111,8 @@ final class Schema<M extends Message, C extends EnrichableMessageContext> implem
         }
 
         private Schema<M, C> create() {
-            for (Class<? extends M> sourceType : sourceTypes) {
-                SchemaFn<? extends M, C> fn = createFn(sourceType);
+            for (var sourceType : sourceTypes) {
+                var fn = createFn(sourceType);
                 schemaMap.put(sourceType, fn);
             }
 

--- a/server/src/main/java/io/spine/server/enrich/SchemaFn.java
+++ b/server/src/main/java/io/spine/server/enrich/SchemaFn.java
@@ -35,6 +35,7 @@ import io.spine.type.TypeName;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -85,9 +86,8 @@ abstract class SchemaFn<M extends Message, C extends EnrichableMessageContext>
                      EnrichmentFn<?, ?, ?> function) {
         requireNonNull(
                 output,
-                String.format(
-                        "`%s` produced `null` for the source message `%s` (context: `%s`).",
-                        function, sourceMessage, context)
+                format("`%s` produced `null` for the source message `%s` (context: `%s`).",
+                       function, sourceMessage, context)
         );
     }
 }

--- a/server/src/main/java/io/spine/server/enrich/SchemaFn.java
+++ b/server/src/main/java/io/spine/server/enrich/SchemaFn.java
@@ -35,6 +35,7 @@ import io.spine.type.TypeName;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Abstract base for functions that produce {@link Enrichment} by applying aggregated enrichment
@@ -52,10 +53,9 @@ abstract class SchemaFn<M extends Message, C extends EnrichableMessageContext>
     public Enrichment apply(M m, C c) {
         checkNotNull(m);
         checkNotNull(c);
-        Container.Builder container = Container.newBuilder();
+        var container = Container.newBuilder();
         applyAndPut(container, m, c);
-        Enrichment result = Enrichment
-                .newBuilder()
+        var result = Enrichment.newBuilder()
                 .setContainer(container)
                 .build();
         return result;
@@ -71,8 +71,7 @@ abstract class SchemaFn<M extends Message, C extends EnrichableMessageContext>
      */
     @SuppressWarnings("CheckReturnValue") // calling builder method.
     static void put(Container.Builder container, Message output) {
-        String typeName = TypeName.of(output)
-                                  .value();
+        var typeName = TypeName.of(output).value();
         container.putItems(typeName, AnyPacker.pack(output));
     }
 
@@ -83,11 +82,12 @@ abstract class SchemaFn<M extends Message, C extends EnrichableMessageContext>
     void checkResult(@Nullable Message output,
                      Message sourceMessage,
                      EnrichableMessageContext context,
-                     EnrichmentFn function) {
-        checkNotNull(
+                     EnrichmentFn<?, ?, ?> function) {
+        requireNonNull(
                 output,
-                "`%s` produced `null` for the source message `%s` (context: `%s`).",
-                function, sourceMessage, context
+                String.format(
+                        "`%s` produced `null` for the source message `%s` (context: `%s`).",
+                        function, sourceMessage, context)
         );
     }
 }

--- a/server/src/main/java/io/spine/server/enrich/SingularFn.java
+++ b/server/src/main/java/io/spine/server/enrich/SingularFn.java
@@ -57,7 +57,7 @@ final class SingularFn<M extends Message, C extends EnrichableMessageContext>
 
     @Override
     void applyAndPut(Container.Builder container, M m, C c) {
-        Message output = function.apply(m, c);
+        var output = function.apply(m, c);
         checkResult(output, m, c, function);
         put(container, output);
     }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@ val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.74")
 val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.76")
 
 /** The version of this library. */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.82")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.83")


### PR DESCRIPTION
This PR is the follow-up to #1425.

The main focus is the `var` introduction to the part of `server` module packages.

Some of the existing warnings were addressed as well.

The library version is set to `2.0.0-SNAPSHOT.83`.
