### PR TITLE
Migrate to JDK 11 and Java 11 syntax [part 3]

### DIFF
--- a/server/src/main/java/io/spine/server/entity/AbstractEntity.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractEntity.java
@@ -32,7 +32,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.flogger.FluentLogger;
 import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import com.google.errorprone.annotations.concurrent.LazyInit;
-import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
 import io.spine.annotation.Internal;
@@ -190,7 +189,7 @@ public abstract class AbstractEntity<I, S extends EntityState<I>>
      */
     @Override
     public final S state() {
-        S result = state;
+        var result = state;
         if (result == null) {
             synchronized (this) {
                 result = state;
@@ -208,7 +207,7 @@ public abstract class AbstractEntity<I, S extends EntityState<I>>
      */
     @Internal
     protected EntityClass<?> thisClass() {
-        EntityClass<?> result = thisClass;
+        var result = thisClass;
         if (result == null) {
             synchronized (this) {
                 result = thisClass;
@@ -243,7 +242,7 @@ public abstract class AbstractEntity<I, S extends EntityState<I>>
     protected final S defaultState() {
         @SuppressWarnings("unchecked")
         // cast is safe because this type of messages is saved to the map
-        S result = (S) thisClass().defaultState();
+        var result = (S) thisClass().defaultState();
         return result;
     }
 
@@ -291,7 +290,7 @@ public abstract class AbstractEntity<I, S extends EntityState<I>>
      * @see #checkEntityState(EntityState)
      */
     private void validate(S newState) throws InvalidEntityStateException {
-        List<ConstraintViolation> violations = checkEntityState(newState);
+        var violations = checkEntityState(newState);
         if (!violations.isEmpty()) {
             throw InvalidEntityStateException.onConstraintViolations(newState, violations);
         }
@@ -307,7 +306,7 @@ public abstract class AbstractEntity<I, S extends EntityState<I>>
      */
     @Override
     public String idAsString() {
-        String result = stringId;
+        var result = stringId;
         if (result == null) {
             synchronized (this) {
                 result = stringId;
@@ -339,7 +338,7 @@ public abstract class AbstractEntity<I, S extends EntityState<I>>
 
     @Override
     public LifecycleFlags getLifecycleFlags() {
-        LifecycleFlags result = this.lifecycleFlags == null
+        var result = this.lifecycleFlags == null
                                 ? LifecycleFlags.getDefaultInstance()
                                 : this.lifecycleFlags;
         return result;
@@ -393,7 +392,7 @@ public abstract class AbstractEntity<I, S extends EntityState<I>>
      */
     protected void checkNotArchived() throws CannotModifyArchivedEntity {
         if (lifecycleFlags().getArchived()) {
-            Any packedId = Identifier.pack(id());
+            var packedId = Identifier.pack(id());
             throw CannotModifyArchivedEntity
                     .newBuilder()
                     .setEntityId(packedId)
@@ -411,7 +410,7 @@ public abstract class AbstractEntity<I, S extends EntityState<I>>
      */
     protected void checkNotDeleted() throws CannotModifyDeletedEntity {
         if (lifecycleFlags().getDeleted()) {
-            Any packedId = Identifier.pack(id());
+            var packedId = Identifier.pack(id());
             throw CannotModifyDeletedEntity.newBuilder()
                     .setEntityId(packedId)
                     .build();
@@ -457,7 +456,7 @@ public abstract class AbstractEntity<I, S extends EntityState<I>>
      * Obtains the version number of the entity.
      */
     protected int versionNumber() {
-        int result = version().getNumber();
+        var result = version().getNumber();
         return result;
     }
 
@@ -467,8 +466,8 @@ public abstract class AbstractEntity<I, S extends EntityState<I>>
         if (version.equals(newVersion)) {
             return;
         }
-        int currentVersionNumber = versionNumber();
-        int newVersionNumber = newVersion.getNumber();
+        var currentVersionNumber = versionNumber();
+        var newVersionNumber = newVersion.getNumber();
         if (currentVersionNumber > newVersionNumber) {
             throw newIllegalArgumentException(
                     "A version with the lower number (%d) passed to `updateVersion()` " +
@@ -535,7 +534,7 @@ public abstract class AbstractEntity<I, S extends EntityState<I>>
     @Override
     public void beforeInvoke(HandlerMethod<?, ?, ?, ?> method) {
         checkNotNull(method);
-        FluentLogger logger = loggerFor(getClass());
+        var logger = loggerFor(getClass());
         this.handlerLog = new HandlerLog(logger, method);
     }
 
@@ -575,7 +574,7 @@ public abstract class AbstractEntity<I, S extends EntityState<I>>
         if (!(o instanceof AbstractEntity)) {
             return false;
         }
-        AbstractEntity<?, ?> that = (AbstractEntity<?, ?>) o;
+        var that = (AbstractEntity<?, ?>) o;
         return Objects.equals(id(), that.id()) &&
                 Objects.equals(state(), that.state()) &&
                 Objects.equals(version(), that.version()) &&

--- a/server/src/main/java/io/spine/server/entity/BatchDispatch.java
+++ b/server/src/main/java/io/spine/server/entity/BatchDispatch.java
@@ -56,18 +56,16 @@ final class BatchDispatch {
      */
     void play(Event event) {
         if (successful) {
-            EventEnvelope eventEnvelope = EventEnvelope.of(event);
-            DispatchOutcome outcome = transaction.play(eventEnvelope);
+            var eventEnvelope = EventEnvelope.of(event);
+            var outcome = transaction.play(eventEnvelope);
             propagation.addOutcome(outcome);
             successful = !outcome.hasError();
             lastMessage = event.messageId();
         } else {
-            Interruption interruption = Interruption
-                    .newBuilder()
+            var interruption = Interruption.newBuilder()
                     .setStoppedAt(lastMessage)
                     .buildPartial();
-            DispatchOutcome outcome = DispatchOutcome
-                    .newBuilder()
+            var outcome = DispatchOutcome.newBuilder()
                     .setPropagatedSignal(event.messageId())
                     .setInterrupted(interruption)
                     .vBuild();

--- a/server/src/main/java/io/spine/server/entity/CompositeEventFilter.java
+++ b/server/src/main/java/io/spine/server/entity/CompositeEventFilter.java
@@ -52,9 +52,9 @@ public final class CompositeEventFilter implements EventFilter {
     @Override
     public Optional<? extends EventMessage> filter(EventMessage event) {
         Optional<? extends EventMessage> result = Optional.of(event);
-        for (EventFilter filter : filters) {
+        for (var filter : filters) {
             result = filter.filter(result.get());
-            if (!result.isPresent()) {
+            if (result.isEmpty()) {
                 return Optional.empty();
             }
         }

--- a/server/src/main/java/io/spine/server/entity/DefaultConverter.java
+++ b/server/src/main/java/io/spine/server/entity/DefaultConverter.java
@@ -48,14 +48,14 @@ final class DefaultConverter<I, E extends AbstractEntity<I, S>, S extends Entity
 
     static <I, E extends AbstractEntity<I, S>, S extends EntityState<I>>
     StorageConverter<I, E, S> forAllFields(TypeUrl stateType, EntityFactory<E> factory) {
-        FieldMask allFields = FieldMask.getDefaultInstance();
+        var allFields = FieldMask.getDefaultInstance();
         return new DefaultConverter<>(stateType, factory, allFields);
     }
 
     @Override
     public StorageConverter<I, E, S> withFieldMask(FieldMask fieldMask) {
-        TypeUrl stateType = entityStateType();
-        EntityFactory<E> factory = entityFactory();
+        var stateType = entityStateType();
+        var factory = entityFactory();
         return new DefaultConverter<>(stateType, factory, fieldMask);
     }
 

--- a/server/src/main/java/io/spine/server/entity/DefaultRecordBasedRepository.java
+++ b/server/src/main/java/io/spine/server/entity/DefaultRecordBasedRepository.java
@@ -30,8 +30,6 @@ import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import io.spine.base.EntityState;
 import io.spine.server.BoundedContext;
-import io.spine.server.entity.model.EntityClass;
-import io.spine.type.TypeUrl;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 /**
@@ -70,8 +68,8 @@ public abstract class DefaultRecordBasedRepository<I,
     @Override
     protected final StorageConverter<I, E, S> storageConverter() {
         if (storageConverter == null) {
-            EntityClass<E> entityClass = entityModelClass();
-            TypeUrl stateType = entityClass.stateTypeUrl();
+            var entityClass = entityModelClass();
+            var stateType = entityClass.stateTypeUrl();
             storageConverter = DefaultConverter.forAllFields(stateType, entityFactory());
         }
         return storageConverter;
@@ -89,6 +87,6 @@ public abstract class DefaultRecordBasedRepository<I,
     public void registerWith(BoundedContext context) {
         super.registerWith(context);
         @SuppressWarnings("unused") // Trigger the method to initialize the converter.
-        StorageConverter<I, E, S> unused = storageConverter();
+        var unused = storageConverter();
     }
 }

--- a/server/src/main/java/io/spine/server/entity/EntityLifecycle.java
+++ b/server/src/main/java/io/spine/server/entity/EntityLifecycle.java
@@ -29,7 +29,6 @@ package io.spine.server.entity;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import com.google.protobuf.Any;
 import io.spine.annotation.Internal;
 import io.spine.base.Error;
 import io.spine.base.EventMessage;
@@ -49,7 +48,6 @@ import io.spine.server.Identity;
 import io.spine.server.delivery.CatchUpId;
 import io.spine.server.delivery.event.EntityPreparedForCatchUp;
 import io.spine.server.dispatch.BatchDispatchOutcome;
-import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.entity.model.EntityClass;
 import io.spine.server.type.CommandEnvelope;
 import io.spine.server.type.EventEnvelope;
@@ -80,7 +78,6 @@ import io.spine.type.TypeUrl;
 import io.spine.validate.ValidationError;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -157,8 +154,7 @@ public class EntityLifecycle {
      *         the kind of the created entity
      */
     public final void onEntityCreated(EntityOption.Kind entityKind) {
-        EntityCreated event = EntityCreated
-                .newBuilder()
+        var event = EntityCreated.newBuilder()
                 .setEntity(entityId)
                 .setKind(entityKind)
                 .vBuild();
@@ -173,17 +169,14 @@ public class EntityLifecycle {
      *         the ID of the command which should be handled by the entity
      */
     public final void onTargetAssignedToCommand(CommandId commandId) {
-        EntityId entityId = EntityId
-                .newBuilder()
+        var entityId = EntityId.newBuilder()
                 .setId(this.entityId.getId())
                 .buildPartial();
-        CommandTarget target = CommandTarget
-                .newBuilder()
+        var target = CommandTarget.newBuilder()
                 .setEntityId(entityId)
                 .setTypeUrl(this.entityId.getTypeUrl())
                 .vBuild();
-        TargetAssignedToCommand event = TargetAssignedToCommand
-                .newBuilder()
+        var event = TargetAssignedToCommand.newBuilder()
                 .setId(commandId)
                 .setTarget(target)
                 .vBuild();
@@ -197,14 +190,13 @@ public class EntityLifecycle {
      *         the dispatched command
      */
     public final void onDispatchCommand(Command command) {
-        CommandDispatchedToHandler systemCommand = CommandDispatchedToHandler
-                .newBuilder()
+        var systemCommand = CommandDispatchedToHandler.newBuilder()
                 .setReceiver(entityId)
                 .setPayload(command)
                 .setWhenDispatched(currentTime())
                 .setEntityType(typeName)
                 .vBuild();
-        Origin systemEventOrigin = command.asMessageOrigin();
+        var systemEventOrigin = command.asMessageOrigin();
         postEvent(systemCommand, systemEventOrigin);
     }
 
@@ -215,11 +207,10 @@ public class EntityLifecycle {
      *         the handled command
      */
     public final void onCommandHandled(Command command) {
-        CommandHandled systemEvent = CommandHandled
-                .newBuilder()
+        var systemEvent = CommandHandled.newBuilder()
                 .setId(command.getId())
                 .vBuild();
-        Origin systemEventOrigin = command.asMessageOrigin();
+        var systemEventOrigin = command.asMessageOrigin();
         postEvent(systemEvent, systemEventOrigin);
     }
 
@@ -232,12 +223,11 @@ public class EntityLifecycle {
      *         the rejection event
      */
     public final void onCommandRejected(CommandId commandId, Event rejection) {
-        CommandRejected systemEvent = CommandRejected
-                .newBuilder()
+        var systemEvent = CommandRejected.newBuilder()
                 .setId(commandId)
                 .setRejectionEvent(rejection)
                 .vBuild();
-        Origin origin = rejection.asMessageOrigin();
+        var origin = rejection.asMessageOrigin();
         postEvent(systemEvent, origin);
     }
 
@@ -248,26 +238,24 @@ public class EntityLifecycle {
      *         the dispatched event
      */
     public final void onDispatchEventToSubscriber(Event event) {
-        EventDispatchedToSubscriber systemCommand = EventDispatchedToSubscriber
-                .newBuilder()
+        var systemCommand = EventDispatchedToSubscriber.newBuilder()
                 .setReceiver(entityId)
                 .setPayload(event)
                 .setWhenDispatched(currentTime())
                 .setEntityType(typeName)
                 .vBuild();
-        Origin origin = event.asMessageOrigin();
+        var origin = event.asMessageOrigin();
         postEvent(systemCommand, origin);
     }
 
     public final void onEventImported(Event event) {
-        EventImported systemEvent = EventImported
-                .newBuilder()
+        var systemEvent = EventImported.newBuilder()
                 .setReceiver(entityId)
                 .setPayload(event)
                 .setWhenImported(currentTime())
                 .setEntityType(typeName)
                 .vBuild();
-        Origin systemEventOrigin = event.asMessageOrigin();
+        var systemEventOrigin = event.asMessageOrigin();
         postEvent(systemEvent, systemEventOrigin);
     }
 
@@ -278,14 +266,13 @@ public class EntityLifecycle {
      *         the dispatched event
      */
     public final void onDispatchEventToReactor(Event event) {
-        EventDispatchedToReactor systemCommand = EventDispatchedToReactor
-                .newBuilder()
+        var systemCommand = EventDispatchedToReactor.newBuilder()
                 .setReceiver(entityId)
                 .setPayload(event)
                 .setWhenDispatched(currentTime())
                 .setEntityType(typeName)
                 .vBuild();
-        Origin origin = event.asMessageOrigin();
+        var origin = event.asMessageOrigin();
         postEvent(systemCommand, origin);
     }
 
@@ -320,8 +307,7 @@ public class EntityLifecycle {
      *         the IDs of handled messages that caused the deletion
      */
     public final void onRemovedFromStorage(Iterable<MessageId> signalIds) {
-        EntityDeleted event = EntityDeleted
-                .newBuilder()
+        var event = EntityDeleted.newBuilder()
                 .setEntity(entityId)
                 .addAllSignalId(ImmutableList.copyOf(signalIds))
                 .setRemovedFromStorage(true)
@@ -336,8 +322,7 @@ public class EntityLifecycle {
      *         {@link #eventFilter}
      */
     public final Optional<Event> onMigrationApplied() {
-        MigrationApplied systemEvent = MigrationApplied
-                .newBuilder()
+        var systemEvent = MigrationApplied.newBuilder()
                 .setEntity(entityId)
                 .setWhen(currentTime())
                 .build();
@@ -360,9 +345,8 @@ public class EntityLifecycle {
                                       MessageId root,
                                       ValidationError error,
                                       Version version) {
-        MessageId withNewVersion = entityId.withVersion(version);
-        ConstraintViolated event = ConstraintViolated
-                .newBuilder()
+        var withNewVersion = entityId.withVersion(version);
+        var event = ConstraintViolated.newBuilder()
                 .setEntity(withNewVersion)
                 .setLastMessage(lastMessage)
                 .setRootMessage(root)
@@ -385,7 +369,7 @@ public class EntityLifecycle {
     public final void onDispatchingFailed(SignalEnvelope<?, ?, ?> signal, Error error) {
         checkNotNull(signal);
         checkNotNull(error);
-        boolean duplicate = postIfDuplicate(signal, error);
+        var duplicate = postIfDuplicate(signal, error);
         if (!duplicate) {
             postHandlerFailed(signal.messageId(), error);
         }
@@ -394,8 +378,7 @@ public class EntityLifecycle {
     public void onDuplicateEvent(EventEnvelope event) {
         checkNotNull(event);
         @SuppressWarnings("deprecation") // Set the deprecated field for compatibility.
-        CannotDispatchDuplicateEvent systemEvent = CannotDispatchDuplicateEvent
-                .newBuilder()
+        var systemEvent = CannotDispatchDuplicateEvent.newBuilder()
                 .setEntity(entityId)
                 .setEvent(event.id())
                 .setDuplicateEvent(event.messageId())
@@ -410,9 +393,8 @@ public class EntityLifecycle {
      *         the ID of the catch-up process
      */
     public void onEntityPreparedForCatchUp(CatchUpId catchUpId) {
-        Any packedId = Identifier.pack(entityId);
-        EntityPreparedForCatchUp event =
-                EntityPreparedForCatchUp.newBuilder()
+        var packedId = Identifier.pack(entityId);
+        var event = EntityPreparedForCatchUp.newBuilder()
                         .setId(catchUpId)
                         .setInstanceId(packedId)
                         .vBuild();
@@ -422,8 +404,7 @@ public class EntityLifecycle {
     public void onDuplicateCommand(CommandEnvelope command) {
         checkNotNull(command);
         @SuppressWarnings("deprecation") // Set the deprecated field for compatibility.
-        CannotDispatchDuplicateCommand systemEvent = CannotDispatchDuplicateCommand
-                .newBuilder()
+        var systemEvent = CannotDispatchDuplicateCommand.newBuilder()
                 .setEntity(entityId)
                 .setCommand(command.id())
                 .setDuplicateCommand(command.messageId())
@@ -432,12 +413,12 @@ public class EntityLifecycle {
     }
 
     public void onCorruptedState(BatchDispatchOutcome outcome) {
-        List<DispatchOutcome> outcomes = outcome.getOutcomeList();
-        MessageId lastSuccessful = MessageId.getDefaultInstance();
+        var outcomes = outcome.getOutcomeList();
+        var lastSuccessful = MessageId.getDefaultInstance();
         MessageId erroneous = null;
         Error error = null;
-        int interruptedCount = 0;
-        for (DispatchOutcome dispatchOutcome : outcomes) {
+        var interruptedCount = 0;
+        for (var dispatchOutcome : outcomes) {
             if (dispatchOutcome.hasSuccess()) {
                 lastSuccessful = dispatchOutcome.getPropagatedSignal();
             } else if (dispatchOutcome.hasError()) {
@@ -453,8 +434,7 @@ public class EntityLifecycle {
         if (erroneous == null) {
             erroneous = MessageId.getDefaultInstance();
         }
-        AggregateHistoryCorrupted event = AggregateHistoryCorrupted
-                .newBuilder()
+        var event = AggregateHistoryCorrupted.newBuilder()
                 .setEntity(entityId)
                 .setEntityType(typeName)
                 .setLastSuccessfulEvent(lastSuccessful)
@@ -468,15 +448,14 @@ public class EntityLifecycle {
     private void postIfChanged(EntityRecordChange change,
                                Collection<? extends MessageId> messageIds,
                                Origin origin) {
-        Any oldState = change.getPreviousValue()
+        var oldState = change.getPreviousValue()
                              .getState();
-        Any newState = change.getNewValue()
+        var newState = change.getNewValue()
                              .getState();
         if (!oldState.equals(newState)) {
-            Version newVersion = change.getNewValue()
-                                       .getVersion();
-            EntityStateChanged event = EntityStateChanged
-                    .newBuilder()
+            var newVersion = change.getNewValue()
+                                   .getVersion();
+            var event = EntityStateChanged.newBuilder()
                     .setEntity(entityId)
                     .setOldState(oldState)
                     .setNewState(newState)
@@ -489,17 +468,16 @@ public class EntityLifecycle {
 
     private void postIfArchived(EntityRecordChange change,
                                 Collection<? extends MessageId> messageIds) {
-        boolean oldValue = change.getPreviousValue()
-                                 .getLifecycleFlags()
-                                 .getArchived();
-        boolean newValue = change.getNewValue()
-                                 .getLifecycleFlags()
-                                 .getArchived();
+        var oldValue = change.getPreviousValue()
+                             .getLifecycleFlags()
+                             .getArchived();
+        var newValue = change.getNewValue()
+                             .getLifecycleFlags()
+                             .getArchived();
         if (newValue && !oldValue) {
-            Version version = change.getNewValue()
-                                    .getVersion();
-            EntityArchived event = EntityArchived
-                    .newBuilder()
+            var version = change.getNewValue()
+                                .getVersion();
+            var event = EntityArchived.newBuilder()
                     .setEntity(entityId)
                     .addAllSignalId(ImmutableList.copyOf(messageIds))
                     .setVersion(version)
@@ -510,17 +488,16 @@ public class EntityLifecycle {
 
     private void postIfDeleted(EntityRecordChange change,
                                Collection<? extends MessageId> messageIds) {
-        boolean oldValue = change.getPreviousValue()
-                                 .getLifecycleFlags()
-                                 .getDeleted();
-        boolean newValue = change.getNewValue()
-                                 .getLifecycleFlags()
-                                 .getDeleted();
+        var oldValue = change.getPreviousValue()
+                             .getLifecycleFlags()
+                             .getDeleted();
+        var newValue = change.getNewValue()
+                             .getLifecycleFlags()
+                             .getDeleted();
         if (newValue && !oldValue) {
-            Version version = change.getNewValue()
-                                    .getVersion();
-            EntityDeleted event = EntityDeleted
-                    .newBuilder()
+            var version = change.getNewValue()
+                                .getVersion();
+            var event = EntityDeleted.newBuilder()
                     .setEntity(entityId)
                     .addAllSignalId(ImmutableList.copyOf(messageIds))
                     .setVersion(version)
@@ -532,17 +509,16 @@ public class EntityLifecycle {
 
     private void postIfExtracted(EntityRecordChange change,
                                  Collection<? extends MessageId> messageIds) {
-        boolean oldValue = change.getPreviousValue()
-                                 .getLifecycleFlags()
-                                 .getArchived();
-        boolean newValue = change.getNewValue()
-                                 .getLifecycleFlags()
-                                 .getArchived();
+        var oldValue = change.getPreviousValue()
+                             .getLifecycleFlags()
+                             .getArchived();
+        var newValue = change.getNewValue()
+                             .getLifecycleFlags()
+                             .getArchived();
         if (!newValue && oldValue) {
-            Version version = change.getNewValue()
-                                    .getVersion();
-            EntityUnarchived event = EntityUnarchived
-                    .newBuilder()
+            var version = change.getNewValue()
+                                .getVersion();
+            var event = EntityUnarchived.newBuilder()
                     .setEntity(entityId)
                     .addAllSignalId(ImmutableList.copyOf(messageIds))
                     .setVersion(version)
@@ -553,17 +529,16 @@ public class EntityLifecycle {
 
     private void postIfRestored(EntityRecordChange change,
                                 Collection<? extends MessageId> messageIds) {
-        boolean oldValue = change.getPreviousValue()
-                                 .getLifecycleFlags()
-                                 .getDeleted();
-        boolean newValue = change.getNewValue()
-                                 .getLifecycleFlags()
-                                 .getDeleted();
+        var oldValue = change.getPreviousValue()
+                             .getLifecycleFlags()
+                             .getDeleted();
+        var newValue = change.getNewValue()
+                             .getLifecycleFlags()
+                             .getDeleted();
         if (!newValue && oldValue) {
-            Version version = change.getNewValue()
-                                    .getVersion();
-            EntityRestored event = EntityRestored
-                    .newBuilder()
+            var version = change.getNewValue()
+                                .getVersion();
+            var event = EntityRestored.newBuilder()
                     .setEntity(entityId)
                     .addAllSignalId(ImmutableList.copyOf(messageIds))
                     .setVersion(version)
@@ -578,34 +553,33 @@ public class EntityLifecycle {
     }
 
     private boolean postIfDuplicateCommand(SignalEnvelope<?, ?, ?> handledSignal, Error error) {
-        String errorType = error.getType();
-        int errorCode = error.getCode();
-        boolean duplicateCommand =
+        var errorType = error.getType();
+        var errorCode = error.getCode();
+        var duplicateCommand =
                 errorType.equals(CommandValidationError.class.getSimpleName())
                         && errorCode == DUPLICATE_COMMAND_VALUE;
         if (duplicateCommand) {
-            CommandEnvelope asCommand = (CommandEnvelope) handledSignal;
+            var asCommand = (CommandEnvelope) handledSignal;
             onDuplicateCommand(asCommand);
         }
         return duplicateCommand;
     }
 
     private boolean postIfDuplicateEvent(SignalEnvelope<?, ?, ?> handledSignal, Error error) {
-        String errorType = error.getType();
-        int errorCode = error.getCode();
-        boolean duplicateEvent =
+        var errorType = error.getType();
+        var errorCode = error.getCode();
+        var duplicateEvent =
                 errorType.equals(EventValidationError.class.getSimpleName())
                         && errorCode == DUPLICATE_EVENT_VALUE;
         if (duplicateEvent) {
-            EventEnvelope asEvent = (EventEnvelope) handledSignal;
+            var asEvent = (EventEnvelope) handledSignal;
             onDuplicateEvent(asEvent);
         }
         return duplicateEvent;
     }
 
     private void postHandlerFailed(MessageId handledSignal, Error error) {
-        HandlerFailedUnexpectedly systemEvent = HandlerFailedUnexpectedly
-                .newBuilder()
+        var systemEvent = HandlerFailedUnexpectedly.newBuilder()
                 .setEntity(entityId)
                 .setHandledSignal(handledSignal)
                 .setError(error)
@@ -625,8 +599,8 @@ public class EntityLifecycle {
      */
     @CanIgnoreReturnValue
     protected Optional<Event> postEvent(EventMessage event, Origin explicitOrigin) {
-        Optional<? extends EventMessage> filtered = eventFilter.filter(event);
-        Optional<Event> result =
+        var filtered = eventFilter.filter(event);
+        var result =
                 filtered.map(systemEvent -> systemWriteSide.postEvent(systemEvent, explicitOrigin));
         return result;
     }
@@ -641,8 +615,8 @@ public class EntityLifecycle {
      */
     @CanIgnoreReturnValue
     protected Optional<Event> postEvent(EventMessage event) {
-        Optional<? extends EventMessage> filtered = eventFilter.filter(event);
-        Optional<Event> result = filtered.map(systemWriteSide::postEvent);
+        var filtered = eventFilter.filter(event);
+        var result = filtered.map(systemWriteSide::postEvent);
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/entity/EntityLifecycleMonitor.java
+++ b/server/src/main/java/io/spine/server/entity/EntityLifecycleMonitor.java
@@ -35,7 +35,6 @@ import io.spine.core.MessageId;
 import io.spine.core.Signal;
 import io.spine.logging.Logging;
 import io.spine.validate.NonValidated;
-import io.spine.validate.ValidationError;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import java.util.List;
@@ -100,7 +99,7 @@ public final class EntityLifecycleMonitor<I> implements TransactionListener<I>, 
      */
     static <I> EntityLifecycleMonitor<I>
     withAcknowledgedMessage(Repository<I, ?> repository, I id, Signal<?, ?, ?> message) {
-        EntityLifecycleMonitor<I> monitor = newInstance(repository, id);
+        var monitor = newInstance(repository, id);
         monitor.lastMessage = message;
         monitor.acknowledgedMessages.add(message.messageId());
         return monitor;
@@ -125,8 +124,7 @@ public final class EntityLifecycleMonitor<I> implements TransactionListener<I>, 
     @Override
     public void onAfterPhase(Phase<I> phase) {
         checkSameEntity(phase.entityId());
-        MessageId messageId = phase.signal()
-                                   .messageId();
+        var messageId = phase.signal().messageId();
         acknowledgedMessages.add(messageId);
     }
 
@@ -159,10 +157,10 @@ public final class EntityLifecycleMonitor<I> implements TransactionListener<I>, 
     @Override
     public void onTransactionFailed(Error cause, EntityRecord entityRecord) {
         if (cause.hasValidationError()) {
-            ValidationError error = cause.getValidationError();
+            var error = cause.getValidationError();
             checkState(lastMessage != null, "Transaction failed but no messages were propagated.");
-            MessageId causeMessage = lastMessage.messageId();
-            MessageId rootMessage = lastMessage.rootMessage();
+            var causeMessage = lastMessage.messageId();
+            var rootMessage = lastMessage.rootMessage();
             repository.lifecycleOf(entityId)
                       .onInvalidEntity(causeMessage,
                                        rootMessage,

--- a/server/src/main/java/io/spine/server/entity/EntityMessageEndpoint.java
+++ b/server/src/main/java/io/spine/server/entity/EntityMessageEndpoint.java
@@ -75,7 +75,7 @@ public abstract class EntityMessageEndpoint<I,
      * @param entity the entity to store
      */
     protected final void store(E entity) {
-        boolean isModified = isModified(entity);
+        var isModified = isModified(entity);
         if (isModified) {
             onModified(entity);
         } else {

--- a/server/src/main/java/io/spine/server/entity/EntityStateChangedFilter.java
+++ b/server/src/main/java/io/spine/server/entity/EntityStateChangedFilter.java
@@ -58,8 +58,7 @@ final class EntityStateChangedFilter implements EventFilter {
      */
     static EntityStateChangedFilter forType(EntityClass<?> entityClass) {
         checkNotNull(entityClass);
-        boolean allowUpdates = entityClass.visibility()
-                                          .isNotNone();
+        var allowUpdates = entityClass.visibility().isNotNone();
         return new EntityStateChangedFilter(allowUpdates);
     }
 

--- a/server/src/main/java/io/spine/server/entity/EntityVisibility.java
+++ b/server/src/main/java/io/spine/server/entity/EntityVisibility.java
@@ -30,14 +30,10 @@ import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.ImmutableGraph;
 import com.google.common.graph.MutableGraph;
 import com.google.errorprone.annotations.Immutable;
-import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.GeneratedMessageV3;
 import io.spine.annotation.Internal;
 import io.spine.base.EntityState;
 import io.spine.code.proto.EntityStateOption;
-import io.spine.core.Event;
-import io.spine.option.EntityOption;
-import io.spine.option.EntityOption.Kind;
 import io.spine.option.EntityOption.Visibility;
 import io.spine.type.TypeName;
 
@@ -99,36 +95,27 @@ public final class EntityVisibility implements Serializable {
      * @param stateClass
      *         the entity state class
      * @return new instance
-     * @implNote The framework treats an {@code Event} as a state of a system {@code
-     *         EEntity}. Therefore, {@code Event.class} is one of the potential arguments passed
-     *         into this method.
-     *         We don't want to define {@code (entity)} option for the {@code Event} message,
-     *         therefore this method handles {@code Event.class} as a special case and returns
-     *         {@code NONE} visibility level for it.
      */
     public static Optional<EntityVisibility> of(Class<? extends EntityState<?>> stateClass) {
         checkNotNull(stateClass);
 
-        if (Event.class.equals(stateClass)) {
-            return Optional.of(new EntityVisibility(NONE));
-        }
         if (!GeneratedMessageV3.class.isAssignableFrom(stateClass)) {
             return Optional.empty();
         }
 
-        Descriptor descriptor = TypeName.of(stateClass)
-                                        .messageDescriptor();
-        Optional<EntityOption> option = EntityStateOption.valueOf(descriptor);
-        if(!option.isPresent()) {
+        var descriptor = TypeName.of(stateClass)
+                                 .messageDescriptor();
+        var option = EntityStateOption.valueOf(descriptor);
+        if(option.isEmpty()) {
             return Optional.empty();
         }
-        EntityOption entityOption = option.get();
-        Visibility visibility = entityOption.getVisibility();
+        var entityOption = option.get();
+        var visibility = entityOption.getVisibility();
         if (visibility == DEFAULT) {
-            Kind kind = entityOption.getKind();
+            var kind = entityOption.getKind();
             visibility = kind == PROJECTION ? FULL : NONE;
         }
-        EntityVisibility result = new EntityVisibility(visibility);
+        var result = new EntityVisibility(visibility);
         return Optional.of(result);
     }
 

--- a/server/src/main/java/io/spine/server/entity/EventBlackList.java
+++ b/server/src/main/java/io/spine/server/entity/EventBlackList.java
@@ -54,13 +54,13 @@ public final class EventBlackList implements EventFilter {
      */
     @SafeVarargs
     public static EventBlackList discardEvents(Class<? extends EventMessage>... eventClasses) {
-        ImmutableSet<EventClass> classes = EventClass.setOf(eventClasses);
+        var classes = EventClass.setOf(eventClasses);
         return new EventBlackList(classes);
     }
 
     @Override
     public Optional<? extends EventMessage> filter(EventMessage event) {
-        EventClass type = EventClass.of(event);
+        var type = EventClass.of(event);
         return forbiddenEvents.contains(type)
                ? Optional.empty()
                : Optional.of(event);

--- a/server/src/main/java/io/spine/server/entity/EventDispatchingRepository.java
+++ b/server/src/main/java/io/spine/server/entity/EventDispatchingRepository.java
@@ -116,8 +116,8 @@ public abstract class EventDispatchingRepository<I,
     }
 
     private void doDispatch(EventEnvelope event) {
-        Set<I> targets = route(event);
-        Event outerObject = event.outerObject();
+        var targets = route(event);
+        var outerObject = event.outerObject();
         targets.forEach(id -> dispatchTo(id, outerObject));
     }
 

--- a/server/src/main/java/io/spine/server/entity/EventFieldFilter.java
+++ b/server/src/main/java/io/spine/server/entity/EventFieldFilter.java
@@ -64,32 +64,32 @@ public final class EventFieldFilter implements EventFilter {
 
     @Override
     public Optional<? extends EventMessage> filter(EventMessage event) {
-        EventMessage masked = mask(event);
+        var masked = mask(event);
         return Optional.of(masked);
     }
 
     @Override
     public ImmutableCollection<Event> filter(Collection<Event> events) {
         return events.stream()
-                     .map(this::maskEvent)
-                     .collect(toImmutableList());
+                .map(this::maskEvent)
+                .collect(toImmutableList());
     }
 
     private Event maskEvent(Event event) {
-        EventMessage message = event.enclosedMessage();
-        EventMessage masked = mask(message);
+        var message = event.enclosedMessage();
+        var masked = mask(message);
         return event.toBuilder()
-                    .setMessage(pack(masked))
-                    .build();
+                .setMessage(pack(masked))
+                .build();
     }
 
     private EventMessage mask(EventMessage event) {
-        EventClass eventClass = EventClass.of(event);
-        FieldMask mask = fieldMasks.get(eventClass);
+        var eventClass = EventClass.of(event);
+        var mask = fieldMasks.get(eventClass);
         if (mask == null || isDefault(mask)) {
             return event;
         } else {
-            EventMessage maskedEvent = applyMask(mask, event);
+            var maskedEvent = applyMask(mask, event);
             return maskedEvent;
         }
     }
@@ -128,7 +128,7 @@ public final class EventFieldFilter implements EventFilter {
         public Builder putMask(Class<? extends EventMessage> eventClass, FieldMask mask) {
             checkNotNull(eventClass);
             checkNotNull(mask);
-            EventClass eventType = EventClass.from(eventClass);
+            var eventType = EventClass.from(eventClass);
             masks.put(eventType, mask);
             return this;
         }

--- a/server/src/main/java/io/spine/server/entity/EventFilter.java
+++ b/server/src/main/java/io/spine/server/entity/EventFilter.java
@@ -92,11 +92,11 @@ public interface EventFilter {
         ImmutableCollection<Event> filteredEvents = events
                 .stream()
                 .map(event -> {
-                    EventMessage eventMessage = event.enclosedMessage();
-                    Optional<? extends EventMessage> filtered = filter(eventMessage);
-                    Optional<Event> result = filtered.map(message -> event.toBuilder()
-                                                                          .setMessage(pack(message))
-                                                                          .build());
+                    var eventMessage = event.enclosedMessage();
+                    var filtered = filter(eventMessage);
+                    var result = filtered.map(message -> event.toBuilder()
+                            .setMessage(pack(message))
+                            .build());
                     return result;
                 })
                 .filter(Optional::isPresent)

--- a/server/src/main/java/io/spine/server/entity/EventPlayer.java
+++ b/server/src/main/java/io/spine/server/entity/EventPlayer.java
@@ -63,9 +63,9 @@ public interface EventPlayer {
      */
     default DispatchOutcome play(Event event) {
         Collection<Event> events = singleton(event);
-        BatchDispatchOutcome batchDispatchOutcome = play(events);
-        DispatchOutcome outcome = batchDispatchOutcome.getOutcomeList()
-                                                      .get(0);
+        var batchDispatchOutcome = play(events);
+        var outcome = batchDispatchOutcome.getOutcomeList()
+                                          .get(0);
         return outcome;
     }
 

--- a/server/src/main/java/io/spine/server/entity/EventPlayingTransaction.java
+++ b/server/src/main/java/io/spine/server/entity/EventPlayingTransaction.java
@@ -68,8 +68,8 @@ class EventPlayingTransaction<I,
      */
     @VisibleForTesting
     public DispatchOutcome play(EventEnvelope event) {
-        VersionIncrement increment = createVersionIncrement(event);
-        EventDispatch<I, E> dsp = new EventDispatch<>(this::dispatch, entity(), event);
+        var increment = createVersionIncrement(event);
+        var dsp = new EventDispatch<>(this::dispatch, entity(), event);
         Phase<I> phase = new EventDispatchingPhase<>(this, dsp, increment);
         return propagate(phase);
     }

--- a/server/src/main/java/io/spine/server/entity/EventProducingRepository.java
+++ b/server/src/main/java/io/spine/server/entity/EventProducingRepository.java
@@ -28,7 +28,6 @@ package io.spine.server.entity;
 
 import com.google.common.collect.ImmutableSet;
 import io.spine.base.RejectionThrowable;
-import io.spine.core.Command;
 import io.spine.core.Event;
 import io.spine.server.event.EventBus;
 import io.spine.server.type.CommandEnvelope;
@@ -71,7 +70,7 @@ public interface EventProducingRepository {
      * Filters the passed events and posts the result to the EventBus.
      */
     default void postEvents(Collection<Event> events) {
-        Iterable<Event> filtered = filter(events);
+        var filtered = filter(events);
         eventBus().post(filtered);
     }
 
@@ -83,8 +82,8 @@ public interface EventProducingRepository {
      */
     default void postIfCommandRejected(SignalEnvelope<?, ?, ?> signal, Throwable cause) {
         if (signal instanceof CommandEnvelope && cause instanceof RejectionThrowable) {
-            Command command = ((CommandEnvelope) signal).outerObject();
-            Event rejection = reject(command, cause);
+            var command = ((CommandEnvelope) signal).outerObject();
+            var rejection = reject(command, cause);
             postEvents(rejection.toSet());
         }
     }

--- a/server/src/main/java/io/spine/server/entity/EventWhiteList.java
+++ b/server/src/main/java/io/spine/server/entity/EventWhiteList.java
@@ -60,13 +60,13 @@ public final class EventWhiteList implements EventFilter {
     @SuppressWarnings("WeakerAccess") // Public API of the framework.
     @SafeVarargs
     public static EventWhiteList allowEvents(Class<? extends EventMessage>... eventClasses) {
-        ImmutableSet<EventClass> classes = EventClass.setOf(eventClasses);
+        var classes = EventClass.setOf(eventClasses);
         return new EventWhiteList(classes);
     }
 
     @Override
     public Optional<? extends EventMessage> filter(EventMessage event) {
-        EventClass type = EventClass.of(event);
+        var type = EventClass.of(event);
         return allowedEvents.contains(type)
                ? Optional.of(event)
                : Optional.empty();

--- a/server/src/main/java/io/spine/server/entity/FieldMasks.java
+++ b/server/src/main/java/io/spine/server/entity/FieldMasks.java
@@ -29,7 +29,6 @@ package io.spine.server.entity;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.Message;
-import com.google.protobuf.ProtocolStringList;
 import com.google.protobuf.util.FieldMaskUtil;
 
 import javax.annotation.Nonnull;
@@ -85,33 +84,33 @@ public final class FieldMasks {
                 .isEmpty()) {
             return message;
         }
-        M result = distill(message, mask);
+        var result = distill(message, mask);
         return result;
     }
 
     private static <M extends Message> M distill(M wholeMessage, FieldMask mask) {
-        Message.Builder builder = wholeMessage.newBuilderForType();
+        var builder = wholeMessage.newBuilderForType();
         FieldMaskUtil.merge(mask, wholeMessage, builder);
         @SuppressWarnings("unchecked") // safe as we got builder of `M`.
-                M result = (M) builder.build();
+        var result = (M) builder.build();
         return result;
     }
 
     private static <M extends Message>
     ImmutableList<M> doApplyMany(FieldMask mask, Collection<M> messages) {
-        ImmutableList<M> input = ImmutableList.copyOf(messages);
+        var input = ImmutableList.copyOf(messages);
         if (input.isEmpty()) {
             return input;
         }
 
-        ProtocolStringList filter = mask.getPathsList();
+        var filter = mask.getPathsList();
         if (filter.isEmpty()) {
             return input;
         }
 
         ImmutableList.Builder<M> filtered = ImmutableList.builder();
-        for (M wholeMessage : messages) {
-            M distilled = distill(wholeMessage, mask);
+        for (var wholeMessage : messages) {
+            var distilled = distill(wholeMessage, mask);
             filtered.add(distilled);
         }
         return filtered.build();

--- a/server/src/main/java/io/spine/server/entity/IdField.java
+++ b/server/src/main/java/io/spine/server/entity/IdField.java
@@ -27,15 +27,12 @@
 package io.spine.server.entity;
 
 import com.google.errorprone.annotations.Immutable;
-import com.google.protobuf.Descriptors.FieldDescriptor;
 import io.spine.base.EntityState;
 import io.spine.code.proto.FieldDeclaration;
 import io.spine.server.entity.model.EntityClass;
 import io.spine.validate.ValidatingBuilder;
 import io.spine.validate.option.Required;
 import org.checkerframework.checker.nullness.qual.Nullable;
-
-import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -48,18 +45,16 @@ final class IdField {
     private final @Nullable FieldDeclaration declaration;
 
     static IdField of(EntityClass<?> entityClass) {
-        EntityState<?> defaultState = entityClass.defaultState();
-        List<FieldDescriptor> fields =
-                defaultState.getDescriptorForType()
-                            .getFields();
+        var defaultState = entityClass.defaultState();
+        var fields = defaultState.getDescriptorForType().getFields();
         if (fields.isEmpty()) {
             /* The entity state is an empty message.
                This is weird for production purposes, but can be used for test stubs. */
             return new IdField(null);
         } else {
-            FieldDescriptor firstField = fields.get(0);
-            Class<?> fieldClass = defaultState.getField(firstField)
-                                              .getClass();
+            var firstField = fields.get(0);
+            var fieldClass = defaultState.getField(firstField)
+                                         .getClass();
             @Nullable FieldDeclaration declaration =
                     fieldClass.equals(entityClass.idClass())
                     ? new FieldDeclaration(firstField)
@@ -91,9 +86,9 @@ final class IdField {
         if (!declared()) {
             return;
         }
-        FieldDescriptor idField = declaration.descriptor();
+        var idField = declaration.descriptor();
         @SuppressWarnings("Immutable") // all supported types of IDs are immutable.
-        Required required = Required.create(false);
+        var required = Required.create(false);
         boolean isRequired = required.valueFrom(idField)
                                      .orElse(true); // assume required, if not set to false
         if (isRequired) {

--- a/server/src/main/java/io/spine/server/entity/InvalidEntityStateException.java
+++ b/server/src/main/java/io/spine/server/entity/InvalidEntityStateException.java
@@ -37,7 +37,6 @@ import io.spine.validate.ConstraintViolation;
 import io.spine.validate.ExceptionFactory;
 import io.spine.validate.ValidationException;
 
-import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -81,7 +80,7 @@ public final class InvalidEntityStateException extends ValidationException {
      */
     public static InvalidEntityStateException
     onConstraintViolations(EntityState<?> state, Iterable<ConstraintViolation> violations) {
-        Factory factory = new Factory(state, violations);
+        var factory = new Factory(state, violations);
         return factory.newException();
     }
 
@@ -148,9 +147,9 @@ public final class InvalidEntityStateException extends ValidationException {
          */
         @Override
         protected Map<String, Value> getMessageTypeAttribute(Message entityState) {
-            String entityStateType = TypeName.of(entityState)
-                                             .value();
-            Value value = Value.newBuilder()
+            var entityStateType = TypeName.of(entityState)
+                                          .value();
+            var value = Value.newBuilder()
                                .setStringValue(entityStateType)
                                .build();
             return ImmutableMap.of(ATTR_ENTITY_STATE_TYPE_NAME, value);
@@ -159,8 +158,8 @@ public final class InvalidEntityStateException extends ValidationException {
         @Override
         protected InvalidEntityStateException
         createException(String exceptionMsg, EntityState state, Error error) {
-            List<ConstraintViolation> violations = error.getValidationError()
-                                                        .getConstraintViolationList();
+            var violations = error.getValidationError()
+                                  .getConstraintViolationList();
             checkArgument(!violations.isEmpty(), "No constraint violations provided.");
             return new InvalidEntityStateException(state, error);
         }

--- a/server/src/main/java/io/spine/server/entity/Migration.java
+++ b/server/src/main/java/io/spine/server/entity/Migration.java
@@ -101,9 +101,9 @@ public abstract class Migration<I,
 
     private void applyTo(E entity) {
         Transaction<I, E, S, ?> tx = txWithLifecycleMonitor();
-        S oldState = entity.state();
-        S newState = apply(oldState);
-        Operation<I, S, E> op = currentOperation();
+        var oldState = entity.state();
+        var newState = apply(oldState);
+        var op = currentOperation();
         op.updateState(newState);
         op.updateLifecycle();
         tx.commit();
@@ -218,10 +218,10 @@ public abstract class Migration<I,
      * the last handled message.
      */
     private Transaction<I, E, S, B> txWithLifecycleMonitor() {
-        E entity = currentOperation().entity;
-        I id = entity.id();
-        Transaction<I, E, S, B> tx = startTransaction(entity);
-        EntityLifecycleMonitor<I> monitor = configureLifecycleMonitor(id);
+        var entity = currentOperation().entity;
+        var id = entity.id();
+        var tx = startTransaction(entity);
+        var monitor = configureLifecycleMonitor(id);
         tx.setListener(monitor);
         currentOperation().tx = tx;
         return tx;
@@ -232,14 +232,14 @@ public abstract class Migration<I,
      * a {@link MigrationApplied} instance as the event-producing message.
      */
     private EntityLifecycleMonitor<I> configureLifecycleMonitor(I id) {
-        RecordBasedRepository<I, E, S> repository = currentOperation().repository;
-        Optional<Event> event = repository.lifecycleOf(id)
-                                          .onMigrationApplied();
-        if (!event.isPresent() || isDefault(event.get())) {
+        var repository = currentOperation().repository;
+        var event = repository.lifecycleOf(id)
+                              .onMigrationApplied();
+        if (event.isEmpty() || isDefault(event.get())) {
             warnOnNoSystemEventsPosted();
             return EntityLifecycleMonitor.newInstance(repository, id);
         }
-        Event migrationApplied = event.get();
+        var migrationApplied = event.get();
         currentOperation().systemEvent = migrationApplied;
         return EntityLifecycleMonitor.withAcknowledgedMessage(repository, id, migrationApplied);
     }
@@ -294,7 +294,7 @@ public abstract class Migration<I,
             if (!entity.state().equals(newState)) {
                 tx.builder().clear()
                             .mergeFrom(newState);
-                Version version = increment(entity.version());
+                var version = increment(entity.version());
                 tx.setVersion(version);
             }
         }

--- a/server/src/main/java/io/spine/server/entity/Phase.java
+++ b/server/src/main/java/io/spine/server/entity/Phase.java
@@ -70,9 +70,8 @@ public abstract class Phase<I> {
      * @return the result of the task execution
      */
     final DispatchOutcome propagate() {
-        DispatchOutcome outcome = performDispatch();
-        return DispatchOutcomeHandler
-                .from(outcome)
+        var outcome = performDispatch();
+        return DispatchOutcomeHandler.from(outcome)
                 .onSuccess(this::incrementTransaction)
                 .handle();
     }

--- a/server/src/main/java/io/spine/server/entity/RecentHistory.java
+++ b/server/src/main/java/io/spine/server/entity/RecentHistory.java
@@ -84,7 +84,7 @@ public final class RecentHistory {
      * @return an events iterator
      */
     public Iterator<Event> iterator() {
-        ImmutableList<Event> events = ImmutableList.copyOf(history);
+        var events = ImmutableList.copyOf(history);
         return events.iterator();
     }
 
@@ -97,7 +97,7 @@ public final class RecentHistory {
      * @return a stream of the recent events
      */
     public Stream<Event> stream() {
-        ImmutableList<Event> events = ImmutableList.copyOf(history);
+        var events = ImmutableList.copyOf(history);
         return events.stream();
     }
 
@@ -107,7 +107,7 @@ public final class RecentHistory {
      * @param events events in the chronological order
      */
     void addAll(Iterable<Event> events) {
-        for (Event event : events) {
+        for (var event : events) {
             history.addFirst(event);
         }
     }
@@ -125,7 +125,7 @@ public final class RecentHistory {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        RecentHistory other = (RecentHistory) obj;
+        var other = (RecentHistory) obj;
         return Objects.equals(this.history, other.history);
     }
 

--- a/server/src/main/java/io/spine/server/entity/Repository.java
+++ b/server/src/main/java/io/spine/server/entity/Repository.java
@@ -46,7 +46,6 @@ import io.spine.server.storage.Storage;
 import io.spine.server.storage.StorageFactory;
 import io.spine.server.type.SignalEnvelope;
 import io.spine.system.server.RoutingFailed;
-import io.spine.system.server.SystemWriteSide;
 import io.spine.type.TypeUrl;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -163,7 +162,7 @@ public abstract class Repository<I, E extends Entity<I, ?>>
     public EntityClass<E> entityModelClass() {
         if (entityClass == null) {
             @SuppressWarnings("unchecked") // The type is ensured by the declaration of this class.
-            Class<E> cast = (Class<E>) GenericParameter.ENTITY.argumentIn(getClass());
+            var cast = (Class<E>) GenericParameter.ENTITY.argumentIn(getClass());
             entityClass = toModelClass(cast);
         }
         return entityClass;
@@ -213,7 +212,7 @@ public abstract class Repository<I, E extends Entity<I, ?>>
     @Internal
     public void registerWith(BoundedContext context) {
         checkNotNull(context);
-        boolean sameValue = context.equals(this.context);
+        var sameValue = context.equals(this.context);
         if (hasContext() && !sameValue) {
             throw newIllegalStateException(
                     "The repository `%s` has the Bounded Context (`%s`) assigned." +
@@ -289,7 +288,7 @@ public abstract class Repository<I, E extends Entity<I, ?>>
      * Initializes the storage of the repository.
      */
     protected final void open() {
-        Storage<I, ?> storage = storage();
+        var storage = storage();
         checkNotNull(storage, "Unable to initialize the storage.");
     }
 
@@ -380,12 +379,12 @@ public abstract class Repository<I, E extends Entity<I, ?>>
     route(Route<M, C, R> routing, SignalEnvelope<?, ?, C> envelope) {
         try {
             @SuppressWarnings("unchecked")
-            M message = (M) envelope.message();
-            R result = routing.apply(message, envelope.context());
+            var message = (M) envelope.message();
+            var result = routing.apply(message, envelope.context());
             checkMatchesIdType(result);
             return Optional.of(result);
         } catch (RuntimeException e) {
-            Throwable cause = getRootCause(e);
+            var cause = getRootCause(e);
             onRoutingFailed(envelope, cause);
             return Optional.empty();
         }
@@ -402,8 +401,8 @@ public abstract class Repository<I, E extends Entity<I, ?>>
     private void checkMatchesIdType(Object result) {
         Class<?> routingResultType = null;
         if (result instanceof Iterable) {
-            Iterable<?> asIterable = (Iterable<?>) result;
-            Object element = getFirst(asIterable, null);
+            var asIterable = (Iterable<?>) result;
+            var element = getFirst(asIterable, null);
             if (element != null) {
                 routingResultType = element.getClass();
             }
@@ -411,8 +410,8 @@ public abstract class Repository<I, E extends Entity<I, ?>>
             routingResultType = result.getClass();
         }
         if (routingResultType != null) {
-            Class<I> idClass = idClass();
-            boolean corresponds = idClass.isAssignableFrom(routingResultType);
+            var idClass = idClass();
+            var corresponds = idClass.isAssignableFrom(routingResultType);
             checkArgument(corresponds, "Message routing failed in `%s` due to the type mismatch. " +
                                   "Expected ID type is `%s`, but was `%s`.",
                           getClass().getName(), idClass.getName(), routingResultType.getName());
@@ -428,8 +427,7 @@ public abstract class Repository<I, E extends Entity<I, ?>>
     @OverridingMethodsMustInvokeSuper
     @Internal
     protected void onRoutingFailed(SignalEnvelope<?, ?, ?> envelope, Throwable cause) {
-        RoutingFailed systemEvent = RoutingFailed
-                .newBuilder()
+        var systemEvent = RoutingFailed.newBuilder()
                 .setEntityType(entityModelClass().typeName())
                 .setHandledSignal(envelope.messageId())
                 .setError(fromThrowable(cause))
@@ -451,10 +449,10 @@ public abstract class Repository<I, E extends Entity<I, ?>>
     @Internal
     public EntityLifecycle lifecycleOf(I id) {
         checkNotNull(id);
-        SystemWriteSide writeSide = context().systemClient()
-                                             .writeSide();
-        EventFilter eventFilter = eventFilter();
-        EntityLifecycle lifecycle = EntityLifecycle
+        var writeSide = context().systemClient()
+                                 .writeSide();
+        var eventFilter = eventFilter();
+        var lifecycle = EntityLifecycle
                 .newBuilder()
                 .setEntityId(id)
                 .setEntityType(entityModelClass())
@@ -483,7 +481,7 @@ public abstract class Repository<I, E extends Entity<I, ?>>
     @SPI
     @Pure
     public EventFilter eventFilter() {
-        EntityClass<E> entityClass = entityModelClass();
+        var entityClass = entityModelClass();
         return EntityStateChangedFilter.forType(entityClass);
     }
 
@@ -534,20 +532,20 @@ public abstract class Repository<I, E extends Entity<I, ?>>
 
         @Override
         public boolean hasNext() {
-            boolean result = index.hasNext();
+            var result = index.hasNext();
             return result;
         }
 
         @Override
         public E next() {
-            I id = index.next();
-            Optional<E> loaded = repository.find(id);
-            if (!loaded.isPresent()) {
-                String idStr = Identifier.toString(id);
+            var id = index.next();
+            var loaded = repository.find(id);
+            if (loaded.isEmpty()) {
+                var idStr = Identifier.toString(id);
                 throw newIllegalStateException("Unable to load entity with ID: `%s`.", idStr);
             }
 
-            E entity = loaded.get();
+            var entity = loaded.get();
             return entity;
         }
     }

--- a/server/src/main/java/io/spine/server/entity/RepositoryCache.java
+++ b/server/src/main/java/io/spine/server/entity/RepositoryCache.java
@@ -103,13 +103,13 @@ public final class RepositoryCache<I, E extends Entity<I, ?>> implements Logging
      * @return loaded entity
      */
     public synchronized E load(I id) {
-        IdInTenant<I> idInTenant = idInTenant(id);
+        var idInTenant = idInTenant(id);
         if (!idsToCache.contains(idInTenant)) {
             return loadFn.apply(idInTenant.value());
         }
 
         if (!cache.containsKey(idInTenant)) {
-            E entity = loadFn.apply(idInTenant.value());
+            var entity = loadFn.apply(idInTenant.value());
             cache.put(idInTenant, entity);
             return entity;
         }
@@ -142,8 +142,8 @@ public final class RepositoryCache<I, E extends Entity<I, ?>> implements Logging
      *         an identifier of the entity to cache
      */
     public synchronized void stopCaching(I id) {
-        IdInTenant<I> idInTenant = idInTenant(id);
-        E entity = cache.get(idInTenant);
+        var idInTenant = idInTenant(id);
+        var entity = cache.get(idInTenant);
         if (entity == null) {
             _warn().log("Cannot find the cached entity in the cache for ID `%s`. " +
                                 "Cache keys: %s. IDs to cache: %s." +
@@ -176,8 +176,8 @@ public final class RepositoryCache<I, E extends Entity<I, ?>> implements Logging
      *         the entity to store
      */
     public synchronized void store(E entity) {
-        I id = entity.id();
-        IdInTenant<I> idInTenant = idInTenant(id);
+        var id = entity.id();
+        var idInTenant = idInTenant(id);
         if (idsToCache.contains(idInTenant)) {
             cache.put(idInTenant, entity);
         } else {
@@ -205,7 +205,7 @@ public final class RepositoryCache<I, E extends Entity<I, ?>> implements Logging
      *         the type of entity
      */
     @FunctionalInterface
-    public interface Store<E extends Entity> extends Consumer<E> {
+    public interface Store<E extends Entity<?, ?>> extends Consumer<E> {
 
     }
 }

--- a/server/src/main/java/io/spine/server/entity/StorageConverter.java
+++ b/server/src/main/java/io/spine/server/entity/StorageConverter.java
@@ -27,7 +27,6 @@
 package io.spine.server.entity;
 
 import com.google.common.base.Converter;
-import com.google.protobuf.Any;
 import com.google.protobuf.FieldMask;
 import io.spine.base.EntityState;
 import io.spine.base.Identifier;
@@ -98,10 +97,9 @@ public abstract class StorageConverter<I, E extends Entity<I, S>, S extends Enti
 
     @Override
     protected EntityRecord doForward(E entity) {
-        Any entityId = Identifier.pack(entity.id());
-        Any stateAny = pack(entity.state());
-        EntityRecord.Builder builder = EntityRecord
-                .newBuilder()
+        var entityId = Identifier.pack(entity.id());
+        var stateAny = pack(entity.state());
+        var builder = EntityRecord.newBuilder()
                 .setEntityId(entityId)
                 .setState(stateAny);
         updateBuilder(builder, entity);
@@ -112,10 +110,10 @@ public abstract class StorageConverter<I, E extends Entity<I, S>, S extends Enti
             the type <E>, and forward conversion is performed on the entity of type <E>. */)
     @Override
     protected E doBackward(EntityRecord entityRecord) {
-        S unpacked = (S) unpack(entityRecord.getState());
-        S state = FieldMasks.applyMask(fieldMask(), unpacked);
-        I id = (I) Identifier.unpack(entityRecord.getEntityId());
-        E entity = entityFactory.create(id);
+        var unpacked = (S) unpack(entityRecord.getState());
+        var state = FieldMasks.applyMask(fieldMask(), unpacked);
+        var id = (I) Identifier.unpack(entityRecord.getEntityId());
+        var entity = entityFactory.create(id);
         checkState(entity != null, "`EntityFactory` produced `null` entity.");
         injectState(entity, state, entityRecord);
         return entity;
@@ -161,7 +159,7 @@ public abstract class StorageConverter<I, E extends Entity<I, S>, S extends Enti
         if (!(obj instanceof StorageConverter)) {
             return false;
         }
-        StorageConverter<?, ?, ?> other = (StorageConverter<?, ?, ?>) obj;
+        var other = (StorageConverter<?, ?, ?>) obj;
         return Objects.equals(this.entityStateType, other.entityStateType)
                 && Objects.equals(this.entityFactory, other.entityFactory)
                 && Objects.equals(this.fieldMask, other.fieldMask);

--- a/server/src/main/java/io/spine/server/entity/TransactionalEntity.java
+++ b/server/src/main/java/io/spine/server/entity/TransactionalEntity.java
@@ -125,11 +125,11 @@ class TransactionalEntity<I, S extends EntityState<I>, B extends ValidatingBuild
      */
     @Internal
     public final boolean changed() {
-        boolean lifecycleFlagsChanged = lifecycleFlagsChanged();
+        var lifecycleFlagsChanged = lifecycleFlagsChanged();
         Transaction<?, ?, ?, ?> tx = this.transaction;
-        boolean stateChanged = tx != null
-                               ? tx.stateChanged()
-                               : this.stateChanged;
+        var stateChanged = tx != null
+                           ? tx.stateChanged()
+                           : this.stateChanged;
         return stateChanged || lifecycleFlagsChanged;
     }
 
@@ -184,7 +184,7 @@ class TransactionalEntity<I, S extends EntityState<I>, B extends ValidatingBuild
     @Internal
     protected final boolean isTransactionInProgress() {
         Transaction<?, ?, ?, ?> tx = this.transaction;
-        boolean result = tx != null && tx.isActive();
+        var result = tx != null && tx.isActive();
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/entity/TransactionalEventPlayer.java
+++ b/server/src/main/java/io/spine/server/entity/TransactionalEventPlayer.java
@@ -53,8 +53,8 @@ final class TransactionalEventPlayer implements EventPlayer {
     @Override
     public BatchDispatchOutcome play(Iterable<Event> events) {
         checkNotNull(events);
-        BatchDispatch process = new BatchDispatch(transaction);
-        for (Event event : events) {
+        var process = new BatchDispatch(transaction);
+        for (var event : events) {
             process.play(event);
         }
         return process.summary();

--- a/server/src/main/java/io/spine/server/entity/VersionIncrement.java
+++ b/server/src/main/java/io/spine/server/entity/VersionIncrement.java
@@ -73,7 +73,7 @@ public abstract class VersionIncrement {
      * and have no common versioning. Thus, a {@code Projection} has its own versioning system.
      * Each event <i>increments</i> the {@code Projection} version by one.
      */
-    public static VersionIncrement sequentially(Transaction tx) {
+    public static VersionIncrement sequentially(Transaction<?, ?, ?, ?> tx) {
         return new AutoIncrement(tx);
     }
 
@@ -91,8 +91,7 @@ public abstract class VersionIncrement {
 
         @Override
         protected Version nextVersion() {
-            Version result = event.context()
-                                  .getVersion();
+            var result = event.context().getVersion();
             return result;
         }
     }
@@ -102,17 +101,17 @@ public abstract class VersionIncrement {
      */
     private static class AutoIncrement extends VersionIncrement {
 
-        private final Transaction transaction;
+        private final Transaction<?, ?, ?, ?> transaction;
 
-        private AutoIncrement(Transaction transaction) {
+        private AutoIncrement(Transaction<?, ?, ?, ?> transaction) {
             super();
             this.transaction = checkNotNull(transaction);
         }
 
         @Override
         protected Version nextVersion() {
-            Version current = transaction.version();
-            Version result = Versions.increment(current);
+            var current = transaction.version();
+            var result = Versions.increment(current);
             return result;
         }
     }

--- a/server/src/main/java/io/spine/server/entity/model/AbstractEntityFactory.java
+++ b/server/src/main/java/io/spine/server/entity/model/AbstractEntityFactory.java
@@ -88,7 +88,7 @@ public abstract class AbstractEntityFactory<E extends Entity<?, ?>> implements E
     @Override
     @SuppressWarnings("SynchronizeOnThis") // Double-check idiom for lazy init.
     public final Constructor<E> constructor() {
-        Constructor<E> result = constructor;
+        var result = constructor;
         if (result == null) {
             synchronized (this) {
                 result = constructor;
@@ -121,7 +121,7 @@ public abstract class AbstractEntityFactory<E extends Entity<?, ?>> implements E
         if (!(obj instanceof AbstractEntityFactory)) {
             return false;
         }
-        final AbstractEntityFactory<?> other = (AbstractEntityFactory<?>) obj;
+        final var other = (AbstractEntityFactory<?>) obj;
         return Objects.equals(this.idClass, other.idClass)
                 && Objects.equals(this.entityClass, other.entityClass);
     }

--- a/server/src/main/java/io/spine/server/entity/model/CommandHandlingEntityClass.java
+++ b/server/src/main/java/io/spine/server/entity/model/CommandHandlingEntityClass.java
@@ -63,11 +63,10 @@ public abstract class CommandHandlingEntityClass<E extends Entity<?, ?>>
 
     @Override
     public ImmutableSet<EventClass> rejections() {
-        ImmutableSet<EventClass> result =
-                commands.methods()
-                        .stream()
-                        .flatMap(m -> m.rejections().stream())
-                        .collect(toImmutableSet());
+        var result = commands.methods()
+                .stream()
+                .flatMap(m -> m.rejections().stream())
+                .collect(toImmutableSet());
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/entity/model/EntityClass.java
+++ b/server/src/main/java/io/spine/server/entity/model/EntityClass.java
@@ -27,7 +27,6 @@
 package io.spine.server.entity.model;
 
 import com.google.errorprone.annotations.concurrent.LazyInit;
-import com.google.protobuf.Descriptors.Descriptor;
 import io.spine.base.EntityState;
 import io.spine.base.Identifier;
 import io.spine.server.entity.DefaultEntityFactory;
@@ -100,8 +99,7 @@ public class EntityClass<E extends Entity<?, ?>> extends ModelClass<E> {
     public static <E extends Entity<?, ?>> EntityClass<E> asEntityClass(Class<E> cls) {
         checkNotNull(cls);
         @SuppressWarnings("unchecked")
-        EntityClass<E> result = (EntityClass<E>)
-                get(cls, EntityClass.class, () -> new EntityClass<>(cls));
+        var result = (EntityClass<E>) get(cls, EntityClass.class, () -> new EntityClass<>(cls));
         return result;
     }
 
@@ -114,8 +112,7 @@ public class EntityClass<E extends Entity<?, ?>> extends ModelClass<E> {
     EntityClass<E> asParameterizedEntityClass(Class<E> cls) {
         checkNotNull(cls);
         @SuppressWarnings("unchecked")
-        EntityClass<E> result = (EntityClass<E>)
-                get(cls, EntityClass.class, () -> new EntityClass<>(cls));
+        var result = (EntityClass<E>) get(cls, EntityClass.class, () -> new EntityClass<>(cls));
         return result;
     }
 
@@ -124,7 +121,7 @@ public class EntityClass<E extends Entity<?, ?>> extends ModelClass<E> {
      */
     public E create(Object constructionArgument) {
         checkNotNull(constructionArgument);
-        E result = factory().create(constructionArgument);
+        var result = factory().create(constructionArgument);
         return result;
     }
 
@@ -149,12 +146,12 @@ public class EntityClass<E extends Entity<?, ?>> extends ModelClass<E> {
      * Obtains the default state for this class of entities.
      */
     public final EntityState<?> defaultState() {
-        EntityState<?> result = defaultState;
+        var result = defaultState;
         if (result == null) {
             synchronized (this) {
                 result = defaultState;
                 if (result == null) {
-                    Class<? extends EntityState<?>> stateClass = stateClass();
+                    var stateClass = stateClass();
                     defaultState = defaultInstance(stateClass);
                     result = defaultState;
                 }
@@ -188,8 +185,8 @@ public class EntityClass<E extends Entity<?, ?>> extends ModelClass<E> {
      * Obtains the entity state type.
      */
     public final MessageType stateType() {
-        Descriptor descriptor = defaultState().getDescriptorForType();
-        MessageType result = new MessageType(descriptor);
+        var descriptor = defaultState().getDescriptorForType();
+        var result = new MessageType(descriptor);
         return result;
     }
 
@@ -204,8 +201,7 @@ public class EntityClass<E extends Entity<?, ?>> extends ModelClass<E> {
      * Obtains the name of this class as an {@link EntityTypeName}.
      */
     public final EntityTypeName typeName() {
-        return EntityTypeName
-                .newBuilder()
+        return EntityTypeName.newBuilder()
                 .setJavaClassName(value().getCanonicalName())
                 .vBuild();
     }
@@ -237,7 +233,7 @@ public class EntityClass<E extends Entity<?, ?>> extends ModelClass<E> {
         if (!super.equals(o)) {
             return false;
         }
-        EntityClass<?> that = (EntityClass<?>) o;
+        var that = (EntityClass<?>) o;
         return Objects.equals(idClass, that.idClass) &&
                 Objects.equals(stateClass, that.stateClass) &&
                 Objects.equals(entityStateType, that.entityStateType);
@@ -266,7 +262,7 @@ public class EntityClass<E extends Entity<?, ?>> extends ModelClass<E> {
      */
     public static <I> Class<I> idClass(Class<? extends Entity<?, ?>> cls) {
         @SuppressWarnings("unchecked") // The type is preserved by the Entity type declaration.
-                Class<I> idClass = (Class<I>) Entity.GenericParameter.ID.argumentIn(cls);
+        var idClass = (Class<I>) Entity.GenericParameter.ID.argumentIn(cls);
         try {
             Identifier.checkSupported(idClass);
         } catch (IllegalArgumentException e) {
@@ -285,7 +281,7 @@ public class EntityClass<E extends Entity<?, ?>> extends ModelClass<E> {
     public static <S extends EntityState<?>> Class<S>
     stateClassOf(Class<? extends Entity<?, ?>> entityClass) {
         @SuppressWarnings("unchecked") // The type is preserved by the Entity type declaration.
-        Class<S> result = (Class<S>) Entity.GenericParameter.STATE.argumentIn(entityClass);
+        var result = (Class<S>) Entity.GenericParameter.STATE.argumentIn(entityClass);
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/entity/model/StateClass.java
+++ b/server/src/main/java/io/spine/server/entity/model/StateClass.java
@@ -52,7 +52,7 @@ public final class StateClass<I> extends MessageClass<EntityState<?>> {
      */
     public static <I> StateClass<I> of(Entity<I, ?> entity) {
         checkNotNull(entity);
-        EntityState<I> state = entity.state();
+        var state = entity.state();
         return of(state);
     }
 

--- a/server/src/main/java/io/spine/server/entity/model/StateSubscribingClass.java
+++ b/server/src/main/java/io/spine/server/entity/model/StateSubscribingClass.java
@@ -51,8 +51,8 @@ public interface StateSubscribingClass {
      * entity states, either domestic or external.
      */
     default boolean subscribesToStates() {
-        boolean dispatchesDomestic = !domesticStates().isEmpty();
-        boolean dispatchesExternal = !externalStates().isEmpty();
+        var dispatchesDomestic = !domesticStates().isEmpty();
+        var dispatchesExternal = !externalStates().isEmpty();
         return dispatchesDomestic || dispatchesExternal;
     }
 }

--- a/server/src/main/java/io/spine/server/entity/storage/AsEntityRecordColumn.java
+++ b/server/src/main/java/io/spine/server/entity/storage/AsEntityRecordColumn.java
@@ -73,7 +73,7 @@ final class AsEntityRecordColumn {
     apply(Column<?, ?> original, Class<V> typeOfValues, Function<EntityRecord, V> getter) {
         checkNotNull(original);
         checkNotNull(typeOfValues);
-        String columnName = columnName(original);
+        var columnName = columnName(original);
         return RecordColumn.create(columnName, typeOfValues, getter::apply);
     }
 

--- a/server/src/main/java/io/spine/server/entity/storage/EntityRecordColumn.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityRecordColumn.java
@@ -127,7 +127,7 @@ final class EntityRecordColumn {
      */
     static boolean isLifecycleColumn(Column<?, ?> column) {
         checkNotNull(column);
-        ColumnName name = column.name();
+        var name = column.name();
         return name.equals(archived.name()) || name.equals(deleted.name());
     }
 }

--- a/server/src/main/java/io/spine/server/entity/storage/EntityRecordSpec.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityRecordSpec.java
@@ -29,7 +29,6 @@ package io.spine.server.entity.storage;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
-import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
 import io.spine.base.EntityState;
@@ -100,7 +99,7 @@ public final class EntityRecordSpec<I, S extends EntityState<I>, E extends Entit
     public static <I, S extends EntityState<I>, E extends Entity<I, S>>
     EntityRecordSpec<I, S, E> of(EntityClass<E> entityClass) {
         checkNotNull(entityClass);
-        Scanner<S, E> scanner = new Scanner<>(entityClass);
+        var scanner = new Scanner<>(entityClass);
         return new EntityRecordSpec<>(entityClass, scanner.columns());
     }
 
@@ -120,8 +119,8 @@ public final class EntityRecordSpec<I, S extends EntityState<I>, E extends Entit
     EntityRecordSpec<I, S, E> of(E entity) {
         checkNotNull(entity);
         @SuppressWarnings("unchecked")  // Ensured by the entity type declaration.
-        EntityClass<E> modelClass = (EntityClass<E>) entity.modelClass();
-        Scanner<S, E> scanner = new Scanner<>(modelClass);
+        var modelClass = (EntityClass<E>) entity.modelClass();
+        var scanner = new Scanner<>(modelClass);
         return new EntityRecordSpec<>(modelClass, scanner.columns());
     }
 
@@ -130,7 +129,7 @@ public final class EntityRecordSpec<I, S extends EntityState<I>, E extends Entit
      */
     public static <I, S extends EntityState<I>, E extends Entity<I, S>>
     EntityRecordSpec<I, S, E> of(Class<E> cls) {
-        EntityClass<E> aClass = asParameterizedEntityClass(cls);
+        var aClass = asParameterizedEntityClass(cls);
         return of(aClass);
     }
 
@@ -174,7 +173,7 @@ public final class EntityRecordSpec<I, S extends EntityState<I>, E extends Entit
     @Override
     @SuppressWarnings("unchecked")      /* See the documentation. */
     public I idFromRecord(EntityRecord record) {
-        Any packed = record.getEntityId();
+        var packed = record.getEntityId();
         return (I) Identifier.unpack(packed);
     }
 
@@ -191,11 +190,9 @@ public final class EntityRecordSpec<I, S extends EntityState<I>, E extends Entit
 
     @Override
     public ImmutableSet<Column<?, ?>> columns() {
-        ImmutableSet<Column<E, ?>> typed = columns.values();
+        var typed = columns.values();
         ImmutableSet.Builder<Column<?, ?>> builder = ImmutableSet.builder();
-        ImmutableSet<Column<?, ?>> result =
-                builder.addAll(typed)
-                       .build();
+        var result = builder.addAll(typed).build();
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/entity/storage/EntityRecordStorage.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityRecordStorage.java
@@ -36,7 +36,6 @@ import io.spine.query.Query;
 import io.spine.query.QueryPredicate;
 import io.spine.query.RecordQuery;
 import io.spine.query.Subject;
-import io.spine.query.SubjectParameter;
 import io.spine.server.ContextSpec;
 import io.spine.server.entity.Entity;
 import io.spine.server.entity.EntityRecord;
@@ -118,7 +117,7 @@ public class EntityRecordStorage<I, S extends EntityState<I>>
      *         if the storage is already closed
      */
     public Iterator<I> index(EntityQuery<I, S, ?> query) {
-        RecordQuery<I, EntityRecord> recordQuery = transform(query);
+        var recordQuery = transform(query);
         return index(recordQuery);
     }
 
@@ -140,7 +139,7 @@ public class EntityRecordStorage<I, S extends EntityState<I>>
      */
     @Override
     public Iterator<EntityRecord> readAll(RecordQuery<I, EntityRecord> query) {
-        RecordQuery<I, EntityRecord> toExecute = onlyActive(query);
+        var toExecute = onlyActive(query);
         return super.readAll(toExecute);
     }
 
@@ -161,7 +160,7 @@ public class EntityRecordStorage<I, S extends EntityState<I>>
      * <p>Only the records of active entities are returned.
      */
     public final Iterator<EntityRecord> findAll(EntityQuery<I, S, ?> query) {
-        RecordQuery<I, EntityRecord> result = transform(query);
+        var result = transform(query);
         return readAll(result);
     }
 
@@ -196,7 +195,7 @@ public class EntityRecordStorage<I, S extends EntityState<I>>
      */
     @Override
     public synchronized void write(I id, EntityRecord record) {
-        EntityRecordWithColumns<I> wrapped = EntityRecordWithColumns.create(id, record);
+        var wrapped = EntityRecordWithColumns.create(id, record);
         write(wrapped);
     }
 
@@ -256,7 +255,7 @@ public class EntityRecordStorage<I, S extends EntityState<I>>
     }
 
     private RecordQuery<I, EntityRecord> onlyActive(RecordQuery<I, EntityRecord> query) {
-        RecordQuery<I, EntityRecord> result = query;
+        var result = query;
         if (hasNoIds(query) && hasNoLifecycleCols(query)) {
             result = query.and((r) -> r.where(archived).is(false)
                                        .where(deleted).is(false));
@@ -267,19 +266,18 @@ public class EntityRecordStorage<I, S extends EntityState<I>>
     private static <I> boolean hasNoLifecycleCols(Query<I, EntityRecord> query) {
         Subject<I, ?> subject = query.subject();
         QueryPredicate<?> predicate = subject.predicate();
-        boolean result = !hasLifecycleColumn(predicate);
+        var result = !hasLifecycleColumn(predicate);
         return result;
     }
 
     private static boolean hasLifecycleColumn(QueryPredicate<?> predicate) {
-        ImmutableList<SubjectParameter<?, ?, ?>> params = predicate.allParams();
-        boolean result =
-                params.stream()
-                      .anyMatch((param) -> isLifecycleColumn(param.column()));
+        var params = predicate.allParams();
+        var result = params.stream()
+                .anyMatch((param) -> isLifecycleColumn(param.column()));
         if (!result) {
             ImmutableList<? extends QueryPredicate<?>> children = predicate.children();
             for (QueryPredicate<?> child : children) {
-                boolean childResult = hasLifecycleColumn(child);
+                var childResult = hasLifecycleColumn(child);
                 if (childResult) {
                     return childResult;
                 }
@@ -289,11 +287,10 @@ public class EntityRecordStorage<I, S extends EntityState<I>>
     }
 
     private RecordQuery<I, EntityRecord> findActiveRecords() {
-        RecordQuery<I, EntityRecord> result =
-                RecordQuery.newBuilder(idType(), EntityRecord.class)
-                           .where(archived).is(false)
-                           .where(deleted).is(false)
-                           .build();
+        var result = RecordQuery.newBuilder(idType(), EntityRecord.class)
+                .where(archived).is(false)
+                .where(deleted).is(false)
+                .build();
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/entity/storage/EntityRecordWithColumns.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityRecordWithColumns.java
@@ -27,7 +27,6 @@
 package io.spine.server.entity.storage;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import io.spine.annotation.SPI;
 import io.spine.base.EntityState;
 import io.spine.base.Identifier;
@@ -78,8 +77,8 @@ public final class EntityRecordWithColumns<I>
     EntityRecordWithColumns<I> create(E entity, EntityRecord record) {
         checkNotNull(entity);
         checkNotNull(record);
-        EntityRecordSpec<I, S, E> recordSpec = EntityRecordSpec.of(entity);
-        Map<ColumnName, @Nullable Object> storageFields = recordSpec.valuesIn(entity);
+        var recordSpec = EntityRecordSpec.of(entity);
+        var storageFields = recordSpec.valuesIn(entity);
         return new EntityRecordWithColumns<>(entity.id(), record, storageFields);
     }
 
@@ -101,7 +100,7 @@ public final class EntityRecordWithColumns<I>
     public static <I> EntityRecordWithColumns<I> create(I id, EntityRecord record) {
         checkNotNull(id);
         checkNotNull(record);
-        ImmutableMap<ColumnName, Object> lifecycleValues = EntityRecordColumn.valuesIn(record);
+        var lifecycleValues = EntityRecordColumn.valuesIn(record);
         return new EntityRecordWithColumns<>(id, record, lifecycleValues);
     }
 
@@ -171,7 +170,7 @@ public final class EntityRecordWithColumns<I>
             return false;
         }
 
-        EntityRecordWithColumns<?> other = (EntityRecordWithColumns<?>) o;
+        var other = (EntityRecordWithColumns<?>) o;
 
         return Objects.equals(id(), other.id()) &&
                 Objects.equals(record(), other.record()) &&

--- a/server/src/main/java/io/spine/server/entity/storage/Scanner.java
+++ b/server/src/main/java/io/spine/server/entity/storage/Scanner.java
@@ -37,7 +37,6 @@ import io.spine.server.entity.Entity;
 import io.spine.server.entity.model.EntityClass;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
@@ -104,8 +103,8 @@ final class Scanner<S extends EntityState<?>, E extends Entity<?, S>> {
     EntityColumns<E> columns() {
         Set<Column<E, ?>> accumulator = new HashSet<>();
 
-        StateColumns<S> stateColumns = stateColumns();
-        for (EntityColumn<S, ?> stateCol : stateColumns) {
+        var stateColumns = stateColumns();
+        for (var stateCol : stateColumns) {
             Column<E, ?> wrapped = wrap(stateCol, (entity) -> stateCol.valueIn(entity.state()));
             accumulator.add(wrapped);
         }
@@ -114,7 +113,7 @@ final class Scanner<S extends EntityState<?>, E extends Entity<?, S>> {
         accumulator.add(wrap(DeletedColumn.instance(), Entity::isDeleted));
         accumulator.add(wrap(VersionColumn.instance(), Entity::version));
 
-        EntityColumns<E> columns = new EntityColumns<>(accumulator);
+        var columns = new EntityColumns<>(accumulator);
         return columns;
     }
 
@@ -128,16 +127,15 @@ final class Scanner<S extends EntityState<?>, E extends Entity<?, S>> {
     @VisibleForTesting
     @SuppressWarnings("OverlyBroadCatchBlock")   /* Treating all exceptions equally. */
     StateColumns<S> stateColumns() {
-        Class<? extends EntityState<?>> stateClass = entityClass.stateClass();
-        Class<?> columnClass = findColumnsClass(stateClass);
+        var stateClass = entityClass.stateClass();
+        var columnClass = findColumnsClass(stateClass);
         if (columnClass == null) {
             return StateColumns.none();
         }
         try {
-            Method getDefinitions = columnClass.getDeclaredMethod(COL_DEFS_METHOD_NAME);
+            var getDefinitions = columnClass.getDeclaredMethod(COL_DEFS_METHOD_NAME);
             @SuppressWarnings("unchecked")  // ensured by the Spine code generation.
-            Set<EntityColumn<S, ?>> columns =
-                    (Set<EntityColumn<S, ?>>) getDefinitions.invoke(null);
+            var columns = (Set<EntityColumn<S, ?>>) getDefinitions.invoke(null);
             return new StateColumns<>(columns);
         } catch (Exception e) {
             throw newIllegalStateException(
@@ -161,9 +159,9 @@ final class Scanner<S extends EntityState<?>, E extends Entity<?, S>> {
      *         or {@code null} if the entity declares no columns
      */
     private static @Nullable Class<?> findColumnsClass(Class<? extends EntityState<?>> stateClass) {
-        Class<?>[] innerClasses = stateClass.getDeclaredClasses();
+        var innerClasses = stateClass.getDeclaredClasses();
         Class<?> columnClass = null;
-        for (Class<?> aClass : innerClasses) {
+        for (var aClass : innerClasses) {
             if (COLS_NESTED_CLASSNAME.equals(aClass.getSimpleName())) {
                 columnClass = aClass;
             }

--- a/server/src/main/java/io/spine/server/entity/storage/ToEntityRecordQuery.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ToEntityRecordQuery.java
@@ -28,21 +28,17 @@ package io.spine.server.entity.storage;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import com.google.protobuf.FieldMask;
 import io.spine.annotation.Internal;
 import io.spine.base.EntityState;
 import io.spine.query.Column;
 import io.spine.query.ComparisonOperator;
-import io.spine.query.Direction;
 import io.spine.query.Either;
 import io.spine.query.EntityQuery;
 import io.spine.query.LogicalOperator;
 import io.spine.query.QueryPredicate;
 import io.spine.query.RecordColumn;
-import io.spine.query.RecordCriterion;
 import io.spine.query.RecordQuery;
 import io.spine.query.RecordQueryBuilder;
-import io.spine.query.SortBy;
 import io.spine.query.Subject;
 import io.spine.query.SubjectParameter;
 import io.spine.server.entity.EntityRecord;
@@ -84,7 +80,7 @@ public final class ToEntityRecordQuery<I, S extends EntityState<I>>
     private ToEntityRecordQuery(EntityQuery<I, S, ?> source) {
         super(source.subject()
                     .idType(), EntityRecord.class);
-        Subject<I, S> subject = source.subject();
+        var subject = source.subject();
         this.setIdParameter(subject.id());
         copyPredicates(subject);
         copySorting(source);
@@ -97,7 +93,7 @@ public final class ToEntityRecordQuery<I, S extends EntityState<I>>
      * of {@code ToEntityRecordQuery}.
      */
     private void copyMask(EntityQuery<I, S, ?> source) {
-        FieldMask mask = source.mask();
+        var mask = source.mask();
         if (mask != null) {
             this.withMask(mask);
         }
@@ -108,7 +104,7 @@ public final class ToEntityRecordQuery<I, S extends EntityState<I>>
      * of {@code ToEntityRecordQuery}.
      */
     private void copyLimit(EntityQuery<I, S, ?> source) {
-        Integer limit = source.limit();
+        var limit = source.limit();
         if (limit != null) {
             this.limit(limit);
         }
@@ -119,11 +115,11 @@ public final class ToEntityRecordQuery<I, S extends EntityState<I>>
      * of {@code ToEntityRecordQuery}.
      */
     private void copySorting(EntityQuery<I, S, ?> source) {
-        ImmutableList<SortBy<?, S>> sorting = source.sorting();
-        for (SortBy<?, S> sortByOrigin : sorting) {
+        var sorting = source.sorting();
+        for (var sortByOrigin : sorting) {
             RecordColumn<EntityRecord, ?> thisColumn =
                     AsEntityRecordColumn.apply(sortByOrigin.column());
-            Direction direction = sortByOrigin.direction();
+            var direction = sortByOrigin.direction();
             if (ASC == direction) {
                 this.sortAscendingBy(thisColumn);
             } else {
@@ -139,11 +135,11 @@ public final class ToEntityRecordQuery<I, S extends EntityState<I>>
      *         the subject which predicates to copy
      */
     private void copyPredicates(Subject<I, S> subject) {
-        QueryPredicate<S> root = subject.predicate();
+        var root = subject.predicate();
         copyDescendants(this, root);
 
-        ImmutableList<QueryPredicate<S>> children = root.children();
-        for (QueryPredicate<S> child : children) {
+        var children = root.children();
+        for (var child : children) {
             copyDescendants(this, child);
         }
     }
@@ -163,16 +159,16 @@ public final class ToEntityRecordQuery<I, S extends EntityState<I>>
     private RecordQueryBuilder<I, EntityRecord>
     copyDescendants(RecordQueryBuilder<I, EntityRecord> builder,
                     QueryPredicate<S> sourcePredicate) {
-        ImmutableList<SubjectParameter<?, ?, ?>> params = sourcePredicate.allParams();
-        ImmutableList<QueryPredicate<S>> children = sourcePredicate.children();
-        LogicalOperator operator = sourcePredicate.operator();
+        var params = sourcePredicate.allParams();
+        var children = sourcePredicate.children();
+        var operator = sourcePredicate.operator();
         if (operator == LogicalOperator.AND) {
             copyParameters(this, params);
-            for (QueryPredicate<S> child : children) {
+            for (var child : children) {
                 copyDescendants(builder, child);
             }
         } else {
-            ImmutableList<Either<RecordQueryBuilder<I, EntityRecord>>> eitherStatements =
+            var eitherStatements =
                     toEither(params, children);
             builder.either(eitherStatements);
         }
@@ -189,11 +185,11 @@ public final class ToEntityRecordQuery<I, S extends EntityState<I>>
     toEither(Iterable<SubjectParameter<?, ?, ?>> params, Iterable<QueryPredicate<S>> predicates) {
         ImmutableList.Builder<Either<RecordQueryBuilder<I, EntityRecord>>> result =
                 ImmutableList.builder();
-        for (SubjectParameter<?, ?, ?> param : params) {
+        for (var param : params) {
             result.add(builder -> addParameter(builder,
                                                param.column(), param.operator(), param.value()));
         }
-        for (QueryPredicate<S> predicate : predicates) {
+        for (var predicate : predicates) {
             result.add(builder -> copyDescendants(builder, predicate));
         }
         return result.build();
@@ -206,7 +202,7 @@ public final class ToEntityRecordQuery<I, S extends EntityState<I>>
     private RecordQueryBuilder<I, EntityRecord>
     copyParameters(RecordQueryBuilder<I, EntityRecord> builder,
                    Iterable<SubjectParameter<?, ?, ?>> params) {
-        for (SubjectParameter<?, ?, ?> parameter : params) {
+        for (var parameter : params) {
             addParameter(builder, parameter.column(), parameter.operator(), parameter.value());
         }
         return builder;
@@ -229,9 +225,9 @@ public final class ToEntityRecordQuery<I, S extends EntityState<I>>
     private RecordQueryBuilder<I, EntityRecord>
     addParameter(RecordQueryBuilder<I, EntityRecord> builder, Column<?, ?> source,
                  ComparisonOperator operator, Object value) {
-        RecordColumn<EntityRecord, Object> column = AsEntityRecordColumn.apply(source);
+        var column = AsEntityRecordColumn.apply(source);
 
-        RecordCriterion<I, EntityRecord, Object> where = builder.where(column);
+        var where = builder.where(column);
         switch (operator) {
             case EQUALS:
                 return where.is(value);

--- a/server/src/main/java/io/spine/server/event/AbstractEventReactor.java
+++ b/server/src/main/java/io/spine/server/event/AbstractEventReactor.java
@@ -41,7 +41,6 @@ import io.spine.server.ContextAware;
 import io.spine.server.Identity;
 import io.spine.server.dispatch.DispatchOutcomeHandler;
 import io.spine.server.event.model.EventReactorClass;
-import io.spine.server.event.model.EventReactorMethod;
 import io.spine.server.stand.Stand;
 import io.spine.server.tenant.TenantAwareRunner;
 import io.spine.server.type.EventClass;
@@ -51,7 +50,6 @@ import io.spine.system.server.NoOpSystemWriteSide;
 import io.spine.system.server.SystemWriteSide;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Suppliers.memoize;
@@ -121,7 +119,7 @@ public abstract class AbstractEventReactor
     }
 
     private void reactAndPost(EventEnvelope event) {
-        Optional<EventReactorMethod> method = thisClass.reactorOf(event);
+        var method = thisClass.reactorOf(event);
         if (method.isPresent()) {
             DispatchOutcomeHandler
                     .from(method.get().invoke(this, event))
@@ -139,8 +137,7 @@ public abstract class AbstractEventReactor
     }
 
     private void postFailure(Error error, EventEnvelope event) {
-        HandlerFailedUnexpectedly systemEvent = HandlerFailedUnexpectedly
-                .newBuilder()
+        var systemEvent = HandlerFailedUnexpectedly.newBuilder()
                 .setEntity(eventAnchor())
                 .setHandledSignal(event.messageId())
                 .setError(error)

--- a/server/src/main/java/io/spine/server/event/AbstractEventSubscriber.java
+++ b/server/src/main/java/io/spine/server/event/AbstractEventSubscriber.java
@@ -36,10 +36,8 @@ import io.spine.server.BoundedContext;
 import io.spine.server.ContextAware;
 import io.spine.server.Identity;
 import io.spine.server.bus.MessageDispatcher;
-import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.dispatch.DispatchOutcomeHandler;
 import io.spine.server.event.model.EventSubscriberClass;
-import io.spine.server.event.model.SubscriberMethod;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
 import io.spine.system.server.HandlerFailedUnexpectedly;
@@ -47,7 +45,6 @@ import io.spine.system.server.NoOpSystemWriteSide;
 import io.spine.system.server.SystemWriteSide;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -109,7 +106,7 @@ public abstract class AbstractEventSubscriber
      * subscriber} method of the entity.
      */
     protected void handle(EventEnvelope event) {
-        DispatchOutcome outcome =
+        var outcome =
                 thisClass.subscriberOf(event)
                          .map(method -> method.invoke(this, event))
                          .orElseGet(() -> ignored(thisClass, event));
@@ -120,8 +117,7 @@ public abstract class AbstractEventSubscriber
     }
 
     private void postFailure(Error error, EventEnvelope event) {
-        HandlerFailedUnexpectedly systemEvent = HandlerFailedUnexpectedly
-                .newBuilder()
+        var systemEvent = HandlerFailedUnexpectedly.newBuilder()
                 .setEntity(eventAnchor())
                 .setHandledSignal(event.messageId())
                 .setError(error)
@@ -142,7 +138,7 @@ public abstract class AbstractEventSubscriber
 
     @Override
     public boolean canDispatch(EventEnvelope event) {
-        Optional<SubscriberMethod> subscriber = thisClass.subscriberOf(event);
+        var subscriber = thisClass.subscriberOf(event);
         return subscriber.isPresent();
     }
 

--- a/server/src/main/java/io/spine/server/event/AbstractStatefulReactor.java
+++ b/server/src/main/java/io/spine/server/event/AbstractStatefulReactor.java
@@ -75,8 +75,8 @@ public abstract class AbstractStatefulReactor<I, S extends Message, B extends Va
      */
     protected AbstractStatefulReactor(TypeUrl stateType) {
         super();
-        Delivery delivery = ServerEnvironment.instance()
-                                             .delivery();
+        var delivery = ServerEnvironment.instance()
+                                        .delivery();
         this.inbox = configureInbox(delivery, stateType);
     }
 
@@ -89,7 +89,7 @@ public abstract class AbstractStatefulReactor<I, S extends Message, B extends Va
     @Override
     public void dispatch(EventEnvelope event) {
         Set<I> targets = route(event);
-        for (I target : targets) {
+        for (var target : targets) {
             inbox.send(event)
                  .toReactor(target);
         }
@@ -121,7 +121,7 @@ public abstract class AbstractStatefulReactor<I, S extends Message, B extends Va
      * as-is.
      */
     protected final void flushState() {
-        S newState = builder().vBuild();
+        var newState = builder().vBuild();
         store(newState);
     }
 
@@ -181,7 +181,7 @@ public abstract class AbstractStatefulReactor<I, S extends Message, B extends Va
 
         @SuppressWarnings("unchecked")
         private void loadIntoBuilder(I id) {
-            Optional<S> existingState = load(id);
+            var existingState = load(id);
             AbstractStatefulReactor.this.builder =
                     existingState.isPresent()
                     ? (B) existingState.get()

--- a/server/src/main/java/io/spine/server/event/AbstractStatefulReactor.java
+++ b/server/src/main/java/io/spine/server/event/AbstractStatefulReactor.java
@@ -52,7 +52,7 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  *         the type of the reactor identifiers
  * @param <S>
  *         the type of reactor states
- * @param <B>>
+ * @param <B>
  *         the type of the builders for the reactor states
  */
 public abstract class AbstractStatefulReactor<I, S extends Message, B extends ValidatingBuilder<S>>

--- a/server/src/main/java/io/spine/server/event/DeadEventTap.java
+++ b/server/src/main/java/io/spine/server/event/DeadEventTap.java
@@ -51,8 +51,8 @@ final class DeadEventTap implements DeadMessageHandler<EventEnvelope> {
     public UnsupportedEventException handle(EventEnvelope event) {
         eventStore().append(event.outerObject());
 
-        EventMessage message = event.message();
-        UnsupportedEventException exception = new UnsupportedEventException(message);
+        var message = event.message();
+        var exception = new UnsupportedEventException(message);
         return exception;
     }
 

--- a/server/src/main/java/io/spine/server/event/EventBus.java
+++ b/server/src/main/java/io/spine/server/event/EventBus.java
@@ -57,6 +57,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static io.spine.grpc.StreamObservers.noOpObserver;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Dispatches incoming events to subscribers and provides ways for registering those subscribers.
@@ -131,7 +132,7 @@ public final class EventBus
     private EventBus(Builder builder) {
         super(builder);
         this.enricher = builder.enricher;
-        this.observer = checkNotNull(builder.observer);
+        this.observer = requireNonNull(builder.observer);
         this.deadMessageHandler = new DeadEventTap(this::eventStore);
     }
 
@@ -226,10 +227,10 @@ public final class EventBus
     }
 
     /**
-     * Obtains {@code Enricher} used by this Event Bus.
+     * Obtains the {@code EventEnricher} used by this Event Bus.
      */
     @VisibleForTesting
-    public final Optional<Enricher> enricher() {
+    public final Optional<EventEnricher> enricher() {
         return Optional.ofNullable(enricher);
     }
 
@@ -237,14 +238,14 @@ public final class EventBus
         if (enricher == null) {
             return event;
         }
-        EventEnvelope maybeEnriched = enricher.enrich(event);
+        var maybeEnriched = enricher.enrich(event);
         return maybeEnriched;
     }
 
     @Override
     protected void dispatch(EventEnvelope event) {
-        EventEnvelope enrichedEnvelope = enrich(event);
-        int dispatchersCalled = callDispatchers(enrichedEnvelope);
+        var enrichedEnvelope = enrich(event);
+        var dispatchersCalled = callDispatchers(enrichedEnvelope);
         checkState(dispatchersCalled != 0,
                    format("Message of type `%s` and ID `%s` has no dispatchers.",
                           event.messageClass(),
@@ -358,7 +359,7 @@ public final class EventBus
             if (observer == null) {
                 observer = noOpObserver();
             }
-            EventBus result = new EventBus(this);
+            var result = new EventBus(this);
             return result;
         }
 

--- a/server/src/main/java/io/spine/server/event/EventComparator.java
+++ b/server/src/main/java/io/spine/server/event/EventComparator.java
@@ -70,7 +70,7 @@ public abstract class EventComparator implements Comparator<Event>, Serializable
 
         @Override
         public int compare(Event e1, Event e2) {
-            int result = Comparator
+            var result = Comparator
                     .comparing(Event::timestamp, Timestamps.comparator())
                     .thenComparing((e) -> e.getContext()
                                            .getVersion()

--- a/server/src/main/java/io/spine/server/event/EventException.java
+++ b/server/src/main/java/io/spine/server/event/EventException.java
@@ -74,14 +74,15 @@ public abstract class EventException extends RuntimeException implements Message
     /**
      * Returns a map with an event type attribute.
      *
-     * @param eventMessage an event message to get the type from
+     * @param eventMessage
+     *         an event message to get the type from
      */
     public static Map<String, Value> eventTypeAttribute(Message eventMessage) {
-        String type = TypeName.of(eventMessage)
-                              .value();
-        Value value = Value.newBuilder()
-                           .setStringValue(type)
-                           .build();
+        var type = TypeName.of(eventMessage)
+                           .value();
+        var value = Value.newBuilder()
+                .setStringValue(type)
+                .build();
         Map<String, Value> result = ImmutableMap.of(ATTR_EVENT_TYPE_NAME, value);
         return result;
     }

--- a/server/src/main/java/io/spine/server/event/EventFactory.java
+++ b/server/src/main/java/io/spine/server/event/EventFactory.java
@@ -30,7 +30,6 @@ import com.google.protobuf.Any;
 import io.spine.base.EventMessage;
 import io.spine.core.ActorContext;
 import io.spine.core.Event;
-import io.spine.core.EventContext;
 import io.spine.core.Version;
 import io.spine.server.type.MessageEnvelope;
 import io.spine.validate.ValidationException;
@@ -60,7 +59,7 @@ public class EventFactory extends EventFactoryBase {
     public static EventFactory on(MessageEnvelope<?, ?, ?> origin, Any producerId) {
         checkNotNull(origin);
         checkNotNull(producerId);
-        EventOrigin eventOrigin = fromAnotherMessage(origin);
+        var eventOrigin = fromAnotherMessage(origin);
         return new EventFactory(eventOrigin, producerId);
     }
 
@@ -78,7 +77,7 @@ public class EventFactory extends EventFactoryBase {
         checkNotNull(producerId);
         checkValid(actorContext);
 
-        EventOrigin origin = EventOrigin.forImport(actorContext);
+        var origin = EventOrigin.forImport(actorContext);
         return new EventFactory(origin, producerId);
     }
 
@@ -100,7 +99,7 @@ public class EventFactory extends EventFactoryBase {
      */
     public Event createEvent(EventMessage msg, Version version)
             throws ValidationException {
-        EventContext context = createContext(version);
+        var context = createContext(version);
         return assemble(msg, context);
     }
 
@@ -112,7 +111,7 @@ public class EventFactory extends EventFactoryBase {
      * @see #createEvent(EventMessage, Version)
      */
     public Event createEvent(EventMessage msg) throws ValidationException {
-        EventContext context = createContext(null);
+        var context = createContext(null);
         return assemble(msg, context);
     }
 }

--- a/server/src/main/java/io/spine/server/event/EventOrigin.java
+++ b/server/src/main/java/io/spine/server/event/EventOrigin.java
@@ -65,7 +65,7 @@ public final class EventOrigin {
      */
     public static EventOrigin fromAnotherMessage(MessageEnvelope<?, ?, ?> envelope) {
         checkNotNull(envelope);
-        Origin origin = envelope.asMessageOrigin();
+        var origin = envelope.asMessageOrigin();
         return new EventOrigin(origin, null);
     }
 
@@ -98,7 +98,7 @@ public final class EventOrigin {
      * @return new {@code EventContext} builder
      */
     EventContext.Builder contextBuilder() {
-        EventContext.Builder builder = EventContext.newBuilder();
+        var builder = EventContext.newBuilder();
         if (otherMessage != null) {
             builder.setPastMessage(otherMessage)
                    .setTimestamp(Time.currentTime());

--- a/server/src/main/java/io/spine/server/event/EventValidator.java
+++ b/server/src/main/java/io/spine/server/event/EventValidator.java
@@ -26,15 +26,11 @@
 
 package io.spine.server.event;
 
-import io.spine.base.EventMessage;
-import io.spine.core.Event;
 import io.spine.server.MessageInvalid;
 import io.spine.server.bus.EnvelopeValidator;
 import io.spine.server.type.EventEnvelope;
-import io.spine.validate.ConstraintViolation;
 import io.spine.validate.Validate;
 
-import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -48,12 +44,12 @@ final class EventValidator implements EnvelopeValidator<EventEnvelope> {
     @Override
     public Optional<MessageInvalid> validate(EventEnvelope event) {
         checkNotNull(event);
-        Event outerObject = event.outerObject();
-        List<ConstraintViolation> violations = Validate.violationsOf(outerObject);
+        var outerObject = event.outerObject();
+        var violations = Validate.violationsOf(outerObject);
         if (violations.isEmpty()) {
             return Optional.empty();
         }
-        EventMessage message = event.message();
+        var message = event.message();
         MessageInvalid result = onConstraintViolations(message, violations);
         return Optional.of(result);
     }

--- a/server/src/main/java/io/spine/server/event/InvalidEventException.java
+++ b/server/src/main/java/io/spine/server/event/InvalidEventException.java
@@ -65,7 +65,7 @@ public class InvalidEventException extends EventException implements MessageInva
     public static
     InvalidEventException onConstraintViolations(EventMessage eventMsg,
                                                  Iterable<ConstraintViolation> violations) {
-        Factory factory = new Factory(eventMsg, violations);
+        var factory = new Factory(eventMsg, violations);
         return factory.newException();
     }
 

--- a/server/src/main/java/io/spine/server/event/UnsupportedEventException.java
+++ b/server/src/main/java/io/spine/server/event/UnsupportedEventException.java
@@ -31,7 +31,6 @@ import io.spine.base.EventMessage;
 import io.spine.core.EventValidationError;
 import io.spine.server.bus.MessageUnhandled;
 import io.spine.server.type.EventClass;
-import io.spine.type.TypeName;
 
 import static java.lang.String.format;
 
@@ -48,9 +47,9 @@ public class UnsupportedEventException extends EventException implements Message
     }
 
     private static String messageFormat(Message eventMsg) {
-        EventClass eventClass = EventClass.of(eventMsg);
-        TypeName typeName = eventClass.typeName();
-        String result = format(
+        var eventClass = EventClass.of(eventMsg);
+        var typeName = eventClass.typeName();
+        var result = format(
                 "There is no registered handler or dispatcher for the event of the class: `%s` " +
                 " (proto type: `%s`).",
                 eventClass,
@@ -60,11 +59,10 @@ public class UnsupportedEventException extends EventException implements Message
 
     /** Creates an instance of unsupported event error. */
     private static Error unsupportedEventError(Message eventMessage) {
-        String type = eventMessage.getDescriptorForType()
-                                  .getFullName();
-        String errMsg = format("Events of the type `%s` are not supported.", type);
-        Error error = Error
-                .newBuilder()
+        var type = eventMessage.getDescriptorForType()
+                               .getFullName();
+        var errMsg = format("Events of the type `%s` are not supported.", type);
+        var error = Error.newBuilder()
                 .setType(EventValidationError.getDescriptor()
                                              .getFullName())
                 .setCode(EventValidationError.UNSUPPORTED_EVENT.getNumber())

--- a/server/src/main/java/io/spine/server/event/model/EventAcceptingMethodParams.java
+++ b/server/src/main/java/io/spine/server/event/model/EventAcceptingMethodParams.java
@@ -77,7 +77,7 @@ enum EventAcceptingMethodParams implements ParameterSpec<EventEnvelope> {
     ) {
         @Override
         public ExtractedArguments extractArguments(EventEnvelope event) {
-            RejectionEnvelope re = new RejectionEnvelope(event);
+            var re = new RejectionEnvelope(event);
             return ofTwo(re.rejectionMessage(), re.commandContext());
         }
     },
@@ -93,7 +93,7 @@ enum EventAcceptingMethodParams implements ParameterSpec<EventEnvelope> {
 
         @Override
         public ExtractedArguments extractArguments(EventEnvelope event) {
-            RejectionEnvelope re = new RejectionEnvelope(event);
+            var re = new RejectionEnvelope(event);
             return ofTwo(re.rejectionMessage(), re.commandMessage());
         }
     },
@@ -110,7 +110,7 @@ enum EventAcceptingMethodParams implements ParameterSpec<EventEnvelope> {
 
         @Override
         public ExtractedArguments extractArguments(EventEnvelope event) {
-            RejectionEnvelope re = new RejectionEnvelope(event);
+            var re = new RejectionEnvelope(event);
             return ofTree(re.rejectionMessage(), re.commandMessage(), re.commandContext());
         }
     };

--- a/server/src/main/java/io/spine/server/event/model/EventHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/EventHandlerMethod.java
@@ -72,7 +72,7 @@ public abstract class EventHandlerMethod<T, R extends MessageClass<?>>
     @Override
     public MethodParams params() {
         if (RejectionHandler.super.handlesRejection()) {
-            MethodParams result = MethodParams.of(rawMethod());
+            var result = MethodParams.of(rawMethod());
             return result;
         }
         return super.params();
@@ -93,8 +93,7 @@ public abstract class EventHandlerMethod<T, R extends MessageClass<?>>
      */
     @Override
     protected void checkAttributesMatch(EventEnvelope event) {
-        boolean external = event.context()
-                                .getExternal();
+        var external = event.context().getExternal();
         ensureExternalMatch(external);
     }
 }

--- a/server/src/main/java/io/spine/server/event/model/EventReactorClass.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReactorClass.java
@@ -67,7 +67,7 @@ public final class EventReactorClass<S extends EventReactor> extends ModelClass<
     asReactorClass(Class<S> cls) {
         checkNotNull(cls);
         @SuppressWarnings("unchecked")
-        EventReactorClass<S> result = (EventReactorClass<S>)
+        var result = (EventReactorClass<S>)
                 get(cls, EventReactorClass.class, () -> new EventReactorClass<>(cls));
         return (result);
     }

--- a/server/src/main/java/io/spine/server/event/model/EventReceivingClassDelegate.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReceivingClassDelegate.java
@@ -40,8 +40,6 @@ import io.spine.type.MessageClass;
 
 import java.util.Optional;
 
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
-
 /**
  * Helper object for storing information about methods and handlers of an
  * {@linkplain EventReceiverClass event receiving class}.
@@ -154,18 +152,17 @@ public class EventReceivingClassDelegate<T extends EventReceiver,
      * Obtains the classes of entity state messages from the passed handlers.
      */
     private ImmutableSet<StateClass<?>> extractStates(boolean external) {
-        EventClass updateEvent = StateClass.updateEvent();
+        var updateEvent = StateClass.updateEvent();
         if (!handlers.containsClass(updateEvent)) {
             return ImmutableSet.of();
         }
-        ImmutableSet<M> stateHandlers = handlers.handlersOf(updateEvent);
-        ImmutableSet<StateClass<?>> result =
-                stateHandlers.stream()
-                        .filter(h -> h instanceof StateSubscriberMethod)
-                        .map(h -> (StateSubscriberMethod) h)
-                        .filter(external ? HandlerMethod::isExternal : HandlerMethod::isDomestic)
-                        .map(StateSubscriberMethod::stateClass)
-                        .collect(toImmutableSet());
+        var stateHandlers = handlers.handlersOf(updateEvent);
+        var result = stateHandlers.stream()
+                .filter(h -> h instanceof StateSubscriberMethod)
+                .map(h -> (StateSubscriberMethod) h)
+                .filter(external ? HandlerMethod::isExternal : HandlerMethod::isDomestic)
+                .map(StateSubscriberMethod::stateClass)
+                .collect(ImmutableSet.<StateClass<?>>toImmutableSet());
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/event/model/EventSubscriberClass.java
+++ b/server/src/main/java/io/spine/server/event/model/EventSubscriberClass.java
@@ -62,7 +62,7 @@ public final class EventSubscriberClass<S extends EventSubscriber> extends Model
     EventSubscriberClass<S> asEventSubscriberClass(Class<S> cls) {
         checkNotNull(cls);
         @SuppressWarnings("unchecked")
-        EventSubscriberClass<S> result = (EventSubscriberClass<S>)
+        var result = (EventSubscriberClass<S>)
                 get(cls, EventSubscriberClass.class, () -> new EventSubscriberClass<>(cls));
         return result;
     }

--- a/server/src/main/java/io/spine/server/event/model/RejectionDispatchKeys.java
+++ b/server/src/main/java/io/spine/server/event/model/RejectionDispatchKeys.java
@@ -55,21 +55,20 @@ final class RejectionDispatchKeys {
     static DispatchKey of(EventClass eventClass, Method rawMethod) {
         checkNotNull(eventClass);
         checkNotNull(rawMethod);
-        Class<?>[] parameters = rawMethod.getParameterTypes();
-        String methodName = rawMethod.getName();
+        var parameters = rawMethod.getParameterTypes();
+        var methodName = rawMethod.getName();
         checkArgument(parameters.length >= 2,
                       "The method `%s` should have at least 2 parameters, but has `%s`.",
                       methodName,
                       parameters.length);
-        Class<?> secondParameter = parameters[1];
+        var secondParameter = parameters[1];
         checkArgument(CommandMessage.class.isAssignableFrom(secondParameter),
                       "The method `%s` should have the second parameter assignable from `CommandMessage`, but has `%s`.",
                       methodName,
                       secondParameter);
         @SuppressWarnings("unchecked") // checked above
-        Class<? extends CommandMessage> commandMessageClass =
-                (Class<? extends CommandMessage>) secondParameter;
-        CommandClass commandClass = CommandClass.from(commandMessageClass);
+        var commandMessageClass = (Class<? extends CommandMessage>) secondParameter;
+        var commandClass = CommandClass.from(commandMessageClass);
         return new DispatchKey(eventClass.value(), commandClass.value());
     }
 }

--- a/server/src/main/java/io/spine/server/event/model/RejectionHandler.java
+++ b/server/src/main/java/io/spine/server/event/model/RejectionHandler.java
@@ -64,7 +64,7 @@ interface RejectionHandler<T, R extends MessageClass<?>>
     @Override
     default DispatchKey key() {
         if (handlesRejection()) {
-            DispatchKey dispatchKey = RejectionDispatchKeys.of(messageClass(), rawMethod());
+            var dispatchKey = RejectionDispatchKeys.of(messageClass(), rawMethod());
             return dispatchKey;
         }
         return HandlerMethod.super.key();

--- a/server/src/main/java/io/spine/server/event/model/StateSubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/StateSubscriberMethod.java
@@ -67,8 +67,8 @@ public final class StateSubscriberMethod extends SubscriberMethod implements Log
     }
 
     private void checkExternal() {
-        BoundedContextName originContext = contextOf(stateType());
-        boolean external = !originContext.equals(contextOfSubscriber);
+        var originContext = contextOf(stateType());
+        var external = !originContext.equals(contextOfSubscriber);
         ensureExternalMatch(external);
     }
 
@@ -88,7 +88,7 @@ public final class StateSubscriberMethod extends SubscriberMethod implements Log
 
     @Override
     protected ArgumentFilter createFilter() {
-        TypeUrl targetType = TypeUrl.of(stateType);
+        var targetType = TypeUrl.of(stateType);
         return ArgumentFilter.acceptingOnly(ENTITY_TYPE_URL, targetType.value());
     }
 
@@ -103,8 +103,8 @@ public final class StateSubscriberMethod extends SubscriberMethod implements Log
     @SuppressWarnings("TestOnlyProblems")
     // Checks that the resulting context is not `AssumingTests` in production environment.
     private BoundedContextName contextOf(Class<?> cls) {
-        Model model = Model.inContextOf(cls);
-        BoundedContextName name = model.contextName();
+        var model = Model.inContextOf(cls);
+        var name = model.contextName();
         if (!Environment.instance().is(Tests.class) && name.equals(assumingTests())) {
             _warn().log(
                     "The class `%s` belongs to the Bounded Context named `%s`," +

--- a/server/src/main/java/io/spine/server/event/model/StateSubscriberSpec.java
+++ b/server/src/main/java/io/spine/server/event/model/StateSubscriberSpec.java
@@ -29,7 +29,6 @@ package io.spine.server.event.model;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.spine.base.EntityState;
-import io.spine.base.EventMessage;
 import io.spine.core.EventContext;
 import io.spine.server.entity.EntityVisibility;
 import io.spine.server.model.ExtractedArguments;
@@ -39,8 +38,6 @@ import io.spine.server.model.TypeMatcher;
 import io.spine.server.type.EventEnvelope;
 import io.spine.system.server.event.EntityStateChanged;
 import io.spine.type.TypeName;
-
-import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.spine.protobuf.AnyPacker.unpack;
@@ -79,13 +76,13 @@ enum StateSubscriberSpec implements ParameterSpec<EventEnvelope> {
             return false;
         }
         @SuppressWarnings("unchecked") // Checked above.
-        Class<? extends EntityState<?>> firstParameter =
+        var firstParameter =
                 (Class<? extends EntityState<?>>) params.type(0);
-        Optional<EntityVisibility> visibilityOption = EntityVisibility.of(firstParameter);
-        if (!visibilityOption.isPresent()) {
+        var visibilityOption = EntityVisibility.of(firstParameter);
+        if (visibilityOption.isEmpty()) {
             return false;
         }
-        EntityVisibility visibility = visibilityOption.get();
+        var visibility = visibilityOption.get();
         if (visibility.canSubscribe()) {
             return true;
         } else {
@@ -95,11 +92,11 @@ enum StateSubscriberSpec implements ParameterSpec<EventEnvelope> {
 
     @Override
     public ExtractedArguments extractArguments(EventEnvelope event) {
-        EventMessage eventMessage = event.message();
+        var eventMessage = event.message();
         checkArgument(eventMessage instanceof EntityStateChanged,
                       "Must be an `%s` event.", EntityStateChanged.class.getSimpleName());
-        EntityStateChanged systemEvent = (EntityStateChanged) eventMessage;
-        EntityState<?> state = (EntityState<?>) unpack(systemEvent.getNewState());
+        var systemEvent = (EntityStateChanged) eventMessage;
+        var state = (EntityState<?>) unpack(systemEvent.getNewState());
         return arrangeArguments(state, event);
     }
 

--- a/server/src/main/java/io/spine/server/event/model/SubscriberSignature.java
+++ b/server/src/main/java/io/spine/server/event/model/SubscriberSignature.java
@@ -84,7 +84,7 @@ public class SubscriberSignature extends EventAcceptingSignature<SubscriberMetho
     }
 
     private static boolean isEntitySubscriber(Method method) {
-        Class<?> firstParam = method.getParameterTypes()[0];
+        var firstParam = method.getParameterTypes()[0];
         return EntityState.class.isAssignableFrom(firstParam);
     }
 }

--- a/server/src/main/java/io/spine/server/event/store/MatchFilter.java
+++ b/server/src/main/java/io/spine/server/event/store/MatchFilter.java
@@ -40,7 +40,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Predicate;
 
 import static io.spine.protobuf.AnyPacker.unpackFunc;
@@ -77,19 +76,19 @@ final class MatchFilter implements Predicate<Event> {
     }
 
     private static @Nullable TypeUrl getEventTypeUrl(EventFilter filter) {
-        String eventType = filter.getEventType();
-        TypeUrl result = eventType.isEmpty()
-                         ? null
-                         : TypeName.of(eventType)
-                                   .toUrl();
+        var eventType = filter.getEventType();
+        var result = eventType.isEmpty()
+                     ? null
+                     : TypeName.of(eventType)
+                               .toUrl();
         return result;
     }
 
     private static @Nullable List<Any> getAggregateIdentifiers(EventFilter filter) {
-        List<Any> aggregateIdList = filter.getAggregateIdList();
-        List<Any> result = aggregateIdList.isEmpty()
-                           ? null
-                           : aggregateIdList;
+        var aggregateIdList = filter.getAggregateIdList();
+        var result = aggregateIdList.isEmpty()
+                     ? null
+                     : aggregateIdList;
         return result;
     }
 
@@ -99,8 +98,8 @@ final class MatchFilter implements Predicate<Event> {
             return false;
         }
 
-        EventMessage eventMessage = event.enclosedMessage();
-        EventContext context = event.context();
+        var eventMessage = event.enclosedMessage();
+        var context = event.context();
 
         if (!checkEventType(eventMessage)) {
             return false;
@@ -114,7 +113,7 @@ final class MatchFilter implements Predicate<Event> {
             return false;
         }
 
-        boolean result = check(context, contextFieldFilters);
+        var result = check(context, contextFieldFilters);
         return result;
     }
 
@@ -122,13 +121,13 @@ final class MatchFilter implements Predicate<Event> {
         if (aggregateIds == null) {
             return true;
         }
-        Any aggregateId = context.getProducerId();
-        boolean result = aggregateIds.contains(aggregateId);
+        var aggregateId = context.getProducerId();
+        var result = aggregateIds.contains(aggregateId);
         return result;
     }
 
     private boolean checkEventType(EventMessage event) {
-        boolean result = (eventTypeUrl == null) || eventTypeUrl.equals(event.typeUrl());
+        var result = (eventTypeUrl == null) || eventTypeUrl.equals(event.typeUrl());
         return result;
     }
 
@@ -136,8 +135,8 @@ final class MatchFilter implements Predicate<Event> {
      * Tells if the passed message matches the filters.
      */
     private static boolean check(Message message, Collection<FieldFilter> filters) {
-        for (FieldFilter filter : filters) {
-            boolean matchesFilter = checkFields(message, filter);
+        for (var filter : filters) {
+            var matchesFilter = checkFields(message, filter);
             if (!matchesFilter) {
                 return false;
             }
@@ -146,21 +145,20 @@ final class MatchFilter implements Predicate<Event> {
     }
 
     private static boolean checkFields(Message object, FieldFilter filter) {
-        Field field = fieldFrom(filter);
-        Optional<Object> value = field.findValue(object);
-        if (!value.isPresent()) {
+        var field = fieldFrom(filter);
+        var value = field.findValue(object);
+        if (value.isEmpty()) {
             /* If there is no value in the field, return `true`
                when the list of required values is also empty. */
-            boolean nothingIsExpected = filter.getValueList().isEmpty();
+            var nothingIsExpected = filter.getValueList().isEmpty();
             return nothingIsExpected;
         }
-        Collection<Message> expectedValues =
-                filter.getValueList()
-                      .stream()
-                      .map(unpackFunc())
-                      .collect(toList());
-        Message msg = (Message) value.get();
-        boolean result = expectedValues.contains(msg);
+        var expectedValues = filter.getValueList()
+                .stream()
+                .map(unpackFunc())
+                .collect(toList());
+        var msg = (Message) value.get();
+        var result = expectedValues.contains(msg);
         return result;
     }
 
@@ -169,8 +167,8 @@ final class MatchFilter implements Predicate<Event> {
      * from the passed filter.
      */
     private static Field fieldFrom(FieldFilter filter) {
-        String path = filter.getFieldPath();
-        String fieldName = path.substring(path.lastIndexOf('.') + 1);
+        var path = filter.getFieldPath();
+        var fieldName = path.substring(path.lastIndexOf('.') + 1);
         if (fieldName.isEmpty()) {
             throw newIllegalArgumentException(
                     "Unable to get a field name from the field filter: `%s`.", filter);

--- a/server/src/main/java/io/spine/server/event/store/MatchesStreamQuery.java
+++ b/server/src/main/java/io/spine/server/event/store/MatchesStreamQuery.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * The predicate for filtering {@code Event} instances by {@link EventStreamQuery}.
@@ -54,12 +55,12 @@ final class MatchesStreamQuery implements Predicate<Event> {
 
     @Override
     public boolean test(@Nullable Event input) {
-        checkNotNull(input);
+        requireNonNull(input);
         if (filterList.isEmpty()) {
             return true; // No filters specified.
         }
         // Check if one of the filters matches. If so, the event matches.
-        for (EventFilter filter : filterList) {
+        for (var filter : filterList) {
             Predicate<Event> filterPredicate = new MatchFilter(filter);
             if (filterPredicate.test(input)) {
                 return true;

--- a/server/src/main/java/io/spine/server/event/store/Queries.java
+++ b/server/src/main/java/io/spine/server/event/store/Queries.java
@@ -26,8 +26,6 @@
 
 package io.spine.server.event.store;
 
-import com.google.common.collect.ImmutableList;
-import com.google.protobuf.Timestamp;
 import io.spine.core.Event;
 import io.spine.core.EventId;
 import io.spine.query.Either;
@@ -35,8 +33,6 @@ import io.spine.query.RecordQuery;
 import io.spine.query.RecordQueryBuilder;
 import io.spine.server.event.EventFilter;
 import io.spine.server.event.EventStreamQuery;
-
-import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -56,13 +52,12 @@ final class Queries {
     static RecordQuery<EventId, Event> convert(EventStreamQuery query) {
         checkNotNull(query);
 
-        RecordQueryBuilder<EventId, Event> builder =
-                RecordQuery.newBuilder(EventId.class, Event.class);
+        var builder = RecordQuery.newBuilder(EventId.class, Event.class);
         if (!query.includeAll()) {
             addTimeBounds(query, builder);
             addTypeParams(query, builder);
         }
-        RecordQuery<EventId, Event> result = addOrderAndLimit(query, builder);
+        var result = addOrderAndLimit(query, builder);
         return result;
     }
 
@@ -70,30 +65,26 @@ final class Queries {
     private static void addTimeBounds(EventStreamQuery query,
                                       RecordQueryBuilder<EventId, Event> builder) {
         if (query.hasAfter()) {
-            Timestamp timestamp = query.getAfter();
-            builder.where(created)
-                   .isGreaterThan(timestamp);
+            var timestamp = query.getAfter();
+            builder.where(created).isGreaterThan(timestamp);
         }
         if (query.hasBefore()) {
-            Timestamp timestamp = query.getBefore();
-            builder.where(created)
-                   .isLessThan(timestamp);
+            var timestamp = query.getBefore();
+            builder.where(created).isLessThan(timestamp);
         }
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")  /* Configuring `builder` step-by-step. */
     private static void addTypeParams(EventStreamQuery query,
                                       RecordQueryBuilder<EventId, Event> builder) {
-        if(query.getFilterCount() == 0) {
+        if (query.getFilterCount() == 0) {
             return;
         }
-        List<EventFilter> filters = query.getFilterList();
-        ImmutableList<Either<RecordQueryBuilder<EventId, Event>>> eitherStatements =
-                filters
-                     .stream()
-                     .filter(Queries::hasEventType)
-                     .map(Queries::toEither)
-                     .collect(toImmutableList());
+        var filters = query.getFilterList();
+        var eitherStatements = filters.stream()
+                .filter(Queries::hasEventType)
+                .map(Queries::toEither)
+                .collect(toImmutableList());
         builder.either(eitherStatements);
     }
 
@@ -104,10 +95,8 @@ final class Queries {
     @SuppressWarnings("ResultOfMethodCallIgnored")  /* Configuring `builder` step-by-step. */
     private static Either<RecordQueryBuilder<EventId, Event>> toEither(EventFilter filter) {
         return builder -> {
-            String type = filter.getEventType()
-                                .trim();
-            builder.where(EventColumn.type)
-                   .is(type);
+            var type = filter.getEventType().trim();
+            builder.where(EventColumn.type).is(type);
             return builder;
         };
     }
@@ -116,8 +105,7 @@ final class Queries {
     addOrderAndLimit(EventStreamQuery query, RecordQueryBuilder<EventId, Event> builder) {
         builder.sortAscendingBy(created);
         if (query.hasLimit()) {
-            builder.limit(query.getLimit()
-                               .getValue());
+            builder.limit(query.getLimit().getValue());
         }
 
         return builder.build();

--- a/server/src/main/java/io/spine/server/integration/AbstractChannelObserver.java
+++ b/server/src/main/java/io/spine/server/integration/AbstractChannelObserver.java
@@ -76,7 +76,7 @@ public abstract class AbstractChannelObserver implements StreamObserver<External
 
     @Override
     public void onError(Throwable t) {
-        boolean wasCompleted = !completed.compareAndSet(false, true);
+        var wasCompleted = !completed.compareAndSet(false, true);
         if (wasCompleted) {
             _warn().log("Observer for `%s` received an error despite being closed.",
                         messageClass.getName());
@@ -87,7 +87,7 @@ public abstract class AbstractChannelObserver implements StreamObserver<External
 
     @Override
     public void onCompleted() {
-        boolean wasNotCompleted = completed.compareAndSet(false, true);
+        var wasNotCompleted = completed.compareAndSet(false, true);
         checkState(wasNotCompleted, "Observer of `%s` is already closed.", messageClass.getName());
     }
 
@@ -100,8 +100,8 @@ public abstract class AbstractChannelObserver implements StreamObserver<External
                           .getName(),
                    message.getOriginalMessage()
                           .getTypeUrl());
-        BoundedContextName source = message.getBoundedContextName();
-        boolean sameContext = boundedContextName.equals(source)
+        var source = message.getBoundedContextName();
+        var sameContext = boundedContextName.equals(source)
                 || boundedContextName.isSystemOf(source)
                 || source.isSystemOf(boundedContextName);
         if (!sameContext) {
@@ -124,7 +124,7 @@ public abstract class AbstractChannelObserver implements StreamObserver<External
         if (!(o instanceof AbstractChannelObserver)) {
             return false;
         }
-        AbstractChannelObserver that = (AbstractChannelObserver) o;
+        var that = (AbstractChannelObserver) o;
         return Objects.equals(boundedContextName, that.boundedContextName) &&
                 Objects.equals(messageClass, that.messageClass);
     }

--- a/server/src/main/java/io/spine/server/integration/AbstractExchange.java
+++ b/server/src/main/java/io/spine/server/integration/AbstractExchange.java
@@ -65,7 +65,7 @@ abstract class AbstractExchange {
      * Returns the subscriber for the passed ID of the channel.
      */
     final Subscriber subscriber(ChannelId channel) {
-        Subscriber result = link.subscriber(channel);
+        var result = link.subscriber(channel);
         return result;
     }
 
@@ -73,7 +73,7 @@ abstract class AbstractExchange {
      * Returns the publisher for the passed ID of the channel.
      */
     final Publisher publisher(ChannelId channel) {
-        Publisher result = link.publisher(channel);
+        var result = link.publisher(channel);
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/integration/BroadcastWantedEvents.java
+++ b/server/src/main/java/io/spine/server/integration/BroadcastWantedEvents.java
@@ -31,8 +31,6 @@ import io.spine.core.BoundedContextName;
 import io.spine.server.transport.Publisher;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.base.Identifier.newUuid;
-import static io.spine.base.Identifier.pack;
 
 /**
  * Notifies other Bounded Contexts that this Bounded Context now requests some set of external
@@ -81,11 +79,10 @@ final class BroadcastWantedEvents {
      * it has {@code external} subscribers.
      */
     synchronized void send() {
-        ExternalEventsWanted request = ExternalEventsWanted
-                .newBuilder()
+        var request = ExternalEventsWanted.newBuilder()
                 .addAllType(wantedEvents)
                 .vBuild();
-        ExternalMessage wrapped = ExternalMessages.of(request, context);
+        var wrapped = ExternalMessages.of(request, context);
         publisher.publish(wrapped.getId(), wrapped);
     }
 }

--- a/server/src/main/java/io/spine/server/integration/BusAdapter.java
+++ b/server/src/main/java/io/spine/server/integration/BusAdapter.java
@@ -59,12 +59,12 @@ final class BusAdapter {
     }
 
     void register(Class<? extends Message> messageClass) {
-        EventDispatcher dispatcher = createDispatcher(messageClass);
+        var dispatcher = createDispatcher(messageClass);
         targetBus.register(dispatcher);
     }
 
     void unregister(Class<? extends Message> messageClass) {
-        EventDispatcher dispatcher = createDispatcher(messageClass);
+        var dispatcher = createDispatcher(messageClass);
         targetBus.unregister(dispatcher);
     }
 
@@ -81,8 +81,8 @@ final class BusAdapter {
      */
     private EventDispatcher createDispatcher(Class<? extends Message> messageClass) {
         @SuppressWarnings("unchecked") // Logically checked.
-        Class<? extends EventMessage> eventClass = (Class<? extends EventMessage>) messageClass;
-        EventClass eventType = EventClass.from(eventClass);
+        var eventClass = (Class<? extends EventMessage>) messageClass;
+        var eventType = EventClass.from(eventClass);
         EventDispatcher result = new DomesticEventPublisher(broker, eventType);
         return result;
     }

--- a/server/src/main/java/io/spine/server/integration/ConfigExchange.java
+++ b/server/src/main/java/io/spine/server/integration/ConfigExchange.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.integration;
 
-import com.google.common.collect.ImmutableSet;
 import io.spine.server.transport.ChannelId;
 import io.spine.type.TypeUrl;
 
@@ -73,7 +72,7 @@ final class ConfigExchange extends SingleChannelExchange implements AutoCloseabl
      * will be transmitted to other Bounded Contexts via this exchange.
      */
     void transmitRequestedEventsFrom(BusAdapter bus) {
-        ObserveWantedEvents observer = new ObserveWantedEvents(context(), bus);
+        var observer = new ObserveWantedEvents(context(), bus);
         subscriber().addObserver(observer);
         observers.add(observer);
     }
@@ -98,7 +97,7 @@ final class ConfigExchange extends SingleChannelExchange implements AutoCloseabl
      * <p>Sends out an instance of {@link ExternalEventsWanted} for that purpose.
      */
     void notifyTypesChanged() {
-        ImmutableSet<ExternalEventType> eventTypes = subscriptionChannels()
+        var eventTypes = subscriptionChannels()
                 .stream()
                 .map(ConfigExchange::typeOfTransmittedEvents)
                 .collect(toImmutableSet());

--- a/server/src/main/java/io/spine/server/integration/DomesticEventPublisher.java
+++ b/server/src/main/java/io/spine/server/integration/DomesticEventPublisher.java
@@ -80,7 +80,7 @@ final class DomesticEventPublisher implements EventDispatcher, Logging {
         if (!(o instanceof DomesticEventPublisher)) {
             return false;
         }
-        DomesticEventPublisher publisher = (DomesticEventPublisher) o;
+        var publisher = (DomesticEventPublisher) o;
         return Objects.equal(eventClasses, publisher.eventClasses);
     }
 

--- a/server/src/main/java/io/spine/server/integration/EventsExchange.java
+++ b/server/src/main/java/io/spine/server/integration/EventsExchange.java
@@ -26,18 +26,12 @@
 
 package io.spine.server.integration;
 
-import io.spine.annotation.Internal;
-import io.spine.core.Event;
 import io.spine.protobuf.AnyPacker;
 import io.spine.server.event.EventDispatcher;
 import io.spine.server.transport.ChannelId;
-import io.spine.server.transport.Publisher;
-import io.spine.server.transport.Subscriber;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
-import io.spine.type.TypeUrl;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.server.transport.MessageChannel.channelIdFor;
 
 /**
@@ -71,12 +65,12 @@ final class EventsExchange extends AbstractExchange {
      *         event to publish
      */
     void publish(EventEnvelope event) {
-        ChannelId channelId = toChannelId(event.messageClass());
-        boolean wantedByOthers = !subscriptionChannels().contains(channelId);
+        var channelId = toChannelId(event.messageClass());
+        var wantedByOthers = !subscriptionChannels().contains(channelId);
         if (wantedByOthers) {
-            Event outerObject = event.outerObject();
-            ExternalMessage msg = ExternalMessages.of(outerObject, context());
-            Publisher publisher = publisher(channelId);
+            var outerObject = event.outerObject();
+            var msg = ExternalMessages.of(outerObject, context());
+            var publisher = publisher(channelId);
             publisher.publish(AnyPacker.pack(event.id()), msg);
         }
     }
@@ -90,10 +84,10 @@ final class EventsExchange extends AbstractExchange {
      */
     void register(EventDispatcher dispatcher) {
         Iterable<EventClass> receivedTypes = dispatcher.externalEventClasses();
-        for (EventClass cls : receivedTypes) {
-            ChannelId channelId = toChannelId(cls);
-            Subscriber subscriber = subscriber(channelId);
-            IncomingEventObserver observer = observerFor(cls);
+        for (var cls : receivedTypes) {
+            var channelId = toChannelId(cls);
+            var subscriber = subscriber(channelId);
+            var observer = observerFor(cls);
             subscriber.addObserver(observer);
         }
     }
@@ -107,10 +101,10 @@ final class EventsExchange extends AbstractExchange {
      */
     void unregister(EventDispatcher dispatcher) {
         Iterable<EventClass> externalEvents = dispatcher.externalEventClasses();
-        for (EventClass cls : externalEvents) {
-            ChannelId channelId = toChannelId(cls);
-            Subscriber subscriber = subscriber(channelId);
-            IncomingEventObserver observer = observerFor(cls);
+        for (var cls : externalEvents) {
+            var channelId = toChannelId(cls);
+            var subscriber = subscriber(channelId);
+            var observer = observerFor(cls);
             subscriber.removeObserver(observer);
         }
     }
@@ -119,7 +113,7 @@ final class EventsExchange extends AbstractExchange {
      * Creates a new observer for a particular type of events.
      */
     private IncomingEventObserver observerFor(EventClass eventType) {
-        IncomingEventObserver observer = new IncomingEventObserver(context(), eventType, bus);
+        var observer = new IncomingEventObserver(context(), eventType, bus);
         return observer;
     }
 
@@ -127,7 +121,7 @@ final class EventsExchange extends AbstractExchange {
      * Creates an ID of the channel that will transmit the events of the given class.
      */
     private static ChannelId toChannelId(EventClass cls) {
-        TypeUrl targetType = cls.typeUrl();
+        var targetType = cls.typeUrl();
         return channelIdFor(targetType);
     }
 }

--- a/server/src/main/java/io/spine/server/integration/ExternalEventTypeMixin.java
+++ b/server/src/main/java/io/spine/server/integration/ExternalEventTypeMixin.java
@@ -40,8 +40,8 @@ interface ExternalEventTypeMixin extends ExternalEventTypeOrBuilder {
      * Obtains the message type as a Java class.
      */
     default Class<? extends Message> asMessageClass() {
-        String rawValue = getTypeUrl();
-        TypeUrl typeUrl = TypeUrl.parse(rawValue);
+        var rawValue = getTypeUrl();
+        var typeUrl = TypeUrl.parse(rawValue);
         return typeUrl.getMessageClass();
     }
 }

--- a/server/src/main/java/io/spine/server/integration/ExternalMessages.java
+++ b/server/src/main/java/io/spine/server/integration/ExternalMessages.java
@@ -25,7 +25,6 @@
  */
 package io.spine.server.integration;
 
-import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
 import io.spine.annotation.Internal;
@@ -59,7 +58,7 @@ final class ExternalMessages {
         checkNotNull(event);
         checkNotNull(origin);
 
-        ExternalMessage result = of(event.getId(), event, origin);
+        var result = of(event.getId(), event, origin);
         return result;
     }
 
@@ -76,7 +75,7 @@ final class ExternalMessages {
         checkNotNull(request);
         checkNotNull(origin);
 
-        ExternalMessage result = of(generateId(), request, origin);
+        var result = of(generateId(), request, origin);
         return result;
     }
 
@@ -89,20 +88,20 @@ final class ExternalMessages {
      */
     static ExternalMessage of(BoundedContextOnline notification) {
         checkNotNull(notification);
-        ExternalMessage result = of(generateId(), notification, notification.getContext());
+        var result = of(generateId(), notification, notification.getContext());
         return result;
     }
 
     private static StringValue generateId() {
-        StringValue result = StringValue.of(Identifier.newUuid());
+        var result = StringValue.of(Identifier.newUuid());
         return result;
     }
 
     private static ExternalMessage of(Message id, Message message, BoundedContextName origin) {
-        Any packedId = Identifier.pack(id);
-        Any packedMessage = AnyPacker.pack(message);
+        var packedId = Identifier.pack(id);
+        var packedMessage = AnyPacker.pack(message);
 
-        ExternalMessage result = ExternalMessage
+        var result = ExternalMessage
                 .newBuilder()
                 .setId(packedId)
                 .setOriginalMessage(packedMessage)

--- a/server/src/main/java/io/spine/server/integration/IncomingEventObserver.java
+++ b/server/src/main/java/io/spine/server/integration/IncomingEventObserver.java
@@ -58,7 +58,7 @@ final class IncomingEventObserver extends AbstractChannelObserver {
 
     @Override
     protected void handle(ExternalMessage message) {
-        Event event = AnyPacker.unpack(message.getOriginalMessage(), Event.class);
+        var event = AnyPacker.unpack(message.getOriginalMessage(), Event.class);
         bus.dispatch(event, noOpObserver());
     }
 }

--- a/server/src/main/java/io/spine/server/integration/IntegrationBroker.java
+++ b/server/src/main/java/io/spine/server/integration/IntegrationBroker.java
@@ -126,7 +126,7 @@ public final class IntegrationBroker implements ContextAware, AutoCloseable {
     private @MonotonicNonNull EventsExchange events;
 
     public IntegrationBroker() {
-        TransportFactory transportFactory = ServerEnvironment
+        var transportFactory = ServerEnvironment
                 .instance()
                 .transportFactory();
         this.subscriberHub = new SubscriberHub(transportFactory);
@@ -138,8 +138,8 @@ public final class IntegrationBroker implements ContextAware, AutoCloseable {
         checkNotRegistered();
         this.contextName = context.name();
 
-        BusAdapter bus = new BusAdapter(this, context.eventBus());
-        TransportLink link = new TransportLink(contextName, subscriberHub, publisherHub);
+        var bus = new BusAdapter(this, context.eventBus());
+        var link = new TransportLink(contextName, subscriberHub, publisherHub);
         config = new ConfigExchange(link);
         events = new EventsExchange(link, bus);
         config.transmitRequestedEventsFrom(bus);
@@ -147,7 +147,7 @@ public final class IntegrationBroker implements ContextAware, AutoCloseable {
     }
 
     private void runStatusExchange(TransportLink link) {
-        StatusExchange statuses = new StatusExchange(link);
+        var statuses = new StatusExchange(link);
         statuses.onBoundedContextOnline((msg) -> config.requestWantedEvents());
         statuses.declareOnlineStatus();
     }

--- a/server/src/main/java/io/spine/server/integration/ObserveWantedEvents.java
+++ b/server/src/main/java/io/spine/server/integration/ObserveWantedEvents.java
@@ -29,11 +29,9 @@ package io.spine.server.integration;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
-import com.google.protobuf.Message;
 import io.spine.core.BoundedContextName;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 
 import static com.google.common.collect.Multimaps.synchronizedSetMultimap;
@@ -74,23 +72,23 @@ final class ObserveWantedEvents extends AbstractChannelObserver implements AutoC
      */
     @Override
     public void handle(ExternalMessage message) {
-        BoundedContextName origin = message.getBoundedContextName();
+        var origin = message.getBoundedContextName();
         if (origin.equals(contextName())) {
             return;
         }
-        ExternalEventsWanted request = unpack(
+        var request = unpack(
                 message.getOriginalMessage(),
                 ExternalEventsWanted.class
         );
-        List<ExternalEventType> externalTypes = request.getTypeList();
+        var externalTypes = request.getTypeList();
         addNewSubscriptions(externalTypes, origin);
         clearStaleSubscriptions(externalTypes, origin);
     }
 
     private void addNewSubscriptions(Iterable<ExternalEventType> types,
                                      BoundedContextName origin) {
-        for (ExternalEventType newType : types) {
-            Collection<BoundedContextName> contextsWithSameRequest = requestedTypes.get(newType);
+        for (var newType : types) {
+            var contextsWithSameRequest = requestedTypes.get(newType);
             if (contextsWithSameRequest.isEmpty()) {
                 // This item has not been requested by anyone yet.
                 // Let's create a subscription.
@@ -101,19 +99,19 @@ final class ObserveWantedEvents extends AbstractChannelObserver implements AutoC
     }
 
     private void registerInAdapter(ExternalEventType type) {
-        Class<? extends Message> messageClass = type.asMessageClass();
+        var messageClass = type.asMessageClass();
         bus.register(messageClass);
     }
 
     private void clearStaleSubscriptions(Collection<ExternalEventType> types,
                                          BoundedContextName origin) {
-        Set<ExternalEventType> toRemove = findStale(types, origin);
-        for (ExternalEventType itemForRemoval : toRemove) {
-            boolean wereNonEmpty = !requestedTypes.get(itemForRemoval)
-                                                  .isEmpty();
+        var toRemove = findStale(types, origin);
+        for (var itemForRemoval : toRemove) {
+            var wereNonEmpty = !requestedTypes.get(itemForRemoval)
+                                              .isEmpty();
             requestedTypes.remove(itemForRemoval, origin);
-            boolean emptyNow = requestedTypes.get(itemForRemoval)
-                                             .isEmpty();
+            var emptyNow = requestedTypes.get(itemForRemoval)
+                                         .isEmpty();
             if (wereNonEmpty && emptyNow) {
                 unregisterInAdapter(itemForRemoval);
             }
@@ -121,7 +119,7 @@ final class ObserveWantedEvents extends AbstractChannelObserver implements AutoC
     }
 
     private void unregisterInAdapter(ExternalEventType type) {
-        Class<? extends Message> messageClass = type.asMessageClass();
+        var messageClass = type.asMessageClass();
         bus.unregister(messageClass);
     }
 
@@ -129,8 +127,8 @@ final class ObserveWantedEvents extends AbstractChannelObserver implements AutoC
                                              BoundedContextName origin) {
         ImmutableSet.Builder<ExternalEventType> result = ImmutableSet.builder();
 
-        for (ExternalEventType previouslyRequestedType : requestedTypes.keySet()) {
-            Collection<BoundedContextName> contextsThatRequested =
+        for (var previouslyRequestedType : requestedTypes.keySet()) {
+            var contextsThatRequested =
                     requestedTypes.get(previouslyRequestedType);
 
             if (contextsThatRequested.contains(origin) &&
@@ -156,7 +154,7 @@ final class ObserveWantedEvents extends AbstractChannelObserver implements AutoC
      */
     @Override
     public void close() {
-        for (ExternalEventType currentlyRequestedMessage : requestedTypes.keySet()) {
+        for (var currentlyRequestedMessage : requestedTypes.keySet()) {
             unregisterInAdapter(currentlyRequestedMessage);
         }
         requestedTypes.clear();

--- a/server/src/main/java/io/spine/server/integration/SingleChannelExchange.java
+++ b/server/src/main/java/io/spine/server/integration/SingleChannelExchange.java
@@ -46,7 +46,7 @@ abstract class SingleChannelExchange extends AbstractExchange {
      * Returns the subscriber of this exchange.
      */
     final Subscriber subscriber() {
-        Subscriber result = subscriber(channel());
+        var result = subscriber(channel());
         return result;
     }
 
@@ -54,7 +54,7 @@ abstract class SingleChannelExchange extends AbstractExchange {
      * Returns the publisher of this exchange.
      */
     final Publisher publisher() {
-        Publisher result = publisher(channel());
+        var result = publisher(channel());
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/integration/StatusExchange.java
+++ b/server/src/main/java/io/spine/server/integration/StatusExchange.java
@@ -64,11 +64,10 @@ final class StatusExchange extends SingleChannelExchange {
      * and available for communication.
      */
     void declareOnlineStatus() {
-        BoundedContextOnline notification =
-                BoundedContextOnline.newBuilder()
-                        .setContext(context())
-                        .vBuild();
-        ExternalMessage message = ExternalMessages.of(notification);
+        var notification = BoundedContextOnline.newBuilder()
+                .setContext(context())
+                .vBuild();
+        var message = ExternalMessages.of(notification);
         publisher().publish(message.getId(), message);
     }
 
@@ -93,12 +92,12 @@ final class StatusExchange extends SingleChannelExchange {
 
         @Override
         protected void handle(ExternalMessage message) {
-            BoundedContextOnline msg = asOriginal(message);
+            var msg = asOriginal(message);
             callback.accept(msg);
         }
 
         private static BoundedContextOnline asOriginal(ExternalMessage message) {
-            BoundedContextOnline msg = unpack(message.getOriginalMessage(), TYPE);
+            var msg = unpack(message.getOriginalMessage(), TYPE);
             return msg;
         }
     }

--- a/server/src/main/java/io/spine/server/integration/ThirdPartyContext.java
+++ b/server/src/main/java/io/spine/server/integration/ThirdPartyContext.java
@@ -29,10 +29,8 @@ package io.spine.server.integration;
 import com.google.protobuf.Any;
 import io.spine.base.EventMessage;
 import io.spine.core.ActorContext;
-import io.spine.core.Event;
 import io.spine.core.UserId;
 import io.spine.server.BoundedContext;
-import io.spine.server.BoundedContextBuilder;
 import io.spine.server.Closeable;
 import io.spine.server.event.EventFactory;
 import io.spine.server.type.EventEnvelope;
@@ -87,13 +85,13 @@ public final class ThirdPartyContext implements Closeable {
     private static ThirdPartyContext newContext(String name, boolean multitenant) {
         checkNotEmptyOrBlank(name);
 
-        BoundedContextBuilder contextBuilder = multitenant
-                                 ? BoundedContext.multitenant(name)
-                                 : BoundedContext.singleTenant(name);
+        var contextBuilder = multitenant
+                             ? BoundedContext.multitenant(name)
+                             : BoundedContext.singleTenant(name);
         contextBuilder.systemSettings()
                .disableCommandLog()
                .forgetEvents();
-        BoundedContext context = contextBuilder.build();
+        var context = contextBuilder.build();
         return new ThirdPartyContext(context);
     }
 
@@ -122,9 +120,9 @@ public final class ThirdPartyContext implements Closeable {
         checkNotNull(eventMessage);
         checkTenant(actorContext, eventMessage);
 
-        EventFactory eventFactory = EventFactory.forImport(actorContext, producerId);
+        var eventFactory = EventFactory.forImport(actorContext, producerId);
         @SuppressWarnings("ConstantConditions")     /* No explicit version to be set. */
-        Event event = eventFactory.createEvent(eventMessage, null);
+                var event = eventFactory.createEvent(eventMessage, null);
         context.internalAccess()
                .broker()
                .publish(EventEnvelope.of(event));
@@ -148,7 +146,7 @@ public final class ThirdPartyContext implements Closeable {
     public void emittedEvent(EventMessage eventMessage, UserId userId) {
         checkNotNull(userId);
         checkNotNull(eventMessage);
-        ActorContext context = ActorContext
+        var context = ActorContext
                 .newBuilder()
                 .setActor(userId)
                 .setTimestamp(currentTime())
@@ -157,9 +155,9 @@ public final class ThirdPartyContext implements Closeable {
     }
 
     private void checkTenant(ActorContext actorContext, EventMessage event) {
-        boolean tenantSupplied = actorContext.hasTenantId();
-        String contextName = context.name().getValue();
-        String eventType = event.getClass().getName();
+        var tenantSupplied = actorContext.hasTenantId();
+        var contextName = context.name().getValue();
+        var eventType = event.getClass().getName();
         if (context.isMultitenant()) {
             checkArgument(tenantSupplied,
                           "Cannot post `%s` into a third-party multitenant context `%s`." +

--- a/server/src/main/java/io/spine/server/integration/TransportLink.java
+++ b/server/src/main/java/io/spine/server/integration/TransportLink.java
@@ -61,7 +61,7 @@ final class TransportLink {
      * Obtains the publisher for the given channel ID.
      */
     Publisher publisher(ChannelId channel) {
-        Publisher result = publisherHub.get(channel);
+        var result = publisherHub.get(channel);
         return result;
     }
 
@@ -69,7 +69,7 @@ final class TransportLink {
      * Obtains the subscriber for the given channel ID.
      */
     Subscriber subscriber(ChannelId channel) {
-        Subscriber result = subscriberHub.get(channel);
+        var result = subscriberHub.get(channel);
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/log/HandlerLifecycle.java
+++ b/server/src/main/java/io/spine/server/log/HandlerLifecycle.java
@@ -41,13 +41,13 @@ import io.spine.server.model.HandlerMethod;
  *         // ...
  *     }
  *
- *    {@literal @Override}
- *     public void beforeInvoke(HandlerMethod<?, ?, ?, ?> method) {
+ *    {@literal @Override                                                       }
+ *    {@literal public void beforeInvoke(HandlerMethod<?, ?, ?, ?> method) {    }
  *         // ...
  *     }
  *
- *    {@literal @Override}
- *     public void afterInvoke(HandlerMethod<?, ?, ?, ?> method) {
+ *    {@literal @Override                                                       }
+ *    {@literal public void afterInvoke(HandlerMethod<?, ?, ?, ?> method) {     }
  *         // ...
  *     }
  * }

--- a/server/src/main/java/io/spine/server/log/HandlerMethodSite.java
+++ b/server/src/main/java/io/spine/server/log/HandlerMethodSite.java
@@ -30,7 +30,6 @@ import com.google.common.base.Objects;
 import com.google.common.flogger.LogSite;
 import com.google.errorprone.annotations.Immutable;
 import io.spine.code.java.ClassName;
-import io.spine.code.java.SimpleClassName;
 import io.spine.server.model.HandlerMethod;
 
 import java.lang.reflect.Method;
@@ -66,10 +65,10 @@ final class HandlerMethodSite extends LogSite {
 
     @Override
     public String getMethodName() {
-        String params = Stream.of(method.getParameterTypes())
-                              .map(Class::getSimpleName)
-                              .collect(joining(", "));
-        String methodName = format("%s(%s)", method.getName(), params);
+        var params = Stream.of(method.getParameterTypes())
+                           .map(Class::getSimpleName)
+                           .collect(joining(", "));
+        var methodName = format("%s(%s)", method.getName(), params);
         return methodName;
     }
 
@@ -80,8 +79,8 @@ final class HandlerMethodSite extends LogSite {
 
     @Override
     public String getFileName() {
-        SimpleClassName className = ClassName.of(method.getDeclaringClass())
-                                        .topLevelClass();
+        var className = ClassName.of(method.getDeclaringClass())
+                                 .topLevelClass();
         return className.value() + ".java";
     }
 
@@ -93,7 +92,7 @@ final class HandlerMethodSite extends LogSite {
         if (!(o instanceof HandlerMethodSite)) {
             return false;
         }
-        HandlerMethodSite site = (HandlerMethodSite) o;
+        var site = (HandlerMethodSite) o;
         return Objects.equal(method, site.method);
     }
 

--- a/server/src/main/java/io/spine/server/model/AbstractHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/model/AbstractHandlerMethod.java
@@ -29,9 +29,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
 import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import com.google.protobuf.Message;
-import io.spine.base.Error;
 import io.spine.base.RejectionThrowable;
-import io.spine.core.MessageId;
 import io.spine.core.Signal;
 import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.dispatch.Success;
@@ -152,8 +150,8 @@ class AbstractHandlerMethod<T,
     @Override
     public final void discoverAttributes() {
         ImmutableSet.Builder<Attribute<?>> builder = ImmutableSet.builder();
-        for (Function<Method, Attribute<?>> fn : attributeSuppliers()) {
-            Attribute<?> attr = fn.apply(method);
+        for (var fn : attributeSuppliers()) {
+            var attr = fn.apply(method);
             builder.add(attr);
         }
         attributes = builder.build();
@@ -215,7 +213,7 @@ class AbstractHandlerMethod<T,
     protected static <M extends Message> Class<M> firstParamType(Method handler) {
         @SuppressWarnings("unchecked")
             // We always expect first param as a Message of required type.
-        Class<M> result = (Class<M>) handler.getParameterTypes()[0];
+        var result = (Class<M>) handler.getParameterTypes()[0];
         return result;
     }
 
@@ -245,7 +243,7 @@ class AbstractHandlerMethod<T,
      * {@code false} otherwise.
      */
     protected final boolean isPublic() {
-        boolean result = Modifier.isPublic(modifiers());
+        var result = Modifier.isPublic(modifiers());
         return result;
     }
 
@@ -254,7 +252,7 @@ class AbstractHandlerMethod<T,
      * {@code false} otherwise.
      */
     protected final boolean isPrivate() {
-        boolean result = Modifier.isPrivate(modifiers());
+        var result = Modifier.isPrivate(modifiers());
         return result;
     }
 
@@ -265,7 +263,7 @@ class AbstractHandlerMethod<T,
 
     private static ImmutableSet<Attribute<?>> discoverAttributes(Method method) {
         checkNotNull(method);
-        ExternalAttribute externalAttribute = ExternalAttribute.of(method);
+        var externalAttribute = ExternalAttribute.of(method);
         return ImmutableSet.of(externalAttribute);
     }
 
@@ -282,30 +280,30 @@ class AbstractHandlerMethod<T,
         checkNotNull(target);
         checkNotNull(envelope);
         checkAttributesMatch(envelope);
-        MessageId signal = envelope.outerObject().messageId();
-        DispatchOutcome.Builder outcome = DispatchOutcome
+        var signal = envelope.outerObject().messageId();
+        var outcome = DispatchOutcome
                 .newBuilder()
                 .setPropagatedSignal(signal);
-        HandlerLifecycle lifecycle = target instanceof HandlerLifecycle
+        var lifecycle = target instanceof HandlerLifecycle
                                             ? (HandlerLifecycle) target
                                             : null;
         if (lifecycle != null) {
             lifecycle.beforeInvoke(this);
         }
         try {
-            Success success = doInvoke(target, envelope);
+            var success = doInvoke(target, envelope);
             outcome.setSuccess(success);
         } catch (IllegalOutcomeException e) {
-            Error error = fromThrowable(e);
+            var error = fromThrowable(e);
             outcome.setError(error);
         } catch (InvocationTargetException e) {
-            Throwable cause = e.getCause();
+            var cause = e.getCause();
             checkNotNull(cause);
             if (cause instanceof RejectionThrowable) {
-                Success success = asRejection(target, envelope, (RejectionThrowable) cause);
+                var success = asRejection(target, envelope, (RejectionThrowable) cause);
                 outcome.setSuccess(success);
             } else {
-                Error error = causeOf(cause);
+                var error = causeOf(cause);
                 outcome.setError(error);
             }
         } catch (IllegalArgumentException | IllegalAccessException e) {
@@ -320,18 +318,18 @@ class AbstractHandlerMethod<T,
 
     private Success doInvoke(T target, E envelope)
             throws IllegalAccessException, InvocationTargetException {
-        ExtractedArguments arguments = parameterSpec.extractArguments(envelope);
-        Object rawOutput = arguments.invokeMethod(method, target);
+        var arguments = parameterSpec.extractArguments(envelope);
+        var rawOutput = arguments.invokeMethod(method, target);
         return toSuccessfulOutcome(rawOutput, target, envelope);
     }
 
     private Success asRejection(T target, E envelope, RejectionThrowable cause) {
-        Optional<Success> maybeSuccess = handleRejection(target, envelope, cause);
+        var maybeSuccess = handleRejection(target, envelope, cause);
         return maybeSuccess.orElseThrow(this::cannotThrowRejections);
     }
 
     private RuntimeException cannotThrowRejections() {
-        String errorMessage = format("`%s` may not throw rejections.", this);
+        var errorMessage = format("`%s` may not throw rejections.", this);
         return new IllegalOutcomeException(errorMessage);
     }
 
@@ -364,15 +362,15 @@ class AbstractHandlerMethod<T,
      * @return full name of the subscriber
      */
     public String getFullName() {
-        String template = "%s.%s(%s)";
-        String className = method.getDeclaringClass()
-                                 .getName();
-        String methodName = method.getName();
-        String parameterTypes =
+        var template = "%s.%s(%s)";
+        var className = method.getDeclaringClass()
+                              .getName();
+        var methodName = method.getName();
+        var parameterTypes =
                 Stream.of(method.getParameterTypes())
                       .map(Class::getSimpleName)
                       .collect(joining(", "));
-        String result = format(template, className, methodName, parameterTypes);
+        var result = format(template, className, methodName, parameterTypes);
         return result;
     }
 
@@ -383,7 +381,7 @@ class AbstractHandlerMethod<T,
 
     @Override
     public int hashCode() {
-        int prime = 31;
+        var prime = 31;
         return (prime * method.hashCode());
     }
 
@@ -395,7 +393,7 @@ class AbstractHandlerMethod<T,
         if (!(obj instanceof AbstractHandlerMethod)) {
             return false;
         }
-        AbstractHandlerMethod<?, ?, ?, ?, ?> other = (AbstractHandlerMethod<?, ?, ?, ?, ?>) obj;
+        var other = (AbstractHandlerMethod<?, ?, ?, ?, ?>) obj;
         return Objects.equals(this.method, other.method);
     }
 

--- a/server/src/main/java/io/spine/server/model/AccessModifier.java
+++ b/server/src/main/java/io/spine/server/model/AccessModifier.java
@@ -139,12 +139,14 @@ public final class AccessModifier implements Predicate<Method> {
         }
     }
 
+    @SuppressWarnings("RedundantExplicitVariableType" /* Due to the regression bug in PMD.
+                                                    See https://github.com/pmd/pmd/issues/2976, */)
     private static boolean inheritedMethod(Method child, Method parent) {
         if (!parent.getName().equals(child.getName())) {
             return false;
         }
-        var parentParams = parent.getParameterTypes();
-        var childParams = child.getParameterTypes();
+        Class<?>[] parentParams = parent.getParameterTypes();
+        Class<?>[] childParams = child.getParameterTypes();
         if (parentParams.length != childParams.length) {
             return false;
         }

--- a/server/src/main/java/io/spine/server/model/AllowedParams.java
+++ b/server/src/main/java/io/spine/server/model/AllowedParams.java
@@ -69,9 +69,8 @@ public final class AllowedParams<E extends MessageEnvelope<?, ?, ?>> {
      *         or {@link Optional#empty() Optional.empty()} if no matching specification is found
      */
     Optional<? extends ParameterSpec<E>> findMatching(Method method) {
-        MethodParams params = MethodParams.of(method);
-        Optional<? extends ParameterSpec<E>> result =
-                specs.stream()
+        var params = MethodParams.of(method);
+        var result = specs.stream()
                      .filter(spec -> spec.matches(params))
                      .findFirst();
         return result;
@@ -85,7 +84,7 @@ public final class AllowedParams<E extends MessageEnvelope<?, ?, ?>> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        AllowedParams<?> params = (AllowedParams<?>) o;
+        var params = (AllowedParams<?>) o;
         return Objects.equal(specs, params.specs);
     }
 

--- a/server/src/main/java/io/spine/server/model/ArgumentFilter.java
+++ b/server/src/main/java/io/spine/server/model/ArgumentFilter.java
@@ -30,7 +30,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.errorprone.annotations.Immutable;
 import com.google.protobuf.Empty;
-import com.google.protobuf.Message;
 import io.spine.base.Field;
 import io.spine.base.FieldPath;
 import io.spine.base.SignalMessage;
@@ -95,8 +94,8 @@ public final class ArgumentFilter implements Predicate<SignalMessage> {
     public static ArgumentFilter createFilter(Method method) {
         @Nullable Where where = filterAnnotationOf(method);
         if (where != null) {
-            String fieldPath = where.field();
-            String value = where.equals();
+            var fieldPath = where.field();
+            var value = where.equals();
             return createFilter(method, fieldPath, value);
         } else {
             return acceptingAll();
@@ -118,23 +117,23 @@ public final class ArgumentFilter implements Predicate<SignalMessage> {
      * Creates a filter for the method using string values found in the annotation for the method.
      */
     private static ArgumentFilter createFilter(Method method, String fieldPath, String value) {
-        Class<Message> paramType = firstParamType(method);
-        Field field = Field.parse(fieldPath);
-        Class<?> fieldType = field.findType(paramType).orElseThrow(() -> new ModelError(
+        var paramType = firstParamType(method);
+        var field = Field.parse(fieldPath);
+        var fieldType = field.findType(paramType).orElseThrow(() -> new ModelError(
                 "The message with the type `%s` does not have the field `%s`.",
                 paramType.getName(), field
         ));
-        Object expectedValue = fromString(value, fieldType);
+        var expectedValue = fromString(value, fieldType);
         return acceptingOnly(field.path(), expectedValue);
     }
 
     private static @Nullable Where filterAnnotationOf(Method method) {
-        Parameter firstParam = firstParameterOf(method);
+        var firstParam = firstParameterOf(method);
         return firstParam.getAnnotation(Where.class);
     }
 
     private static Parameter firstParameterOf(Method method) {
-        Parameter[] parameters = method.getParameters();
+        var parameters = method.getParameters();
         checkArgument(parameters.length >= 1,
                       "The method `%s.%s()` does not have parameters.",
                       method.getDeclaringClass().getName(), method.getName());
@@ -175,14 +174,14 @@ public final class ArgumentFilter implements Predicate<SignalMessage> {
         if (acceptsAll()) {
             return true;
         }
-        Object eventField = field.valueIn(msg);
-        boolean result = eventField.equals(expectedValue);
+        var eventField = field.valueIn(msg);
+        var result = eventField.equals(expectedValue);
         return result;
     }
 
     @Override
     public String toString() {
-        MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this);
+        var helper = MoreObjects.toStringHelper(this);
         if (acceptsAll()) {
             helper.add("acceptsAll", true);
         } else {
@@ -200,7 +199,7 @@ public final class ArgumentFilter implements Predicate<SignalMessage> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ArgumentFilter filter = (ArgumentFilter) o;
+        var filter = (ArgumentFilter) o;
         return Objects.equals(field, filter.field) &&
                 Objects.equals(expectedValue, filter.expectedValue);
     }

--- a/server/src/main/java/io/spine/server/model/ClassMap.java
+++ b/server/src/main/java/io/spine/server/model/ClassMap.java
@@ -84,18 +84,18 @@ final class ClassMap {
     ModelClass<T> get(Class<? extends T> rawClass,
                       Class<M> requestedClass,
                       Supplier<ModelClass<T>> supplier) {
-        String key = nameOf(rawClass);
+        var key = nameOf(rawClass);
         @SuppressWarnings("unchecked")
             /* The cast is protected by generic parameters of this method.
                We store the model class with the correct type, getting it from the supplier
                passed to this method. */
-        ModelClass<T> modelClass = (ModelClass<T>) classes.get(key);
+        var modelClass = (ModelClass<T>) classes.get(key);
         if (modelClass == null) {
             return setEntry(key, supplier);
         }
 
         @SuppressWarnings("unchecked")
-        Class<? extends ModelClass<?>> currentClass =
+        var currentClass =
                 (Class<? extends ModelClass<?>>) modelClass.getClass();
         if (currentClass.equals(requestedClass)) {
             return modelClass;
@@ -131,9 +131,9 @@ final class ClassMap {
         ImmutableMap.Builder<Set<CommandClass>, CommandHandlingClass<?, ?>> duplicates =
                 ImmutableMap.builder();
 
-        for (ModelClass<?> modelClass : classes.values()) {
+        for (var modelClass : classes.values()) {
             if (modelClass instanceof CommandHandlingClass) {
-                CommandHandlingClass<?, ?> commandHandler =
+                var commandHandler =
                         (CommandHandlingClass<?, ?>) modelClass;
                 Set<CommandClass> alreadyHandled = commandHandler.commands();
                 Set<CommandClass> intersection = intersection(alreadyHandled, candidateCommands);
@@ -143,8 +143,7 @@ final class ClassMap {
             }
         }
 
-        ImmutableMap<Set<CommandClass>, CommandHandlingClass<?, ?>> currentHandlers =
-                duplicates.build();
+        var currentHandlers = duplicates.build();
         if (!currentHandlers.isEmpty()) {
             throw new DuplicateCommandHandlerError(candidate, currentHandlers);
         }

--- a/server/src/main/java/io/spine/server/model/DispatchKey.java
+++ b/server/src/main/java/io/spine/server/model/DispatchKey.java
@@ -93,7 +93,7 @@ public final class DispatchKey {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final DispatchKey other = (DispatchKey) obj;
+        final var other = (DispatchKey) obj;
         return Objects.equals(this.messageClass, other.messageClass)
                 && Objects.equals(this.filter, other.filter)
                 && Objects.equals(this.originClass, other.originClass);
@@ -102,7 +102,7 @@ public final class DispatchKey {
     @SuppressWarnings("DuplicateStringLiteralInspection")   // Both classes have `filter` field.
     @Override
     public String toString() {
-        MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this);
+        var helper = MoreObjects.toStringHelper(this);
         helper.add("messageClass", messageClass.getName());
         if (filter != null && !filter.acceptsAll()) {
             helper.add("filter", filter);

--- a/server/src/main/java/io/spine/server/model/DuplicateCommandHandlerError.java
+++ b/server/src/main/java/io/spine/server/model/DuplicateCommandHandlerError.java
@@ -60,16 +60,15 @@ public final class DuplicateCommandHandlerError extends ModelError {
         checkNotNull(duplicatingClass);
         checkNotNull(registeredHandlers);
         @SuppressWarnings("MagicNumber") // the buffer size that should cover most cases.
-        StringBuilder builder = new StringBuilder(512);
+        var builder = new StringBuilder(512);
 
         builder.append(format("The class `%s` declares handler ", duplicatingClass));
 
         // Do we have more than one command to report?
-        long totalDuplicatedCommands =
-                registeredHandlers.keySet()
-                                  .stream()
-                                  .mapToLong(Collection::size)
-                                  .sum();
+        var totalDuplicatedCommands = registeredHandlers.keySet()
+                .stream()
+                .mapToLong(Collection::size)
+                .sum();
         checkState(totalDuplicatedCommands >= 1);
         builder.append(
                 totalDuplicatedCommands == 1
@@ -87,28 +86,27 @@ public final class DuplicateCommandHandlerError extends ModelError {
                 : "other classes."
         );
 
-        String newLine = format("%n");
+        var newLine = format("%n");
         builder.append(newLine);
 
         // Now list the commands and their handlers.
-        for (Set<CommandClass> commandClasses : registeredHandlers.keySet()) {
+        for (var commandClasses : registeredHandlers.keySet()) {
             builder.append(newLine);
             if (commandClasses.size() > 1) {
                 builder.append(" Commands ");
-                String commandsBackTicked =
-                        commandClasses.stream()
-                                      .collect(toEnumerationBackticked());
+                var commandsBackTicked = commandClasses.stream()
+                        .collect(toEnumerationBackticked());
                 builder.append(commandsBackTicked);
                 builder.append(" are handled by ");
             } else {
                 // One command.
                 builder.append(" The command ");
-                CommandClass cmdClass = commandClasses.iterator()
-                                                      .next();
+                var cmdClass = commandClasses.iterator()
+                                             .next();
                 builder.append(backtick(cmdClass));
                 builder.append(" is handled by ");
             }
-            CommandHandlingClass<?, ?> handlingClass = registeredHandlers.get(commandClasses);
+            var handlingClass = registeredHandlers.get(commandClasses);
             builder.append(backtick(handlingClass));
             builder.append('.');
         }

--- a/server/src/main/java/io/spine/server/model/EventProducingMethod.java
+++ b/server/src/main/java/io/spine/server/model/EventProducingMethod.java
@@ -26,11 +26,9 @@
 
 package io.spine.server.model;
 
-import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.spine.base.EventMessage;
 import io.spine.core.Event;
-import io.spine.core.Version;
 import io.spine.server.EventProducer;
 import io.spine.server.dispatch.ProducedEvents;
 import io.spine.server.dispatch.Success;
@@ -65,14 +63,14 @@ public interface EventProducingMethod<T extends EventProducer,
      */
     @Override
     default Success toSuccessfulOutcome(@Nullable Object rawResult, T target, E handledSignal) {
-        MethodResult result = MethodResult.from(rawResult);
-        EventFactory eventFactory = EventFactory.on(handledSignal, target.producerId());
-        Version version = target.version();
+        var result = MethodResult.from(rawResult);
+        var eventFactory = EventFactory.on(handledSignal, target.producerId());
+        var version = target.version();
 
-        ProducedEvents.Builder producedEvents = ProducedEvents.newBuilder();
-        ImmutableList<EventMessage> eventMessages = result.messages(EventMessage.class);
-        for (EventMessage msg : eventMessages) {
-            Event event = eventFactory.createEvent(msg, version);
+        var producedEvents = ProducedEvents.newBuilder();
+        var eventMessages = result.messages(EventMessage.class);
+        for (var msg : eventMessages) {
+            var event = eventFactory.createEvent(msg, version);
             producedEvents.addEvent(event);
         }
         return Success

--- a/server/src/main/java/io/spine/server/model/ExternalAttribute.java
+++ b/server/src/main/java/io/spine/server/model/ExternalAttribute.java
@@ -29,7 +29,6 @@ import com.google.errorprone.annotations.Immutable;
 import io.spine.core.External;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -77,12 +76,12 @@ enum ExternalAttribute implements Attribute<Boolean> {
     }
 
     private static boolean isExternal(Method method) {
-        Parameter[] params = method.getParameters();
+        var params = method.getParameters();
         if (params.length == 0) {
             return false;
         }
-        Parameter firstParam = params[0];
-        boolean hasAnnotation = firstParam.getAnnotation(External.class) != null;
+        var firstParam = params[0];
+        var hasAnnotation = firstParam.getAnnotation(External.class) != null;
         return hasAnnotation;
     }
 }

--- a/server/src/main/java/io/spine/server/model/HandlerMap.java
+++ b/server/src/main/java/io/spine/server/model/HandlerMap.java
@@ -87,8 +87,8 @@ public final class HandlerMap<M extends MessageClass<?>,
     HandlerMap<M, P, H> create(Class<?> declaringClass, MethodSignature<H, ?> signature) {
         checkNotNull(declaringClass);
         checkNotNull(signature);
-        ImmutableSetMultimap<DispatchKey, H> map = findMethodsBy(declaringClass, signature);
-        ImmutableSet<M> messageClasses = messageClasses(map.values());
+        var map = findMethodsBy(declaringClass, signature);
+        var messageClasses = messageClasses(map.values());
         return new HandlerMap<>(map, messageClasses);
     }
 
@@ -127,8 +127,7 @@ public final class HandlerMap<M extends MessageClass<?>,
      * Obtains the classes of messages produced by the handler methods in this map.
      */
     public ImmutableSet<R> producedTypes() {
-        ImmutableSet<R> result = map
-                .values()
+        var result = map.values()
                 .stream()
                 .map(HandlerMethod::producedMessages)
                 .flatMap(Set::stream)
@@ -150,16 +149,16 @@ public final class HandlerMap<M extends MessageClass<?>,
      *         the class of the message, from which the handled message is originate
      */
     private ImmutableSet<H> handlersOf(M messageClass, MessageClass<?> originClass) {
-        DispatchKey key =
+        var key =
                 originClass.equals(EmptyClass.instance())
                 ? new DispatchKey(messageClass.value(), null)
                 : new DispatchKey(messageClass.value(), originClass.value());
         // If we have a handler with origin type, use the key. Otherwise, find handlers only
         // by the first parameter.
-        DispatchKey presentKey = map.containsKey(key)
-                                 ? key
-                                 : new DispatchKey(messageClass.value(), null);
-        ImmutableSet<H> handlers = map.get(presentKey);
+        var presentKey = map.containsKey(key)
+                         ? key
+                         : new DispatchKey(messageClass.value(), null);
+        var handlers = map.get(presentKey);
         return handlers;
     }
 
@@ -171,7 +170,7 @@ public final class HandlerMap<M extends MessageClass<?>,
      * @return a handler method for the given signal or {@code Optional.empty()}
      */
     public Optional<H> findHandlerFor(SignalEnvelope<?, ?, ?> message) {
-        MessageClass<?> messageClass = message.messageClass();
+        var messageClass = message.messageClass();
         MessageClass<?> originClass;
         if (message instanceof EnvelopeWithOrigin) {
             originClass = ((EnvelopeWithOrigin<?, ?, ?>) message).originClass();
@@ -179,7 +178,7 @@ public final class HandlerMap<M extends MessageClass<?>,
             originClass = EmptyClass.instance();
         }
         @SuppressWarnings("unchecked")
-        ImmutableSet<H> handlers = handlersOf(((M) messageClass), originClass);
+        var handlers = handlersOf(((M) messageClass), originClass);
         return handlers.stream()
                        .sorted(comparing((H h) -> h.filter().pathLength()).reversed())
                        .filter(h -> h.filter().test(message.message()))
@@ -196,9 +195,9 @@ public final class HandlerMap<M extends MessageClass<?>,
      *         if the handler the the message was not found
      */
     public H getHandlerFor(SignalEnvelope<?, ?, ?> message) {
-        Optional<H> handler = findHandlerFor(message);
+        var handler = findHandlerFor(message);
         return handler.orElseThrow(() -> {
-            String msg = format(
+            var msg = format(
                     "No handler method found for the type `%s`.", message.messageClass()
             );
             _error().log(msg);
@@ -219,10 +218,9 @@ public final class HandlerMap<M extends MessageClass<?>,
 
     private static <M extends MessageClass<?>, H extends HandlerMethod<?, M, ?, ?>>
     ImmutableSet<M> messageClasses(Collection<H> handlerMethods) {
-        ImmutableSet<M> result =
-                handlerMethods.stream()
-                              .map(HandlerMethod::messageClass)
-                              .collect(toImmutableSet());
+        var result = handlerMethods.stream()
+                .map(HandlerMethod::messageClass)
+                .collect(toImmutableSet());
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/model/HandlerMethod.java
+++ b/server/src/main/java/io/spine/server/model/HandlerMethod.java
@@ -28,7 +28,6 @@ package io.spine.server.model;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.Immutable;
-import com.google.protobuf.Message;
 import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.dispatch.Success;
 import io.spine.server.type.MessageEnvelope;
@@ -142,7 +141,7 @@ public interface HandlerMethod<T,
      * @see ExternalAttribute
      */
     default void ensureExternalMatch(boolean expectedValue) throws SignalOriginMismatchError {
-        boolean actualValue = isExternal();
+        var actualValue = isExternal();
         if (actualValue != expectedValue) {
             throw new SignalOriginMismatchError(this, expectedValue, actualValue);
         }
@@ -152,7 +151,7 @@ public interface HandlerMethod<T,
      * Creates a handler method dispatch key out of the {@linkplain #messageClass() message class}.
      */
     default DispatchKey key() {
-        Class<? extends Message> rawCls = messageClass().value();
+        var rawCls = messageClass().value();
         return new DispatchKey(rawCls, filter(), null);
     }
 }

--- a/server/src/main/java/io/spine/server/model/MatchCriterion.java
+++ b/server/src/main/java/io/spine/server/model/MatchCriterion.java
@@ -83,8 +83,7 @@ public enum MatchCriterion {
                        + " of `@%s` for allowed parameter types.") {
         @Override
         Optional<SignatureMismatch> test(Method method, MethodSignature<?, ?> signature) {
-            Optional<? extends ParameterSpec<?>> matching =
-                    signature.params().findMatching(method);
+            var matching = signature.params().findMatching(method);
             if (matching.isPresent()) {
                 return Optional.empty();
             }
@@ -102,8 +101,8 @@ public enum MatchCriterion {
                             + "Refer to the `%s` annotation docs for details.") {
         @Override
         Optional<SignatureMismatch> test(Method method, MethodSignature<?, ?> signature) {
-            ImmutableSet<AccessModifier> recommended = signature.modifier();
-            boolean hasMatch = recommended.stream().anyMatch(m -> m.test(method));
+            var recommended = signature.modifier();
+            var hasMatch = recommended.stream().anyMatch(m -> m.test(method));
             if (hasMatch) {
                 return Optional.empty();
             }
@@ -114,9 +113,9 @@ public enum MatchCriterion {
         createMismatch(Method method,
                        MethodSignature<?, ?> signature,
                        ImmutableSet<AccessModifier> recommended) {
-            String methodReference = methodAsString(method);
-            String annotationName = signature.annotation().getSimpleName();
-            AccessModifier currentModifier = AccessModifier.fromMethod(method);
+            var methodReference = methodAsString(method);
+            var annotationName = signature.annotation().getSimpleName();
+            var currentModifier = AccessModifier.fromMethod(method);
             return SignatureMismatch.create(
                     this, methodReference, currentModifier, recommended, annotationName);
         }
@@ -132,13 +131,12 @@ public enum MatchCriterion {
         Optional<SignatureMismatch> test(Method method, MethodSignature<?, ?> signature) {
             @Nullable Class<? extends Throwable> allowed =
                     signature.allowedThrowable().orElse(null);
-            MethodExceptionCheck checker = check(method, allowed);
-            ImmutableList<Class<? extends Throwable>> prohibited = checker.findProhibited();
+            var checker = check(method, allowed);
+            var prohibited = checker.findProhibited();
             if (prohibited.isEmpty()) {
                 return Optional.empty();
             }
-            ProhibitedExceptionMessage errorMessage
-                    = new ProhibitedExceptionMessage(method, prohibited, allowed);
+            var errorMessage = new ProhibitedExceptionMessage(method, prohibited, allowed);
             return SignatureMismatch.create(this, errorMessage);
         }
     };
@@ -172,7 +170,7 @@ public enum MatchCriterion {
     }
 
     protected final String formatMsg(Object... args) {
-        String message = format(Locale.ROOT, format, args);
+        var message = format(Locale.ROOT, format, args);
         return message;
     }
 
@@ -181,16 +179,16 @@ public enum MatchCriterion {
      */
     protected final Optional<SignatureMismatch>
     createMismatch(Method method, Class<? extends Annotation> annotation) {
-        String methodReference = methodAsString(method);
-        String annotationName = annotation.getSimpleName();
+        var methodReference = methodAsString(method);
+        var annotationName = annotation.getSimpleName();
         return SignatureMismatch.create(this, methodReference, annotationName);
     }
 
     private static String methodAsString(Method method) {
-        String declaringClassName = method.getDeclaringClass()
-                                          .getCanonicalName();
-        String parameterTypes = Diags.join(method.getParameterTypes());
-        String result = format("%s.%s(%s)", declaringClassName, method.getName(), parameterTypes);
+        var declaringClassName = method.getDeclaringClass()
+                                       .getCanonicalName();
+        var parameterTypes = Diags.join(method.getParameterTypes());
+        var result = format("%s.%s(%s)", declaringClassName, method.getName(), parameterTypes);
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
@@ -130,7 +130,7 @@ public final class MethodAccessChecker implements Logging {
     }
 
     private String methodFullName() {
-        String result = method.getDeclaringClass().getName() + '.' + method.getName() + "()";
+        var result = method.getDeclaringClass().getName() + '.' + method.getName() + "()";
         return result;
     }
 
@@ -142,8 +142,8 @@ public final class MethodAccessChecker implements Logging {
      *         otherwise
      */
     private static boolean isPackagePrivate(Method method) {
-        int modifiers = method.getModifiers();
-        boolean result = !(Modifier.isPublic(modifiers)
+        var modifiers = method.getModifiers();
+        var result = !(Modifier.isPublic(modifiers)
                          || Modifier.isProtected(modifiers)
                          || Modifier.isPrivate(modifiers));
         return result;

--- a/server/src/main/java/io/spine/server/model/MethodExceptionCheck.java
+++ b/server/src/main/java/io/spine/server/model/MethodExceptionCheck.java
@@ -68,15 +68,15 @@ final class MethodExceptionCheck {
      *         an empty list if the method does not declare such exceptions
      */
     ImmutableList<Class<? extends Throwable>> findProhibited() {
-        Class<?>[] thrownExceptions = method.getExceptionTypes();
+        var thrownExceptions = method.getExceptionTypes();
         if (thrownExceptions.length == 0) {
             return ImmutableList.of();
         }
         ImmutableList.Builder<Class<? extends Throwable>> result = ImmutableList.builder();
-        for (Class<?> exceptionType : thrownExceptions) {
+        for (var exceptionType : thrownExceptions) {
             if (allowedThrowable == null || !allowedThrowable.isAssignableFrom(exceptionType)) {
                 @SuppressWarnings("unchecked")  // As all exceptions extend `Throwable`.
-                Class<? extends Throwable> asThrowableCls =
+                var asThrowableCls =
                         (Class<? extends Throwable>) exceptionType;
                 result.add(asThrowableCls);
             }

--- a/server/src/main/java/io/spine/server/model/MethodParams.java
+++ b/server/src/main/java/io/spine/server/model/MethodParams.java
@@ -57,9 +57,9 @@ public final class MethodParams {
      */
     public static MethodParams of(SubscriberMethod method) {
         checkNotNull(method);
-        ArgumentFilter filter = method.filter();
-        Class<?>[] paramTypes = method.rawMethod()
-                                      .getParameterTypes();
+        var filter = method.filter();
+        var paramTypes = method.rawMethod()
+                               .getParameterTypes();
         return new MethodParams(filter, paramTypes);
     }
 
@@ -107,7 +107,7 @@ public final class MethodParams {
      * @param index the zero-based index of the type.
      */
     public Class<?> type(int index) {
-        Class<?> type = params.get(index);
+        var type = params.get(index);
         return type;
     }
 
@@ -118,7 +118,7 @@ public final class MethodParams {
         if (size() != 1) {
             return false;
         }
-        Class<?> firstParam = type(0);
+        var firstParam = type(0);
         return type.test(firstParam);
     }
 
@@ -130,9 +130,9 @@ public final class MethodParams {
             return false;
         }
 
-        for (int i = 0; i < size(); i++) {
-            Class<?> actual = type(i);
-            Class<?> expected = types[i];
+        for (var i = 0; i < size(); i++) {
+            var actual = type(i);
+            var expected = types[i];
             if (!exactly(expected).test(actual)) {
                 return false;
             }
@@ -155,9 +155,9 @@ public final class MethodParams {
             return false;
         }
 
-        for (int i = 0; i < size(); i++) {
-            Class<?> actual = type(i);
-            TypeMatcher matcher = criteria.get(i);
+        for (var i = 0; i < size(); i++) {
+            var actual = type(i);
+            var matcher = criteria.get(i);
             if (!matcher.test(actual)) {
                 return false;
             }
@@ -175,11 +175,11 @@ public final class MethodParams {
      */
     public static boolean firstIsCommand(Method method) {
         checkNotNull(method);
-        MethodParams params = of(method);
+        var params = of(method);
         if (params.size() == 0) {
             return false;
         }
-        boolean result = CommandMessage.class.isAssignableFrom(params.type(0));
+        var result = CommandMessage.class.isAssignableFrom(params.type(0));
         return result;
     }
 
@@ -191,7 +191,7 @@ public final class MethodParams {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        MethodParams other = (MethodParams) o;
+        var other = (MethodParams) o;
         return params.equals(other.params) &&
                 Objects.equals(filter, other.filter);
     }

--- a/server/src/main/java/io/spine/server/model/MethodResult.java
+++ b/server/src/main/java/io/spine/server/model/MethodResult.java
@@ -77,9 +77,9 @@ final class MethodResult {
     }
 
     static MethodResult from(@Nullable Object rawMethodOutput) {
-        List<Message> messages = toMessages(rawMethodOutput);
+        var messages = toMessages(rawMethodOutput);
         messages.forEach(MethodResult::checkNotRejection);
-        ImmutableList<Message> filtered = filterIgnored(messages);
+        var filtered = filterIgnored(messages);
         return new MethodResult(filtered);
     }
 
@@ -88,12 +88,12 @@ final class MethodResult {
             return ImmutableList.of();
         } else if (output instanceof Optional) {
             // Allow `Optional` for event reactions and command generation in response to events.
-            Optional<?> optional = (Optional<?>) output;
+            var optional = (Optional<?>) output;
             return optional.map(MethodResult::singleton)
                            .orElse(ImmutableList.of());
         } else if (output instanceof Iterable) {
             @SuppressWarnings("unchecked")
-            Iterable<Message> messages = (Iterable<Message>) output;
+            var messages = (Iterable<Message>) output;
             return ImmutableList.copyOf(messages);
         } else {
             // Another type of result is single event message (as Message).
@@ -102,7 +102,7 @@ final class MethodResult {
     }
 
     private static List<Message> singleton(Object messageDisguised) {
-        Message message = (Message) messageDisguised;
+        var message = (Message) messageDisguised;
         return ImmutableList.of(message);
     }
 
@@ -110,7 +110,7 @@ final class MethodResult {
      * Filters the list removing instances of the {@linkplain #IGNORED_MESSAGES ignored types}.
      */
     private static ImmutableList<Message> filterIgnored(List<Message> messages) {
-        ImmutableList<Message> result = messages
+        var result = messages
                 .stream()
                 .filter(message -> !IGNORED_MESSAGES.contains(message))
                 .collect(toImmutableList());
@@ -138,7 +138,7 @@ final class MethodResult {
     <T extends Message> ImmutableList<T> messages(
             @SuppressWarnings("unused") Class<T> messageType) {
         @SuppressWarnings("unchecked")
-        ImmutableList<T> castMessages = (ImmutableList<T>) this.messages;
+        var castMessages = (ImmutableList<T>) this.messages;
         return castMessages;
     }
 

--- a/server/src/main/java/io/spine/server/model/MethodResults.java
+++ b/server/src/main/java/io/spine/server/model/MethodResults.java
@@ -27,7 +27,6 @@
 package io.spine.server.model;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Streams;
 import com.google.common.graph.Traverser;
 import com.google.common.reflect.TypeToken;
 import io.spine.base.CommandMessage;
@@ -38,10 +37,10 @@ import io.spine.server.type.EventClass;
 import io.spine.type.MessageClass;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Type;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Streams.stream;
 import static io.spine.util.Exceptions.newIllegalArgumentException;
 
 /**
@@ -80,16 +79,15 @@ final class MethodResults {
         are only used for convenience. */
     static <P extends MessageClass<?>> ImmutableSet<P> collectMessageClasses(Method method) {
         checkNotNull(method);
-        Type returnType = method.getGenericReturnType();
-        Iterable<Type> allTypes = Traverser.forTree(Types::resolveArguments)
-                                           .breadthFirst(returnType);
-        ImmutableSet<P> result =
-                Streams.stream(allTypes)
-                       .map(TypeToken::of)
-                       .map(TypeToken::getRawType)
-                       .filter(MethodResults::isCommandOrEvent)
-                       .map(c -> (P) toMessageClass(c))
-                       .collect(toImmutableSet());
+        var returnType = method.getGenericReturnType();
+        var allTypes = Traverser.forTree(Types::resolveArguments)
+                                .breadthFirst(returnType);
+        var result = stream(allTypes)
+                .map(TypeToken::of)
+                .map(TypeToken::getRawType)
+                .filter(MethodResults::isCommandOrEvent)
+                .map(c -> (P) toMessageClass(c))
+                .collect(toImmutableSet());
         return result;
     }
 
@@ -104,8 +102,8 @@ final class MethodResults {
         if (Nothing.class.equals(cls)) {
             return false;
         }
-        boolean isCommandOrEvent = CommandMessage.class.isAssignableFrom(cls)
-                                || EventMessage.class.isAssignableFrom(cls);
+        var isCommandOrEvent = CommandMessage.class.isAssignableFrom(cls)
+                || EventMessage.class.isAssignableFrom(cls);
         return isCommandOrEvent;
     }
 

--- a/server/src/main/java/io/spine/server/model/MethodScan.java
+++ b/server/src/main/java/io/spine/server/model/MethodScan.java
@@ -64,8 +64,8 @@ final class MethodScan<H extends HandlerMethod<?, ?, ?, ?>> {
      */
     static <H extends HandlerMethod<?, ?, ?, ?>> ImmutableSetMultimap<DispatchKey, H>
     findMethodsBy(Class<?> declaringClass, MethodSignature<H, ?> signature) {
-        MethodScan<H> operation = new MethodScan<>(declaringClass, signature);
-        ImmutableSetMultimap<DispatchKey, H> result = operation.perform();
+        var operation = new MethodScan<>(declaringClass, signature);
+        var result = operation.perform();
         return result;
     }
 
@@ -83,8 +83,8 @@ final class MethodScan<H extends HandlerMethod<?, ?, ?, ?>> {
      * <p>Multiple calls to this method may cause {@link DuplicateHandlerMethodError}s.
      */
     private ImmutableSetMultimap<DispatchKey, H> perform() {
-        Method[] declaredMethods = declaringClass.getDeclaredMethods();
-        for (Method method : declaredMethods) {
+        var declaredMethods = declaringClass.getDeclaredMethods();
+        for (var method : declaredMethods) {
             if (!method.isBridge() && !method.isSynthetic()) {
                 scanMethod(method);
             }
@@ -104,12 +104,12 @@ final class MethodScan<H extends HandlerMethod<?, ?, ?, ?>> {
     }
 
     private void checkNotRemembered(H handler) {
-        DispatchKey key = handler.key();
+        var key = handler.key();
         if (seenMethods.containsKey(key)) {
-            Method alreadyPresent = seenMethods.get(key)
-                                               .rawMethod();
-            String methodName = alreadyPresent.getName();
-            String duplicateMethodName = handler.rawMethod().getName();
+            var alreadyPresent = seenMethods.get(key)
+                                            .rawMethod();
+            var methodName = alreadyPresent.getName();
+            var duplicateMethodName = handler.rawMethod().getName();
             throw new DuplicateHandlerMethodError(
                     declaringClass, key, methodName, duplicateMethodName
             );
@@ -119,15 +119,15 @@ final class MethodScan<H extends HandlerMethod<?, ?, ?, ?>> {
     }
 
     private void checkForFilterClashes(HandlerMethod<?, ?, ?, ?> handler) {
-        ArgumentFilter filter = handler.filter();
+        var filter = handler.filter();
         if (filter.acceptsAll()) {
             return;
         }
-        MessageClass<?> handledClass = handler.messageClass();
+        var handledClass = handler.messageClass();
 
         // It is OK to keep only the last filtering handler in the map (and not all of them)
         // because filtered fields are required to be the same.
-        HandlerMethod<?, ?, ?, ?> existingHandler = messageToHandler.put(handledClass, handler);
+        var existingHandler = messageToHandler.put(handledClass, handler);
         if (existingHandler != null && !filter.sameField(existingHandler.filter())) {
             // There is already a handler for this message class.
             // Check that the field which is used as the condition for filtering is the same.

--- a/server/src/main/java/io/spine/server/model/MethodSignature.java
+++ b/server/src/main/java/io/spine/server/model/MethodSignature.java
@@ -33,7 +33,6 @@ import io.spine.server.type.MessageEnvelope;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -136,17 +135,15 @@ public abstract class MethodSignature<H extends HandlerMethod<?, ?, E, ?>,
         if (skipMethod(method)) {
             return false;
         }
-        Collection<SignatureMismatch> mismatches = match(method);
-        boolean hasErrors =
-                mismatches.stream()
-                          .anyMatch(SignatureMismatch::isError);
+        var mismatches = match(method);
+        var hasErrors = mismatches.stream()
+                .anyMatch(SignatureMismatch::isError);
         if (hasErrors) {
             throw new SignatureMismatchException(mismatches);
         }
-        List<SignatureMismatch> warnings =
-                mismatches.stream()
-                          .filter(SignatureMismatch::isWarning)
-                          .collect(toList());
+        var warnings = mismatches.stream()
+                .filter(SignatureMismatch::isWarning)
+                .collect(toList());
         if (!warnings.isEmpty()) {
             warnings.stream()
                     .map(SignatureMismatch::toString)
@@ -159,7 +156,7 @@ public abstract class MethodSignature<H extends HandlerMethod<?, ?, E, ?>,
      * Verifies if the passed return type conforms this method signature.
      */
     final boolean returnTypeMatches(Method method) {
-        boolean conforms = returnTypes().matches(method, mayReturnIgnored());
+        var conforms = returnTypes().matches(method, mayReturnIgnored());
         return conforms;
     }
 
@@ -217,13 +214,13 @@ public abstract class MethodSignature<H extends HandlerMethod<?, ?, E, ?>,
      *         encountered
      */
     public final Optional<H> classify(Method method) throws SignatureMismatchException {
-        boolean matches = matches(method);
+        var matches = matches(method);
         if (!matches) {
             return Optional.empty();
         }
-        Optional<? extends ParameterSpec<E>> matchingSpec = params().findMatching(method);
+        var matchingSpec = params().findMatching(method);
         return matchingSpec.map(spec -> {
-            H handler = create(method, spec);
+            var handler = create(method, spec);
             handler.discoverAttributes();
             return handler;
         });

--- a/server/src/main/java/io/spine/server/model/Model.java
+++ b/server/src/main/java/io/spine/server/model/Model.java
@@ -86,30 +86,29 @@ public class Model {
      * @see BoundedContext
      */
     public static synchronized <T> Model inContextOf(Class<? extends T> rawClass) {
-        Model model = models.get(rawClass);
+        var model = models.get(rawClass);
         if (model != null) {
             return model;
         }
-        Optional<BoundedContextName> optional = findContext(rawClass);
+        var optional = findContext(rawClass);
 
         // If no name of a Bounded Context found, assume the default name.
         // This is a safety net for newcomers and our tests.
         // We may want to make this check strict, and require specifying Bounded Context names.
-        BoundedContextName context = optional.orElseGet(BoundedContextNames::assumingTests);
+        var context = optional.orElseGet(BoundedContextNames::assumingTests);
 
         // Try to find a Model if it already exists.
-        Optional<Model> alreadyAvailable =
-                models.values()
-                      .stream()
-                      .filter((m) -> m.context.equals(context))
-                      .findAny();
+        var alreadyAvailable = models.values()
+                .stream()
+                .filter((m) -> m.context.equals(context))
+                .findAny();
         if (alreadyAvailable.isPresent()) {
             return alreadyAvailable.get();
         }
 
         // Since a model is not found, create for new Bounded Context and associated with the
         // passed raw class.
-        Model newModel = new Model(context);
+        var newModel = new Model(context);
         models.put(rawClass, newModel);
         return newModel;
     }
@@ -120,19 +119,18 @@ public class Model {
      */
     @VisibleForTesting
     static <T> Optional<BoundedContextName> findContext(Class<? extends T> rawClass) {
-        ClassName clazzName = ClassName.of(rawClass);
+        var clazzName = ClassName.of(rawClass);
         try {
             return knownContexts.get(clazzName, () -> {
                 Optional<BoundedContextName> result;
 
-                PackageInfo pkg = PackageInfo.of(rawClass);
-                Optional<BoundedContext> annotation = pkg.findAnnotation(BoundedContext.class);
-                if (!annotation.isPresent()) {
+                var pkg = PackageInfo.of(rawClass);
+                var annotation = pkg.findAnnotation(BoundedContext.class);
+                if (annotation.isEmpty()) {
                     result = Optional.empty();
                 } else {
-                    String nameAsString = annotation.get()
-                                                    .value();
-                    BoundedContextName contextName = BoundedContextNames.newName(nameAsString);
+                    var nameAsString = annotation.get().value();
+                    var contextName = BoundedContextNames.newName(nameAsString);
                     result = Optional.of(contextName);
                 }
                 return result;
@@ -161,7 +159,7 @@ public class Model {
      * Clears all models, and then clears the {@link #models} map.
      */
     private static void reset() {
-        for (Model model : models.values()) {
+        for (var model : models.values()) {
             model.clear();
         }
         models.clear();
@@ -197,7 +195,7 @@ public class Model {
     ModelClass<T> getClass(Class<? extends T> cls,
                            Class<M> classOfModelClass,
                            Supplier<ModelClass<T>> supplier) {
-        ModelClass<T> result = classes.get(cls, classOfModelClass, supplier);
+        var result = classes.get(cls, classOfModelClass, supplier);
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/model/ModelClass.java
+++ b/server/src/main/java/io/spine/server/model/ModelClass.java
@@ -54,8 +54,8 @@ public abstract class ModelClass<T> extends ClassTypeValue<T> {
     ModelClass<T> get(Class<T> rawClass,
                       Class<M> requestedModelClass,
                       Supplier<ModelClass<T>> supplier) {
-        Model model = Model.inContextOf(rawClass);
-        ModelClass<T> result = model.getClass(rawClass, requestedModelClass, supplier);
+        var model = Model.inContextOf(rawClass);
+        var result = model.getClass(rawClass, requestedModelClass, supplier);
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/model/ReturnTypes.java
+++ b/server/src/main/java/io/spine/server/model/ReturnTypes.java
@@ -96,17 +96,17 @@ public final class ReturnTypes {
      *         is {@code true} if the method can return {@link Nothing}
      */
     boolean matches(Method method, boolean mayReturnIgnored) {
-        TypeToken<?> actualReturnType = Invokable.from(method).getReturnType();
+        var actualReturnType = Invokable.from(method).getReturnType();
         if (!mayReturnIgnored && ignored(actualReturnType)) {
             return false;
         }
-        boolean conformsWhitelist = whitelist.stream()
-                                             .anyMatch(t -> conforms(t, actualReturnType));
+        var conformsWhitelist = whitelist.stream()
+                .anyMatch(t -> conforms(t, actualReturnType));
         if (!conformsWhitelist) {
             return false;
         }
-        boolean conformsBlacklist = blacklist.stream()
-                                             .noneMatch(t -> conforms(t, actualReturnType));
+        var conformsBlacklist = blacklist.stream()
+                .noneMatch(t -> conforms(t, actualReturnType));
         return conformsBlacklist;
     }
 
@@ -129,8 +129,8 @@ public final class ReturnTypes {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ReturnTypes types1 = (ReturnTypes) o;
-        return whitelist.equals(types1.whitelist);
+        var other = (ReturnTypes) o;
+        return whitelist.equals(other.whitelist);
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/model/SignatureMismatch.java
+++ b/server/src/main/java/io/spine/server/model/SignatureMismatch.java
@@ -98,7 +98,7 @@ public final class SignatureMismatch {
     static Optional<SignatureMismatch> create(MatchCriterion criterion, Object... values) {
         checkNotNull(criterion);
         checkNotNull(values);
-        SignatureMismatch result = new SignatureMismatch(criterion, values);
+        var result = new SignatureMismatch(criterion, values);
         return Optional.of(result);
     }
 

--- a/server/src/main/java/io/spine/server/model/TypeMatcher.java
+++ b/server/src/main/java/io/spine/server/model/TypeMatcher.java
@@ -112,14 +112,14 @@ public interface TypeMatcher extends Predicate<Class<?>> {
             return true;
         }
 
-        Class<?> rawExpected = expected.getRawType();
-        Class<?> rawActual = actual.getRawType();
+        var rawExpected = expected.getRawType();
+        var rawActual = actual.getRawType();
         if (!rawExpected.isAssignableFrom(rawActual)) {
             return false;
         }
 
         TypeVariable<? extends Class<?>>[] expectedTypeParams = rawExpected.getTypeParameters();
-        int expectedParamCount = expectedTypeParams.length;
+        var expectedParamCount = expectedTypeParams.length;
         if (expectedParamCount == 0) {
             return true;
         }
@@ -127,7 +127,7 @@ public interface TypeMatcher extends Predicate<Class<?>> {
         TypeVariable<? extends Class<?>>[] actualTypeParams = rawActual.getTypeParameters();
 
         if (expectedParamCount == 1) {
-            TypeToken<?> expectedGenericType = expected.resolveType(expectedTypeParams[0]);
+            var expectedGenericType = expected.resolveType(expectedTypeParams[0]);
             return matchActualGenericsToOne(actual, expectedGenericType);
         } else if (expectedParamCount != actualTypeParams.length) {
             return false;
@@ -146,8 +146,8 @@ public interface TypeMatcher extends Predicate<Class<?>> {
     static TypeToken<?> resolve(TypeToken<?> type, TypeVariable<? extends Class<?>> param) {
         checkNotNull(type);
         checkNotNull(param);
-        TypeToken<?> actualGenericType = type.resolveType(param);
-        Class<?> rawType = actualGenericType.getRawType();
+        var actualGenericType = type.resolveType(param);
+        var rawType = actualGenericType.getRawType();
         TypeVariable<? extends Class<?>>[] parameters = rawType.getTypeParameters();
         if (Optional.class.isAssignableFrom(rawType) && parameters.length == 1) {
             actualGenericType = actualGenericType.resolveType(parameters[0]);
@@ -167,11 +167,11 @@ public interface TypeMatcher extends Predicate<Class<?>> {
     static boolean matchOneToOne(TypeToken<?> expected, TypeToken<?> actual) {
         checkNotNull(expected);
         checkNotNull(actual);
-        TypeVariable<? extends Class<?>>[] expectedTypeParams = genericTypesOf(expected);
-        TypeVariable<? extends Class<?>>[] actualTypeParams = genericTypesOf(actual);
-        for (int paramIndex = 0; paramIndex < expectedTypeParams.length; paramIndex++) {
-            TypeToken<?> expectedGeneric = resolve(expected, expectedTypeParams[paramIndex]);
-            TypeToken<?> actualGeneric = resolve(actual, actualTypeParams[paramIndex]);
+        var expectedTypeParams = genericTypesOf(expected);
+        var actualTypeParams = genericTypesOf(actual);
+        for (var paramIndex = 0; paramIndex < expectedTypeParams.length; paramIndex++) {
+            var expectedGeneric = resolve(expected, expectedTypeParams[paramIndex]);
+            var actualGeneric = resolve(actual, actualTypeParams[paramIndex]);
             if (differs(actualGeneric, expectedGeneric)) {
                 return false;
             }
@@ -189,10 +189,10 @@ public interface TypeMatcher extends Predicate<Class<?>> {
     matchActualGenericsToOne(TypeToken<?> whoseGenerics, TypeToken<?> expectedGenericType) {
         checkNotNull(whoseGenerics);
         checkNotNull(expectedGenericType);
-        TypeVariable<? extends Class<?>>[] actualTypeParams = genericTypesOf(whoseGenerics);
+        var actualTypeParams = genericTypesOf(whoseGenerics);
         if (actualTypeParams.length > 0) {
-            for (TypeVariable<? extends Class<?>> param : actualTypeParams) {
-                TypeToken<?> actualGenericType = resolve(whoseGenerics, param);
+            for (var param : actualTypeParams) {
+                var actualGenericType = resolve(whoseGenerics, param);
                 if (differs(actualGenericType, expectedGenericType)) {
                     return false;
                 }
@@ -211,7 +211,7 @@ public interface TypeMatcher extends Predicate<Class<?>> {
      */
     static ImmutableSet<Class<? extends Message>> messagesFitting(TypeToken<?> type) {
         checkNotNull(type);
-        Class<?> rawType = type.getRawType();
+        var rawType = type.getRawType();
         TypeVariable<? extends Class<?>>[] parameters = rawType.getTypeParameters();
         if (0 == parameters.length) {
             return type.isSubtypeOf(Message.class)
@@ -220,8 +220,8 @@ public interface TypeMatcher extends Predicate<Class<?>> {
         }
 
         ImmutableSet.Builder<Class<? extends Message>> builder = ImmutableSet.builder();
-        for (TypeVariable<? extends Class<?>> parameter : parameters) {
-            TypeToken<?> genericType = resolve(type, parameter);
+        for (var parameter : parameters) {
+            var genericType = resolve(type, parameter);
             if (genericType.isSubtypeOf(Message.class)) {
                 builder.add(asMessageType(genericType.getRawType()));
             }

--- a/server/src/main/java/io/spine/server/model/VoidMethod.java
+++ b/server/src/main/java/io/spine/server/model/VoidMethod.java
@@ -54,7 +54,7 @@ public interface VoidMethod<T,
     @Override
     default Success toSuccessfulOutcome(@Nullable Object result, T target, E handledSignal) {
         if (result != null) {
-            String errorMessage = format(
+            var errorMessage = format(
                     "Method `%s` should NOT produce any result. Produced: `%s`.",
                     this,
                     result

--- a/server/src/main/java/io/spine/server/procman/PmCommandEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmCommandEndpoint.java
@@ -27,10 +27,8 @@
 package io.spine.server.procman;
 
 import io.spine.annotation.Internal;
-import io.spine.server.command.DispatchCommand;
 import io.spine.server.delivery.CommandEndpoint;
 import io.spine.server.dispatch.DispatchOutcome;
-import io.spine.server.entity.EntityLifecycle;
 import io.spine.server.type.CommandEnvelope;
 
 import static io.spine.server.command.DispatchCommand.operationFor;
@@ -65,8 +63,8 @@ public class PmCommandEndpoint<I, P extends ProcessManager<I, ?, ?>>
 
     @Override
     protected DispatchOutcome invokeDispatcher(P processManager) {
-        EntityLifecycle lifecycle = repository().lifecycleOf(processManager.id());
-        DispatchCommand<I> dispatch = operationFor(lifecycle, processManager, envelope());
+        var lifecycle = repository().lifecycleOf(processManager.id());
+        var dispatch = operationFor(lifecycle, processManager, envelope());
         PmTransaction<I, ?, ?> tx = (PmTransaction<I, ?, ?>) processManager.tx();
         return tx.perform(dispatch);
     }

--- a/server/src/main/java/io/spine/server/procman/PmEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmEndpoint.java
@@ -54,7 +54,7 @@ abstract class PmEndpoint<I,
 
     @Override
     protected boolean isModified(P processManager) {
-        boolean result = processManager.changed();
+        var result = processManager.changed();
         return result;
     }
 
@@ -74,7 +74,7 @@ abstract class PmEndpoint<I,
     @SuppressWarnings("UnnecessaryInheritDoc") // IDEA bug.
     @Override
     public void dispatchTo(I id) {
-        P manager = repository().findOrCreate(id);
+        var manager = repository().findOrCreate(id);
         DispatchOutcomeHandler
                 .from(runTransactionFor(manager))
                 .onSuccess(success -> store(manager))
@@ -97,7 +97,7 @@ abstract class PmEndpoint<I,
 
     protected DispatchOutcome runTransactionFor(P processManager) {
         PmTransaction<?, ?, ?> tx = repository().beginTransactionFor(processManager);
-        DispatchOutcome outcome = invokeDispatcher(processManager);
+        var outcome = invokeDispatcher(processManager);
         tx.commitIfActive();
         return outcome;
     }

--- a/server/src/main/java/io/spine/server/procman/PmTransaction.java
+++ b/server/src/main/java/io/spine/server/procman/PmTransaction.java
@@ -76,7 +76,7 @@ public class PmTransaction<I,
      * @see ProcessManager#dispatchCommand(CommandEnvelope)
      */
     final DispatchOutcome perform(DispatchCommand<I> dispatch) {
-        VersionIncrement vi = createVersionIncrement();
+        var vi = createVersionIncrement();
         Phase<I> phase = new CommandDispatchingPhase<>(this, dispatch, vi);
         return propagate(phase);
     }

--- a/server/src/main/java/io/spine/server/procman/ProcessManager.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManager.java
@@ -32,25 +32,18 @@ import io.spine.annotation.Internal;
 import io.spine.base.EntityState;
 import io.spine.server.command.CommandHandlingEntity;
 import io.spine.server.command.Commander;
-import io.spine.server.command.model.CommandHandlerMethod;
-import io.spine.server.command.model.CommandReactionMethod;
-import io.spine.server.command.model.CommandSubstituteMethod;
 import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.entity.HasLifecycleColumns;
 import io.spine.server.entity.HasVersionColumn;
 import io.spine.server.entity.Transaction;
 import io.spine.server.entity.TransactionalEntity;
 import io.spine.server.event.EventReactor;
-import io.spine.server.event.model.EventReactorMethod;
 import io.spine.server.log.LoggingEntity;
 import io.spine.server.procman.model.ProcessManagerClass;
-import io.spine.server.type.CommandClass;
 import io.spine.server.type.CommandEnvelope;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
 import io.spine.validate.ValidatingBuilder;
-
-import java.util.Optional;
 
 import static io.spine.server.Ignored.ignored;
 import static io.spine.server.procman.model.ProcessManagerClass.asProcessManagerClass;
@@ -171,17 +164,17 @@ public abstract class ProcessManager<I,
     @Override
     protected DispatchOutcome dispatchCommand(CommandEnvelope command) {
         ProcessManagerClass<?> thisClass = thisClass();
-        CommandClass commandClass = command.messageClass();
+        var commandClass = command.messageClass();
 
         if (thisClass.handlesCommand(commandClass)) {
-            CommandHandlerMethod method = thisClass.handlerOf(command);
-            DispatchOutcome outcome = method.invoke(this, command);
+            var method = thisClass.handlerOf(command);
+            var outcome = method.invoke(this, command);
             return outcome;
         }
 
         if (thisClass.substitutesCommand(commandClass)) {
-            CommandSubstituteMethod method = thisClass.commanderOf(command);
-            DispatchOutcome outcome = method.invoke(this, command);
+            var method = thisClass.commanderOf(command);
+            var outcome = method.invoke(this, command);
             return outcome;
         }
 
@@ -211,16 +204,16 @@ public abstract class ProcessManager<I,
      */
     DispatchOutcome dispatchEvent(EventEnvelope event) {
         ProcessManagerClass<?> thisClass = thisClass();
-        EventClass eventClass = event.messageClass();
-        Optional<EventReactorMethod> reactorMethod = thisClass.reactorOf(event);
+        var eventClass = event.messageClass();
+        var reactorMethod = thisClass.reactorOf(event);
         if (thisClass.reactsOnEvent(eventClass) && reactorMethod.isPresent()) {
-            DispatchOutcome outcome = reactorMethod.get().invoke(this, event);
+            var outcome = reactorMethod.get().invoke(this, event);
             return outcome;
         }
 
-        Optional<CommandReactionMethod> commanderMethod = thisClass.commanderOf(event);
+        var commanderMethod = thisClass.commanderOf(event);
         if (thisClass.producesCommandsOn(eventClass) && commanderMethod.isPresent()) {
-            DispatchOutcome outcome = commanderMethod.get().invoke(this, event);
+            var outcome = commanderMethod.get().invoke(this, event);
             return outcome;
         }
         _debug().log("Process manager %s filtered out and ignored event %s[ID: %s].",

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerMigration.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerMigration.java
@@ -54,7 +54,7 @@ public abstract class ProcessManagerMigration<I,
     @SuppressWarnings("unchecked") // Logically correct.
     @Override
     protected Transaction<I, P, S, B> startTransaction(P entity) {
-        Transaction<I, P, S, B> tx = (Transaction<I, P, S, B>) new PmTransaction<>(entity);
+        var tx = (Transaction<I, P, S, B>) new PmTransaction<>(entity);
         return tx;
     }
 }

--- a/server/src/main/java/io/spine/server/procman/model/ProcessManagerClass.java
+++ b/server/src/main/java/io/spine/server/procman/model/ProcessManagerClass.java
@@ -27,7 +27,6 @@
 package io.spine.server.procman.model;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets.SetView;
 import io.spine.server.command.model.CommandReactionMethod;
 import io.spine.server.command.model.CommandSubstituteMethod;
 import io.spine.server.command.model.CommanderClass;
@@ -75,35 +74,33 @@ public final class ProcessManagerClass<P extends ProcessManager<?, ?, ?>>
     ProcessManagerClass<P> asProcessManagerClass(Class<P> cls) {
         checkNotNull(cls);
         @SuppressWarnings("unchecked")
-        ProcessManagerClass<P> result = (ProcessManagerClass<P>)
+        var result = (ProcessManagerClass<P>)
                 get(cls, ProcessManagerClass.class, () -> new ProcessManagerClass<>(cls));
         return result;
     }
 
     @Override
     public ImmutableSet<CommandClass> commands() {
-        SetView<CommandClass> result =
-                union(super.commands(), commanderDelegate.commands());
+        var result = union(super.commands(), commanderDelegate.commands());
         return result.immutableCopy();
     }
 
     @Override
     public ImmutableSet<EventClass> events() {
-        SetView<EventClass> result =
-                union(reactorDelegate.events(), commanderDelegate.events());
+        var result = union(reactorDelegate.events(), commanderDelegate.events());
         return result.immutableCopy();
     }
 
     @Override
     public ImmutableSet<EventClass> domesticEvents() {
-        SetView<EventClass> result =
+        var result =
                 union(reactorDelegate.domesticEvents(), commanderDelegate.domesticEvents());
         return result.immutableCopy();
     }
 
     @Override
     public ImmutableSet<EventClass> externalEvents() {
-        SetView<EventClass> result =
+        var result =
                 union(reactorDelegate.externalEvents(), commanderDelegate.externalEvents());
         return result.immutableCopy();
     }
@@ -112,8 +109,8 @@ public final class ProcessManagerClass<P extends ProcessManager<?, ?, ?>>
      * Obtains event classes produced by this process manager class.
      */
     public ImmutableSet<EventClass> outgoingEvents() {
-        SetView<EventClass> methodResults = union(commandOutput(), reactionOutput());
-        SetView<EventClass> result = union(methodResults, rejections());
+        var methodResults = union(commandOutput(), reactionOutput());
+        var result = union(methodResults, rejections());
         return result.immutableCopy();
     }
 

--- a/server/src/main/java/io/spine/server/projection/CatchUpEndpoint.java
+++ b/server/src/main/java/io/spine/server/projection/CatchUpEndpoint.java
@@ -70,7 +70,7 @@ final class CatchUpEndpoint<I, P extends Projection<I, S, ?>, S extends EntitySt
 
     @Override
     public void dispatchTo(I entityId) {
-        TypeName actualTypeName = envelope().messageTypeName();
+        var actualTypeName = envelope().messageTypeName();
         if (actualTypeName.equals(CATCH_UP_STARTED)) {
             onCatchUpStarted(entityId);
         } else {
@@ -79,8 +79,8 @@ final class CatchUpEndpoint<I, P extends Projection<I, S, ?>, S extends EntitySt
     }
 
     private void onCatchUpStarted(I entityId) {
-        ProjectionRepository<I, P, ?> repository = repository();
-        CatchUpStarted event = (CatchUpStarted) envelope().message();
+        var repository = repository();
+        var event = (CatchUpStarted) envelope().message();
         repository.recordStorage()
                   .delete(entityId);
         repository.lifecycleOf(entityId)

--- a/server/src/main/java/io/spine/server/projection/Projection.java
+++ b/server/src/main/java/io/spine/server/projection/Projection.java
@@ -140,8 +140,7 @@ public abstract class Projection<I,
     }
 
     private DispatchOutcome unhandledEvent(EventEnvelope event) {
-        Error error = Error
-                .newBuilder()
+        var error = Error.newBuilder()
                 .setType(EventValidationError.getDescriptor().getFullName())
                 .setCode(UNSUPPORTED_EVENT_VALUE)
                 .setMessage(format(
@@ -149,8 +148,7 @@ public abstract class Projection<I,
                         thisClass(), event.messageTypeName()
                 ))
                 .buildPartial();
-        return DispatchOutcome
-                .newBuilder()
+        return DispatchOutcome.newBuilder()
                 .setPropagatedSignal(event.outerObject().messageId())
                 .setError(error)
                 .vBuild();
@@ -158,7 +156,7 @@ public abstract class Projection<I,
 
     @Override
     public BatchDispatchOutcome play(Iterable<Event> events) {
-        EventPlayer eventPlayer = EventPlayer.forTransactionOf(this);
+        var eventPlayer = EventPlayer.forTransactionOf(this);
         return eventPlayer.play(events);
     }
 }

--- a/server/src/main/java/io/spine/server/projection/ProjectionEndpoint.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionEndpoint.java
@@ -29,7 +29,6 @@ package io.spine.server.projection;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.spine.annotation.Internal;
 import io.spine.base.EntityState;
-import io.spine.base.Error;
 import io.spine.server.delivery.EventEndpoint;
 import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.entity.EntityLifecycleMonitor;
@@ -71,8 +70,8 @@ public class ProjectionEndpoint<I, P extends Projection<I, S, ?>, S extends Enti
 
     @Override
     public void dispatchTo(I entityId) {
-        ProjectionRepository<I, P, ?> repository = repository();
-        P projection = repository.findOrCreate(entityId);
+        var repository = repository();
+        var projection = repository.findOrCreate(entityId);
         runTransactionFor(projection);
         store(projection);
     }
@@ -84,16 +83,16 @@ public class ProjectionEndpoint<I, P extends Projection<I, S, ?>, S extends Enti
     }
 
     protected void runTransactionFor(P projection) {
-        ProjectionTransaction<I, S, ?> tx = start((Projection<I, S, ?>) projection);
+        var tx = start((Projection<I, S, ?>) projection);
         TransactionListener<I> listener =
                 EntityLifecycleMonitor.newInstance(repository(), projection.id());
         tx.setListener(listener);
-        DispatchOutcome outcome = invokeDispatcher(projection);
+        var outcome = invokeDispatcher(projection);
         tx.commitIfActive();
         if (outcome.hasSuccess()) {
             afterDispatched(projection.id());
         } else if (outcome.hasError()) {
-            Error error = outcome.getError();
+            var error = outcome.getError();
             repository().lifecycleOf(projection.id())
                         .onDispatchingFailed(envelope(), error);
         }
@@ -107,13 +106,13 @@ public class ProjectionEndpoint<I, P extends Projection<I, S, ?>, S extends Enti
 
     @Override
     protected boolean isModified(P projection) {
-        boolean result = projection.changed();
+        var result = projection.changed();
         return result;
     }
 
     @Override
     protected void onModified(P projection) {
-        ProjectionRepository<I, P, ?> repository = repository();
+        var repository = repository();
         repository.store(projection);
     }
 

--- a/server/src/main/java/io/spine/server/projection/ProjectionMigration.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionMigration.java
@@ -54,7 +54,7 @@ public abstract class ProjectionMigration<I,
     @Override
     @SuppressWarnings("unchecked") // Logically correct.
     protected Transaction<I, P, S, B> startTransaction(P entity) {
-        Transaction<I, P, S, B> tx = (Transaction<I, P, S, B>) ProjectionTransaction.start(entity);
+        var tx = (Transaction<I, P, S, B>) ProjectionTransaction.start(entity);
         return tx;
     }
 }

--- a/server/src/main/java/io/spine/server/projection/ProjectionTransaction.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionTransaction.java
@@ -75,7 +75,7 @@ public class ProjectionTransaction<I,
     ProjectionTransaction<I, S, B> start(Projection<I, S, B> projection) {
         checkNotNull(projection);
 
-        ProjectionTransaction<I, S, B> tx = new ProjectionTransaction<>(projection);
+        var tx = new ProjectionTransaction<>(projection);
         return tx;
     }
 

--- a/server/src/main/java/io/spine/server/projection/model/ProjectionClass.java
+++ b/server/src/main/java/io/spine/server/projection/model/ProjectionClass.java
@@ -69,7 +69,7 @@ public final class ProjectionClass<P extends Projection<?, ?, ?>>
     asProjectionClass(Class<P> cls) {
         checkNotNull(cls);
         @SuppressWarnings("unchecked")
-        ProjectionClass<P> result = (ProjectionClass<P>)
+        var result = (ProjectionClass<P>)
                 get(cls, ProjectionClass.class, () -> new ProjectionClass<>(cls));
         return result;
     }

--- a/server/src/main/java/io/spine/server/route/ByContext.java
+++ b/server/src/main/java/io/spine/server/route/ByContext.java
@@ -43,7 +43,7 @@ final class ByContext<I> implements EventRoute<I, EventMessage> {
 
     @Override
     public Set<I> apply(EventMessage message, EventContext context) {
-        @SuppressWarnings("unchecked") I id = (I) context.producer();
+        @SuppressWarnings("unchecked") var id = (I) context.producer();
         return EventRoute.withId(id);
     }
 }

--- a/server/src/main/java/io/spine/server/route/ByFirstMessageField.java
+++ b/server/src/main/java/io/spine/server/route/ByFirstMessageField.java
@@ -49,7 +49,7 @@ final class ByFirstMessageField<I> implements EventRoute<I, EventMessage> {
 
     @Override
     public Set<I> apply(EventMessage message, EventContext context) {
-        I id = field.apply(message, context);
+        var id = field.apply(message, context);
         return EventRoute.withId(id);
     }
 }

--- a/server/src/main/java/io/spine/server/route/CommandRouting.java
+++ b/server/src/main/java/io/spine/server/route/CommandRouting.java
@@ -124,8 +124,7 @@ public final class CommandRouting<I> extends MessageRouting<CommandMessage, Comm
     CommandRouting<I> route(Class<M> commandType, CommandRoute<I, M> via)
             throws IllegalStateException {
         @SuppressWarnings("unchecked") // The cast is required to adapt the type to internal API.
-        Route<CommandMessage, CommandContext, I> casted =
-                (Route<CommandMessage, CommandContext, I>) via;
+        var casted = (Route<CommandMessage, CommandContext, I>) via;
         addRoute(commandType, casted);
         return this;
     }
@@ -140,11 +139,11 @@ public final class CommandRouting<I> extends MessageRouting<CommandMessage, Comm
      * @return optionally available route
      */
     public <M extends CommandMessage> Optional<CommandRoute<I, M>> get(Class<M> commandClass) {
-        Match match = routeFor(commandClass);
+        var match = routeFor(commandClass);
         if (match.found()) {
             @SuppressWarnings({"unchecked", "RedundantSuppression"})
             // protected by generic params of this class
-            Optional<CommandRoute<I, M>> result = Optional.of((CommandRoute<I, M>) match.route());
+            var result = Optional.of((CommandRoute<I, M>) match.route());
             return result;
         }
         return Optional.empty();

--- a/server/src/main/java/io/spine/server/route/DefaultCommandRoute.java
+++ b/server/src/main/java/io/spine/server/route/DefaultCommandRoute.java
@@ -61,7 +61,7 @@ public final class DefaultCommandRoute<I> implements CommandRoute<I, CommandMess
     @Override
     public I apply(CommandMessage message, CommandContext ignored) throws MessageFieldException {
         checkNotNull(message);
-        I result = field.apply(message, ignored);
+        var result = field.apply(message, ignored);
         return result;
     }
 
@@ -69,7 +69,7 @@ public final class DefaultCommandRoute<I> implements CommandRoute<I, CommandMess
      * Verifies of the passed command message potentially has a field with an entity ID.
      */
     public static boolean exists(CommandMessage commandMessage) {
-        boolean hasAtLeastOneField =
+        var hasAtLeastOneField =
                 !commandMessage.getDescriptorForType()
                                .getFields()
                                .isEmpty();

--- a/server/src/main/java/io/spine/server/route/DefaultStateRoute.java
+++ b/server/src/main/java/io/spine/server/route/DefaultStateRoute.java
@@ -26,14 +26,13 @@
 
 package io.spine.server.route;
 
-import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
 import io.spine.base.EntityState;
 import io.spine.core.EventContext;
 import io.spine.protobuf.Messages;
 
-import java.util.Optional;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -62,8 +61,7 @@ final class DefaultStateRoute<I> implements StateUpdateRoute<I, EntityState<?>> 
     /**
      * Descriptors of fields matching the ID class by message type.
      */
-    private final ConcurrentHashMap<Class<? extends Message>, FieldDescriptor> fields =
-            new ConcurrentHashMap<>();
+    private final Map<Class<? extends Message>, FieldDescriptor> fields = new ConcurrentHashMap<>();
 
     private DefaultStateRoute(Class<I> idClass) {
         this.idClass = idClass;
@@ -81,9 +79,9 @@ final class DefaultStateRoute<I> implements StateUpdateRoute<I, EntityState<?>> 
     }
 
     boolean supports(Class<? extends EntityState<?>> stateType) {
-        Descriptor type = Messages.defaultInstance(stateType)
-                                  .getDescriptorForType();
-        Optional<FieldDescriptor> idField = findField(idClass, type);
+        var type = Messages.defaultInstance(stateType)
+                           .getDescriptorForType();
+        var idField = findField(idClass, type);
         return idField.isPresent();
     }
 
@@ -109,25 +107,25 @@ final class DefaultStateRoute<I> implements StateUpdateRoute<I, EntityState<?>> 
     public Set<I> apply(EntityState<?> state, EventContext ignored) {
         checkNotNull(state);
         checkNotNull(ignored);
-        Class<? extends EntityState> messageClass = state.getClass();
-        FieldDescriptor field = fields.get(messageClass);
+        var messageClass = state.getClass();
+        var field = fields.get(messageClass);
         if (field != null) {
             return fieldToSet(field, state);
         }
 
-        FieldDescriptor fd = findField(idClass, state.getDescriptorForType())
+        var fd = findField(idClass, state.getDescriptorForType())
                 .orElseThrow(() -> newIllegalStateException(
                         "Unable to find a field matching the type `%s`" +
                                 " in the message of the type `%s`.",
                         idClass, messageClass.getCanonicalName()));
         fields.put(messageClass, fd);
-        Set<I> result = fieldToSet(fd, state);
+        var result = fieldToSet(fd, state);
         return result;
     }
 
     private Set<I> fieldToSet(FieldDescriptor field, EntityState<?> state) {
-        Object fieldValue = state.getField(field);
-        I id = idClass.cast(fieldValue);
+        var fieldValue = state.getField(field);
+        var id = idClass.cast(fieldValue);
         return withId(id);
     }
 }

--- a/server/src/main/java/io/spine/server/route/EventFnRoute.java
+++ b/server/src/main/java/io/spine/server/route/EventFnRoute.java
@@ -66,7 +66,7 @@ final class EventFnRoute<I, E extends EventMessage> implements EventRoute<I, E> 
 
     @Override
     public Set<I> apply(E message, EventContext context) {
-        I id = fn.apply(message, context);
+        var id = fn.apply(message, context);
         return EventRoute.withId(id);
     }
 }

--- a/server/src/main/java/io/spine/server/route/EventRouting.java
+++ b/server/src/main/java/io/spine/server/route/EventRouting.java
@@ -153,8 +153,7 @@ public final class EventRouting<I>
     EventRouting<I> route(Class<E> eventType, EventRoute<I, ? super E> via)
             throws IllegalStateException {
         @SuppressWarnings("unchecked") // The cast is required to adapt the type to internal API.
-        Route<EventMessage, EventContext, Set<I>> casted =
-                (Route<EventMessage, EventContext, Set<I>>) via;
+        var casted = (Route<EventMessage, EventContext, Set<I>>) via;
         addRoute(eventType, casted);
         return this;
     }
@@ -232,11 +231,11 @@ public final class EventRouting<I>
      * @return optionally available route
      */
     public <M extends EventMessage> Optional<EventRoute<I, M>> get(Class<M> eventClass) {
-        Match match = routeFor(eventClass);
+        var match = routeFor(eventClass);
         if (match.found()) {
             @SuppressWarnings({"unchecked", "RedundantSuppression"})
             // protected by generic params of this class
-            Optional<EventRoute<I, M>> result = Optional.of((EventRoute<I, M>) match.route());
+            var result = Optional.of((EventRoute<I, M>) match.route());
             return result;
         }
         return Optional.empty();

--- a/server/src/main/java/io/spine/server/route/FirstField.java
+++ b/server/src/main/java/io/spine/server/route/FirstField.java
@@ -26,11 +26,8 @@
 
 package io.spine.server.route;
 
-import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
-
-import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.util.Exceptions.newIllegalStateException;
@@ -60,8 +57,8 @@ final class FirstField<I, M extends Message, C extends Message> implements Unica
     @Override
     public I apply(M message, C context) {
         checkNotNull(message);
-        FieldDescriptor field = fieldIn(message);
-        I result = getValue(field, message);
+        var field = fieldIn(message);
+        var result = getValue(field, message);
         return result;
     }
 
@@ -73,13 +70,13 @@ final class FirstField<I, M extends Message, C extends Message> implements Unica
      *          the field is a repeated field or a map
      */
     private FieldDescriptor fieldIn(M message) {
-        Descriptor type = message.getDescriptorForType();
-        List<FieldDescriptor> fields = type.getFields();
+        var type = message.getDescriptorForType();
+        var fields = type.getFields();
         if (fields.isEmpty()) {
             throw error("Cannot use the type `%s` for routing: it does not declare any field.",
                         type.getFullName());
         }
-        FieldDescriptor field = fields.get(0);
+        var field = fields.get(0);
         if (field.isMapField()) {
             throw error("The field `%s` is a map and cannot be used for routing.",
                         field.getFullName());
@@ -102,8 +99,8 @@ final class FirstField<I, M extends Message, C extends Message> implements Unica
      * Obtains the value of first field making sure the value is of the expected type.
      */
     private I getValue(FieldDescriptor field, M message) {
-        Object value = message.getField(field);
-        Class<?> valueClass = value.getClass();
+        var value = message.getField(field);
+        var valueClass = value.getClass();
         if (!idClass.isAssignableFrom(valueClass)) {
             throw newIllegalStateException(
                     "The field `%s` has the type `%s` which is not assignable" +
@@ -113,7 +110,7 @@ final class FirstField<I, M extends Message, C extends Message> implements Unica
                     idClass.getName()
             );
         }
-        I result = idClass.cast(value);
+        var result = idClass.cast(value);
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/route/MessageRouting.java
+++ b/server/src/main/java/io/spine/server/route/MessageRouting.java
@@ -31,11 +31,11 @@ import io.spine.base.MessageContext;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.util.Exceptions.newIllegalStateException;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -87,8 +87,8 @@ abstract class MessageRouting<M extends Message, C extends MessageContext, R>
      */
     public boolean supports(Class<? extends M> messageType) {
         checkNotNull(messageType);
-        Match match = routeFor(messageType);
-        boolean result = match.found();
+        var match = routeFor(messageType);
+        var result = match.found();
         return result;
     }
 
@@ -115,11 +115,11 @@ abstract class MessageRouting<M extends Message, C extends MessageContext, R>
             throws IllegalStateException {
         checkNotNull(messageType);
         checkNotNull(via);
-        Match match = routeFor(messageType);
+        var match = routeFor(messageType);
         if (match.found()) {
-            String requestedClass = messageType.getName();
-            String entryClass = match.entryClass()
-                                     .getName();
+            var requestedClass = messageType.getName();
+            var entryClass = match.entryClass()
+                                  .getName();
             if (match.direct()) {
                 throw newIllegalStateException(
                         "The route for the message class `%s` already set. " +
@@ -145,12 +145,12 @@ abstract class MessageRouting<M extends Message, C extends MessageContext, R>
      */
     Match routeFor(Class<? extends M> msgCls) {
         checkNotNull(msgCls);
-        Match direct = findDirect(msgCls);
+        var direct = findDirect(msgCls);
         if (direct.found()) {
             return direct;
         }
 
-        Match viaInterface = findViaInterface(msgCls);
+        var viaInterface = findViaInterface(msgCls);
         if (viaInterface.found()) {
             // Store the found route for later direct use.
             routes.put(msgCls, viaInterface.route());
@@ -161,7 +161,7 @@ abstract class MessageRouting<M extends Message, C extends MessageContext, R>
     }
 
     private Match findDirect(Class<? extends M> msgCls) {
-        Route<M, C, R> route = routes.get(msgCls);
+        var route = routes.get(msgCls);
         if (route != null) {
             return new Match(msgCls, msgCls, route);
         }
@@ -169,14 +169,14 @@ abstract class MessageRouting<M extends Message, C extends MessageContext, R>
     }
 
     private Match findViaInterface(Class<? extends M> msgCls) {
-        List<Map.Entry<Class<? extends M>, Route<M, C, R>>> interfaceEntries =
+        var interfaceEntries =
                 routes.entrySet()
                       .stream()
                       .filter(e -> e.getKey()
                                     .isInterface())
                       .collect(toList());
-        for (Map.Entry<Class<? extends M>, Route<M, C, R>> entry : interfaceEntries) {
-            Class<? extends M> key = entry.getKey();
+        for (var entry : interfaceEntries) {
+            var key = entry.getKey();
             if (key.isAssignableFrom(msgCls)) {
                 return new Match(msgCls, key, entry.getValue());
             }
@@ -213,15 +213,15 @@ abstract class MessageRouting<M extends Message, C extends MessageContext, R>
     public R apply(M message, C context) {
         checkNotNull(message);
         checkNotNull(context);
-        @SuppressWarnings("unchecked") Class<? extends M>
+        @SuppressWarnings("unchecked") var
         cls = (Class<? extends M>) message.getClass();
-        Match match = routeFor(cls);
+        var match = routeFor(cls);
         if (match.found()) {
-            Route<M, C, R> func = match.route();
-            R result = func.apply(message, context);
+            var func = match.route();
+            var result = func.apply(message, context);
             return result;
         }
-        R result = defaultRoute().apply(message, context);
+        var result = defaultRoute().apply(message, context);
         return result;
     }
 
@@ -269,11 +269,11 @@ abstract class MessageRouting<M extends Message, C extends MessageContext, R>
         }
 
         Class<? extends M> entryClass() {
-            return checkNotNull(entryClass);
+            return requireNonNull(entryClass);
         }
 
         Route<M, C, R> route() {
-            return checkNotNull(route);
+            return requireNonNull(route);
         }
     }
 }

--- a/server/src/main/java/io/spine/server/route/StateUpdateRouting.java
+++ b/server/src/main/java/io/spine/server/route/StateUpdateRouting.java
@@ -79,10 +79,10 @@ public final class StateUpdateRouting<I>
      */
     @Override
     public boolean supports(Class<? extends EntityState<?>> stateType) {
-        boolean customRouteSet = super.supports(stateType);
+        var customRouteSet = super.supports(stateType);
         @SuppressWarnings({"unchecked", "RedundantSuppression"}) // cast to the type used in ctor.
-        DefaultStateRoute<I> defaultRoute = (DefaultStateRoute<I>) defaultRoute();
-        boolean defaultRouteAvailable = defaultRoute.supports(stateType);
+        var defaultRoute = (DefaultStateRoute<I>) defaultRoute();
+        var defaultRouteAvailable = defaultRoute.supports(stateType);
         return customRouteSet || defaultRouteAvailable;
     }
 
@@ -107,8 +107,7 @@ public final class StateUpdateRouting<I>
     StateUpdateRouting<I> route(Class<S> stateClass, StateUpdateRoute<I, S> via)
             throws IllegalStateException {
         @SuppressWarnings("unchecked") // Logically valid.
-        Route<EntityState<?>, EventContext, Set<I>> route =
-                (Route<EntityState<?>, EventContext, Set<I>>) via;
+        var route = (Route<EntityState<?>, EventContext, Set<I>>) via;
         addRoute(stateClass, route);
         return this;
     }
@@ -123,7 +122,7 @@ public final class StateUpdateRouting<I>
     EventRoute<I, EntityStateChanged> eventRoute() {
         return (event, context) -> {
             @SuppressWarnings("unchecked")      // `EntityStateChanged` passes the `EntityState`s.
-            EntityState<I> state = (EntityState<I>) AnyPacker.unpack(event.getNewState());
+            var state = (EntityState<I>) AnyPacker.unpack(event.getNewState());
             return apply(state, context);
         };
     }

--- a/server/src/main/java/io/spine/server/security/Security.java
+++ b/server/src/main/java/io/spine/server/security/Security.java
@@ -54,7 +54,7 @@ public final class Security extends SecurityManager {
      */
     private Class previousCallerClass() {
         Class[] context = getClassContext();
-        Class result = context[3];
+        var result = context[3];
         return result;
     }
 
@@ -63,17 +63,17 @@ public final class Security extends SecurityManager {
      * the Spine Event Engine framework or its tests.
      */
     public static void allowOnlyFrameworkServer() {
-        Class callingClass = INSTANCE.previousCallerClass();
+        var callingClass = INSTANCE.previousCallerClass();
         if (!belongsToServer(callingClass)) {
             throw nonAllowedCaller(callingClass);
         }
     }
 
     private static boolean belongsToServer(Class callingClass) {
-        PackageName serverPackage = PackageName.of(Server.class);
-        PackageName systemServerPackage = PackageName.of(SystemContext.class);
-        String callingClassName = callingClass.getName();
-        boolean result =
+        var serverPackage = PackageName.of(Server.class);
+        var systemServerPackage = PackageName.of(SystemContext.class);
+        var callingClassName = callingClass.getName();
+        var result =
                 callingClassName.startsWith(serverPackage.value())
                 || callingClassName.startsWith(systemServerPackage.value())
                 || callingClassName.startsWith("io.spine.testing.server");
@@ -81,7 +81,7 @@ public final class Security extends SecurityManager {
     }
 
     private static SecurityException nonAllowedCaller(Class callingClass) {
-        String msg = format(
+        var msg = format(
                 "The class `%s` is not allowed to make this call.", callingClass.getName()
         );
         throw new SecurityException(msg);

--- a/server/src/main/java/io/spine/server/stand/AbstractTargetValidator.java
+++ b/server/src/main/java/io/spine/server/stand/AbstractTargetValidator.java
@@ -31,8 +31,6 @@ import io.spine.option.EntityOption.Visibility;
 import io.spine.server.entity.EntityVisibility;
 import io.spine.type.TypeUrl;
 
-import java.util.Optional;
-
 /**
  * An abstract base for {@code RequestValidator}s, that check
  * whether the {@link Target target} is supported.
@@ -53,21 +51,21 @@ abstract class AbstractTargetValidator<M extends Message> extends RequestValidat
     }
 
     boolean typeRegistryContains(Target target) {
-        TypeUrl typeUrl = getTypeOf(target);
-        boolean result = typeRegistry.allTypes()
-                                     .contains(typeUrl);
+        var typeUrl = getTypeOf(target);
+        var result = typeRegistry.allTypes()
+                                 .contains(typeUrl);
         return result;
     }
 
     boolean visibilitySufficient(Target target) {
-        TypeUrl typeUrl = getTypeOf(target);
-        Optional<EntityVisibility> visibility = EntityVisibility.of(typeUrl.getMessageClass());
+        var typeUrl = getTypeOf(target);
+        var visibility = EntityVisibility.of(typeUrl.getMessageClass());
         return visibility.isPresent() && visibility.get()
                                                    .isAsLeast(requiredVisibility);
     }
 
     static TypeUrl getTypeOf(Target target) {
-        String typeAsString = target.getType();
+        var typeAsString = target.getType();
         return TypeUrl.parse(typeAsString);
     }
 }

--- a/server/src/main/java/io/spine/server/stand/EntityQueryProcessor.java
+++ b/server/src/main/java/io/spine/server/stand/EntityQueryProcessor.java
@@ -26,7 +26,6 @@
 package io.spine.server.stand;
 
 import com.google.common.collect.ImmutableCollection;
-import com.google.common.collect.ImmutableList;
 import io.spine.client.EntityStateWithVersion;
 import io.spine.client.Query;
 import io.spine.client.ResponseFormat;
@@ -51,29 +50,28 @@ class EntityQueryProcessor implements QueryProcessor {
 
     @Override
     public ImmutableCollection<EntityStateWithVersion> process(Query query) {
-        Iterator<EntityRecord> entities = query.all()
-                                          ? loadAll(query.responseFormat())
-                                          : loadByQuery(query);
-        ImmutableList<EntityStateWithVersion> result = stream(entities)
+        var entities = query.all()
+                       ? loadAll(query.responseFormat())
+                       : loadByQuery(query);
+        var result = stream(entities)
                 .map(EntityQueryProcessor::toEntityState)
                 .collect(toImmutableList());
         return result;
     }
 
     private Iterator<EntityRecord> loadByQuery(Query query) {
-        Iterator<EntityRecord> entities =
+        var entities =
                 repository.findRecords(query.filters(), query.responseFormat());
         return entities;
     }
 
     private Iterator<EntityRecord> loadAll(ResponseFormat format) {
-        Iterator<EntityRecord> entities = repository.findRecords(format);
+        var entities = repository.findRecords(format);
         return entities;
     }
 
     private static EntityStateWithVersion toEntityState(EntityRecord record) {
-        EntityStateWithVersion result = EntityStateWithVersion
-                .newBuilder()
+        var result = EntityStateWithVersion.newBuilder()
                 .setState(record.getState())
                 .setVersion(record.getVersion())
                 .build();

--- a/server/src/main/java/io/spine/server/stand/EntityUpdateHandler.java
+++ b/server/src/main/java/io/spine/server/stand/EntityUpdateHandler.java
@@ -34,7 +34,6 @@ import io.spine.client.EntityStateUpdate;
 import io.spine.client.EntityUpdates;
 import io.spine.client.Subscription;
 import io.spine.client.SubscriptionUpdate;
-import io.spine.client.TargetFilters;
 import io.spine.core.Responses;
 import io.spine.protobuf.AnyPacker;
 import io.spine.server.type.EventEnvelope;
@@ -87,15 +86,15 @@ final class EntityUpdateHandler extends UpdateHandler {
 
     @Override
     protected boolean typeMatches(EventEnvelope event) {
-        String expectedTypeUrl = target().getType();
-        String actualTypeUrl = asEntityEvent(event).getEntity()
-                                                   .getTypeUrl();
+        var expectedTypeUrl = target().getType();
+        var actualTypeUrl = asEntityEvent(event).getEntity()
+                                                .getTypeUrl();
         return expectedTypeUrl.equals(actualTypeUrl);
     }
 
     @Override
     protected Any extractId(EventEnvelope event) {
-        Any entityId = asEntityEvent(event).getEntity()
+        var entityId = asEntityEvent(event).getEntity()
                                            .getId();
         return entityId;
     }
@@ -107,44 +106,40 @@ final class EntityUpdateHandler extends UpdateHandler {
     /**
      * Checks if the entity state matches the subscription filters.
      */
-    private boolean stateMatches(EntityState state) {
-        TargetFilters filters = target().getFilters();
-        boolean result = filters
-                .getFilterList()
+    private boolean stateMatches(EntityState<?> state) {
+        var filters = target().getFilters();
+        var result = filters.getFilterList()
                 .stream()
                 .allMatch(f -> f.test(state));
         return result;
     }
 
-    private static EntityState newStateFrom(EventEnvelope event) {
-        EntityStateChanged eventMessage = asEntityEvent(event);
-        Any newState = eventMessage.getNewState();
-        EntityState result = (EntityState) AnyPacker.unpack(newState);
+    private static EntityState<?> newStateFrom(EventEnvelope event) {
+        var eventMessage = asEntityEvent(event);
+        var newState = eventMessage.getNewState();
+        var result = (EntityState<?>) AnyPacker.unpack(newState);
         return result;
     }
 
-    private static EntityState oldStateFrom(EventEnvelope event) {
-        EntityStateChanged eventMessage = asEntityEvent(event);
-        Any newState = eventMessage.getOldState();
-        EntityState result = (EntityState) AnyPacker.unpack(newState);
+    private static EntityState<?> oldStateFrom(EventEnvelope event) {
+        var eventMessage = asEntityEvent(event);
+        var newState = eventMessage.getOldState();
+        var result = (EntityState<?>) AnyPacker.unpack(newState);
         return result;
     }
 
     private static Any packId(EntityStateChanged event) {
-        EntityId entityId = EntityId
-                .newBuilder()
-                .setId(event.getEntity()
-                            .getId())
+        var entityId = EntityId.newBuilder()
+                .setId(event.getEntity().getId())
                 .build();
         return Identifier.pack(entityId);
     }
 
     private SubscriptionUpdate newStateUpdate(EventEnvelope event) {
-        EntityStateChanged theEvent = asEntityEvent(event);
-        Any packedId = packId(theEvent);
-        Any packedState = theEvent.getNewState();
-        EntityStateUpdate stateUpdate = EntityStateUpdate
-                .newBuilder()
+        var theEvent = asEntityEvent(event);
+        var packedId = packId(theEvent);
+        var packedState = theEvent.getNewState();
+        var stateUpdate = EntityStateUpdate.newBuilder()
                 .setId(packedId)
                 .setState(packedState)
                 .vBuild();
@@ -152,10 +147,9 @@ final class EntityUpdateHandler extends UpdateHandler {
     }
 
     private SubscriptionUpdate noLongerMatching(EventEnvelope event) {
-        EntityStateChanged theEvent = asEntityEvent(event);
-        Any packedId = packId(theEvent);
-        EntityStateUpdate stateUpdate = EntityStateUpdate
-                .newBuilder()
+        var theEvent = asEntityEvent(event);
+        var packedId = packId(theEvent);
+        var stateUpdate = EntityStateUpdate.newBuilder()
                 .setId(packedId)
                 .setNoLongerMatching(true)
                 .vBuild();
@@ -163,12 +157,10 @@ final class EntityUpdateHandler extends UpdateHandler {
     }
 
     private SubscriptionUpdate toSubscriptionUpdate(EntityStateUpdate stateUpdate) {
-        EntityUpdates updates = EntityUpdates
-                .newBuilder()
+        var updates = EntityUpdates.newBuilder()
                 .addUpdate(stateUpdate)
                 .vBuild();
-        SubscriptionUpdate result = SubscriptionUpdate
-                .newBuilder()
+        var result = SubscriptionUpdate.newBuilder()
                 .setSubscription(subscription())
                 .setResponse(Responses.ok())
                 .setEntityUpdates(updates)

--- a/server/src/main/java/io/spine/server/stand/EventTap.java
+++ b/server/src/main/java/io/spine/server/stand/EventTap.java
@@ -28,7 +28,6 @@ package io.spine.server.stand;
 
 import io.spine.server.bus.Listener;
 import io.spine.server.type.EventEnvelope;
-import io.spine.type.TypeUrl;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -49,7 +48,7 @@ final class EventTap implements Listener<EventEnvelope> {
 
     @Override
     public void accept(EventEnvelope event) {
-        TypeUrl typeUrl = event.typeUrl();
+        var typeUrl = event.typeUrl();
         if (!event.isExternal() && subscriptionRegistry.hasType(typeUrl)) {
             subscriptionRegistry.byType(typeUrl)
                                 .stream()

--- a/server/src/main/java/io/spine/server/stand/EventUpdateHandler.java
+++ b/server/src/main/java/io/spine/server/stand/EventUpdateHandler.java
@@ -32,9 +32,7 @@ import io.spine.client.EventUpdates;
 import io.spine.client.Filters;
 import io.spine.client.Subscription;
 import io.spine.client.SubscriptionUpdate;
-import io.spine.client.TargetFilters;
 import io.spine.core.Event;
-import io.spine.core.EventId;
 import io.spine.server.type.EventEnvelope;
 
 import java.util.Optional;
@@ -52,25 +50,25 @@ final class EventUpdateHandler extends UpdateHandler {
 
     @Override
     Optional<SubscriptionUpdate> detectUpdate(EventEnvelope event) {
-        boolean matches = typeMatches(event) && (includeAll() || matchByFilters(event));
+        var matches = typeMatches(event) && (includeAll() || matchByFilters(event));
         if (!matches) {
             return Optional.empty();
         }
-        SubscriptionUpdate update = createSubscriptionUpdate(event);
+        var update = createSubscriptionUpdate(event);
         return Optional.of(update);
     }
 
     @Override
     protected Any extractId(EventEnvelope event) {
-        EventId eventId = event.id();
-        Any result = Identifier.pack(eventId);
+        var eventId = event.id();
+        var result = Identifier.pack(eventId);
         return result;
     }
 
     @Override
     boolean typeMatches(EventEnvelope event) {
-        String expectedTypeUrl = target().getType();
-        String actualTypeUrl = event.typeUrl().value();
+        var expectedTypeUrl = target().getType();
+        var actualTypeUrl = event.typeUrl().value();
         return expectedTypeUrl.equals(actualTypeUrl);
     }
 
@@ -78,8 +76,8 @@ final class EventUpdateHandler extends UpdateHandler {
      * Matches an event to the subscription filters.
      */
     private boolean matchByFilters(EventEnvelope event) {
-        boolean idMatches = idMatches(event);
-        boolean eventMatches = eventMatches(event);
+        var idMatches = idMatches(event);
+        var eventMatches = eventMatches(event);
         return idMatches && eventMatches;
     }
 
@@ -87,9 +85,8 @@ final class EventUpdateHandler extends UpdateHandler {
      * Creates a subscription update with a single {@link Event} obtained from the envelope.
      */
     private SubscriptionUpdate createSubscriptionUpdate(EventEnvelope event) {
-        EventUpdates updates = extractEventUpdates(event);
-        SubscriptionUpdate result = SubscriptionUpdate
-                .newBuilder()
+        var updates = extractEventUpdates(event);
+        var result = SubscriptionUpdate.newBuilder()
                 .setSubscription(subscription())
                 .setResponse(ok())
                 .setEventUpdates(updates)
@@ -98,9 +95,8 @@ final class EventUpdateHandler extends UpdateHandler {
     }
 
     private static EventUpdates extractEventUpdates(EventEnvelope event) {
-        Event eventObject = event.outerObject();
-        EventUpdates result = EventUpdates
-                .newBuilder()
+        var eventObject = event.outerObject();
+        var result = EventUpdates.newBuilder()
                 .addEvent(eventObject)
                 .build();
         return result;
@@ -110,10 +106,9 @@ final class EventUpdateHandler extends UpdateHandler {
      * Checks if the event message matches the subscription filters.
      */
     private boolean eventMatches(EventEnvelope event) {
-        TargetFilters filters = target().getFilters();
-        Event evt = event.outerObject();
-        boolean result = filters
-                .getFilterList()
+        var filters = target().getFilters();
+        var evt = event.outerObject();
+        var result = filters.getFilterList()
                 .stream()
                 .map(Filters::toEventFilter)
                 .allMatch(f -> f.test(evt));

--- a/server/src/main/java/io/spine/server/stand/InMemoryEventRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/InMemoryEventRegistry.java
@@ -54,7 +54,7 @@ final class InMemoryEventRegistry implements EventRegistry {
     @Override
     public void register(Repository<?, ?> repository) {
         if (repository instanceof EventProducingRepository) {
-            EventProducingRepository repo = (EventProducingRepository) repository;
+            var repo = (EventProducingRepository) repository;
             repo.outgoingEvents()
                 .forEach(this::putIntoMap);
         }
@@ -87,7 +87,7 @@ final class InMemoryEventRegistry implements EventRegistry {
     }
 
     private void putIntoMap(EventClass eventClass) {
-        TypeUrl typeUrl = eventClass.typeUrl();
+        var typeUrl = eventClass.typeUrl();
         eventClasses.put(typeUrl, eventClass);
     }
 }

--- a/server/src/main/java/io/spine/server/stand/InMemoryTypeRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/InMemoryTypeRegistry.java
@@ -67,11 +67,11 @@ final class InMemoryTypeRegistry implements TypeRegistry {
     @SuppressWarnings("ChainOfInstanceofChecks")
     @Override
     public <I, E extends Entity<I, ?>> void register(Repository<I, E> repository) {
-        TypeUrl entityType = repository.entityStateType();
+        var entityType = repository.entityStateType();
 
         if (repository instanceof QueryableRepository) {
             @SuppressWarnings("unchecked")  /* Guaranteed by the `QueryableRepository` contract. */
-            QueryableRepository<I, ?> recordRepo = (QueryableRepository<I, ?>) repository;
+            var recordRepo = (QueryableRepository<I, ?>) repository;
             repositories.put(entityType, recordRepo);
         }
         if (repository instanceof AggregateRepository) {
@@ -82,14 +82,14 @@ final class InMemoryTypeRegistry implements TypeRegistry {
 
     @Override
     public Optional<QueryableRepository<?, ?>> recordRepositoryOf(TypeUrl type) {
-        QueryableRepository<?, ?> repo = repositories.get(type);
+        var repo = repositories.get(type);
         Optional<QueryableRepository<?, ?>> result = ofNullable(repo);
         return result;
     }
 
     @Override
     public ImmutableSet<TypeUrl> aggregateTypes() {
-        ImmutableSet<TypeUrl> result = ImmutableSet.copyOf(aggregateTypes);
+        var result = ImmutableSet.copyOf(aggregateTypes);
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/stand/MultitenantSubscriptionRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/MultitenantSubscriptionRegistry.java
@@ -37,7 +37,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Registry for subscription management in a multi-tenant context.
@@ -97,19 +97,18 @@ final class MultitenantSubscriptionRegistry implements SubscriptionRegistry {
     }
 
     private SubscriptionRegistry registrySlice() {
-        TenantFunction<SubscriptionRegistry> func =
-                new TenantFunction<SubscriptionRegistry>(isMultitenant()) {
-                    @Override
-                    public SubscriptionRegistry apply(@Nullable TenantId tenantId) {
-                        checkNotNull(tenantId);
-                        SubscriptionRegistry slice = tenantSlices.computeIfAbsent(
-                                tenantId,
-                                id -> new TenantSubscriptionRegistry()
-                        );
-                        return slice;
-                    }
-                };
-        SubscriptionRegistry result = func.execute();
-        return result;
+        var func = new TenantFunction<SubscriptionRegistry>(isMultitenant()) {
+            @Override
+            public SubscriptionRegistry apply(@Nullable TenantId tenantId) {
+                requireNonNull(tenantId);
+                var slice = tenantSlices.computeIfAbsent(
+                        tenantId,
+                        id -> new TenantSubscriptionRegistry()
+                );
+                return slice;
+            }
+        };
+        var result = func.execute();
+        return requireNonNull(result);
     }
 }

--- a/server/src/main/java/io/spine/server/stand/QueryValidator.java
+++ b/server/src/main/java/io/spine/server/stand/QueryValidator.java
@@ -30,9 +30,6 @@ import com.google.protobuf.Value;
 import io.spine.base.Error;
 import io.spine.client.Query;
 import io.spine.client.QueryValidationError;
-import io.spine.client.ResponseFormat;
-import io.spine.client.Target;
-import io.spine.type.TypeUrl;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static io.spine.client.QueryValidationError.INVALID_QUERY;
@@ -51,18 +48,17 @@ final class QueryValidator extends AbstractTargetValidator<Query> {
 
     @Override
     protected @Nullable Error checkOwnRules(Query request) {
-        ResponseFormat format = request.getFormat();
-        int limit = format.getLimit();
+        var format = request.getFormat();
+        var limit = format.getLimit();
         if (limit > 0) {
-            boolean orderByMissing = format.getOrderByCount() == 0;
+            var orderByMissing = format.getOrderByCount() == 0;
             if (orderByMissing) {
-                Value limitValue = Value
+                var limitValue = Value
                         .newBuilder()
                         .setNumberValue(limit)
                         .build();
                 @SuppressWarnings("DuplicateStringLiteralInspection") // "limit" is used in tests.
-                Error error = Error
-                        .newBuilder()
+                var error = Error.newBuilder()
                         .setType(QueryValidationError.class.getSimpleName())
                         .setCode(INVALID_QUERY.getNumber())
                         .setMessage("Query limit cannot be set without ordering.")
@@ -92,19 +88,19 @@ final class QueryValidator extends AbstractTargetValidator<Query> {
 
     @Override
     protected boolean isSupported(Query request) {
-        Target target = request.getTarget();
+        var target = request.getTarget();
         return typeRegistryContains(target) && visibilitySufficient(target);
     }
 
     @Override
     protected InvalidRequestException unsupportedException(Query request, Error error) {
-        String message = errorMessage(request);
+        var message = errorMessage(request);
         return new InvalidQueryException(message, request, error);
     }
 
     @Override
     protected String errorMessage(Query request) {
-        TypeUrl targetType = getTypeOf(request.getTarget());
+        var targetType = getTypeOf(request.getTarget());
         return format("The query target type is not supported: %s", targetType.toTypeName());
     }
 }

--- a/server/src/main/java/io/spine/server/stand/RequestValidator.java
+++ b/server/src/main/java/io/spine/server/stand/RequestValidator.java
@@ -29,13 +29,10 @@ import com.google.protobuf.Message;
 import com.google.protobuf.ProtocolMessageEnum;
 import io.spine.base.Error;
 import io.spine.type.TypeName;
-import io.spine.validate.ConstraintViolation;
 import io.spine.validate.Validate;
 import io.spine.validate.ValidationError;
 import io.spine.validate.diags.ViolationText;
 import org.checkerframework.checker.nullness.qual.Nullable;
-
-import java.util.List;
 
 import static java.lang.String.format;
 
@@ -129,18 +126,17 @@ abstract class RequestValidator<M extends Message> {
             return null;
         }
 
-        ProtocolMessageEnum unsupportedErrorCode = unsupportedTargetErrorCode();
-        String errorMessage = errorMessage(request);
-        String errorTypeName = unsupportedErrorCode.getDescriptorForType()
-                                                   .getFullName();
-        Error error = Error
-                .newBuilder()
+        var unsupportedErrorCode = unsupportedTargetErrorCode();
+        var errorMessage = errorMessage(request);
+        var errorTypeName = unsupportedErrorCode.getDescriptorForType()
+                                                .getFullName();
+        var error = Error.newBuilder()
                 .setType(errorTypeName)
                 .setCode(unsupportedErrorCode.getNumber())
                 .setMessage(errorMessage)
                 .build();
 
-        InvalidRequestException exception = unsupportedException(request, error);
+        var exception = unsupportedException(request, error);
         return exception;
     }
 
@@ -151,34 +147,33 @@ abstract class RequestValidator<M extends Message> {
      * @return an instance of exception or null if the request message is valid.
      */
     private @Nullable InvalidRequestException validateMessage(M request) {
-        List<ConstraintViolation> violations = Validate.violationsOf(request);
+        var violations = Validate.violationsOf(request);
         if (violations.isEmpty()) {
             return null;
         }
-        ValidationError validationError = ValidationError
+        var validationError = ValidationError
                 .newBuilder()
                 .addAllConstraintViolation(violations)
                 .build();
-        ProtocolMessageEnum errorCode = invalidMessageErrorCode();
-        String typeName = errorCode.getDescriptorForType()
-                                   .getFullName();
-        String errorMessage = errorConstraintsViolated(request);
-        String violationsText = ViolationText.ofAll(violations);
-        String errorText = format("%s %s", errorMessage, violationsText);
-        Error error = Error
-                .newBuilder()
+        var errorCode = invalidMessageErrorCode();
+        var typeName = errorCode.getDescriptorForType()
+                                .getFullName();
+        var errorMessage = errorConstraintsViolated(request);
+        var violationsText = ViolationText.ofAll(violations);
+        var errorText = format("%s %s", errorMessage, violationsText);
+        var error = Error.newBuilder()
                 .setType(typeName)
                 .setCode(errorCode.getNumber())
                 .setValidationError(validationError)
                 .setMessage(errorText)
                 .build();
-        String exceptionMsg = formatExceptionMessage(request, error);
-        InvalidRequestException exception = invalidMessageException(exceptionMsg, request, error);
+        var exceptionMsg = formatExceptionMessage(request, error);
+        var exception = invalidMessageException(exceptionMsg, request, error);
         return exception;
     }
 
     private @Nullable InvalidRequestException validateOwnRules(M request) {
-        Error error = checkOwnRules(request);
+        var error = checkOwnRules(request);
         if (error == null) {
             return null;
         } else {

--- a/server/src/main/java/io/spine/server/stand/SubscriptionRecord.java
+++ b/server/src/main/java/io/spine/server/stand/SubscriptionRecord.java
@@ -70,7 +70,7 @@ final class SubscriptionRecord {
      * Creates a record managing an event subscription.
      */
     private static SubscriptionRecord createEventRecord(Subscription subscription) {
-        EventUpdateHandler handler = new EventUpdateHandler(subscription);
+        var handler = new EventUpdateHandler(subscription);
         return new SubscriptionRecord(subscription, subscription.targetType(), handler);
     }
 
@@ -81,7 +81,7 @@ final class SubscriptionRecord {
      * callback and matcher (to validate the entity state packed inside the event).
      */
     private static SubscriptionRecord createEntityRecord(Subscription subscription) {
-        EntityUpdateHandler handler = new EntityUpdateHandler(subscription);
+        var handler = new EntityUpdateHandler(subscription);
         return new SubscriptionRecord(subscription, ENTITY_STATE_CHANGED, handler);
     }
 
@@ -139,7 +139,7 @@ final class SubscriptionRecord {
         if (!(o instanceof SubscriptionRecord)) {
             return false;
         }
-        SubscriptionRecord that = (SubscriptionRecord) o;
+        var that = (SubscriptionRecord) o;
         return Objects.equal(subscription, that.subscription);
     }
 

--- a/server/src/main/java/io/spine/server/stand/SubscriptionValidator.java
+++ b/server/src/main/java/io/spine/server/stand/SubscriptionValidator.java
@@ -29,11 +29,11 @@ import com.google.protobuf.ProtocolMessageEnum;
 import io.spine.base.Error;
 import io.spine.client.Subscription;
 import io.spine.client.SubscriptionValidationError;
-import io.spine.core.TenantId;
 import io.spine.server.tenant.TenantAwareFunction;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Validates the {@linkplain Subscription} instances submitted to {@linkplain Stand}.
@@ -87,15 +87,15 @@ final class SubscriptionValidator extends RequestValidator<Subscription> {
     }
 
     private boolean checkInRegistry(Subscription request) {
-        TenantId tenantId = request.getTopic()
-                                   .getContext()
-                                   .getTenantId();
-        Boolean result = new TenantAwareFunction<Subscription, Boolean>(tenantId) {
+        var tenantId = request.getTopic()
+                              .getContext()
+                              .getTenantId();
+        var result = new TenantAwareFunction<Subscription, Boolean>(tenantId) {
 
             @Override
             public Boolean apply(@Nullable Subscription input) {
-                checkNotNull(input);
-                boolean result = registry.containsId(input.getId());
+                requireNonNull(input);
+                var result = registry.containsId(input.getId());
                 return result;
             }
         }.execute(request);

--- a/server/src/main/java/io/spine/server/stand/TenantSubscriptionRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/TenantSubscriptionRegistry.java
@@ -61,22 +61,22 @@ final class TenantSubscriptionRegistry implements SubscriptionRegistry {
         lockAndRun(() -> {
             checkState(subscriptionToAttrs.containsKey(subscription),
                        "Cannot find the subscription in the registry.");
-            SubscriptionRecord subscriptionRecord = subscriptionToAttrs.get(subscription);
+            var subscriptionRecord = subscriptionToAttrs.get(subscription);
             subscriptionRecord.activate(callback);
         });
     }
 
     @Override
     public Subscription add(Topic topic) {
-        Subscription subscription = Subscriptions.from(topic);
+        var subscription = Subscriptions.from(topic);
         add(subscription);
         return subscription;
     }
 
     @Override
     public void add(Subscription subscription) {
-        SubscriptionRecord record = SubscriptionRecord.of(subscription);
-        TypeUrl type = record.targetType();
+        var record = SubscriptionRecord.of(subscription);
+        var type = record.targetType();
         lockAndRun(() -> {
             typeToRecord.put(type, record);
             subscriptionToAttrs.put(subscription, record);
@@ -89,7 +89,7 @@ final class TenantSubscriptionRegistry implements SubscriptionRegistry {
             if (!subscriptionToAttrs.containsKey(subscription)) {
                 return;
             }
-            SubscriptionRecord record = subscriptionToAttrs.get(subscription);
+            var record = subscriptionToAttrs.get(subscription);
             typeToRecord.remove(record.targetType(), record);
             subscriptionToAttrs.remove(subscription);
         });
@@ -102,13 +102,13 @@ final class TenantSubscriptionRegistry implements SubscriptionRegistry {
 
     @Override
     public boolean hasType(TypeUrl type) {
-        boolean result = typeToRecord.containsKey(type);
+        var result = typeToRecord.containsKey(type);
         return result;
     }
 
     @Override
     public boolean containsId(SubscriptionId subscriptionId) {
-        for (Subscription existingItem : subscriptionToAttrs.keySet()) {
+        for (var existingItem : subscriptionToAttrs.keySet()) {
             if (existingItem.getId().equals(subscriptionId)) {
                 return true;
             }

--- a/server/src/main/java/io/spine/server/stand/TopicValidator.java
+++ b/server/src/main/java/io/spine/server/stand/TopicValidator.java
@@ -25,14 +25,11 @@
  */
 package io.spine.server.stand;
 
-import com.google.protobuf.Message;
 import com.google.protobuf.ProtocolMessageEnum;
 import io.spine.base.Error;
 import io.spine.base.EventMessage;
-import io.spine.client.Target;
 import io.spine.client.Topic;
 import io.spine.client.TopicValidationError;
-import io.spine.type.TypeUrl;
 
 import static io.spine.client.TopicValidationError.INVALID_TOPIC;
 import static io.spine.client.TopicValidationError.UNSUPPORTED_TOPIC_TARGET;
@@ -67,13 +64,13 @@ final class TopicValidator extends AbstractTargetValidator<Topic> {
 
     @Override
     protected boolean isSupported(Topic request) {
-        Target target = request.getTarget();
-        boolean supportedEntityTopic = typeRegistryContains(target) && visibilitySufficient(target);
+        var target = request.getTarget();
+        var supportedEntityTopic = typeRegistryContains(target) && visibilitySufficient(target);
         if (supportedEntityTopic) {
             return true;
         } else {
-            Class<Message> targetClass = target.type().getMessageClass();
-            boolean supportedEventTopic = EventMessage.class.isAssignableFrom(targetClass);
+            var targetClass = target.type().getMessageClass();
+            var supportedEventTopic = EventMessage.class.isAssignableFrom(targetClass);
             return supportedEventTopic;
         }
     }
@@ -81,13 +78,13 @@ final class TopicValidator extends AbstractTargetValidator<Topic> {
     @Override
     protected InvalidRequestException unsupportedException(Topic request,
                                                            Error error) {
-        String messageText = errorMessage(request);
+        var messageText = errorMessage(request);
         return new InvalidTopicException(messageText, request, error);
     }
 
     @Override
     protected String errorMessage(Topic request) {
-        TypeUrl targetType = getTypeOf(request.getTarget());
+        var targetType = getTypeOf(request.getTarget());
         return format("The topic target type is not supported: %s", targetType.toTypeName());
     }
 }

--- a/server/src/main/java/io/spine/server/stand/UpdateHandler.java
+++ b/server/src/main/java/io/spine/server/stand/UpdateHandler.java
@@ -31,7 +31,6 @@ import io.spine.client.IdFilter;
 import io.spine.client.Subscription;
 import io.spine.client.SubscriptionUpdate;
 import io.spine.client.Target;
-import io.spine.client.TargetFilters;
 import io.spine.logging.Logging;
 import io.spine.server.type.EventEnvelope;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -150,16 +149,16 @@ abstract class UpdateHandler implements Logging {
      * Checks if the event matches the subscription ID filter.
      */
     boolean idMatches(EventEnvelope event) {
-        TargetFilters filters = target().getFilters();
-        IdFilter idFilter = filters.getIdFilter();
-        boolean idFilterSet = !IdFilter.getDefaultInstance()
-                                       .equals(idFilter);
+        var filters = target().getFilters();
+        var idFilter = filters.getIdFilter();
+        var idFilterSet = !IdFilter.getDefaultInstance()
+                                   .equals(idFilter);
         if (!idFilterSet) {
             return true;
         }
-        Any id = extractId(event);
-        boolean result = idFilter.getIdList()
-                                 .contains(id);
+        var id = extractId(event);
+        var result = idFilter.getIdList()
+                             .contains(id);
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/storage/AbstractColumnMapping.java
+++ b/server/src/main/java/io/spine/server/storage/AbstractColumnMapping.java
@@ -73,7 +73,7 @@ public abstract class AbstractColumnMapping<R> implements ColumnMapping<R> {
     public <T> ColumnTypeMapping<T, ? extends R> of(Class<T> type) {
         checkNotNull(type);
         ColumnTypeMapping<?, ? extends R> result;
-        Optional<ColumnTypeMapping<?, ? extends R>> rule = customMappingFor(type);
+        var rule = customMappingFor(type);
         if (rule.isPresent()) {
             result = rule.get();
         } else {

--- a/server/src/main/java/io/spine/server/storage/ColumnTypeMapping.java
+++ b/server/src/main/java/io/spine/server/storage/ColumnTypeMapping.java
@@ -53,7 +53,7 @@ public interface ColumnTypeMapping<T, R> extends Function<T, R> {
     @Internal
     @SuppressWarnings("unchecked") // See doc.
     default R applyTo(Object object) {
-        T value = (T) object;
+        var value = (T) object;
         return apply(value);
     }
 

--- a/server/src/main/java/io/spine/server/storage/MessageRecordSpec.java
+++ b/server/src/main/java/io/spine/server/storage/MessageRecordSpec.java
@@ -143,7 +143,7 @@ public final class MessageRecordSpec<I, R extends Message> extends RecordSpec<I,
     @Override
     public Optional<Column<?, ?>> findColumn(ColumnName name) {
         checkNotNull(name);
-        RecordColumn<R, ?> result = columns.get(name);
+        var result = columns.get(name);
         return Optional.ofNullable(result);
     }
 

--- a/server/src/main/java/io/spine/server/storage/MessageStorage.java
+++ b/server/src/main/java/io/spine/server/storage/MessageStorage.java
@@ -31,8 +31,6 @@ import io.spine.annotation.Internal;
 import io.spine.annotation.SPI;
 import io.spine.server.ContextSpec;
 
-import java.util.List;
-
 import static com.google.common.collect.Streams.stream;
 import static java.util.stream.Collectors.toList;
 
@@ -83,7 +81,7 @@ public abstract class MessageStorage<I, M extends Message> extends RecordStorage
      *         if the storage is already closed
      */
     protected void write(M message) {
-        RecordWithColumns<I, M> withCols = toRecord(message);
+        var withCols = toRecord(message);
         write(withCols);
     }
 
@@ -104,7 +102,7 @@ public abstract class MessageStorage<I, M extends Message> extends RecordStorage
      */
     @Override
     public synchronized void write(I id, M message) {
-        RecordWithColumns<I, M> record = RecordWithColumns.create(id, message, recordSpec());
+        var record = RecordWithColumns.create(id, message, recordSpec());
         write(record);
     }
 
@@ -120,8 +118,8 @@ public abstract class MessageStorage<I, M extends Message> extends RecordStorage
      *         if the storage is already closed
      */
     protected void writeBatch(Iterable<M> messages) {
-        List<RecordWithColumns<I, M>> records = stream(messages).map(this::toRecord)
-                                                                .collect(toList());
+        var records = stream(messages).map(this::toRecord)
+                                      .collect(toList());
         writeAll(records);
     }
 

--- a/server/src/main/java/io/spine/server/storage/QueryConverter.java
+++ b/server/src/main/java/io/spine/server/storage/QueryConverter.java
@@ -31,7 +31,6 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.Immutable;
 import com.google.protobuf.Message;
 import io.spine.annotation.SPI;
-import io.spine.base.FieldPath;
 import io.spine.base.Identifier;
 import io.spine.client.CompositeFilter;
 import io.spine.client.Filter;
@@ -48,7 +47,6 @@ import io.spine.query.RecordQuery;
 import io.spine.query.RecordQueryBuilder;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -88,9 +86,9 @@ public final class QueryConverter {
         checkNotNull(filters);
         checkNotNull(format);
 
-        Class<I> idType = spec.idType();
-        Class<R> recordType = spec.storedType();
-        RecordQueryBuilder<I, R> builder = RecordQuery.newBuilder(idType, recordType);
+        var idType = spec.idType();
+        var recordType = spec.storedType();
+        var builder = RecordQuery.newBuilder(idType, recordType);
 
         identifiers(builder, filters.getIdFilter());
         filters(builder, spec, filters);
@@ -121,9 +119,9 @@ public final class QueryConverter {
         checkNotNull(spec);
         checkNotNull(format);
 
-        Class<I> idType = spec.idType();
-        Class<R> recordType = spec.storedType();
-        RecordQueryBuilder<I, R> builder = RecordQuery.newBuilder(idType, recordType);
+        var idType = spec.idType();
+        var recordType = spec.storedType();
+        var builder = RecordQuery.newBuilder(idType, recordType);
         fieldMask(builder, format);
         orderByAndLimit(builder, spec, format);
         return builder.build();
@@ -131,7 +129,7 @@ public final class QueryConverter {
 
     private static <I, R extends Message> void
     filters(RecordQueryBuilder<I, R> builder, RecordSpec<I, R, ?> spec, TargetFilters filters) {
-        for (CompositeFilter composite : filters.getFilterList()) {
+        for (var composite : filters.getFilterList()) {
             convertComposite(composite, builder, spec);
         }
     }
@@ -140,7 +138,7 @@ public final class QueryConverter {
     convertComposite(CompositeFilter composite,
                      RecordQueryBuilder<I, R> builder,
                      RecordSpec<I, R, ?> spec) {
-        CompositeFilter.CompositeOperator compositeOperator = composite.getOperator();
+        var compositeOperator = composite.getOperator();
 
         switch (compositeOperator) {
             case ALL:
@@ -171,11 +169,11 @@ public final class QueryConverter {
     doCompositeWithAnd(CompositeFilter filter,
                        RecordQueryBuilder<I, R> builder,
                        RecordSpec<I, R, ?> spec) {
-        for (Filter childFilter : filter.getFilterList()) {
+        for (var childFilter : filter.getFilterList()) {
             doSimpleFilter(childFilter, builder, spec);
         }
-        List<CompositeFilter> childComposites = filter.getCompositeFilterList();
-        for (CompositeFilter child : childComposites) {
+        var childComposites = filter.getCompositeFilterList();
+        for (var child : childComposites) {
             convertComposite(child, builder, spec);
         }
 
@@ -197,12 +195,12 @@ public final class QueryConverter {
         ImmutableList.Builder<Either<RecordQueryBuilder<I, R>>> eithers =
                 ImmutableList.builder();
 
-        ImmutableList<Either<RecordQueryBuilder<I, R>>> simpleEithers =
+        var simpleEithers =
                 simpleFiltersToEither(filter.getFilterList(), spec);
-        ImmutableList<Either<RecordQueryBuilder<I, R>>> compositeEithers =
+        var compositeEithers =
                 compositesToEither(filter.getCompositeFilterList(), spec);
 
-        ImmutableList<Either<RecordQueryBuilder<I, R>>> result =
+        var result =
                 eithers.addAll(simpleEithers)
                        .addAll(compositeEithers)
                        .build();
@@ -251,13 +249,13 @@ public final class QueryConverter {
      */
     private static <I, R extends Message> void
     doSimpleFilter(Filter filter, RecordQueryBuilder<I, R> builder, RecordSpec<I, R, ?> spec) {
-        ColumnName name = columnNameOf(filter);
-        Column<?, ?> column = findColumn(spec, name);
-        AsRecordColumn<R> convertedColumn = new AsRecordColumn<>(column);
+        var name = columnNameOf(filter);
+        var column = findColumn(spec, name);
+        var convertedColumn = new AsRecordColumn<R>(column);
 
-        Object value = TypeConverter.toObject(filter.getValue(), column.type());
+        var value = TypeConverter.toObject(filter.getValue(), column.type());
 
-        Filter.Operator operator = filter.getOperator();
+        var operator = filter.getOperator();
         switch (operator) {
             case EQUAL:
                 builder.where(convertedColumn).is(value);
@@ -287,11 +285,11 @@ public final class QueryConverter {
     private static <I, R extends Message>
     void identifiers(RecordQueryBuilder<I, R> builder, IdFilter idFilter) {
         if (idFilter.getIdCount() > 0) {
-            List<I> ids = idFilter.getIdList()
-                                  .stream()
-                                  .map(Identifier::unpack)
-                                  .map(id -> (I) id)
-                                  .collect(toList());
+            var ids = idFilter.getIdList()
+                    .stream()
+                    .map(Identifier::unpack)
+                    .map(id -> (I) id)
+                    .collect(toList());
             builder.id().in(ids);
         }
     }
@@ -307,14 +305,14 @@ public final class QueryConverter {
     void orderByAndLimit(RecordQueryBuilder<I, R> builder,
                          RecordSpec<I, R, ?> spec,
                          ResponseFormat format) {
-        boolean hasOrderBy = false;
-        for (OrderBy protoOrderBy : format.getOrderByList()) {
+        var hasOrderBy = false;
+        for (var protoOrderBy : format.getOrderByList()) {
             hasOrderBy = true;
-            ColumnName columnName = ColumnName.of(protoOrderBy.getColumn());
-            OrderBy.Direction protoDirection = protoOrderBy.getDirection();
+            var columnName = ColumnName.of(protoOrderBy.getColumn());
+            var protoDirection = protoOrderBy.getDirection();
 
-            Column<?, ?> column = findColumn(spec, columnName);
-            AsRecordColumn<R> convertedColumn = new AsRecordColumn<>(column);
+            var column = findColumn(spec, columnName);
+            var convertedColumn = new AsRecordColumn<R>(column);
             if (protoDirection == OrderBy.Direction.ASCENDING) {
                 builder.sortAscendingBy(convertedColumn);
             } else {
@@ -322,7 +320,7 @@ public final class QueryConverter {
             }
         }
 
-        int limit = format.getLimit();
+        var limit = format.getLimit();
         if (limit > 0) {
             checkArgument(hasOrderBy, "Storage query must have at least one ordering directive " +
                     "if the limit is set.");
@@ -332,20 +330,20 @@ public final class QueryConverter {
 
     private static <I, R extends Message> Column<?, ?>
     findColumn(RecordSpec<I, R, ?> spec, ColumnName columnName) {
-        Optional<Column<?, ?>> maybeColumn = spec.findColumn(columnName);
+        var maybeColumn = spec.findColumn(columnName);
         checkArgument(maybeColumn.isPresent(),
                       "Cannot find the column `%s` for the type `%s`.",
                       columnName, spec.storedType());
-        Column<?, ?> column = maybeColumn.get();
+        var column = maybeColumn.get();
         return column;
     }
 
     private static ColumnName columnNameOf(Filter filter) {
-        FieldPath fieldPath = filter.getFieldPath();
+        var fieldPath = filter.getFieldPath();
         checkArgument(fieldPath.getFieldNameCount() == 1,
                       "Incorrect Column name in Entity Filter: `%s`.",
                       join(".", fieldPath.getFieldNameList()));
-        String column = fieldPath.getFieldName(0);
+        var column = fieldPath.getFieldName(0);
         return ColumnName.of(column);
     }
 

--- a/server/src/main/java/io/spine/server/storage/RecordStorage.java
+++ b/server/src/main/java/io/spine/server/storage/RecordStorage.java
@@ -109,7 +109,7 @@ public abstract class RecordStorage<I, R extends Message> extends AbstractStorag
     @Override
     public Optional<R> read(I id) {
         checkNotClosed();
-        RecordQuery<I, R> query = toQuery(id);
+        var query = toQuery(id);
         return readSingleRecord(query);
     }
 
@@ -127,7 +127,7 @@ public abstract class RecordStorage<I, R extends Message> extends AbstractStorag
      */
     protected Optional<R> read(I id, FieldMask mask) {
         checkNotClosed();
-        RecordQuery<I, R> query = toQuery(id, mask);
+        var query = toQuery(id, mask);
         return readSingleRecord(query);
     }
 
@@ -142,7 +142,7 @@ public abstract class RecordStorage<I, R extends Message> extends AbstractStorag
      */
     protected Iterator<R> readAll() {
         checkNotClosed();
-        RecordQuery<I, R> query = queryForAll();
+        var query = queryForAll();
         return readAll(query);
     }
 
@@ -159,7 +159,7 @@ public abstract class RecordStorage<I, R extends Message> extends AbstractStorag
      */
     protected Iterator<R> readAll(Iterable<I> ids) {
         checkNotClosed();
-        RecordQuery<I, R> query = toQuery(ids);
+        var query = toQuery(ids);
         return readAll(query);
     }
 
@@ -179,7 +179,7 @@ public abstract class RecordStorage<I, R extends Message> extends AbstractStorag
      */
     protected Iterator<R> readAll(Iterable<I> ids, FieldMask mask) {
         checkNotClosed();
-        RecordQuery<I, R> query = toQuery(ids, mask);
+        var query = toQuery(ids, mask);
         return readAll(query);
     }
 
@@ -230,7 +230,7 @@ public abstract class RecordStorage<I, R extends Message> extends AbstractStorag
      *         if the storage was closed before
      */
     protected void deleteAll(Iterable<I> ids) {
-        for (I id : ids) {
+        for (var id : ids) {
             delete(id);
         }
     }
@@ -330,7 +330,7 @@ public abstract class RecordStorage<I, R extends Message> extends AbstractStorag
     }
 
     private Optional<R> readSingleRecord(RecordQuery<I, R> query) {
-        Iterator<R> iterator = readAll(query);
+        var iterator = readAll(query);
         return iterator.hasNext()
                ? Optional.of(iterator.next())
                : Optional.empty();

--- a/server/src/main/java/io/spine/server/storage/RecordWithColumns.java
+++ b/server/src/main/java/io/spine/server/storage/RecordWithColumns.java
@@ -81,7 +81,7 @@ public class RecordWithColumns<I, R extends Message> {
         checkNotNull(identifier);
         checkNotNull(record);
         checkNotNull(recordSpec);
-        Map<ColumnName, @Nullable Object> storageFields = recordSpec.valuesIn(record);
+        var storageFields = recordSpec.valuesIn(record);
         return of(identifier, record, storageFields);
     }
 
@@ -92,8 +92,8 @@ public class RecordWithColumns<I, R extends Message> {
     RecordWithColumns<I, R> create(R record, RecordSpec<I, R, R> recordSpec) {
         checkNotNull(record);
         checkNotNull(recordSpec);
-        Map<ColumnName, @Nullable Object> storageFields = recordSpec.valuesIn(record);
-        I identifier = recordSpec.idValueIn(record);
+        var storageFields = recordSpec.valuesIn(record);
+        var identifier = recordSpec.idValueIn(record);
         return of(identifier, record, storageFields);
     }
 
@@ -171,14 +171,14 @@ public class RecordWithColumns<I, R extends Message> {
             throw newIllegalStateException("Column with the name `%s` was not found.",
                                            columnName);
         }
-        Object columnValue = storageFields.get(columnName);
+        var columnValue = storageFields.get(columnName);
         if (columnValue == null) {
-            V result = columnMapping.ofNull()
-                                    .apply(null);
+            var result = columnMapping.ofNull()
+                                      .apply(null);
             return result;
         }
-        V result = columnMapping.of(columnValue.getClass())
-                                .applyTo(columnValue);
+        var result = columnMapping.of(columnValue.getClass())
+                                  .applyTo(columnValue);
         return result;
     }
 
@@ -194,7 +194,7 @@ public class RecordWithColumns<I, R extends Message> {
      * Determines if there is a column with the specified name among the storage fields.
      */
     public final boolean hasColumn(ColumnName name) {
-        boolean result = storageFields.containsKey(name);
+        var result = storageFields.containsKey(name);
         return result;
     }
 
@@ -217,7 +217,7 @@ public class RecordWithColumns<I, R extends Message> {
         if (!(o instanceof RecordWithColumns)) {
             return false;
         }
-        RecordWithColumns<?, ?> columns = (RecordWithColumns<?, ?>) o;
+        var columns = (RecordWithColumns<?, ?>) o;
         return Objects.equals(id, columns.id) &&
                 Objects.equals(record, columns.record) &&
                 Objects.equals(storageFields, columns.storageFields);

--- a/server/src/main/java/io/spine/server/storage/StorageFactory.java
+++ b/server/src/main/java/io/spine/server/storage/StorageFactory.java
@@ -150,8 +150,7 @@ public interface StorageFactory extends AutoCloseable {
      */
     default <I, S extends EntityState<I>> EntityRecordStorage<I, S>
     createEntityRecordStorage(ContextSpec context, Class<? extends Entity<I, S>> entityClass) {
-        EntityRecordStorage<I, S> result =
-                new EntityRecordStorage<>(context, this, entityClass);
+        var result = new EntityRecordStorage<>(context, this, entityClass);
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/storage/memory/MultitenantStorage.java
+++ b/server/src/main/java/io/spine/server/storage/memory/MultitenantStorage.java
@@ -35,8 +35,8 @@ import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Collections.synchronizedMap;
+import static java.util.Objects.requireNonNull;
 
 /**
  * The multitenant storage.
@@ -64,10 +64,10 @@ abstract class MultitenantStorage<S extends TenantDataStorage<?, ?>> {
      * <p>If the slice has not been created for this tenant, it will be created.
      */
     final S currentSlice() {
-        TenantFunction<S> func = new TenantFunction<S>(isMultitenant()) {
+        var func = new TenantFunction<S>(isMultitenant()) {
             @Override
             public @Nullable S apply(@Nullable TenantId tenantId) {
-                checkNotNull(tenantId);
+                requireNonNull(tenantId);
                 lock.lock();
                 try {
                     return tenantSlices.computeIfAbsent(tenantId, id -> createSlice());
@@ -76,8 +76,8 @@ abstract class MultitenantStorage<S extends TenantDataStorage<?, ?>> {
                 }
             }
         };
-        S result = func.execute();
-        checkNotNull(result, "Current tenant slice is null.");
+        var result = func.execute();
+        requireNonNull(result, "Current tenant slice is `null`.");
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/storage/memory/RecordComparator.java
+++ b/server/src/main/java/io/spine/server/storage/memory/RecordComparator.java
@@ -29,7 +29,6 @@ package io.spine.server.storage.memory;
 import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
-import io.spine.query.ColumnName;
 import io.spine.query.Direction;
 import io.spine.query.RecordColumn;
 import io.spine.query.SortBy;
@@ -85,10 +84,10 @@ public class RecordComparator<I, R extends Message>
         checkArgument(!sortByList.isEmpty(),
                       "`RecordComparator` requires at least one `SortBy` instance.");
         Comparator<RecordWithColumns<I, R>> result = null;
-        for (SortBy<?, R> sortBy : sortByList) {
+        for (var sortBy : sortByList) {
             Comparator<RecordWithColumns<I, R>> thisComparator;
-            Direction direction = sortBy.direction();
-            RecordColumn<R, ?> column = sortBy.column();
+            var direction = sortBy.direction();
+            var column = sortBy.column();
             thisComparator = direction == Direction.ASC
                              ? ascending(column)
                              : descending(column);
@@ -116,9 +115,9 @@ public class RecordComparator<I, R extends Message>
         checkNotNull(a);
         checkNotNull(b);
 
-        ColumnName columnName = column.name();
-        Object aValue = a.columnValue(columnName);
-        Object bValue = b.columnValue(columnName);
+        var columnName = column.name();
+        var aValue = a.columnValue(columnName);
+        var bValue = b.columnValue(columnName);
         if (aValue == null) {
             return bValue == null ? 0 : -1;
         }
@@ -127,12 +126,12 @@ public class RecordComparator<I, R extends Message>
         }
         if (aValue instanceof Comparable) {
             @SuppressWarnings({"unchecked", "rawtypes"}) // For convenience.
-                    int result = ((Comparable) aValue).compareTo(bValue);
+            var result = ((Comparable) aValue).compareTo(bValue);
             return result;
         }
 
         if (aValue instanceof Timestamp) {
-            int result = Timestamps.compare((Timestamp) aValue, (Timestamp) bValue);
+            var result = Timestamps.compare((Timestamp) aValue, (Timestamp) bValue);
             return result;
         }
         throw newIllegalStateException(

--- a/server/src/main/java/io/spine/server/storage/memory/RecordQueryMatcher.java
+++ b/server/src/main/java/io/spine/server/storage/memory/RecordQueryMatcher.java
@@ -30,8 +30,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Message;
-import io.spine.query.Column;
-import io.spine.query.LogicalOperator;
 import io.spine.query.QueryPredicate;
 import io.spine.query.RecordQuery;
 import io.spine.query.Subject;
@@ -79,7 +77,7 @@ public class RecordQueryMatcher<I, R extends Message>
         if (input == null) {
             return false;
         }
-        boolean result = idMatches(input) && columnValuesMatch(input);
+        var result = idMatches(input) && columnValuesMatch(input);
         return result;
     }
 
@@ -87,7 +85,7 @@ public class RecordQueryMatcher<I, R extends Message>
         if (acceptedIds.isEmpty()) {
             return true;
         }
-        I actualId = record.id();
+        var actualId = record.id();
         return acceptedIds.contains(actualId);
     }
 
@@ -99,9 +97,9 @@ public class RecordQueryMatcher<I, R extends Message>
     checkPredicate(RecordWithColumns<I, R> record, QueryPredicate<R> predicate) {
         boolean match;
 
-        LogicalOperator operator = predicate.operator();
-        ImmutableList<SubjectParameter<R, ?, ?>> parameters = predicate.parameters();
-        ImmutableList<QueryPredicate<R>> children = predicate.children();
+        var operator = predicate.operator();
+        var parameters = predicate.parameters();
+        var children = predicate.children();
         switch (operator) {
             case AND:
                 match = checkAnd(record, parameters, children);
@@ -122,11 +120,11 @@ public class RecordQueryMatcher<I, R extends Message>
         if (params.isEmpty() && predicates.isEmpty()) {
             return true;
         }
-        boolean paramsMatch =
+        var paramsMatch =
                 params.stream()
                       .allMatch(param -> matches(record, param));
         if (paramsMatch) {
-            boolean predicatesMatch =
+            var predicatesMatch =
                     predicates.stream()
                               .allMatch(predicate -> checkPredicate(record,
                                                                     predicate));
@@ -142,11 +140,11 @@ public class RecordQueryMatcher<I, R extends Message>
         if (params.isEmpty() && predicates.isEmpty()) {
             return true;
         }
-        boolean paramsMatch =
+        var paramsMatch =
                 params.stream()
                       .anyMatch(param -> matches(record, param));
         if (!paramsMatch) {
-            boolean predicatesMatch =
+            var predicatesMatch =
                     predicates.stream()
                               .anyMatch(predicate -> checkPredicate(record, predicate));
             return predicatesMatch;
@@ -156,13 +154,13 @@ public class RecordQueryMatcher<I, R extends Message>
 
     private static <I, R extends Message> boolean
     matches(RecordWithColumns<I, R> recWithColumns, SubjectParameter<R, ?, ?> param) {
-        Column<R, ?> column = param.column();
+        var column = param.column();
         if (!recWithColumns.hasColumn(column.name())) {
             return false;
         }
         @Nullable Object columnValue = recWithColumns.columnValue(param.column()
                                                                        .name());
-        boolean result = checkSingleParameter(param, columnValue);
+        var result = checkSingleParameter(param, columnValue);
         return result;
     }
 
@@ -171,9 +169,9 @@ public class RecordQueryMatcher<I, R extends Message>
         if (actualValue == null) {
             return false;
         }
-        Object paramValue = parameter.value();
-        boolean result = parameter.operator()
-                                  .eval(actualValue, paramValue);
+        var paramValue = parameter.value();
+        var result = parameter.operator()
+                              .eval(actualValue, paramValue);
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/storage/memory/StorageSpec.java
+++ b/server/src/main/java/io/spine/server/storage/memory/StorageSpec.java
@@ -102,7 +102,7 @@ public final class StorageSpec<I> implements Serializable {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        StorageSpec<?> other = (StorageSpec<?>) obj;
+        var other = (StorageSpec<?>) obj;
         return Objects.equals(this.context, other.context)
                 && Objects.equals(this.entityStateUrl, other.entityStateUrl);
     }

--- a/server/src/main/java/io/spine/server/storage/memory/TenantRecords.java
+++ b/server/src/main/java/io/spine/server/storage/memory/TenantRecords.java
@@ -26,13 +26,11 @@
 
 package io.spine.server.storage.memory;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.protobuf.Any;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.Message;
 import io.spine.query.RecordQuery;
-import io.spine.query.SortBy;
 import io.spine.query.Subject;
 import io.spine.server.entity.EntityRecord;
 import io.spine.server.storage.RecordWithColumns;
@@ -72,8 +70,7 @@ final class TenantRecords<I, R extends Message>
 
     @Override
     public Iterator<I> index() {
-        Iterator<I> result = records.keySet()
-                                    .iterator();
+        var result = records.keySet().iterator();
         return result;
     }
 
@@ -81,9 +78,9 @@ final class TenantRecords<I, R extends Message>
      * Obtains the iterator over the identifiers of the records which match the passed query.
      */
     public Iterator<I> index(RecordQuery<I, R> query) {
-        List<RecordWithColumns<I, R>> subset = findRecords(query);
+        var subset = findRecords(query);
         @SuppressWarnings("ConstantConditions")  // Elements of the returned list are non-`null`.
-        Iterator<I> result = Iterators.transform(subset.iterator(), RecordWithColumns::id);
+        var result = Iterators.transform(subset.iterator(), RecordWithColumns::id);
         return result;
     }
 
@@ -103,7 +100,7 @@ final class TenantRecords<I, R extends Message>
 
     @Override
     public Optional<RecordWithColumns<I, R>> get(I id) {
-        RecordWithColumns<I, R> record = records.get(id);
+        var record = records.get(id);
         return Optional.ofNullable(record);
     }
 
@@ -112,10 +109,9 @@ final class TenantRecords<I, R extends Message>
     }
 
     Iterator<R> readAll(RecordQuery<I, R> query) {
-        FieldMask fieldMask = query.mask();
-        List<RecordWithColumns<I, R>> records = findRecords(query);
-        return records
-                .stream()
+        var fieldMask = query.mask();
+        var records = findRecords(query);
+        return records.stream()
                 .map(RecordWithColumns::record)
                 .map(new FieldMaskApplier(fieldMask))
                 .iterator();
@@ -123,8 +119,8 @@ final class TenantRecords<I, R extends Message>
 
     private List<RecordWithColumns<I, R>> findRecords(RecordQuery<I, R> query) {
         synchronized (records) {
-            Map<I, RecordWithColumns<I, R>> filtered = filterRecords(query.subject());
-            Stream<RecordWithColumns<I, R>> stream = filtered.values()
+            var filtered = filterRecords(query.subject());
+            var stream = filtered.values()
                                                              .stream();
             return sortAndLimit(stream, query).collect(toList());
         }
@@ -132,12 +128,12 @@ final class TenantRecords<I, R extends Message>
 
     private static <I, R extends Message> Stream<RecordWithColumns<I, R>>
     sortAndLimit(Stream<RecordWithColumns<I, R>> data, RecordQuery<I, R> query) {
-        Stream<RecordWithColumns<I, R>> stream = data;
-        ImmutableList<SortBy<?, R>> sortingSpecs = query.sorting();
+        var stream = data;
+        var sortingSpecs = query.sorting();
         if (sortingSpecs.size() > 0) {
             stream = stream.sorted(accordingTo(sortingSpecs.asList()));
         }
-        Integer limit = query.limit();
+        var limit = query.limit();
         if (limit != null && limit > 0) {
             stream = stream.limit(limit);
         }
@@ -149,7 +145,7 @@ final class TenantRecords<I, R extends Message>
      * {@linkplain Subject subject of the record query}.
      */
     private Map<I, RecordWithColumns<I, R>> filterRecords(Subject<I, R> subject) {
-        RecordQueryMatcher<I, R> matcher = new RecordQueryMatcher<>(subject);
+        var matcher = new RecordQueryMatcher<>(subject);
         return filterValues(records, matcher::test);
     }
 
@@ -188,18 +184,17 @@ final class TenantRecords<I, R extends Message>
 
         private EntityRecord maskEntityRecord(EntityRecord input) {
             checkNotNull(input);
-            Any maskedState = maskAny(input.getState());
-            EntityRecord result = EntityRecord
-                    .newBuilder(input)
+            var maskedState = maskAny(input.getState());
+            var result = EntityRecord.newBuilder(input)
                     .setState(maskedState)
                     .build();
             return result;
         }
 
         private Any maskAny(Any message) {
-            Message stateMessage = unpack(message);
-            Message maskedMessage = applyMask(fieldMask, stateMessage);
-            Any result = pack(maskedMessage);
+            var stateMessage = unpack(message);
+            var maskedMessage = applyMask(fieldMask, stateMessage);
+            var result = pack(maskedMessage);
             return result;
         }
     }

--- a/server/src/main/java/io/spine/server/tenant/CurrentTenant.java
+++ b/server/src/main/java/io/spine/server/tenant/CurrentTenant.java
@@ -53,7 +53,7 @@ final class CurrentTenant {
      *         the current thread works not in a multi-tenant context
      */
     static Optional<TenantId> get() {
-        TenantId result = threadLocal.get();
+        var result = threadLocal.get();
         return Optional.ofNullable(result);
     }
 
@@ -66,8 +66,8 @@ final class CurrentTenant {
      * @throws IllegalStateException if the is no current tenant ID set
      */
     static TenantId ensure() throws IllegalStateException {
-        Optional<TenantId> currentTenant = get();
-        if (!currentTenant.isPresent()) {
+        var currentTenant = get();
+        if (currentTenant.isEmpty()) {
             throw new IllegalStateException(
                     "No current `TenantId` set in multi-tenant execution context.");
         }

--- a/server/src/main/java/io/spine/server/tenant/IdInTenant.java
+++ b/server/src/main/java/io/spine/server/tenant/IdInTenant.java
@@ -59,7 +59,7 @@ public final class IdInTenant<I> {
      */
     public static <I> IdInTenant<I> of(I id, boolean multitenant) {
         checkNotNull(id);
-        TenantId tenant = TenantAware.currentTenant(multitenant);
+        var tenant = TenantAware.currentTenant(multitenant);
         return new IdInTenant<>(id, tenant);
     }
 
@@ -95,7 +95,7 @@ public final class IdInTenant<I> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        IdInTenant<?> another = (IdInTenant<?>) o;
+        var another = (IdInTenant<?>) o;
         return Objects.equals(id, another.id) &&
                 Objects.equals(tenantId, another.tenantId);
     }

--- a/server/src/main/java/io/spine/server/tenant/TenantAware.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantAware.java
@@ -30,8 +30,6 @@ import io.spine.annotation.Internal;
 import io.spine.core.TenantId;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-import java.util.Optional;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.protobuf.Messages.isDefault;
 
@@ -74,7 +72,7 @@ abstract class TenantAware {
      */
     @Internal
     public static boolean isTenantSet() {
-        Optional<TenantId> currentTenant = CurrentTenant.get();
+        var currentTenant = CurrentTenant.get();
         return currentTenant.isPresent();
     }
 

--- a/server/src/main/java/io/spine/server/tenant/TenantAwareFunction.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantAwareFunction.java
@@ -29,7 +29,6 @@ package io.spine.server.tenant;
 import io.spine.annotation.SPI;
 import io.spine.core.TenantId;
 
-import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -65,7 +64,7 @@ public abstract class TenantAwareFunction<F, T> extends TenantAware implements F
      */
     public T execute(F input) {
         T result;
-        Optional<TenantId> remembered = CurrentTenant.get();
+        var remembered = CurrentTenant.get();
         try {
             CurrentTenant.set(tenantId());
             result = apply(input);

--- a/server/src/main/java/io/spine/server/tenant/TenantAwareOperation.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantAwareOperation.java
@@ -29,8 +29,6 @@ package io.spine.server.tenant;
 import io.spine.annotation.SPI;
 import io.spine.core.TenantId;
 
-import java.util.Optional;
-
 /**
  * An abstract base for operations on a tenant data.
  *
@@ -74,7 +72,7 @@ public abstract class TenantAwareOperation extends TenantAware implements Runnab
      * </ol>
      */
     public void execute() {
-        Optional<TenantId> remembered = CurrentTenant.get();
+        var remembered = CurrentTenant.get();
         try {
             CurrentTenant.set(tenantId());
             run();

--- a/server/src/main/java/io/spine/server/tenant/TenantAwareRunner.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantAwareRunner.java
@@ -81,7 +81,7 @@ public final class TenantAwareRunner {
      */
     public <T> T evaluate(Supplier<T> operation) {
         checkNotNull(operation);
-        T result = new TenantAwareFunction0<T>(tenant) {
+        var result = new TenantAwareFunction0<T>(tenant) {
             @Override
             public T apply() {
                 return operation.get();

--- a/server/src/main/java/io/spine/server/tenant/TenantFunction.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantFunction.java
@@ -57,8 +57,8 @@ public abstract class TenantFunction<T> extends TenantAware implements Function<
      * @return the result of the function
      */
     public @Nullable T execute() {
-        TenantId currentTenant = tenantId();
-        T result = apply(currentTenant);
+        var currentTenant = tenantId();
+        var result = apply(currentTenant);
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/tenant/TenantIndex.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantIndex.java
@@ -28,7 +28,6 @@ package io.spine.server.tenant;
 
 import io.spine.core.TenantId;
 import io.spine.server.ServerEnvironment;
-import io.spine.server.storage.StorageFactory;
 
 import java.util.Set;
 
@@ -59,10 +58,10 @@ public interface TenantIndex extends AutoCloseable {
      * Creates default implementation of {@code TenantIndex} for a multi-tenant context.
      */
     static TenantIndex defaultMultitenant() {
-        StorageFactory factory = ServerEnvironment.instance()
-                                                  .storageFactory();
+        var factory = ServerEnvironment.instance()
+                                       .storageFactory();
         @SuppressWarnings("ClassReferencesSubclass") // OK for this default impl.
-        DefaultTenantStorage tenantRepo = new DefaultTenantStorage(factory);
+        var tenantRepo = new DefaultTenantStorage(factory);
         return tenantRepo;
     }
 

--- a/server/src/main/java/io/spine/server/tenant/TenantStorage.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantStorage.java
@@ -36,8 +36,6 @@ import io.spine.server.ContextSpec;
 import io.spine.server.storage.MessageStorage;
 import io.spine.server.storage.RecordStorage;
 
-import java.util.Iterator;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -72,9 +70,9 @@ public abstract class TenantStorage<T extends Message>
             return;
         }
 
-        Optional<T> optional = read(id);
-        if (!optional.isPresent()) {
-            T newRecord = create(id);
+        var optional = read(id);
+        if (optional.isEmpty()) {
+            var newRecord = create(id);
             write(id, newRecord);
         }
         cache(id);
@@ -102,7 +100,7 @@ public abstract class TenantStorage<T extends Message>
      * @return {@code true} if the value was cached before and removed, {@code false} otherwise
      */
     protected final boolean unCache(TenantId id) {
-        boolean result = cache.remove(id);
+        var result = cache.remove(id);
         return result;
     }
 
@@ -115,7 +113,7 @@ public abstract class TenantStorage<T extends Message>
 
     @Override
     public final Set<TenantId> all() {
-        Iterator<TenantId> index = index();
+        var index = index();
         Set<TenantId> result = ImmutableSet.copyOf(index);
         cache.addAll(result);
         return result;

--- a/server/src/main/java/io/spine/server/transport/ChannelHub.java
+++ b/server/src/main/java/io/spine/server/transport/ChannelHub.java
@@ -90,7 +90,7 @@ public abstract class ChannelHub<C extends MessageChannel> implements AutoClosea
      * @return a channel with the key
      */
     public C get(ChannelId channelId) {
-        C channel = channels.computeIfAbsent(channelId, this::newChannel);
+        var channel = channels.computeIfAbsent(channelId, this::newChannel);
         return channel;
     }
 
@@ -98,16 +98,16 @@ public abstract class ChannelHub<C extends MessageChannel> implements AutoClosea
      * Closes the stale channels and removes those from the hub.
      */
     public void closeStaleChannels() {
-        Set<ChannelId> staleChannels = detectStale();
-        for (ChannelId id : staleChannels) {
+        var staleChannels = detectStale();
+        for (var id : staleChannels) {
             channels.remove(id);
         }
     }
 
     private Set<ChannelId> detectStale() {
         Set<ChannelId> toRemove = newHashSet();
-        for (ChannelId channelId : channels.keySet()) {
-            C channel = channels.get(channelId);
+        for (var channelId : channels.keySet()) {
+            var channel = channels.get(channelId);
             if (channel.isStale()) {
                 try {
                     channel.close();
@@ -123,7 +123,7 @@ public abstract class ChannelHub<C extends MessageChannel> implements AutoClosea
 
     @Override
     public void close() throws Exception {
-        for (C channel : channels.values()) {
+        for (var channel : channels.values()) {
             channel.close();
         }
         channels.clear();

--- a/server/src/main/java/io/spine/server/transport/MessageChannel.java
+++ b/server/src/main/java/io/spine/server/transport/MessageChannel.java
@@ -50,21 +50,22 @@ public interface MessageChannel extends AutoCloseable {
      * Obtains the type of the messages transferred through this channel.
      */
     default TypeUrl targetType() {
-        ChannelId channelId = id();
+        var channelId = id();
         return TypeUrl.parse(channelId.getTargetType());
     }
 
     /**
      * Converts the given message type into a {@link ChannelId}.
      *
-     * @param messageType the type of messages transmitted through the channel
+     * @param messageType
+     *         the type of messages transmitted through the channel
      * @return channel ID
      */
     static ChannelId channelIdFor(TypeUrl messageType) {
         checkNotNull(messageType);
-        ChannelId channelId = ChannelId.newBuilder()
-                                       .setTargetType(messageType.value())
-                                       .build();
+        var channelId = ChannelId.newBuilder()
+                .setTargetType(messageType.value())
+                .build();
         return channelId;
     }
 }

--- a/server/src/main/java/io/spine/server/transport/Statuses.java
+++ b/server/src/main/java/io/spine/server/transport/Statuses.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.transport;
 
-import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.spine.annotation.Internal;
@@ -69,9 +68,9 @@ public final class Statuses {
      * @see #invalidArgumentWithCause(MessageError)
      */
     private static StatusRuntimeException createException(Throwable cause, Error error) {
-        Metadata metadata = MetadataConverter.toMetadata(error);
-        StatusRuntimeException result = INVALID_ARGUMENT.withCause(cause)
-                                                        .asRuntimeException(metadata);
+        var metadata = MetadataConverter.toMetadata(error);
+        var result = INVALID_ARGUMENT.withCause(cause)
+                                     .asRuntimeException(metadata);
         return result;
     }
 }

--- a/server/src/main/java/io/spine/server/transport/Subscriber.java
+++ b/server/src/main/java/io/spine/server/transport/Subscriber.java
@@ -99,14 +99,14 @@ public abstract class Subscriber extends AbstractChannel {
     }
 
     protected final void callObservers(ExternalMessage message) {
-        for (StreamObserver<ExternalMessage> observer : observers()) {
+        for (var observer : observers()) {
             observer.onNext(message);
         }
     }
 
     @Override
     public void close() {
-        for (StreamObserver<ExternalMessage> observer : observers) {
+        for (var observer : observers) {
             observer.onCompleted();
         }
         observers.clear();

--- a/server/src/main/java/io/spine/server/transport/memory/InMemoryPublisher.java
+++ b/server/src/main/java/io/spine/server/transport/memory/InMemoryPublisher.java
@@ -56,8 +56,8 @@ public final class InMemoryPublisher extends AbstractChannel implements Publishe
 
     @Override
     public Ack publish(Any messageId, ExternalMessage message) {
-        Iterable<Subscriber> localSubscribers = subscribers();
-        for (Subscriber localSubscriber : localSubscribers) {
+        var localSubscribers = subscribers();
+        for (var localSubscriber : localSubscribers) {
             localSubscriber.onMessage(message);
         }
         return acknowledge(messageId);

--- a/server/src/main/java/io/spine/server/transport/memory/InMemoryTransportFactory.java
+++ b/server/src/main/java/io/spine/server/transport/memory/InMemoryTransportFactory.java
@@ -70,14 +70,14 @@ public class InMemoryTransportFactory implements TransportFactory {
     @Override
     public final synchronized Publisher createPublisher(ChannelId id) {
         checkNotNull(id);
-        InMemoryPublisher result = new InMemoryPublisher(id, providerOf(subscribers()));
+        var result = new InMemoryPublisher(id, providerOf(subscribers()));
         return result;
     }
 
     @Override
     public final synchronized Subscriber createSubscriber(ChannelId id) {
         checkNotNull(id);
-        Subscriber subscriber = newSubscriber(id);
+        var subscriber = newSubscriber(id);
         subscribers().put(id, subscriber);
         return subscriber;
     }

--- a/server/src/main/java/io/spine/server/tuple/Either.java
+++ b/server/src/main/java/io/spine/server/tuple/Either.java
@@ -77,9 +77,9 @@ public abstract class Either implements Iterable<Message>, Serializable {
      */
     @SuppressWarnings("TypeParameterUnusedInFormals") // We want to save of casts at the callers.
     protected static <T> T get(Either either, IndexOf index) {
-        int requestedIdx = index.value();
+        var requestedIdx = index.value();
         if (requestedIdx != either.index()) {
-            String errMsg =
+            var errMsg =
                     format("`Either` instance has value of a different type than requested. " +
                                    "Value index in `Either` is %d. Requested index: %d",
                            either.index(), requestedIdx);
@@ -87,7 +87,7 @@ public abstract class Either implements Iterable<Message>, Serializable {
         }
 
         @SuppressWarnings("unchecked") // It's the caller responsibility to ensure correct type.
-        T result = (T) either.value();
+        var result = (T) either.value();
         return result;
 
     }
@@ -105,7 +105,7 @@ public abstract class Either implements Iterable<Message>, Serializable {
         if (!(obj instanceof Either)) {
             return false;
         }
-        Either other = (Either) obj;
+        var other = (Either) obj;
         return Objects.equals(this.value, other.value)
                 && (this.index == other.index);
     }

--- a/server/src/main/java/io/spine/server/tuple/EitherOf2.java
+++ b/server/src/main/java/io/spine/server/tuple/EitherOf2.java
@@ -53,7 +53,7 @@ public final class EitherOf2<A extends Message, B extends Message>
      */
     public static <A extends Message, B extends Message> EitherOf2<A, B> withA(A a) {
         checkNotNull(a);
-        EitherOf2<A, B> result = new EitherOf2<>(a, IndexOf.A);
+        var result = new EitherOf2<A, B>(a, IndexOf.A);
         return result;
     }
 
@@ -62,7 +62,7 @@ public final class EitherOf2<A extends Message, B extends Message>
      */
     public static <A extends Message, B extends Message> EitherOf2<A, B> withB(B b) {
         checkNotNull(b);
-        EitherOf2<A, B> result = new EitherOf2<>(b, IndexOf.B);
+        var result = new EitherOf2<A, B>(b, IndexOf.B);
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/tuple/EitherOf3.java
+++ b/server/src/main/java/io/spine/server/tuple/EitherOf3.java
@@ -56,7 +56,7 @@ public final class EitherOf3<A extends Message, B extends Message, C extends Mes
     public static <A extends Message, B extends Message, C extends Message>
     EitherOf3<A, B, C> withA(A a) {
         checkNotNull(a);
-        EitherOf3<A, B, C> result = new EitherOf3<>(a, IndexOf.A);
+        var result = new EitherOf3<A, B, C>(a, IndexOf.A);
         return result;
     }
 
@@ -66,7 +66,7 @@ public final class EitherOf3<A extends Message, B extends Message, C extends Mes
     public static <A extends Message, B extends Message, C extends Message>
     EitherOf3<A, B, C> withB(B b) {
         checkNotNull(b);
-        EitherOf3<A, B, C> result = new EitherOf3<>(b, IndexOf.B);
+        var result = new EitherOf3<A, B, C>(b, IndexOf.B);
         return result;
     }
 
@@ -76,7 +76,7 @@ public final class EitherOf3<A extends Message, B extends Message, C extends Mes
     public static <A extends Message, B extends Message, C extends Message>
     EitherOf3<A, B, C> withC(C c) {
         checkNotNull(c);
-        EitherOf3<A, B, C> result = new EitherOf3<>(c, IndexOf.C);
+        var result = new EitherOf3<A, B, C>(c, IndexOf.C);
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/tuple/EitherOf4.java
+++ b/server/src/main/java/io/spine/server/tuple/EitherOf4.java
@@ -61,7 +61,7 @@ public final class EitherOf4<A extends Message,
     public static <A extends Message, B extends Message, C extends Message, D extends Message>
     EitherOf4<A, B, C, D> withA(A a) {
         checkNotNull(a);
-        EitherOf4<A, B, C, D> result = new EitherOf4<>(a, IndexOf.A);
+        var result = new EitherOf4<A, B, C, D>(a, IndexOf.A);
         return result;
     }
 
@@ -71,7 +71,7 @@ public final class EitherOf4<A extends Message,
     public static <A extends Message, B extends Message, C extends Message, D extends Message>
     EitherOf4<A, B, C, D> withB(B b) {
         checkNotNull(b);
-        EitherOf4<A, B, C, D> result = new EitherOf4<>(b, IndexOf.B);
+        var result = new EitherOf4<A, B, C, D>(b, IndexOf.B);
         return result;
     }
 
@@ -81,7 +81,7 @@ public final class EitherOf4<A extends Message,
     public static <A extends Message, B extends Message, C extends Message, D extends Message>
     EitherOf4<A, B, C, D> withC(C c) {
         checkNotNull(c);
-        EitherOf4<A, B, C, D> result = new EitherOf4<>(c, IndexOf.C);
+        var result = new EitherOf4<A, B, C, D>(c, IndexOf.C);
         return result;
     }
 
@@ -91,7 +91,7 @@ public final class EitherOf4<A extends Message,
     public static <A extends Message, B extends Message, C extends Message, D extends Message>
     EitherOf4<A, B, C, D> withD(D d) {
         checkNotNull(d);
-        EitherOf4<A, B, C, D> result = new EitherOf4<>(d, IndexOf.D);
+        var result = new EitherOf4<A, B, C, D>(d, IndexOf.D);
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/tuple/EitherOf5.java
+++ b/server/src/main/java/io/spine/server/tuple/EitherOf5.java
@@ -65,7 +65,7 @@ public class EitherOf5<A extends Message,
     <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
     EitherOf5<A, B, C, D, E> withA(A a) {
         checkNotNull(a);
-        EitherOf5<A, B, C, D, E> result = new EitherOf5<>(a, IndexOf.A);
+        var result = new EitherOf5<A, B, C, D, E>(a, IndexOf.A);
         return result;
     }
 
@@ -76,7 +76,7 @@ public class EitherOf5<A extends Message,
     <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
     EitherOf5<A, B, C, D, E> withB(B b) {
         checkNotNull(b);
-        EitherOf5<A, B, C, D, E> result = new EitherOf5<>(b, IndexOf.B);
+        var result = new EitherOf5<A, B, C, D, E>(b, IndexOf.B);
         return result;
     }
 
@@ -87,7 +87,7 @@ public class EitherOf5<A extends Message,
     <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
     EitherOf5<A, B, C, D, E> withC(C c) {
         checkNotNull(c);
-        EitherOf5<A, B, C, D, E> result = new EitherOf5<>(c, IndexOf.C);
+        var result = new EitherOf5<A, B, C, D, E>(c, IndexOf.C);
         return result;
     }
 
@@ -98,7 +98,7 @@ public class EitherOf5<A extends Message,
     <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
     EitherOf5<A, B, C, D, E> withD(D d) {
         checkNotNull(d);
-        EitherOf5<A, B, C, D, E> result = new EitherOf5<>(d, IndexOf.D);
+        var result = new EitherOf5<A, B, C, D, E>(d, IndexOf.D);
         return result;
     }
 
@@ -109,7 +109,7 @@ public class EitherOf5<A extends Message,
     <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
     EitherOf5<A, B, C, D, E> withE(E e) {
         checkNotNull(e);
-        EitherOf5<A, B, C, D, E> result = new EitherOf5<>(e, IndexOf.E);
+        var result = new EitherOf5<A, B, C, D, E>(e, IndexOf.E);
         return result;
     }
 

--- a/server/src/main/java/io/spine/server/tuple/Element.java
+++ b/server/src/main/java/io/spine/server/tuple/Element.java
@@ -66,7 +66,7 @@ final class Element implements Serializable {
         } else if (value instanceof Optional) {
             this.type = Type.OPTIONAL;
         } else if (value instanceof GeneratedMessageV3) {
-            GeneratedMessageV3 messageV3 = (GeneratedMessageV3) value;
+            var messageV3 = (GeneratedMessageV3) value;
             checkNotDefault(messageV3);
             this.type = Type.MESSAGE;
         } else {
@@ -84,7 +84,7 @@ final class Element implements Serializable {
     @SuppressWarnings("TypeParameterUnusedInFormals") // See Javadoc.
     static <T> T value(Tuple tuple, IndexOf index) {
         @SuppressWarnings("unchecked") // The caller is responsible for the correct type.
-        T value = (T) tuple.get(index.value());
+        var value = (T) tuple.get(index.value());
         return value;
     }
 
@@ -110,9 +110,9 @@ final class Element implements Serializable {
             case EITHER:
                 return ((Either) value).value();
             case OPTIONAL: {
-                Optional<?> optional = (Optional<?>) value;
-                Message result = optional.map(o -> (Message) o)
-                                         .orElseGet(Empty::getDefaultInstance);
+                var optional = (Optional<?>) value;
+                var result = optional.map(o -> (Message) o)
+                                     .orElseGet(Empty::getDefaultInstance);
                 return result;
             }
             default:
@@ -131,7 +131,7 @@ final class Element implements Serializable {
             obj = (Serializable) value;
             out.writeObject(obj);
         } else /* (type == Type.OPTIONAL) */ {
-            Optional<?> optionalValue = (Optional<?>) value;
+            var optionalValue = (Optional<?>) value;
             obj = (Serializable) optionalValue.orElse(null);
         }
         out.writeObject(obj);
@@ -166,7 +166,7 @@ final class Element implements Serializable {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        Element other = (Element) obj;
+        var other = (Element) obj;
         return Objects.equals(this.value, other.value)
                 && this.type == other.type;
     }

--- a/server/src/main/java/io/spine/server/tuple/Pair.java
+++ b/server/src/main/java/io/spine/server/tuple/Pair.java
@@ -67,9 +67,9 @@ public final class Pair<A extends Message, B>
      * Creates a new pair of values.
      */
     public static <A extends Message, B extends Message> Pair<A, B> of(A a, B b) {
-        A safeA = checkNotNullOrEmpty(a);
-        B safeB = checkNotNullOrEmpty(b);
-        Pair<A, B> result = new Pair<>(safeA, safeB);
+        var safeA = checkNotNullOrEmpty(a);
+        var safeB = checkNotNullOrEmpty(b);
+        var result = new Pair<>(safeA, safeB);
         return result;
     }
 
@@ -82,7 +82,7 @@ public final class Pair<A extends Message, B>
     Pair<A, Optional<B>> withNullable(A a, @Nullable B b) {
         checkNotNullOrEmpty(a);
         checkNotEmpty(b);
-        Pair<A, Optional<B>> result = new Pair<>(a, ofNullable(b));
+        var result = new Pair<>(a, ofNullable(b));
         return result;
     }
 
@@ -102,7 +102,7 @@ public final class Pair<A extends Message, B>
     ) {
         checkNotNullOrEmpty(a);
         checkNotNull(b);
-        Pair<A, Optional<B>> result = new Pair<>(a, b);
+        var result = new Pair<>(a, b);
         return result;
     }
 
@@ -112,7 +112,7 @@ public final class Pair<A extends Message, B>
     public static <A extends Message, B extends Either> Pair<A, B> withEither(A a, B b) {
         checkNotNullOrEmpty(a);
         checkNotNull(b);
-        Pair<A, B> result = new Pair<>(a, b);
+        var result = new Pair<>(a, b);
         return result;
     }
 
@@ -138,7 +138,7 @@ public final class Pair<A extends Message, B>
 
     @Override
     public boolean hasB() {
-        B value = getB();
+        var value = getB();
         return isOptionalPresent(value);
     }
 

--- a/server/src/main/java/io/spine/server/tuple/Pair.java
+++ b/server/src/main/java/io/spine/server/tuple/Pair.java
@@ -122,7 +122,7 @@ public final class Pair<A extends Message, B>
     }
 
     /**
-     * {@inheritDoc}
+     * Tells whether the first element of the tuple is set.
      *
      * <p>Always returns {@code true}.
      */

--- a/server/src/main/java/io/spine/server/tuple/Quartet.java
+++ b/server/src/main/java/io/spine/server/tuple/Quartet.java
@@ -74,7 +74,7 @@ public final class Quartet<A extends Message, B, C, D>
     public static <A extends Message, B extends Message, C extends Message, D extends Message>
     Quartet<A, B, C, D> of(A a, B b, C c, D d) {
         checkAllNotNullOrEmpty(a, b, c, d);
-        Quartet<A, B, C, D> result = new Quartet<>(a, b, c, d);
+        var result = new Quartet<>(a, b, c, d);
         return result;
     }
 
@@ -85,7 +85,7 @@ public final class Quartet<A extends Message, B, C, D>
     Quartet<A, B, C, Optional<D>> withNullable(A a, B b, C c, @Nullable D d) {
         checkAllNotNullOrEmpty(a, b, c);
         checkNotEmpty(d);
-        Quartet<A, B, C, Optional<D>> result = new Quartet<>(a, b, c, ofNullable(d));
+        var result = new Quartet<>(a, b, c, ofNullable(d));
         return result;
     }
 
@@ -96,8 +96,7 @@ public final class Quartet<A extends Message, B, C, D>
     Quartet<A, B, Optional<C>, Optional<D>> withNullable2(A a, B b, @Nullable C c, @Nullable D d) {
         checkAllNotNullOrEmpty(a, b);
         checkAllNotEmpty(c, d);
-        Quartet<A, B, Optional<C>, Optional<D>> result =
-                new Quartet<>(a, b, ofNullable(c), ofNullable(d));
+        var result = new Quartet<>(a, b, ofNullable(c), ofNullable(d));
         return result;
     }
 
@@ -109,8 +108,7 @@ public final class Quartet<A extends Message, B, C, D>
     withNullable3(A a, @Nullable B b, @Nullable C c, @Nullable D d) {
         checkNotNullOrEmpty(a);
         checkAllNotEmpty(b, c, d);
-        Quartet<A, Optional<B>, Optional<C>, Optional<D>> result =
-                new Quartet<>(a, ofNullable(b), ofNullable(c), ofNullable(d));
+        var result = new Quartet<>(a, ofNullable(b), ofNullable(c), ofNullable(d));
         return result;
     }
 
@@ -136,7 +134,7 @@ public final class Quartet<A extends Message, B, C, D>
 
     @Override
     public boolean hasB() {
-        B value = getB();
+        var value = getB();
         return isOptionalPresent(value);
     }
 
@@ -147,7 +145,7 @@ public final class Quartet<A extends Message, B, C, D>
 
     @Override
     public boolean hasC() {
-        C value = getC();
+        var value = getC();
         return isOptionalPresent(value);
     }
 
@@ -158,7 +156,7 @@ public final class Quartet<A extends Message, B, C, D>
 
     @Override
     public boolean hasD() {
-        D value = getD();
+        var value = getD();
         return isOptionalPresent(value);
     }
 

--- a/server/src/main/java/io/spine/server/tuple/Quartet.java
+++ b/server/src/main/java/io/spine/server/tuple/Quartet.java
@@ -118,7 +118,7 @@ public final class Quartet<A extends Message, B, C, D>
     }
 
     /**
-     * {@inheritDoc}
+     * Tells whether the first element of the tuple is set.
      *
      * <p>Always returns {@code true}.
      */

--- a/server/src/main/java/io/spine/server/tuple/Quintet.java
+++ b/server/src/main/java/io/spine/server/tuple/Quintet.java
@@ -78,7 +78,7 @@ public final class Quintet<A extends Message, B, C, D, E>
     <A extends Message, B extends Message, C extends Message, D extends Message, E extends Message>
     Quintet<A, B, C, D, E> of(A a, B b, C c, D d, E e) {
         checkAllNotNullOrEmpty(a, b, c, d, e);
-        Quintet<A, B, C, D, E> result = new Quintet<>(a, b, c, d, e);
+        var result = new Quintet<>(a, b, c, d, e);
         return result;
     }
 
@@ -91,7 +91,7 @@ public final class Quintet<A extends Message, B, C, D, E>
     withNullable(A a, B b, C c, D d, @Nullable E e) {
         checkAllNotNullOrEmpty(a, b, c, d);
         checkNotEmpty(e);
-        Quintet<A, B, C, D, Optional<E>> result = new Quintet<>(a, b, c, d, ofNullable(e));
+        var result = new Quintet<>(a, b, c, d, ofNullable(e));
         return result;
     }
 
@@ -104,8 +104,7 @@ public final class Quintet<A extends Message, B, C, D, E>
     withNullable2(A a, B b, C c, @Nullable D d, @Nullable E e) {
         checkAllNotNullOrEmpty(a, b, c);
         checkAllNotEmpty(e, d);
-        Quintet<A, B, C, Optional<D>, Optional<E>> result =
-                new Quintet<>(a, b, c, ofNullable(d), ofNullable(e));
+        var result = new Quintet<>(a, b, c, ofNullable(d), ofNullable(e));
         return result;
     }
 
@@ -118,8 +117,7 @@ public final class Quintet<A extends Message, B, C, D, E>
     withNullable3(A a, B b, @Nullable C c, @Nullable D d, @Nullable E e) {
         checkAllNotNullOrEmpty(a, b);
         checkAllNotEmpty(c, d, e);
-        Quintet<A, B, Optional<C>, Optional<D>, Optional<E>> result =
-                new Quintet<>(a, b, ofNullable(c), ofNullable(d), ofNullable(e));
+        var result = new Quintet<>(a, b, ofNullable(c), ofNullable(d), ofNullable(e));
         return result;
     }
 
@@ -132,8 +130,7 @@ public final class Quintet<A extends Message, B, C, D, E>
     withNullable4(A a, @Nullable B b, @Nullable C c, @Nullable D d, @Nullable E e) {
         checkNotNullOrEmpty(a);
         checkAllNotEmpty(b, c, d, e);
-        Quintet<A, Optional<B>, Optional<C>, Optional<D>, Optional<E>> result =
-                new Quintet<>(a, ofNullable(b), ofNullable(c), ofNullable(d), ofNullable(e));
+        var result = new Quintet<>(a, ofNullable(b), ofNullable(c), ofNullable(d), ofNullable(e));
         return result;
     }
 
@@ -159,7 +156,7 @@ public final class Quintet<A extends Message, B, C, D, E>
 
     @Override
     public boolean hasB() {
-        B value = getB();
+        var value = getB();
         return isOptionalPresent(value);
     }
 
@@ -170,7 +167,7 @@ public final class Quintet<A extends Message, B, C, D, E>
 
     @Override
     public boolean hasC() {
-        C value = getC();
+        var value = getC();
         return isOptionalPresent(value);
     }
 
@@ -181,7 +178,7 @@ public final class Quintet<A extends Message, B, C, D, E>
 
     @Override
     public boolean hasD() {
-        D value = getD();
+        var value = getD();
         return isOptionalPresent(value);
     }
 
@@ -192,7 +189,7 @@ public final class Quintet<A extends Message, B, C, D, E>
 
     @Override
     public boolean hasE() {
-        E value = getE();
+        var value = getE();
         return isOptionalPresent(value);
     }
 

--- a/server/src/main/java/io/spine/server/tuple/Quintet.java
+++ b/server/src/main/java/io/spine/server/tuple/Quintet.java
@@ -140,7 +140,7 @@ public final class Quintet<A extends Message, B, C, D, E>
     }
 
     /**
-     * {@inheritDoc}
+     * Tells whether the first element of the tuple is set.
      *
      * <p>Always returns {@code true}.
      */

--- a/server/src/main/java/io/spine/server/tuple/Triplet.java
+++ b/server/src/main/java/io/spine/server/tuple/Triplet.java
@@ -71,7 +71,7 @@ public final class Triplet<A extends Message, B, C>
     public static <A extends Message, B extends Message, C extends Message>
     Triplet<A, B, C> of(A a, B b, C c) {
         checkAllNotNullOrEmpty(a, b, c);
-        Triplet<A, B, C> result = new Triplet<>(a, b, c);
+        var result = new Triplet<>(a, b, c);
         return result;
     }
 
@@ -82,7 +82,7 @@ public final class Triplet<A extends Message, B, C>
     Triplet<A, B, Optional<C>> withNullable(A a, B b, @Nullable C c) {
         checkAllNotNullOrEmpty(a, b);
         checkNotEmpty(c);
-        Triplet<A, B, Optional<C>> result = new Triplet<>(a, b, ofNullable(c));
+        var result = new Triplet<>(a, b, ofNullable(c));
         return result;
     }
 
@@ -93,8 +93,7 @@ public final class Triplet<A extends Message, B, C>
     Triplet<A, Optional<B>, Optional<C>> withNullable2(A a, @Nullable B b, @Nullable C c) {
         checkNotNullOrEmpty(a);
         checkAllNotEmpty(b, c);
-        Triplet<A, Optional<B>, Optional<C>> result =
-                new Triplet<>(a, ofNullable(b), ofNullable(c));
+        var result = new Triplet<>(a, ofNullable(b), ofNullable(c));
         return result;
     }
 
@@ -120,7 +119,7 @@ public final class Triplet<A extends Message, B, C>
 
     @Override
     public boolean hasB() {
-        B value = getB();
+        var value = getB();
         return isOptionalPresent(value);
     }
 
@@ -131,7 +130,7 @@ public final class Triplet<A extends Message, B, C>
 
     @Override
     public boolean hasC() {
-        C value = getC();
+        var value = getC();
         return isOptionalPresent(value);
     }
 

--- a/server/src/main/java/io/spine/server/tuple/Triplet.java
+++ b/server/src/main/java/io/spine/server/tuple/Triplet.java
@@ -103,7 +103,7 @@ public final class Triplet<A extends Message, B, C>
     }
 
     /**
-     * {@inheritDoc}
+     * Tells whether the first element of the tuple is set.
      *
      * <p>Always returns {@code true}.
      */

--- a/server/src/main/java/io/spine/server/tuple/Tuple.java
+++ b/server/src/main/java/io/spine/server/tuple/Tuple.java
@@ -67,9 +67,9 @@ public abstract class Tuple implements Iterable<Message>, Serializable {
         super();
 
         ImmutableList.Builder<Element> builder = ImmutableList.builder();
-        for (Object value : values) {
+        for (var value : values) {
             checkNotNull(value);
-            Element element = new Element(value);
+            var element = new Element(value);
             builder.add(element);
         }
 
@@ -88,9 +88,9 @@ public abstract class Tuple implements Iterable<Message>, Serializable {
         if (value == null) {
             return null;
         }
-        boolean isEmpty = value instanceof Empty;
+        var isEmpty = value instanceof Empty;
         if (isEmpty) {
-            String shortClassName = checkingClass.getSimpleName();
+            var shortClassName = checkingClass.getSimpleName();
             throw newIllegalArgumentException(
                     "`%s` cannot have `Empty` elements. Use `Optional` instead",
                     shortClassName);
@@ -99,23 +99,24 @@ public abstract class Tuple implements Iterable<Message>, Serializable {
     }
 
     @CanIgnoreReturnValue
+    @SuppressWarnings("ConstantConditions") /* `checkNotNull` is used by design. */
     static <M extends Message, T extends Tuple>
     M checkNotNullOrEmpty(Class<T> checkingClass, M value) {
-        M result = checkNotEmpty(checkingClass, value);
+        var result = checkNotEmpty(checkingClass, value);
         checkNotNull(result);
         return result;
     }
 
     static <T extends Tuple>
     void checkAllNotNullOrEmpty(Class<T> checkingClass, Message... values) {
-        for (Message value : values) {
+        for (var value : values) {
             checkNotNullOrEmpty(checkingClass, value);
         }
     }
 
     static <T extends Tuple>
     void checkAllNotEmpty(Class<T> checkingClass, Message... values) {
-        for (Message value : values) {
+        for (var value : values) {
             checkNotEmpty(checkingClass, value);
         }
     }
@@ -134,8 +135,8 @@ public abstract class Tuple implements Iterable<Message>, Serializable {
      * @throws IndexOutOfBoundsException if the index is out of range
      */
     protected final Object get(int index) {
-        Element element = values.get(index);
-        Object result = element.value();
+        var element = values.get(index);
+        var result = element.value();
         return result;
     }
 
@@ -152,7 +153,7 @@ public abstract class Tuple implements Iterable<Message>, Serializable {
         if (!(obj instanceof Tuple)) {
             return false;
         }
-        Tuple other = (Tuple) obj;
+        var other = (Tuple) obj;
         return Objects.equals(this.values, other.values);
     }
 
@@ -175,8 +176,8 @@ public abstract class Tuple implements Iterable<Message>, Serializable {
 
         @Override
         public Message next() {
-            Element next = source.next();
-            Message result = next.toMessage();
+            var next = source.next();
+            var result = next.toMessage();
             return result;
         }
     }

--- a/server/src/main/java/io/spine/server/tuple/Values.java
+++ b/server/src/main/java/io/spine/server/tuple/Values.java
@@ -51,7 +51,7 @@ final class Values {
         if(!(value instanceof Optional)) {
             return true;
         }
-        Optional<?> asOptional = (Optional<?>) value;
+        var asOptional = (Optional<?>) value;
         return asOptional.isPresent();
     }
 }

--- a/server/src/main/java/io/spine/server/type/AbstractMessageEnvelope.java
+++ b/server/src/main/java/io/spine/server/type/AbstractMessageEnvelope.java
@@ -68,7 +68,7 @@ public abstract class AbstractMessageEnvelope<I extends Message, T, C extends Me
         if (!(obj instanceof AbstractMessageEnvelope)) {
             return false;
         }
-        AbstractMessageEnvelope<?, ?, ?> other = (AbstractMessageEnvelope<?, ?, ?>) obj;
+        var other = (AbstractMessageEnvelope<?, ?, ?>) obj;
         return Objects.equals(this.object, other.object);
     }
 

--- a/server/src/main/java/io/spine/server/type/CommandClass.java
+++ b/server/src/main/java/io/spine/server/type/CommandClass.java
@@ -77,8 +77,8 @@ public final class CommandClass extends MessageClass<CommandMessage> {
      * @return new instance
      */
     public static CommandClass of(Message commandOrMessage) {
-        CommandMessage commandMessage = Commands.ensureMessage(commandOrMessage);
-        TypeUrl typeUrl = TypeUrl.of(commandMessage.getDefaultInstanceForType());
+        var commandMessage = Commands.ensureMessage(commandOrMessage);
+        var typeUrl = TypeUrl.of(commandMessage.getDefaultInstanceForType());
         return new CommandClass(commandMessage.getClass(), typeUrl);
     }
 
@@ -87,7 +87,7 @@ public final class CommandClass extends MessageClass<CommandMessage> {
      */
     public static ImmutableSet<CommandClass> setOf(Iterable<Class<? extends CommandMessage>> classes) {
         ImmutableSet.Builder<CommandClass> builder = ImmutableSet.builder();
-        for (Class<? extends CommandMessage> cls : classes) {
+        for (var cls : classes) {
             builder.add(from(cls));
         }
         return builder.build();

--- a/server/src/main/java/io/spine/server/type/EventClass.java
+++ b/server/src/main/java/io/spine/server/type/EventClass.java
@@ -90,7 +90,7 @@ public final class EventClass extends MessageClass<EventMessage> {
             throw illegalStateWithCauseOf(e);
         }
         @SuppressWarnings("unchecked") // Safe as declared by `RejectionThrowable.messageThrown`.
-        Class<? extends RejectionMessage> returnType = (Class<? extends RejectionMessage>)
+        var returnType = (Class<? extends RejectionMessage>)
                 messageThrownMethod.getReturnType();
         return from(returnType);
     }
@@ -132,8 +132,8 @@ public final class EventClass extends MessageClass<EventMessage> {
      * @return new instance
      */
     public static EventClass of(Message eventOrMessage) {
-        EventMessage eventMessage = ensureMessage(eventOrMessage);
-        TypeUrl typeUrl = eventMessage.typeUrl();
+        var eventMessage = ensureMessage(eventOrMessage);
+        var typeUrl = eventMessage.typeUrl();
         return new EventClass(eventMessage.getClass(), typeUrl);
     }
 
@@ -142,7 +142,7 @@ public final class EventClass extends MessageClass<EventMessage> {
      */
     public static ImmutableSet<EventClass> setOf(Iterable<Class<? extends EventMessage>> classes) {
         ImmutableSet.Builder<EventClass> builder = ImmutableSet.builder();
-        for (Class<? extends EventMessage> cls : classes) {
+        for (var cls : classes) {
             builder.add(from(cls));
         }
         return builder.build();

--- a/server/src/main/java/io/spine/server/type/EventEnvelope.java
+++ b/server/src/main/java/io/spine/server/type/EventEnvelope.java
@@ -26,20 +26,16 @@
 
 package io.spine.server.type;
 
-import io.spine.base.CommandMessage;
 import io.spine.base.EventMessage;
 import io.spine.core.Enrichment;
 import io.spine.core.Event;
 import io.spine.core.EventContext;
 import io.spine.core.EventId;
-import io.spine.core.RejectionEventContext;
 import io.spine.core.TenantId;
 import io.spine.server.enrich.EnrichmentService;
 import io.spine.type.MessageClass;
 import io.spine.type.TypeName;
 import io.spine.type.TypeUrl;
-
-import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -75,7 +71,7 @@ public final class EventEnvelope
      */
     @Override
     public EventId id() {
-        EventId result = outerObject().getId();
+        var result = outerObject().getId();
         return result;
     }
 
@@ -122,7 +118,7 @@ public final class EventEnvelope
      * Obtains the type of the event message.
      */
     public TypeName messageTypeName() {
-        TypeName result = TypeName.of(message());
+        var result = TypeName.of(message());
         return result;
     }
 
@@ -135,9 +131,9 @@ public final class EventEnvelope
     @Override
     public MessageClass<?> originClass() {
         if (isRejection()) {
-            RejectionEventContext rejection = context().getRejection();
-            CommandMessage commandMessage = rejection.getCommand()
-                                                     .enclosedMessage();
+            var rejection = context().getRejection();
+            var commandMessage = rejection.getCommand()
+                                          .enclosedMessage();
             return CommandClass.of(commandMessage);
         } else {
             return EmptyClass.instance();
@@ -164,7 +160,7 @@ public final class EventEnvelope
      * Returns {@code true} is the wrapped event is external, {@code false} otherwise.
      */
     public boolean isExternal() {
-        boolean external = context().getExternal();
+        var external = context().getExternal();
         return external;
     }
 
@@ -173,9 +169,9 @@ public final class EventEnvelope
         if (!isEnrichmentEnabled()) {
             return this;
         }
-        Optional<Enrichment> enrichment = service.createEnrichment(message(), this.context());
-        EventEnvelope result = enrichment.map(this::withEnrichment)
-                                         .orElse(this);
+        var enrichment = service.createEnrichment(message(), this.context());
+        var result = enrichment.map(this::withEnrichment)
+                               .orElse(this);
         return result;
     }
 
@@ -183,7 +179,7 @@ public final class EventEnvelope
      * Verifies if the enrichment of the message is enabled.
      */
     public final boolean isEnrichmentEnabled() {
-        boolean result = enrichment().getModeCase() != Enrichment.ModeCase.DO_NOT_ENRICH;
+        var result = enrichment().getModeCase() != Enrichment.ModeCase.DO_NOT_ENRICH;
         return result;
     }
 
@@ -192,15 +188,13 @@ public final class EventEnvelope
     }
 
     private EventEnvelope withEnrichment(Enrichment enrichment) {
-        EventContext context =
-                this.context()
-                    .toBuilder()
-                    .setEnrichment(enrichment)
-                    .build();
-        Event enrichedCopy =
-                outerObject().toBuilder()
-                             .setContext(context)
-                             .build();
+        var context = this.context()
+                .toBuilder()
+                .setEnrichment(enrichment)
+                .build();
+        var enrichedCopy = outerObject().toBuilder()
+                .setContext(context)
+                .build();
         return of(enrichedCopy);
     }
 }

--- a/server/src/main/java/io/spine/system/server/CommandLogProjection.java
+++ b/server/src/main/java/io/spine/system/server/CommandLogProjection.java
@@ -27,7 +27,6 @@
 package io.spine.system.server;
 
 import io.spine.core.Command;
-import io.spine.core.CommandContext;
 import io.spine.core.CommandContext.Schedule;
 import io.spine.core.CommandId;
 import io.spine.core.Responses;
@@ -72,7 +71,7 @@ final class CommandLogProjection
 
     @Subscribe
     void on(CommandScheduled event) {
-        Command updatedCommand = updateSchedule(event.getSchedule());
+        var updatedCommand = updateSchedule(event.getSchedule());
         timeline().setWhenScheduled(currentTime());
         builder().setCommand(updatedCommand);
     }
@@ -84,7 +83,7 @@ final class CommandLogProjection
 
     @Subscribe
     void on(TargetAssignedToCommand event) {
-        CommandTarget target = event.getTarget();
+        var target = event.getTarget();
         timeline().setWhenTargetAssigned(currentTime());
         builder().setTarget(target);
     }
@@ -98,8 +97,7 @@ final class CommandLogProjection
     void on(@Where(field = "handled_signal.id.type_url",
                    equals = "type.spine.io/spine.core.Command")
             HandlerFailedUnexpectedly event) {
-        Status status = Status
-                .newBuilder()
+        var status = Status.newBuilder()
                 .setError(event.getError())
                 .build();
         setStatus(status);
@@ -107,8 +105,7 @@ final class CommandLogProjection
 
     @Subscribe
     void on(CommandErrored event) {
-        Status status = Status
-                .newBuilder()
+        var status = Status.newBuilder()
                 .setError(event.getError())
                 .build();
         setStatus(status);
@@ -121,8 +118,7 @@ final class CommandLogProjection
      */
     @Subscribe
     void on(CommandRejected event) {
-        Status status = Status
-                .newBuilder()
+        var status = Status.newBuilder()
                 .setRejection(event.getRejectionEvent())
                 .build();
         setStatus(status);
@@ -130,8 +126,7 @@ final class CommandLogProjection
 
     @Subscribe
     void on(CommandTransformed event) {
-        Substituted substituted = Substituted
-                .newBuilder()
+        var substituted = Substituted.newBuilder()
                 .setCommand(event.getId())
                 .build();
         timeline().setSubstituted(substituted);
@@ -139,12 +134,10 @@ final class CommandLogProjection
 
     @Subscribe
     void on(CommandSplit event) {
-        Sequence sequence = Sequence
-                .newBuilder()
+        var sequence = Sequence.newBuilder()
                 .addAllItem(event.getProducedList())
                 .build();
-        Substituted substituted = Substituted
-                .newBuilder()
+        var substituted = Substituted.newBuilder()
                 .setSequence(sequence)
                 .build();
         timeline().setSubstituted(substituted);
@@ -152,16 +145,14 @@ final class CommandLogProjection
     }
 
     private Command updateSchedule(Schedule schedule) {
-        Command command = builder().getCommand();
-        CommandContext updatedContext =
-                command.context()
-                       .toBuilder()
-                       .setSchedule(schedule)
-                       .build();
-        Command updatedCommand =
-                command.toBuilder()
-                       .setContext(updatedContext)
-                       .build();
+        var command = builder().getCommand();
+        var updatedContext = command.context()
+                .toBuilder()
+                .setSchedule(schedule)
+                .build();
+        var updatedCommand = command.toBuilder()
+                .setContext(updatedContext)
+                .build();
         return updatedCommand;
     }
 

--- a/server/src/main/java/io/spine/system/server/DefaultSystemWriteSide.java
+++ b/server/src/main/java/io/spine/system/server/DefaultSystemWriteSide.java
@@ -31,6 +31,7 @@ import io.spine.base.EventMessage;
 import io.spine.core.Event;
 import io.spine.core.Origin;
 import io.spine.core.UserId;
+import io.spine.core.Versions;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.grpc.StreamObservers.noOpObserver;
@@ -61,7 +62,7 @@ final class DefaultSystemWriteSide implements SystemWriteSide {
     public Event postEvent(EventMessage systemEvent, Origin origin) {
         checkNotNull(systemEvent);
         checkNotNull(origin);
-        Event event = event(systemEvent, origin);
+        var event = event(systemEvent, origin);
         if (system.config().postEventsInParallel()) {
             commonPool().execute(() -> postEvent(event));
         } else {
@@ -71,8 +72,8 @@ final class DefaultSystemWriteSide implements SystemWriteSide {
     }
 
     private Event event(EventMessage message, Origin origin) {
-        SystemEventFactory factory = forMessage(message, origin, system.isMultitenant());
-        Event event = factory.createEvent(message, null);
+        var factory = forMessage(message, origin, system.isMultitenant());
+        var event = factory.createEvent(message, Versions.zero());
         return event;
     }
 

--- a/server/src/main/java/io/spine/system/server/ReadSideFunction.java
+++ b/server/src/main/java/io/spine/system/server/ReadSideFunction.java
@@ -43,7 +43,7 @@ public interface ReadSideFunction extends Function<TenantId, SystemReadSide> {
 
     static ReadSideFunction delegatingTo(SystemReadSide delegate) {
         return (t) -> {
-            SystemReadSide result = TenantAwareSystemReadSide.forTenant(t, delegate);
+            var result = TenantAwareSystemReadSide.forTenant(t, delegate);
             return result;
         };
     }

--- a/server/src/main/java/io/spine/system/server/ScheduledCommand.java
+++ b/server/src/main/java/io/spine/system/server/ScheduledCommand.java
@@ -47,20 +47,20 @@ final class ScheduledCommand
 
     @Subscribe
     void on(CommandScheduled event, EventContext context) {
-        Command command = context.get(Command.class);
-        Command commandWithSchedule = withSchedule(command, event.getSchedule());
+        var command = context.get(Command.class);
+        var commandWithSchedule = withSchedule(command, event.getSchedule());
         builder().setId(event.getId())
                  .setCommand(commandWithSchedule)
                  .setSchedulingTime(context.getTimestamp());
     }
 
     private static Command withSchedule(Command source, CommandContext.Schedule schedule) {
-        CommandContext updatedContext =
+        var updatedContext =
                 source.context()
                       .toBuilder()
                       .setSchedule(schedule)
                       .build();
-        Command updatedCommand =
+        var updatedCommand =
                 source.toBuilder()
                       .setContext(updatedContext)
                       .build();

--- a/server/src/main/java/io/spine/system/server/ScheduledCommandRepository.java
+++ b/server/src/main/java/io/spine/system/server/ScheduledCommandRepository.java
@@ -31,7 +31,6 @@ import io.spine.server.projection.ProjectionRepository;
 import io.spine.server.route.EventRouting;
 import io.spine.system.server.event.CommandDispatched;
 
-import java.util.Optional;
 import java.util.Set;
 
 import static io.spine.server.route.EventRoute.noTargets;
@@ -51,8 +50,8 @@ final class ScheduledCommandRepository
     }
 
     private Set<CommandId> routeToExisting(CommandDispatched event) {
-        CommandId id = event.getId();
-        Optional<ScheduledCommand> existing = find(id);
+        var id = event.getId();
+        var existing = find(id);
         return existing.isPresent()
                ? withId(id)
                : noTargets();

--- a/server/src/main/java/io/spine/system/server/SystemConfig.java
+++ b/server/src/main/java/io/spine/system/server/SystemConfig.java
@@ -70,7 +70,7 @@ final class SystemConfig implements SystemFeatures {
         if (!(o instanceof SystemConfig)) {
             return false;
         }
-        SystemConfig config = (SystemConfig) o;
+        var config = (SystemConfig) o;
         return commandLog == config.commandLog &&
                 storeEvents == config.storeEvents &&
                 parallelPosting == config.parallelPosting;

--- a/server/src/main/java/io/spine/system/server/SystemContext.java
+++ b/server/src/main/java/io/spine/system/server/SystemContext.java
@@ -31,10 +31,6 @@ import io.spine.server.BoundedContext;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.ServerEnvironment;
 import io.spine.server.event.EventDispatcher;
-import io.spine.server.event.EventEnricher;
-import io.spine.server.trace.TracerFactory;
-
-import java.util.Optional;
 
 /**
  * An implementation of {@link BoundedContext} used for the System domain.
@@ -72,10 +68,10 @@ public final class SystemContext extends BoundedContext {
      * @return new {@code SystemBoundedContext}
      */
     public static SystemContext newInstance(BoundedContextBuilder builder) {
-        CommandLogRepository commandLog = new CommandLogRepository();
-        EventEnricher enricher = SystemEnricher.create(commandLog);
+        var commandLog = new CommandLogRepository();
+        var enricher = SystemEnricher.create(commandLog);
         builder.enrichEventsUsing(enricher);
-        SystemContext result = new SystemContext(builder);
+        var result = new SystemContext(builder);
         result.registerRepositories(commandLog);
         result.registerTracing();
         result.init();
@@ -90,7 +86,7 @@ public final class SystemContext extends BoundedContext {
     }
 
     private void registerTracing() {
-        Optional<TracerFactory> tracing = ServerEnvironment.instance().tracing();
+        var tracing = ServerEnvironment.instance().tracing();
         tracing.ifPresent(factory -> {
             EventDispatcher observer = new TraceEventObserver(spec(), factory);
             registerEventDispatcher(observer);

--- a/server/src/main/java/io/spine/system/server/SystemEnricher.java
+++ b/server/src/main/java/io/spine/system/server/SystemEnricher.java
@@ -35,8 +35,6 @@ import io.spine.server.event.EventEnricher;
 import io.spine.server.projection.Projection;
 import io.spine.system.server.event.CommandScheduled;
 
-import java.util.Optional;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -59,7 +57,7 @@ final class SystemEnricher {
      */
     public static EventEnricher create(CommandLogRepository repo) {
         checkNotNull(repo);
-        EventEnricher enricher = EventEnricher
+        var enricher = EventEnricher
                 .newBuilder()
                 .add(CommandScheduled.class, Command.class, commandLookup(repo))
                 .build();
@@ -72,10 +70,10 @@ final class SystemEnricher {
     }
 
     private static Command findCommand(CommandLogRepository repo, CommandId id) {
-        Optional<CommandLogProjection> commandLifecycle = repo.find(id);
-        Command command = commandLifecycle.map(Projection::state)
-                                          .map(CommandLog::getCommand)
-                                          .orElse(Command.getDefaultInstance());
+        var commandLifecycle = repo.find(id);
+        var command = commandLifecycle.map(Projection::state)
+                                      .map(CommandLog::getCommand)
+                                      .orElse(Command.getDefaultInstance());
         return command;
     }
 }

--- a/server/src/main/java/io/spine/system/server/SystemEventFactory.java
+++ b/server/src/main/java/io/spine/system/server/SystemEventFactory.java
@@ -30,15 +30,11 @@ import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import io.spine.base.EventMessage;
 import io.spine.base.Identifier;
-import io.spine.client.ActorRequestFactory;
-import io.spine.core.ActorContext;
 import io.spine.core.EventContext;
 import io.spine.core.Origin;
 import io.spine.server.event.EventFactory;
 import io.spine.server.event.EventOrigin;
 import io.spine.server.route.EventRoute;
-
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.spine.protobuf.Messages.isNotDefault;
@@ -62,27 +58,27 @@ final class SystemEventFactory extends EventFactory {
      * @return new instance of {@code SystemEventFactory}
      */
     static SystemEventFactory forMessage(EventMessage message, Origin origin, boolean multitenant) {
-        Message aggregateId = aggregateIdFrom(message);
-        Any producerId = Identifier.pack(aggregateId);
+        var aggregateId = aggregateIdFrom(message);
+        var producerId = Identifier.pack(aggregateId);
         EventOrigin eventOrigin;
         if (isNotDefault(origin)) {
             eventOrigin = EventOrigin.from(origin);
         } else {
-            ActorRequestFactory factory = SystemRequestFactory.instance(multitenant);
-            ActorContext importContext = factory.newActorContext();
+            var factory = SystemRequestFactory.instance(multitenant);
+            var importContext = factory.newActorContext();
             eventOrigin = EventOrigin.forImport(importContext);
         }
         return new SystemEventFactory(eventOrigin, producerId);
     }
 
     private static Message aggregateIdFrom(EventMessage systemEvent) {
-        Set<Object> routingOut =
+        var routingOut =
                 EventRoute.byFirstMessageField(Object.class)
                           .apply(systemEvent, EventContext.getDefaultInstance());
         checkArgument(routingOut.size() == 1,
                       "System event message must have entity ID in the first field.");
-        Object id = routingOut.iterator()
-                              .next();
+        var id = routingOut.iterator()
+                           .next();
         checkArgument(id instanceof Message, "System entity ID must be a `Message`.");
         return (Message) id;
     }

--- a/server/src/main/java/io/spine/system/server/SystemRequestFactory.java
+++ b/server/src/main/java/io/spine/system/server/SystemRequestFactory.java
@@ -31,8 +31,8 @@ import io.spine.core.TenantId;
 import io.spine.server.tenant.TenantFunction;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.system.server.DefaultSystemWriteSide.SYSTEM_USER;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Creates an actor request factory for producing requests under the context of specified tenant.
@@ -59,23 +59,22 @@ final class SystemRequestFactory {
     }
 
     private static ActorRequestFactory newForCurrentTenant() {
-        TenantFunction<ActorRequestFactory> createFactory =
-                new TenantFunction<ActorRequestFactory>(true) {
-                    @Override
-                    public ActorRequestFactory apply(@Nullable TenantId tenantId) {
-                        checkNotNull(tenantId);
-                        return newFactoryFor(tenantId);
-                    }
-                };
-        ActorRequestFactory result = createFactory.execute();
-        checkNotNull(result);
+        var createFactory = new TenantFunction<ActorRequestFactory>(true) {
+            @Override
+            public ActorRequestFactory apply(@Nullable TenantId tenantId) {
+                requireNonNull(tenantId);
+                return newFactoryFor(tenantId);
+            }
+        };
+        var result = createFactory.execute();
+        requireNonNull(result);
         return result;
     }
 
     private static ActorRequestFactory newFactoryFor(@Nullable TenantId tenantId) {
         return ActorRequestFactory.newBuilder()
-                                  .setActor(SYSTEM_USER)
-                                  .setTenantId(tenantId)
-                                  .build();
+                .setActor(SYSTEM_USER)
+                .setTenantId(tenantId)
+                .build();
     }
 }

--- a/server/src/main/java/io/spine/system/server/SystemSettings.java
+++ b/server/src/main/java/io/spine/system/server/SystemSettings.java
@@ -61,7 +61,7 @@ public final class SystemSettings implements SystemFeatures {
      * </ol>
      */
     public static SystemSettings defaults() {
-        SystemSettings settings = new SystemSettings()
+        var settings = new SystemSettings()
                 .disableCommandLog()
                 .forgetEvents();
         if (Environment.instance().is(Tests.class)) {
@@ -187,7 +187,7 @@ public final class SystemSettings implements SystemFeatures {
         if (!(o instanceof SystemSettings)) {
             return false;
         }
-        SystemSettings settings = (SystemSettings) o;
+        var settings = (SystemSettings) o;
         return commandLog == settings.commandLog &&
                 storeEvents == settings.storeEvents &&
                 parallelPosting == settings.parallelPosting;

--- a/server/src/main/java/io/spine/system/server/TenantAwareSystemWriteSide.java
+++ b/server/src/main/java/io/spine/system/server/TenantAwareSystemWriteSide.java
@@ -72,7 +72,7 @@ final class TenantAwareSystemWriteSide implements SystemWriteSide {
     @CanIgnoreReturnValue
     @Override
     public Event postEvent(EventMessage systemEvent, Origin origin) {
-        Event event = runner.evaluate(() -> delegate.postEvent(systemEvent, origin));
+        var event = runner.evaluate(() -> delegate.postEvent(systemEvent, origin));
         return event;
     }
 }

--- a/server/src/main/java/io/spine/system/server/TraceEventObserver.java
+++ b/server/src/main/java/io/spine/system/server/TraceEventObserver.java
@@ -27,12 +27,9 @@
 package io.spine.system.server;
 
 import io.spine.annotation.Internal;
-import io.spine.core.Signal;
 import io.spine.core.Subscribe;
-import io.spine.logging.Logging;
 import io.spine.server.ContextSpec;
 import io.spine.server.event.AbstractEventSubscriber;
-import io.spine.server.trace.Tracer;
 import io.spine.server.trace.TracerFactory;
 import io.spine.system.server.event.CommandDispatchedToHandler;
 import io.spine.system.server.event.EventDispatchedToReactor;
@@ -46,7 +43,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * An event subscriber which listens to {@linkplain SignalDispatchedMixin dispatching events}.
  */
 @Internal
-public final class TraceEventObserver extends AbstractEventSubscriber implements Logging {
+public final class TraceEventObserver extends AbstractEventSubscriber {
 
     private final ContextSpec context;
     private final TracerFactory tracing;
@@ -78,8 +75,8 @@ public final class TraceEventObserver extends AbstractEventSubscriber implements
     }
 
     private void trace(SignalDispatchedMixin<?> event) {
-        Signal<?, ?, ?> payload = event.getPayload();
-        try (Tracer tracer = tracing.trace(context, payload)) {
+        var payload = event.getPayload();
+        try (var tracer = tracing.trace(context, payload)) {
             tracer.processedBy(event.getReceiver(), event.getEntityType());
         } catch (Exception e) {
             _error().withCause(e)

--- a/server/src/main/java/io/spine/system/server/WriteSideFunction.java
+++ b/server/src/main/java/io/spine/system/server/WriteSideFunction.java
@@ -43,7 +43,7 @@ public interface WriteSideFunction extends Function<TenantId, SystemWriteSide> {
 
     static WriteSideFunction delegatingTo(SystemWriteSide delegate) {
         return (t) -> {
-            SystemWriteSide result = TenantAwareSystemWriteSide.forTenant(t, delegate);
+            var result = TenantAwareSystemWriteSide.forTenant(t, delegate);
             return result;
         };
     }

--- a/server/src/main/java/io/spine/system/server/event/EntityLifecycleEvent.java
+++ b/server/src/main/java/io/spine/system/server/event/EntityLifecycleEvent.java
@@ -44,8 +44,8 @@ public interface EntityLifecycleEvent extends EventMessage {
     MessageId getEntity();
 
     default TypeUrl entityType() {
-        String typeUrl = getEntity().getTypeUrl();
-        TypeUrl result = TypeUrl.parse(typeUrl);
+        var typeUrl = getEntity().getTypeUrl();
+        var result = TypeUrl.parse(typeUrl);
         return result;
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@ val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.74")
 val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.76")
 
 /** The version of this library. */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.83")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.84")


### PR DESCRIPTION
This PR is the follow-up to #1426.

It completes the `var` replacement for all production sources in `core-java`. 

Some of the existing warnings were addressed as well. 

The library version is set to `2.0.0-SNAPSHOT.84`.
