### PR TITLE
Migrate to JDK 11 and Java 11 syntax [part 4]

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.84`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.85`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -316,10 +316,10 @@
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.41.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.36.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.41.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.36.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
 1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
@@ -478,11 +478,6 @@
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : org.ow2.asm. **Name** : asm-analysis. **Version** : 9.1.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
@@ -510,12 +505,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 29 15:58:27 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 29 20:50:02 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.84`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.85`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -791,10 +786,10 @@ This report was generated on **Mon Nov 29 15:58:27 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.41.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.36.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.41.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.36.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
 1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
@@ -953,11 +948,6 @@ This report was generated on **Mon Nov 29 15:58:27 EET 2021** using [Gradle-Lice
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : org.ow2.asm. **Name** : asm-analysis. **Version** : 9.1.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
@@ -985,12 +975,12 @@ This report was generated on **Mon Nov 29 15:58:27 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 29 15:58:28 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 29 20:50:03 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.84`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.85`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1306,10 +1296,10 @@ This report was generated on **Mon Nov 29 15:58:28 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.41.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.36.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.41.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.36.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
 1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
@@ -1468,11 +1458,6 @@ This report was generated on **Mon Nov 29 15:58:28 EET 2021** using [Gradle-Lice
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : org.ow2.asm. **Name** : asm-analysis. **Version** : 9.1.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
@@ -1500,12 +1485,12 @@ This report was generated on **Mon Nov 29 15:58:28 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 29 15:58:29 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 29 20:50:04 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.84`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.85`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -1913,10 +1898,10 @@ This report was generated on **Mon Nov 29 15:58:29 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.41.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.36.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.41.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.36.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
 1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
@@ -2083,11 +2068,6 @@ This report was generated on **Mon Nov 29 15:58:29 EET 2021** using [Gradle-Lice
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : org.ow2.asm. **Name** : asm-analysis. **Version** : 9.1.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
@@ -2115,12 +2095,12 @@ This report was generated on **Mon Nov 29 15:58:29 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 29 15:58:29 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 29 20:50:05 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.84`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.85`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2444,10 +2424,10 @@ This report was generated on **Mon Nov 29 15:58:29 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.41.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.36.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.41.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.36.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
 1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
@@ -2606,11 +2586,6 @@ This report was generated on **Mon Nov 29 15:58:29 EET 2021** using [Gradle-Lice
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : org.ow2.asm. **Name** : asm-analysis. **Version** : 9.1.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
@@ -2638,12 +2613,12 @@ This report was generated on **Mon Nov 29 15:58:29 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 29 15:58:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 29 20:50:06 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.84`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.85`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3011,10 +2986,10 @@ This report was generated on **Mon Nov 29 15:58:30 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.41.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.36.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.41.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.36.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
 1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
@@ -3173,11 +3148,6 @@ This report was generated on **Mon Nov 29 15:58:30 EET 2021** using [Gradle-Lice
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : org.ow2.asm. **Name** : asm-analysis. **Version** : 9.1.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
@@ -3205,12 +3175,12 @@ This report was generated on **Mon Nov 29 15:58:30 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 29 15:58:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 29 20:50:07 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.84`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.85`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3578,10 +3548,10 @@ This report was generated on **Mon Nov 29 15:58:30 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.41.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.36.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.41.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.36.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
 1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
@@ -3740,11 +3710,6 @@ This report was generated on **Mon Nov 29 15:58:30 EET 2021** using [Gradle-Lice
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : org.ow2.asm. **Name** : asm-analysis. **Version** : 9.1.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
@@ -3772,12 +3737,12 @@ This report was generated on **Mon Nov 29 15:58:30 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 29 15:58:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 29 20:50:07 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.84`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.85`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4189,10 +4154,10 @@ This report was generated on **Mon Nov 29 15:58:31 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.41.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.36.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.41.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.36.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
 1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
@@ -4351,11 +4316,6 @@ This report was generated on **Mon Nov 29 15:58:31 EET 2021** using [Gradle-Lice
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
-     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
-     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : org.ow2.asm. **Name** : asm-analysis. **Version** : 9.1.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
@@ -4383,4 +4343,4 @@ This report was generated on **Mon Nov 29 15:58:31 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Nov 29 15:58:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 29 20:50:08 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.83`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.84`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -316,10 +316,10 @@
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
 1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
@@ -478,6 +478,11 @@
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.ow2.asm. **Name** : asm-analysis. **Version** : 9.1.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
@@ -505,12 +510,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 27 19:57:25 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 29 15:58:27 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.83`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.84`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -786,10 +791,10 @@ This report was generated on **Sat Nov 27 19:57:25 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
 1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
@@ -948,6 +953,11 @@ This report was generated on **Sat Nov 27 19:57:25 EET 2021** using [Gradle-Lice
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.ow2.asm. **Name** : asm-analysis. **Version** : 9.1.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
@@ -975,12 +985,12 @@ This report was generated on **Sat Nov 27 19:57:25 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 27 19:57:26 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 29 15:58:28 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.83`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.84`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1296,10 +1306,10 @@ This report was generated on **Sat Nov 27 19:57:26 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
 1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
@@ -1458,6 +1468,11 @@ This report was generated on **Sat Nov 27 19:57:26 EET 2021** using [Gradle-Lice
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.ow2.asm. **Name** : asm-analysis. **Version** : 9.1.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
@@ -1485,12 +1500,12 @@ This report was generated on **Sat Nov 27 19:57:26 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 27 19:57:26 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 29 15:58:29 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.83`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.84`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -1898,10 +1913,10 @@ This report was generated on **Sat Nov 27 19:57:26 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
 1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
@@ -2068,6 +2083,11 @@ This report was generated on **Sat Nov 27 19:57:26 EET 2021** using [Gradle-Lice
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.ow2.asm. **Name** : asm-analysis. **Version** : 9.1.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
@@ -2095,12 +2115,12 @@ This report was generated on **Sat Nov 27 19:57:26 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 27 19:57:27 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 29 15:58:29 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.83`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.84`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2424,10 +2444,10 @@ This report was generated on **Sat Nov 27 19:57:27 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
 1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
@@ -2586,6 +2606,11 @@ This report was generated on **Sat Nov 27 19:57:27 EET 2021** using [Gradle-Lice
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.ow2.asm. **Name** : asm-analysis. **Version** : 9.1.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
@@ -2613,12 +2638,12 @@ This report was generated on **Sat Nov 27 19:57:27 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 27 19:57:27 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 29 15:58:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.83`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.84`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2986,10 +3011,10 @@ This report was generated on **Sat Nov 27 19:57:27 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
 1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
@@ -3148,6 +3173,11 @@ This report was generated on **Sat Nov 27 19:57:27 EET 2021** using [Gradle-Lice
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.ow2.asm. **Name** : asm-analysis. **Version** : 9.1.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
@@ -3175,12 +3205,12 @@ This report was generated on **Sat Nov 27 19:57:27 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 27 19:57:28 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 29 15:58:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.83`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.84`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3548,10 +3578,10 @@ This report was generated on **Sat Nov 27 19:57:28 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
 1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
@@ -3710,6 +3740,11 @@ This report was generated on **Sat Nov 27 19:57:28 EET 2021** using [Gradle-Lice
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.ow2.asm. **Name** : asm-analysis. **Version** : 9.1.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
@@ -3737,12 +3772,12 @@ This report was generated on **Sat Nov 27 19:57:28 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 27 19:57:28 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 29 15:58:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.83`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.84`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4154,10 +4189,10 @@ This report was generated on **Sat Nov 27 19:57:28 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
 1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
@@ -4316,6 +4351,11 @@ This report was generated on **Sat Nov 27 19:57:28 EET 2021** using [Gradle-Lice
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.ow2.asm. **Name** : asm-analysis. **Version** : 9.1.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
@@ -4343,4 +4383,4 @@ This report was generated on **Sat Nov 27 19:57:28 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 27 19:57:29 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 29 15:58:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.84</version>
+<version>2.0.0-SNAPSHOT.85</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -207,7 +207,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>
     <artifactId>pmd-java</artifactId>
-    <version>6.41.0</version>
+    <version>6.36.0</version>
   </dependency>
   <dependency>
     <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.83</version>
+<version>2.0.0-SNAPSHOT.84</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -207,7 +207,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>
     <artifactId>pmd-java</artifactId>
-    <version>6.36.0</version>
+    <version>6.41.0</version>
   </dependency>
   <dependency>
     <groupId>org.jacoco</groupId>

--- a/server/src/main/kotlin/io/spine/server/bus/MessageIdExtensions.kt
+++ b/server/src/main/kotlin/io/spine/server/bus/MessageIdExtensions.kt
@@ -28,6 +28,7 @@
 
 package io.spine.server.bus
 
+import com.google.common.annotations.VisibleForTesting
 import com.google.protobuf.Message
 import io.spine.base.Error
 import io.spine.base.RejectionThrowable
@@ -57,7 +58,8 @@ public fun Message.acknowledge(): Ack = ackWithStatus(statusOk())
  * @param cause the error which prevented the message from being handled
  * @receiver the ID of the message which caused the error
  */
-internal fun Message.causedError(cause: Error): Ack = ackWithStatus(errorWith(cause))
+@VisibleForTesting
+public fun Message.causedError(cause: Error): Ack = ackWithStatus(errorWith(cause))
 
 /**
  * Reject a command with this ID with the passed rejection event.

--- a/server/src/test/java/io/spine/client/AbstractClientTest.java
+++ b/server/src/test/java/io/spine/client/AbstractClientTest.java
@@ -66,8 +66,8 @@ abstract class AbstractClientTest {
 
     @BeforeEach
     void createServerAndClient() throws IOException {
-        String serverName = generateServerName();
-        Server.Builder serverBuilder = Server.inProcess(serverName);
+        var serverName = generateServerName();
+        var serverBuilder = Server.inProcess(serverName);
         contexts().forEach(serverBuilder::add);
         server = serverBuilder.build();
         server.start();

--- a/server/src/test/java/io/spine/client/ClientBuilderTest.java
+++ b/server/src/test/java/io/spine/client/ClientBuilderTest.java
@@ -132,7 +132,7 @@ class ClientBuilderTest {
         @Test
         @DisplayName("passing it to the created `Client`")
         void value() {
-            Client.Builder builder = usingChannel(channel);
+            var builder = usingChannel(channel);
 
             assertThat(builder.host())
                     .isNull();
@@ -154,8 +154,8 @@ class ClientBuilderTest {
         @Test
         @DisplayName("via value and unit")
         void valueAndUnit() {
-            int value = 100;
-            TimeUnit unit = TimeUnit.MILLISECONDS;
+            var value = 100;
+            var unit = TimeUnit.MILLISECONDS;
             builder.shutdownTimeout(value, unit);
 
             client = builder.build();
@@ -187,7 +187,7 @@ class ClientBuilderTest {
         @Test
         @DisplayName("which is non-null and not default")
         void correctValue() {
-            TenantId expected = GivenTenantId.generate();
+            var expected = GivenTenantId.generate();
             client = builder.forTenant(expected)
                             .build();
             assertThat(client.tenant()).hasValue(expected);
@@ -215,7 +215,7 @@ class ClientBuilderTest {
         @Test
         @DisplayName("which is non-null and not default")
         void correctValue() {
-            UserId expected = GivenUserId.generated();
+            var expected = GivenUserId.generated();
             client = builder.withGuestId(expected)
                             .build();
 
@@ -226,7 +226,7 @@ class ClientBuilderTest {
         @Test
         @DisplayName("which is not empty or a blank string")
         void correctStringValue() {
-            UserId expected = GivenUserId.generated();
+            var expected = GivenUserId.generated();
 
             client = builder.withGuestId(expected.getValue())
                             .build();

--- a/server/src/test/java/io/spine/client/ClientEndToEnd.java
+++ b/server/src/test/java/io/spine/client/ClientEndToEnd.java
@@ -113,9 +113,8 @@ class ClientEndToEnd {
     @Test
     @DisplayName("post Command and subscribe to Event which is not declared explicitly")
     void subscribeToEvent() {
-        AtomicBoolean fired = new AtomicBoolean(false);
-        CreateTask task = CreateTask
-                .newBuilder()
+        var fired = new AtomicBoolean(false);
+        var task = CreateTask.newBuilder()
                 .setId(TaskId.generate())
                 .setName("My task")
                 .setAuthor(GivenUserId.generated())

--- a/server/src/test/java/io/spine/client/ClientErrorHandlersTest.java
+++ b/server/src/test/java/io/spine/client/ClientErrorHandlersTest.java
@@ -58,7 +58,7 @@ public class ClientErrorHandlersTest extends AbstractClientTest {
      */
     @Override
     protected Client.Builder newClientBuilder(String serverName) {
-        Client.Builder builder = super.newClientBuilder(serverName);
+        var builder = super.newClientBuilder(serverName);
         builder.onStreamingError(errorHandler)
                .onServerError(serverErrorHandler);
         return builder;

--- a/server/src/test/java/io/spine/client/ClientRequestTest.java
+++ b/server/src/test/java/io/spine/client/ClientRequestTest.java
@@ -73,7 +73,7 @@ class ClientRequestTest extends AbstractClientTest {
                     .setUser(GivenUserId.generated())
                     .build();
 
-            CommandRequest commandRequest = request.command(msg);
+            var commandRequest = request.command(msg);
             assertThat(commandRequest.message())
                     .isEqualTo(msg);
         }
@@ -82,7 +82,7 @@ class ClientRequestTest extends AbstractClientTest {
         @DisplayName("`SubscriptionRequest`")
         void subscription() {
             Class<? extends EntityState<?>> messageType = UserAccount.class;
-            SubscriptionRequest<? extends EntityState<?>> subscriptionRequest =
+            var subscriptionRequest =
                     request.subscribeTo(messageType);
 
             assertThat(subscriptionRequest.messageType())
@@ -93,7 +93,7 @@ class ClientRequestTest extends AbstractClientTest {
         @DisplayName("`EventSubscriptionRequest`")
         void eventSubscription() {
             Class<? extends EventMessage> eventType = UserLoggedIn.class;
-            EventSubscriptionRequest<? extends EventMessage> eventSubscriptionRequest =
+            var eventSubscriptionRequest =
                     request.subscribeToEvent(eventType);
 
             assertThat(eventSubscriptionRequest.messageType())
@@ -104,9 +104,8 @@ class ClientRequestTest extends AbstractClientTest {
     @Test
     @DisplayName("run `EntityQuery`")
     void runEntityQuery() {
-        ActiveUsers.Query query = ActiveUsers.query()
-                                             .build();
-        ImmutableList<ActiveUsers> results = request.run(query);
+        var query = ActiveUsers.query().build();
+        var results = request.run(query);
         assertThat(results).isNotNull();
     }
 }

--- a/server/src/test/java/io/spine/client/ClientTest.java
+++ b/server/src/test/java/io/spine/client/ClientTest.java
@@ -27,7 +27,6 @@
 package io.spine.client;
 
 import com.google.common.collect.ImmutableList;
-import io.spine.core.UserId;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.test.client.ClientTestContext;
 import io.spine.test.client.users.ActiveUsers;
@@ -70,7 +69,7 @@ class ClientTest extends AbstractClientTest {
     @Test
     @DisplayName("close upon request")
     void closing() {
-        Client client = client();
+        var client = client();
         client.close();
         assertFalse(client.isOpen());
     }
@@ -78,7 +77,7 @@ class ClientTest extends AbstractClientTest {
     @Test
     @DisplayName("have `shutdown()` alias method")
     void shutdown() {
-        Client client = client();
+        var client = client();
         client.shutdown();
         assertFalse(client.isOpen());
     }
@@ -86,8 +85,8 @@ class ClientTest extends AbstractClientTest {
     @Test
     @DisplayName("create requests on behalf of a user")
     void onBehalf() {
-        UserId expected = GivenUserId.generated();
-        ClientRequest request = client().onBehalfOf(expected);
+        var expected = GivenUserId.generated();
+        var request = client().onBehalfOf(expected);
         assertThat(request.user())
                 .isEqualTo(expected);
     }
@@ -95,7 +94,7 @@ class ClientTest extends AbstractClientTest {
     @Test
     @DisplayName("create requests for a guest user")
     void guestRequest() {
-        ClientRequest request = client().asGuest();
+        var request = client().asGuest();
         assertThat(request.user())
                 .isEqualTo(Client.DEFAULT_GUEST_ID);
     }
@@ -109,21 +108,21 @@ class ClientTest extends AbstractClientTest {
         @BeforeEach
         void createSubscriptions() {
             subscriptions = new ArrayList<>();
-            UserId currentUser = GivenUserId.generated();
-            Client client = client();
-            Subscription userLoggedIn =
+            var currentUser = GivenUserId.generated();
+            var client = client();
+            var userLoggedIn =
                     client.onBehalfOf(currentUser)
                           .subscribeToEvent(UserLoggedIn.class)
                           .where(eq(UserLoggedIn.Field.user(), currentUser))
                           .observe((e) -> {})
                           .post();
-            Subscription userLoggedOut =
+            var userLoggedOut =
                     client.onBehalfOf(currentUser)
                           .subscribeToEvent(UserLoggedOut.class)
                           .where(eq(UserLoggedOut.Field.user(), currentUser))
                           .observe((e) -> {})
                           .post();
-            Subscription loginStatus =
+            var loginStatus =
                     client.onBehalfOf(currentUser)
                           .subscribeTo(LoginStatus.class)
                           .where(EntityStateFilter.eq(LoginStatus.Field.userId(),
@@ -139,8 +138,8 @@ class ClientTest extends AbstractClientTest {
         @Test
         @DisplayName("remembering them until canceled")
         void remembering() {
-            Client client = client();
-            Subscriptions remembered = client.subscriptions();
+            var client = client();
+            var remembered = client.subscriptions();
             subscriptions.forEach(
                     (s) -> assertTrue(remembered.contains(s))
             );
@@ -155,8 +154,8 @@ class ClientTest extends AbstractClientTest {
         @Test
         @DisplayName("clear subscriptions when closing")
         void clearing() {
-            Client client = client();
-            Subscriptions subscriptions = client.subscriptions();
+            var client = client();
+            var subscriptions = client.subscriptions();
             this.subscriptions.forEach(
                     (s) -> assertTrue(subscriptions.contains(s))
             );
@@ -175,21 +174,19 @@ class ClientTest extends AbstractClientTest {
         @Test
         @DisplayName("entities by ID")
         void byId() {
-            Client client = client();
-            UserId user = GivenUserId.generated();
+            var client = client();
+            var user = GivenUserId.generated();
 
-            LogInUser command = LogInUser.newBuilder()
-                                         .setUser(user)
-                                         .build();
+            var command = LogInUser.newBuilder()
+                    .setUser(user)
+                    .build();
             client.asGuest()
                   .command(command)
                   .postAndForget();
-            ActiveUsers.Query query = ActiveUsers.query()
-                                                 .id().is(THE_ID)
-                                                 .build();
-            ImmutableList<ActiveUsers> users =
-                    client.onBehalfOf(user)
-                          .run(query);
+            var query= ActiveUsers.query()
+                                   .id().is(THE_ID)
+                                   .build();
+            var users = client.onBehalfOf(user).run(query);
             assertThat(users)
                     .comparingExpectedFieldsOnly()
                     .containsExactly(ActiveUsers.newBuilder()

--- a/server/src/test/java/io/spine/client/CommandRequestTest.java
+++ b/server/src/test/java/io/spine/client/CommandRequestTest.java
@@ -141,7 +141,7 @@ class CommandRequestTest extends AbstractClientTest {
         }
 
         @SafeVarargs
-        private final void assertDelivered(Class<? extends EventMessage>... classes) {
+        private void assertDelivered(Class<? extends EventMessage>... classes) {
             assertThat(counter.containsAll(classes))
                     .isTrue();
         }
@@ -197,7 +197,7 @@ class CommandRequestTest extends AbstractClientTest {
                     handlerInvoked = true;
                     passedThrowable = th;
                 };
-                RuntimeException exception = new RuntimeException("Consumer-generated error.");
+                var exception = new RuntimeException("Consumer-generated error.");
 
                 commandRequest.onConsumingError(handler)
                               .observe(UserLoggedIn.class, e -> {
@@ -239,11 +239,10 @@ class CommandRequestTest extends AbstractClientTest {
                     returnedError = error;
                 };
 
-                UnsupportedCommand commandMessage = UnsupportedCommand
-                        .newBuilder()
+                var commandMessage = UnsupportedCommand.newBuilder()
                         .setUser(GivenUserId.generated())
                         .build();
-                CommandRequest request =
+                var request =
                         client().asGuest()
                                 .command(commandMessage)
                                 .onServerError(handler);
@@ -253,8 +252,7 @@ class CommandRequestTest extends AbstractClientTest {
                         .isNotNull();
                 assertThat(postedMessage)
                         .isInstanceOf(Command.class);
-                Command expected = Command
-                        .newBuilder()
+                var expected = Command.newBuilder()
                         .setMessage(AnyPacker.pack(commandMessage))
                         .build();
                 assertThat(postedMessage)

--- a/server/src/test/java/io/spine/client/ConsumerCallCounter.java
+++ b/server/src/test/java/io/spine/client/ConsumerCallCounter.java
@@ -58,7 +58,7 @@ final class ConsumerCallCounter {
 
     @SafeVarargs
     final boolean containsAll(Class<? extends EventMessage>... types) {
-        ImmutableList<Class<? extends EventMessage>> asList = ImmutableList.copyOf(types);
+        var asList = ImmutableList.copyOf(types);
         return eventTypes.containsAll(asList);
     }
 }

--- a/server/src/test/java/io/spine/client/EventSubscriptionRequestTest.java
+++ b/server/src/test/java/io/spine/client/EventSubscriptionRequestTest.java
@@ -127,8 +127,7 @@ class EventSubscriptionRequestTest extends AbstractClientTest {
         void byMessageField() {
             assertThat(rememberedMessage)
                     .isInstanceOf(UserLoggedIn.class);
-            UserLoggedIn expected = UserLoggedIn
-                    .newBuilder()
+            var expected = UserLoggedIn.newBuilder()
                     .setUser(userId)
                     .build();
             ProtoTruth.assertThat(rememberedMessage)

--- a/server/src/test/java/io/spine/core/CoreMixinsTest.java
+++ b/server/src/test/java/io/spine/core/CoreMixinsTest.java
@@ -30,8 +30,6 @@ import io.spine.core.given.CoreMixinsTestEnv;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
-
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 
@@ -46,21 +44,21 @@ class CoreMixinsTest {
     @Test
     @DisplayName("`CommandIdMixin` " + SHOULD_MAKE_FIELDS_REACHABLE)
     void commandIdMixin() {
-        CommandId msg = CommandId.generate();
+        var msg = CommandId.generate();
         assertThat(msg.checkFieldsReachable()).isTrue();
     }
 
     @Test
     @DisplayName("`CommandMixin` " + SHOULD_MAKE_FIELDS_REACHABLE)
     void commandMixin() {
-        Command command = CoreMixinsTestEnv.command();
+        var command = CoreMixinsTestEnv.command();
         assertThat(command.checkFieldsReachable()).isTrue();
     }
 
     @Test
     @DisplayName("`EventContextMixin` " + SHOULD_MAKE_FIELDS_REACHABLE)
     void eventContextMixin() {
-        Event event = CoreMixinsTestEnv.event();
+        var event = CoreMixinsTestEnv.event();
         assertThat(event.getContext()
                         .checkFieldsReachable()).isTrue();
     }
@@ -68,7 +66,7 @@ class CoreMixinsTest {
     @Test
     @DisplayName("`EventIdMixin` " + SHOULD_MAKE_FIELDS_REACHABLE)
     void eventIdMixin() {
-        Event event = CoreMixinsTestEnv.event();
+        var event = CoreMixinsTestEnv.event();
         assertThat(event.getId()
                         .checkFieldsReachable()).isTrue();
     }
@@ -76,23 +74,22 @@ class CoreMixinsTest {
     @Test
     @DisplayName("`EventMixin` " + SHOULD_MAKE_FIELDS_REACHABLE)
     void eventMixin() {
-        Event event = CoreMixinsTestEnv.event();
+        var event = CoreMixinsTestEnv.event();
         assertThat(event.checkFieldsReachable()).isTrue();
     }
 
     @Test
     @DisplayName("`MessageIdMixin` " + SHOULD_MAKE_FIELDS_REACHABLE)
     void messageIdMixin() {
-        MessageId messageId = CoreMixinsTestEnv.messageId();
+        var messageId = CoreMixinsTestEnv.messageId();
         assertThat(messageId.checkFieldsReachable()).isTrue();
     }
 
-    @SuppressWarnings("OptionalGetWithoutIsPresent")    // Checked by `Truth8.assertThat()`.
     @Test
     @DisplayName("`OriginMixin` " + SHOULD_MAKE_FIELDS_REACHABLE)
+    @SuppressWarnings("OptionalGetWithoutIsPresent")    // Checked by `Truth8.assertThat()`.
     void originIdMixin() {
-        Optional<Origin> origin = CoreMixinsTestEnv.event()
-                                                   .origin();
+        var origin = CoreMixinsTestEnv.event().origin();
         assertThat(origin).isPresent();
         assertThat(origin.get()
                          .checkFieldsReachable()).isTrue();

--- a/server/src/test/java/io/spine/core/EnrichmentsTest.java
+++ b/server/src/test/java/io/spine/core/EnrichmentsTest.java
@@ -45,8 +45,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
-
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static io.spine.base.Identifier.newUuid;
@@ -84,14 +82,11 @@ class EnrichmentsTest extends UtilityClassTest<Enrichments> {
      * for details.
      */
     private static EventContext givenContextEnrichedWith(Message enrichment) {
-        String enrichmentKey = TypeName.of(enrichment)
-                                       .value();
-        Enrichment.Builder enrichments = Enrichment
-                .newBuilder()
+        var enrichmentKey = TypeName.of(enrichment).value();
+        var enrichments = Enrichment.newBuilder()
                 .setContainer(Container.newBuilder()
-                                       .putItems(enrichmentKey, pack(enrichment)));
-        EventContext context = context()
-                .toBuilder()
+                                      .putItems(enrichmentKey, pack(enrichment)));
+        var context = context().toBuilder()
                 .setEnrichment(enrichments)
                 .build();
         return context;
@@ -99,13 +94,11 @@ class EnrichmentsTest extends UtilityClassTest<Enrichments> {
 
     @BeforeEach
     void setUp() {
-        String producerId = newUuid();
-        projectCreated = EtProjectCreated
-                .newBuilder()
+        var producerId = newUuid();
+        projectCreated = EtProjectCreated.newBuilder()
                 .setId(producerId)
                 .build();
-        projectInfo = EtProjectInfo
-                .newBuilder()
+        projectInfo = EtProjectInfo.newBuilder()
                 .setProjectName("Project info of " + getClass().getSimpleName())
                 .build();
         eventFactory = TestEventFactory.newInstance(Identifier.pack(producerId), getClass());
@@ -116,7 +109,7 @@ class EnrichmentsTest extends UtilityClassTest<Enrichments> {
     @Test
     @DisplayName("recognize if event enrichment is enabled")
     void recognizeEnrichmentEnabled() {
-        EventEnvelope event = EventEnvelope.of(eventFactory.createEvent(projectCreated));
+        var event = EventEnvelope.of(eventFactory.createEvent(projectCreated));
 
         assertTrue(event.isEnrichmentEnabled());
     }
@@ -124,7 +117,7 @@ class EnrichmentsTest extends UtilityClassTest<Enrichments> {
     @Test
     @DisplayName("recognize if event enrichment is disabled")
     void recognizeEnrichmentDisabled() {
-        EventEnvelope event = EventEnvelope.of(GivenEvent.withDisabledEnrichmentOf(projectCreated));
+        var event = EventEnvelope.of(GivenEvent.withDisabledEnrichmentOf(projectCreated));
 
         assertFalse(event.isEnrichmentEnabled());
     }
@@ -132,7 +125,7 @@ class EnrichmentsTest extends UtilityClassTest<Enrichments> {
     @Test
     @DisplayName("verify if there are enrichments")
     void getAllEnrichments() {
-        EventContext context = givenContextEnrichedWith(projectInfo);
+        var context = givenContextEnrichedWith(projectInfo);
 
         assertThat(hasEnrichments(context))
                 .isTrue();
@@ -153,9 +146,9 @@ class EnrichmentsTest extends UtilityClassTest<Enrichments> {
     @Test
     @DisplayName("obtain specific event enrichment from context")
     void obtainSpecificEnrichment() {
-        EventContext context = givenContextEnrichedWith(projectInfo);
+        var context = givenContextEnrichedWith(projectInfo);
 
-        OptionalSubject assertEnrichment = assertEnrichment(context, projectInfo.getClass());
+        var assertEnrichment = assertEnrichment(context, projectInfo.getClass());
         assertEnrichment.isPresent();
         assertEnrichment.hasValue(projectInfo);
     }
@@ -170,11 +163,11 @@ class EnrichmentsTest extends UtilityClassTest<Enrichments> {
     @Test
     @DisplayName("return absent if there is no specified enrichment in context")
     void returnAbsentOnEnrichmentNotFound() {
-        EventContext context = givenContextEnrichedWith(
+        var context = givenContextEnrichedWith(
                 EtProjectDetails.newBuilder()
-                .setProjectDescription(TestValues.randomString())
-                .setLogoUrl("https://spine.io/img/spine-logo-white.svg")
-                .build()
+                        .setProjectDescription(TestValues.randomString())
+                        .setLogoUrl("https://spine.io/img/spine-logo-white.svg")
+                        .build()
         );
         assertEnrichment(context, EtProjectInfo.class)
               .isEmpty();
@@ -184,13 +177,13 @@ class EnrichmentsTest extends UtilityClassTest<Enrichments> {
      * Verifies if the passed event context has at least one enrichment.
      */
     private static boolean hasEnrichments(EventContext context) {
-        Optional<Container> optional = containerIn(context);
-        if (!optional.isPresent()) {
+        var optional = containerIn(context);
+        if (optional.isEmpty()) {
             return false;
         }
-        Container container = optional.get();
-        boolean result = !container.getItemsMap()
-                                   .isEmpty();
+        var container = optional.get();
+        var result = !container.getItemsMap()
+                               .isEmpty();
         return result;
     }
 }

--- a/server/src/test/java/io/spine/core/EventContextTest.java
+++ b/server/src/test/java/io/spine/core/EventContextTest.java
@@ -53,10 +53,10 @@ class EventContextTest {
 
     @BeforeEach
     void setUp() {
-        CommandEnvelope cmd = generate();
-        StringValue producerId = StringValue.of(getClass().getSimpleName());
-        EventFactory eventFactory = EventFactory.on(cmd, Identifier.pack(producerId));
-        Event event = eventFactory.createEvent(GivenEvent.message(), null);
+        var cmd = generate();
+        var producerId = StringValue.of(getClass().getSimpleName());
+        var eventFactory = EventFactory.on(cmd, Identifier.pack(producerId));
+        var event = eventFactory.createEvent(GivenEvent.message(), null);
         context = event.context();
     }
 
@@ -71,8 +71,8 @@ class EventContextTest {
         @Test
         @DisplayName("of the event without origin")
         void forEventWithoutOrigin() {
-            EventContext context = contextWithoutOrigin().build();
-            Event event = event(context);
+            var context = contextWithoutOrigin().build();
+            var event = event(context);
             assertThrowsFor(event);
         }
 
@@ -80,10 +80,10 @@ class EventContextTest {
         @Test
         @DisplayName("of the event whose event context has no origin")
         void forEventContextWithoutOrigin() {
-            EventContext context = contextWithoutOrigin()
+            var context = contextWithoutOrigin()
                     .setEventContext(contextWithoutOrigin())
                     .build();
-            Event event = event(context);
+            var event = event(context);
             assertThrowsFor(event);
         }
 
@@ -115,8 +115,8 @@ class EventContextTest {
         @Test
         @DisplayName("producer")
         void producer() {
-            StringValue msg = unpack(context.getProducerId(), StringValue.class);
-            String id = (String) context.producer();
+            var msg = unpack(context.getProducerId(), StringValue.class);
+            var id = (String) context.producer();
             assertThat(id)
                  .isEqualTo(msg.getValue());
         }

--- a/server/src/test/java/io/spine/core/EventTest.java
+++ b/server/src/test/java/io/spine/core/EventTest.java
@@ -29,7 +29,6 @@ import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Any;
 import com.google.protobuf.StringValue;
 import io.spine.base.CommandMessage;
-import io.spine.base.EventMessage;
 import io.spine.base.Identifier;
 import io.spine.base.RejectionThrowable;
 import io.spine.base.Time;
@@ -43,7 +42,6 @@ import io.spine.test.core.given.EtDoSomething;
 import io.spine.test.core.given.EtProjectCreated;
 import io.spine.testing.UtilityClassTest;
 import io.spine.testing.client.TestActorRequestFactory;
-import io.spine.type.TypeName;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -79,9 +77,9 @@ public class EventTest extends UtilityClassTest<Events> {
 
     @BeforeEach
     void setUp() {
-        CommandEnvelope cmd = generate();
-        StringValue producerId = StringValue.of(getClass().getSimpleName());
-        EventFactory eventFactory = EventFactory.on(cmd, Identifier.pack(producerId));
+        var cmd = generate();
+        var producerId = StringValue.of(getClass().getSimpleName());
+        var eventFactory = EventFactory.on(cmd, Identifier.pack(producerId));
         event = eventFactory.createEvent(GivenEvent.message(), null);
         context = event.context();
     }
@@ -93,8 +91,7 @@ public class EventTest extends UtilityClassTest<Events> {
     @Override
     protected void configure(NullPointerTester tester) {
         super.configure(tester);
-        EntityAlreadyArchived defaultRejectionThrowable = EntityAlreadyArchived
-                .newBuilder()
+        var defaultRejectionThrowable = EntityAlreadyArchived.newBuilder()
                 .setEntityId(Any.getDefaultInstance())
                 .build();
         tester.setDefault(StringValue.class, StringValue.getDefaultInstance())
@@ -111,8 +108,8 @@ public class EventTest extends UtilityClassTest<Events> {
         @Test
         @DisplayName("message")
         void message() {
-            EventMessage message = GivenEvent.message();
-            Event event = GivenEvent.withMessage(message);
+            var message = GivenEvent.message();
+            var event = GivenEvent.withMessage(message);
             assertThat(event.enclosedMessage())
                  .isEqualTo(message);
         }
@@ -120,7 +117,7 @@ public class EventTest extends UtilityClassTest<Events> {
         @Test
         @DisplayName("timestamp")
         void timestamp() {
-            Event event = GivenEvent.occurredMinutesAgo(1);
+            var event = GivenEvent.occurredMinutesAgo(1);
 
             assertThat(event.timestamp())
                     .isEqualTo(event.context()
@@ -130,8 +127,8 @@ public class EventTest extends UtilityClassTest<Events> {
         @Test
         @DisplayName("root command ID")
         void rootCommandId() {
-            CommandEnvelope command = generate();
-            Event event = newEvent(command);
+            var command = generate();
+            var event = newEvent(command);
 
             assertThat(event.rootMessage().asCommandId())
                     .isEqualTo(command.id());
@@ -140,18 +137,18 @@ public class EventTest extends UtilityClassTest<Events> {
         @Test
         @DisplayName("type name")
         void typeName() {
-            CommandEnvelope command = generate();
-            Event event = newEvent(command);
+            var command = generate();
+            var event = newEvent(command);
 
-            TypeName typeName = EventEnvelope.of(event)
-                                             .messageTypeName();
+            var typeName = EventEnvelope.of(event)
+                                        .messageTypeName();
             assertNotNull(typeName);
             assertEquals(EtProjectCreated.class.getSimpleName(), typeName.simpleName());
         }
 
         private Event newEvent(CommandEnvelope command) {
-            StringValue producerId = StringValue.of(getClass().getSimpleName());
-            EventFactory ef = EventFactory.on(command, Identifier.pack(producerId));
+            var producerId = StringValue.of(getClass().getSimpleName());
+            var ef = EventFactory.on(command, Identifier.pack(producerId));
             return ef.createEvent(GivenEvent.message(), null);
         }
     }
@@ -164,14 +161,13 @@ public class EventTest extends UtilityClassTest<Events> {
         @Test
         @DisplayName("from the previous message")
         void fromPastMessage() {
-            TenantId targetTenantId = tenantId();
-            Origin origin = Origin
-                    .newBuilder()
+            var targetTenantId = tenantId();
+            var origin = Origin.newBuilder()
                     .setActorContext(ActorContext.newBuilder().setTenantId(targetTenantId))
                     .buildPartial();
-            EventContext context = contextWithoutOrigin().setPastMessage(origin)
-                                                         .buildPartial();
-            Event event = event(context);
+            var context = contextWithoutOrigin().setPastMessage(origin)
+                                                .buildPartial();
+            var event = event(context);
 
             assertThat(event.tenant())
                     .isEqualTo(targetTenantId);
@@ -181,11 +177,11 @@ public class EventTest extends UtilityClassTest<Events> {
         @Test
         @DisplayName("from enclosed command context")
         void fromCommandContext() {
-            TenantId targetTenantId = tenantId();
-            CommandContext commandContext = commandContext(targetTenantId);
-            EventContext context = contextWithoutOrigin().setCommandContext(commandContext)
-                                                         .buildPartial();
-            Event event = event(context);
+            var targetTenantId = tenantId();
+            var commandContext = commandContext(targetTenantId);
+            var context = contextWithoutOrigin().setCommandContext(commandContext)
+                                                .buildPartial();
+            var event = event(context);
 
             assertThat(event.tenant())
                     .isEqualTo(targetTenantId);
@@ -195,17 +191,17 @@ public class EventTest extends UtilityClassTest<Events> {
         @Test
         @DisplayName("from enclosed context of origin event, which had command as origin")
         void fromEventContextWithCommandContext() {
-            TenantId targetTenantId = tenantId();
-            CommandContext commandContext = commandContext(targetTenantId);
-            EventContext outerContext =
+            var targetTenantId = tenantId();
+            var commandContext = commandContext(targetTenantId);
+            var outerContext =
                     contextWithoutOrigin()
                             .setCommandContext(commandContext)
                             .build();
-            EventContext context =
+            var context =
                     contextWithoutOrigin()
                             .setEventContext(outerContext)
                             .build();
-            Event event = event(context);
+            var event = event(context);
 
             assertThat(event.tenant())
                     .isEqualTo(targetTenantId);
@@ -215,9 +211,9 @@ public class EventTest extends UtilityClassTest<Events> {
     @Test
     @DisplayName("tell if it is a rejection")
     void tellWhenRejection() {
-        TestActorRequestFactory requestFactory = new TestActorRequestFactory(getClass());
-        Command cmd = requestFactory.createCommand(commandMessage());
-        Event event = reject(cmd, new StubRejectionThrowable());
+        var requestFactory = new TestActorRequestFactory(getClass());
+        var cmd = requestFactory.createCommand(commandMessage());
+        var event = reject(cmd, new StubRejectionThrowable());
 
         assertThat(event.isRejection())
                 .isTrue();
@@ -235,29 +231,26 @@ public class EventTest extends UtilityClassTest<Events> {
     @Test
     @DisplayName("clear enrichments from the event and its origin")
     void clearEnrichments() {
-        Enrichment someEnrichment = Enrichment
-                .newBuilder()
+        var someEnrichment = Enrichment.newBuilder()
                 .setDoNotEnrich(true)
                 .build();
-        EventContext.Builder grandOriginContext =
-                context.toBuilder()
-                       .setEnrichment(someEnrichment);
-        EventContext.Builder originContext =
+        var grandOriginContext = context.toBuilder().setEnrichment(someEnrichment);
+        var originContext =
                 contextWithoutOrigin()
                         .setEventContext(grandOriginContext)
                         .setEnrichment(someEnrichment);
-        EventContext eventContext =
+        var eventContext =
                 contextWithoutOrigin()
                         .setEventContext(originContext)
                         .setEnrichment(someEnrichment)
                         .build();
-        Event event = event(eventContext);
+        var event = event(eventContext);
 
-        Event eventWithoutEnrichments = event.clearEnrichments();
+        var eventWithoutEnrichments = event.clearEnrichments();
 
-        EventContext context = eventWithoutEnrichments.getContext();
-        EventContext origin = context.getEventContext();
-        EventContext grandOrigin = origin.getEventContext();
+        var context = eventWithoutEnrichments.getContext();
+        var origin = context.getEventContext();
+        var grandOrigin = origin.getEventContext();
 
         assertThat(context.hasEnrichment()).isFalse();
         assertThat(origin.hasEnrichment()).isFalse();
@@ -268,27 +261,24 @@ public class EventTest extends UtilityClassTest<Events> {
     @Test
     @DisplayName("clear enrichment hierarchy")
     void clearEnrichmentHierarchy() {
-        Enrichment someEnrichment = Enrichment
-                .newBuilder()
+        var someEnrichment = Enrichment.newBuilder()
                 .setDoNotEnrich(true)
                 .build();
-        EventContext.Builder grandOriginContext =
-                context.toBuilder()
-                       .setEnrichment(someEnrichment);
-        EventContext.Builder originContext =
+        var grandOriginContext = context.toBuilder().setEnrichment(someEnrichment);
+        var originContext =
                 contextWithoutOrigin()
                         .setEventContext(grandOriginContext);
-        EventContext context =
+        var context =
                 contextWithoutOrigin()
                         .setEventContext(originContext)
                         .build();
-        Event event = event(context);
+        var event = event(context);
 
-        Event eventWithoutEnrichments = event.clearAllEnrichments();
+        var eventWithoutEnrichments = event.clearAllEnrichments();
 
-        EventContext grandOrigin = eventWithoutEnrichments.getContext()
-                                                          .getEventContext()
-                                                          .getEventContext();
+        var grandOrigin = eventWithoutEnrichments.getContext()
+                                                 .getEventContext()
+                                                 .getEventContext();
         assertThat(grandOrigin.hasEnrichment()).isFalse();
     }
 

--- a/server/src/test/java/io/spine/core/EventsTest.java
+++ b/server/src/test/java/io/spine/core/EventsTest.java
@@ -51,7 +51,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * <p>This test suite is placed under the {@code server} module to avoid dependency on the event
  * generation code which belongs to server-side.
  */
-@DisplayName("Events utility should")
+@DisplayName("`Events` utility should")
 public class EventsTest extends UtilityClassTest<Events> {
 
     private static final TestActorRequestFactory requestFactory =
@@ -65,9 +65,9 @@ public class EventsTest extends UtilityClassTest<Events> {
 
     @BeforeEach
     void setUp() {
-        CommandEnvelope cmd = generate();
-        StringValue producerId = StringValue.of(getClass().getSimpleName());
-        EventFactory eventFactory = EventFactory.on(cmd, Identifier.pack(producerId));
+        var cmd = generate();
+        var producerId = StringValue.of(getClass().getSimpleName());
+        var eventFactory = EventFactory.on(cmd, Identifier.pack(producerId));
         event = eventFactory.createEvent(GivenEvent.message(), null);
     }
 
@@ -78,8 +78,7 @@ public class EventsTest extends UtilityClassTest<Events> {
     @Override
     protected void configure(NullPointerTester tester) {
         super.configure(tester);
-        EntityAlreadyArchived defaultRejectionThrowable = EntityAlreadyArchived
-                .newBuilder()
+        var defaultRejectionThrowable = EntityAlreadyArchived.newBuilder()
                 .setEntityId(Any.getDefaultInstance())
                 .build();
         tester.setDefault(StringValue.class, StringValue.getDefaultInstance())
@@ -92,16 +91,16 @@ public class EventsTest extends UtilityClassTest<Events> {
     @Test
     @DisplayName("provide stringifier for event ID")
     void provideEventIdStringifier() {
-        EventId id = event.getId();
+        var id = event.getId();
 
-        String str = Stringifiers.toString(id);
-        EventId convertedBack = Stringifiers.fromString(str, EventId.class);
+        var str = Stringifiers.toString(id);
+        var convertedBack = Stringifiers.fromString(str, EventId.class);
 
         assertEquals(id, convertedBack);
     }
 
     @Test
-    @DisplayName("provide empty Iterable")
+    @DisplayName("provide empty `Iterable`")
     void provideEmptyIterable() {
         for (Object ignored : nothing()) {
             fail("Something found in nothing().");

--- a/server/src/test/java/io/spine/core/SignalTest.java
+++ b/server/src/test/java/io/spine/core/SignalTest.java
@@ -27,7 +27,6 @@
 package io.spine.core;
 
 import io.spine.base.CommandMessage;
-import io.spine.server.event.EventFactory;
 import io.spine.server.type.EventEnvelope;
 import io.spine.server.type.given.GivenEvent;
 import io.spine.testing.core.given.GivenUserId;
@@ -51,16 +50,16 @@ class SignalTest {
     @Test
     @DisplayName("produce correct origin")
     void produceOrigin() {
-        Event originalEvent = GivenEvent.arbitrary();
-        UserId producerEntityId = GivenUserId.generated();
-        EventFactory factory = on(EventEnvelope.of(originalEvent), pack(producerEntityId));
-        Event derivativeEvent = factory.createEvent(GivenEvent.message(), null);
-        Origin origin = derivativeEvent.getContext().getPastMessage();
+        var originalEvent = GivenEvent.arbitrary();
+        var producerEntityId = GivenUserId.generated();
+        var factory = on(EventEnvelope.of(originalEvent), pack(producerEntityId));
+        var derivativeEvent = factory.createEvent(GivenEvent.message(), null);
+        var origin = derivativeEvent.getContext().getPastMessage();
         assertThat(origin.getMessage())
                 .isEqualTo(originalEvent.messageId());
-        Origin grandOrigin = origin.getGrandOrigin();
-        TypeUrl grandOriginType = TypeUrl.parse(grandOrigin.getMessage()
-                                                           .getTypeUrl());
+        var grandOrigin = origin.getGrandOrigin();
+        var grandOriginType = TypeUrl.parse(grandOrigin.getMessage()
+                                                       .getTypeUrl());
         assertThat(grandOriginType.toJavaClass())
                 .isAssignableTo(CommandMessage.class);
         assertThat(grandOrigin.hasGrandOrigin())

--- a/server/src/test/java/io/spine/core/given/CoreMixinsTestEnv.java
+++ b/server/src/test/java/io/spine/core/given/CoreMixinsTestEnv.java
@@ -47,9 +47,8 @@ public final class CoreMixinsTestEnv {
     }
 
     public static MessageId messageId() {
-        Event event = event();
-        return MessageId
-                .newBuilder()
+        var event = event();
+        return MessageId.newBuilder()
                 .setId(pack(event.getId()))
                 .setTypeUrl(event.typeUrl().value())
                 .setVersion(event.getContext()
@@ -58,9 +57,8 @@ public final class CoreMixinsTestEnv {
     }
 
     public static Command command() {
-        TestActorRequestFactory factory = new TestActorRequestFactory(CoreMixinsTestEnv.class);
-        MixinCreateProject cmdMessage = MixinCreateProject
-                .newBuilder()
+        var factory = new TestActorRequestFactory(CoreMixinsTestEnv.class);
+        var cmdMessage = MixinCreateProject.newBuilder()
                 .setProjectId(newUuid().hashCode())
                 .setName("A Project")
                 .build();
@@ -68,9 +66,8 @@ public final class CoreMixinsTestEnv {
     }
 
     public static Event event() {
-        TestEventFactory factory = TestEventFactory.newInstance(CoreMixinsTestEnv.class);
-        StandardRejections.EntityAlreadyDeleted msg = StandardRejections.EntityAlreadyDeleted
-                .newBuilder()
+        var factory = TestEventFactory.newInstance(CoreMixinsTestEnv.class);
+        var msg = StandardRejections.EntityAlreadyDeleted.newBuilder()
                 .setEntityId(
                         pack(StringValue.of("deleted-entity-id")))
                 .build();

--- a/server/src/test/java/io/spine/server/BoundedContextBuilderTest.java
+++ b/server/src/test/java/io/spine/server/BoundedContextBuilderTest.java
@@ -59,7 +59,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("BoundedContext Builder should")
+@DisplayName("`BoundedContextBuilder` should")
 class BoundedContextBuilderTest {
 
     private BoundedContextBuilder builder;
@@ -83,7 +83,7 @@ class BoundedContextBuilderTest {
         @Test
         @DisplayName("name if it was set")
         void name() {
-            String nameString = getClass().getName();
+            var nameString = getClass().getName();
             assertEquals(nameString, BoundedContext.singleTenant(nameString)
                                                    .name()
                                                    .getValue());
@@ -103,7 +103,7 @@ class BoundedContextBuilderTest {
     class CreateDefault {
 
         @Test
-        @DisplayName("TenantIndex")
+        @DisplayName("`TenantIndex`")
         void tenantIndex() {
             assertNotNull(BoundedContextBuilder.assumingTests(true)
                                                .build()
@@ -112,17 +112,17 @@ class BoundedContextBuilderTest {
         }
 
         @Test
-        @DisplayName("CommandBus and EventBus simultaneously")
+        @DisplayName("`CommandBus` and `EventBus` simultaneously")
         void commandBusAndEventBus() {
-            BoundedContext boundedContext = builder.build();
+            var boundedContext = builder.build();
             assertNotNull(boundedContext.commandBus());
             assertNotNull(boundedContext.eventBus());
         }
 
         @Test
-        @DisplayName("AggregateRootDirectory")
+        @DisplayName("`AggregateRootDirectory`")
         void aggregateRootDirectory() {
-            BoundedContext context = builder.build();
+            var context = builder.build();
             assertNotNull(context.internalAccess()
                                  .aggregateRootDirectory());
         }
@@ -131,7 +131,7 @@ class BoundedContextBuilderTest {
     @Test
     @DisplayName("support multitenancy")
     void supportMultitenancy() {
-        BoundedContextBuilder builder = BoundedContextBuilder.assumingTests(true);
+        var builder = BoundedContextBuilder.assumingTests(true);
         assertTrue(builder.isMultitenant());
     }
 
@@ -140,7 +140,7 @@ class BoundedContextBuilderTest {
     void setTenantIndex() {
         TenantIndex tenantIndex = new StubTenantIndex();
 
-        BoundedContextBuilder builder = BoundedContextBuilder
+        var builder = BoundedContextBuilder
                 .assumingTests()
                 .setTenantIndex(tenantIndex);
 
@@ -258,7 +258,7 @@ class BoundedContextBuilderTest {
         }
 
         @Test
-        @DisplayName("register repository if it's passed as command dispatcher")
+        @DisplayName("register repository if it's passed as a command dispatcher")
         void registerRepo() {
             assertFalse(builder.hasRepository(repository));
             builder.addCommandDispatcher(repository);
@@ -266,7 +266,7 @@ class BoundedContextBuilderTest {
         }
 
         @Test
-        @DisplayName("remove registered repository if it's passed as command dispatcher")
+        @DisplayName("remove registered repository if it's passed as a command dispatcher")
         void removeRegisteredRepo() {
             builder.add(repository);
             assertTrue(builder.hasRepository(repository));
@@ -276,7 +276,7 @@ class BoundedContextBuilderTest {
         }
 
         @Test
-        @DisplayName("check repository presence in Builder if it's queried as command dispatcher")
+        @DisplayName("check repository presence if it's queried as a command dispatcher")
         void checkHasRepo() {
             builder.add(repository);
             assertTrue(builder.hasCommandDispatcher(repository));
@@ -337,7 +337,7 @@ class BoundedContextBuilderTest {
         }
 
         @Test
-        @DisplayName("check repository presence in Builder if it's queried as event dispatcher")
+        @DisplayName("check repository presence if it's queried as an event dispatcher")
         void checkHasRepo() {
             builder.add(repository);
             assertTrue(builder.hasEventDispatcher(repository));

--- a/server/src/test/java/io/spine/server/BoundedContextTest.java
+++ b/server/src/test/java/io/spine/server/BoundedContextTest.java
@@ -45,16 +45,12 @@ import io.spine.server.bc.given.SecretProjectRepository;
 import io.spine.server.bc.given.TestEventSubscriber;
 import io.spine.server.entity.Entity;
 import io.spine.server.entity.Repository;
-import io.spine.server.stand.Stand;
 import io.spine.system.server.SystemClient;
 import io.spine.system.server.SystemContext;
 import io.spine.test.bc.Project;
-import io.spine.test.bc.ProjectId;
 import io.spine.test.bc.SecretProject;
 import io.spine.testing.logging.Interceptor;
-import io.spine.testing.logging.LogRecordSubject;
 import io.spine.testing.server.model.ModelTests;
-import io.spine.type.TypeUrl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -65,7 +61,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.List;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.logging.Level;
@@ -74,6 +69,7 @@ import java.util.stream.Stream;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static io.spine.core.BoundedContextNames.newName;
+import static io.spine.testing.TestValues.nullRef;
 import static io.spine.testing.TestValues.randomString;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -84,12 +80,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>Messages used in this test suite are defined in:
  * <ul>
- *     <li>spine/test/bc/project.proto - data types
- *     <li>spine/test/bc/command_factory_test.proto — commands
- *     <li>spine/test/bc/events.proto — events.
+ *     <li>{@code spine/test/bc/project.proto} - data types
+ *     <li>{@code spine/test/bc/commands.proto} — commands
+ *     <li>{@code spine/test/bc/events.proto} — events.
  * </ul>
  */
-@DisplayName("BoundedContext should")
+@DisplayName("`BoundedContext` should")
 class BoundedContextTest {
 
     private final TestEventSubscriber subscriber = new TestEventSubscriber();
@@ -126,20 +122,20 @@ class BoundedContextTest {
     class Return {
 
         @Test
-        @DisplayName("EventBus")
+        @DisplayName("`EventBus`")
         void eventBus() {
             assertNotNull(context.eventBus());
         }
 
         @Test
-        @DisplayName("IntegrationBroker")
+        @DisplayName("`IntegrationBroker`")
         void integrationBroker() {
             assertNotNull(context.internalAccess()
                                  .broker());
         }
 
         @Test
-        @DisplayName("CommandDispatcher")
+        @DisplayName("`CommandDispatcher`")
         void commandDispatcher() {
             assertNotNull(context.commandBus());
         }
@@ -147,7 +143,7 @@ class BoundedContextTest {
         @Test
         @DisplayName("multitenancy state")
         void ifSetMultitenant() {
-            BoundedContext bc = BoundedContextBuilder.assumingTests(true).build();
+            var bc = BoundedContextBuilder.assumingTests(true).build();
             assertTrue(bc.isMultitenant());
         }
     }
@@ -157,19 +153,19 @@ class BoundedContextTest {
     class Register {
 
         @Test
-        @DisplayName("AggregateRepository")
+        @DisplayName("`AggregateRepository`")
         void aggregateRepository() {
             registerAndAssertRepository(ProjectAggregate.class);
         }
 
         @Test
-        @DisplayName("ProcessManagerRepository")
+        @DisplayName("`ProcessManagerRepository`")
         void processManagerRepository() {
             registerAndAssertRepository(ProjectProcessManager.class);
         }
 
         @Test
-        @DisplayName("ProjectionRepository")
+        @DisplayName("`ProjectionRepository`")
         void projectionRepository() {
             registerAndAssertRepository(ProjectReport.class);
         }
@@ -180,7 +176,7 @@ class BoundedContextTest {
         }
 
         @Test
-        @DisplayName("DefaultRepository via passed entity class")
+        @DisplayName("`DefaultRepository` via passed entity class")
         void entityClass() {
             context.register(ProjectAggregate.class);
             assertTrue(context.hasEntitiesOfType(ProjectAggregate.class));
@@ -232,14 +228,14 @@ class BoundedContextTest {
     }
 
     @Test
-    @DisplayName("propagate registered repositories to Stand")
+    @DisplayName("propagate registered repositories to `Stand`")
     void propagateRepositoriesToStand() {
-        BoundedContext context = BoundedContextBuilder.assumingTests().build();
-        Stand stand = context.stand();
+        var context = BoundedContextBuilder.assumingTests().build();
+        var stand = context.stand();
 
-        Repository<ProjectId, ProjectAggregate> repo =
+        var repo =
                 DefaultRepository.of(ProjectAggregate.class);
-        TypeUrl stateType = repo.entityStateType();
+        var stateType = repo.entityStateType();
 
         assertThat(stand.exposedTypes())
                 .doesNotContain(stateType);
@@ -276,6 +272,7 @@ class BoundedContextTest {
      * </ul>
      * All of the returned repositories manage entities of the same state type.
      */
+    @SuppressWarnings("unused") /* A method source. */
     private static Stream<Arguments> sameStateRepositories() {
         Set<Repository<?, ?>> repositories =
                 ImmutableSet.of(DefaultRepository.of(ProjectAggregate.class),
@@ -287,9 +284,9 @@ class BoundedContextTest {
                                 DefaultRepository.of(FinishedProjectProjection.class),
                                 DefaultRepository.of(ProjectRemovalProcman.class));
 
-        Set<List<Repository<?, ?>>> cartesianProduct =
+        var cartesianProduct =
                 Sets.cartesianProduct(repositories, sameStateRepositories);
-        Stream<Arguments> result =
+        var result =
                 cartesianProduct.stream()
                                 .map(repos -> Arguments.of(repos.get(0), repos.get(1)));
         return result;
@@ -298,8 +295,7 @@ class BoundedContextTest {
     @Test
     @DisplayName("assign storage during registration if repository does not have one")
     void setStorageOnRegister() {
-        Repository<ProjectId, ProjectAggregate> repository =
-                DefaultRepository.of(ProjectAggregate.class);
+        var repository = DefaultRepository.of(ProjectAggregate.class);
         context.register(repository);
         assertTrue(repository.storageAssigned());
     }
@@ -311,7 +307,7 @@ class BoundedContextTest {
         private BoundedContext context;
 
         @Test
-        @DisplayName("CommandBus")
+        @DisplayName("`CommandBus`")
         void toCommandBus() {
             context = multiTenant();
             assertMultitenancyEqual(context::isMultitenant, context.commandBus()::isMultitenant);
@@ -321,7 +317,7 @@ class BoundedContextTest {
         }
 
         @Test
-        @DisplayName("Stand")
+        @DisplayName("`Stand`")
         void toStand() {
             context = multiTenant();
 
@@ -370,7 +366,7 @@ class BoundedContextTest {
     }
 
     @Test
-    @DisplayName("throw ISE when obtaining a repository for non-registered entity state class")
+    @DisplayName("throw `ISE` when obtaining a repository for non-registered entity state class")
     void throwOnNoRepoRegistered() {
         // Attempt to get a repository without registering.
         assertThrows(IllegalStateException.class,
@@ -391,17 +387,17 @@ class BoundedContextTest {
     }
 
     @Test
-    @DisplayName("prohibit 3rd party descendants")
+    @DisplayName("prohibit 3rd-party descendants")
     void noExternalDescendants() {
         assertThrows(
                 IllegalStateException.class,
                 () ->
                 new BoundedContext(BoundedContextBuilder.assumingTests()) {
-                    @SuppressWarnings("ReturnOfNull") // OK for this test dummy.
+
                     @Internal
                     @Override
                     public SystemClient systemClient() {
-                        return null;
+                        return nullRef();
                     }
                 }
         );
@@ -420,9 +416,7 @@ class BoundedContextTest {
 
         @BeforeEach
         void closeContext() throws Exception {
-            BoundedContext context =
-                    BoundedContext.singleTenant(contextName.getValue())
-                                  .build();
+            var context = BoundedContext.singleTenant(contextName.getValue()).build();
             domainInterceptor = new Interceptor(DomainContext.class, debugLevel);
             domainInterceptor.intercept();
             systemInterceptor = new Interceptor(SystemContext.class, debugLevel);
@@ -440,9 +434,7 @@ class BoundedContextTest {
         @Test
         @DisplayName("log its closing")
         void logClosing() {
-            LogRecordSubject assertDomainLog =
-                    domainInterceptor.assertLog()
-                                     .record();
+            var assertDomainLog = domainInterceptor.assertLog().record();
             assertDomainLog.hasLevelThat()
                            .isEqualTo(debugLevel);
             assertDomainLog.hasMessageThat()
@@ -452,9 +444,7 @@ class BoundedContextTest {
         @Test
         @DisplayName("close its System context")
         void closeSystem() {
-            LogRecordSubject assertSystemLog =
-                    systemInterceptor.assertLog()
-                                     .record();
+            var assertSystemLog = systemInterceptor.assertLog().record();
             assertSystemLog.hasLevelThat()
                            .isEqualTo(debugLevel);
             assertSystemLog.hasMessageThat()
@@ -465,7 +455,7 @@ class BoundedContextTest {
     @Test
     @DisplayName("return its name in `toString()`")
     void stringForm() {
-        String name = randomString();
+        var name = randomString();
 
         assertThat(BoundedContext.singleTenant(name)
                                  .build()

--- a/server/src/test/java/io/spine/server/EnvSettingTest.java
+++ b/server/src/test/java/io/spine/server/EnvSettingTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
@@ -75,7 +74,7 @@ class EnvSettingTest {
         @DisplayName("using the `null` as the env value")
         @SuppressWarnings("ThrowableNotThrown")
         void forEnv() {
-            EnvSetting<StorageFactory> setting = new EnvSetting<>();
+            var setting = new EnvSetting<StorageFactory>();
             assertNpe(() -> setting.use(InMemoryStorageFactory.newInstance(), null));
         }
 
@@ -111,8 +110,8 @@ class EnvSettingTest {
         }
 
         private void testReturnsForEnv(Class<? extends EnvironmentType> type) {
-            InMemoryStorageFactory factory = InMemoryStorageFactory.newInstance();
-            EnvSetting<StorageFactory> storageFactory = new EnvSetting<>();
+            var factory = InMemoryStorageFactory.newInstance();
+            var storageFactory = new EnvSetting<StorageFactory>();
             storageFactory.use(factory, type);
             assertThat(storageFactory.optionalValue(type))
                     .isPresent();
@@ -161,19 +160,19 @@ class EnvSettingTest {
             }
 
             void testAssignsDefaultForEnv(Class<? extends EnvironmentType> type) {
-                MemoizingStorageFactory memoizingFactory = new MemoizingStorageFactory();
-                EnvSetting<StorageFactory> storageFactory =
-                        new EnvSetting<>(type, () -> memoizingFactory);
+                var memoizingFactory = new MemoizingStorageFactory();
+                var storageFactory =
+                        new EnvSetting<StorageFactory>(type, () -> memoizingFactory);
                 assertThat(storageFactory.value(type))
                         .isSameInstanceAs(memoizingFactory);
             }
 
             void testRetainsDefaultForEnv(Class<? extends EnvironmentType> type) {
-                MemoizingStorageFactory defaultFactory = new MemoizingStorageFactory();
-                EnvSetting<StorageFactory> storageFactory =
-                        new EnvSetting<>(type, () -> defaultFactory);
+                var defaultFactory = new MemoizingStorageFactory();
+                var storageFactory =
+                        new EnvSetting<StorageFactory>(type, () -> defaultFactory);
 
-                MemoizingStorageFactory actualFactory = new MemoizingStorageFactory();
+                var actualFactory = new MemoizingStorageFactory();
                 storageFactory.use(actualFactory, type);
 
                 assertThat(storageFactory.value(type)).isSameInstanceAs(actualFactory);
@@ -204,16 +203,16 @@ class EnvSettingTest {
         }
 
         private void testLazyForEnv(Class<? extends EnvironmentType> type) {
-            InMemoryStorageFactory factory = InMemoryStorageFactory.newInstance();
-            EnvSetting<StorageFactory> storageFactory = new EnvSetting<>();
-            AtomicBoolean resolved = new AtomicBoolean(false);
+            var factory = InMemoryStorageFactory.newInstance();
+            var storageFactory = new EnvSetting<StorageFactory>();
+            var resolved = new AtomicBoolean(false);
             storageFactory.lazyUse(() -> {
                 resolved.set(true);
                 return factory;
             }, type);
             assertThat(resolved.get()).isFalse();
 
-            Optional<StorageFactory> actual = storageFactory.optionalValue(type);
+            var actual = storageFactory.optionalValue(type);
             assertThat(actual)
                     .isPresent();
             assertThat(resolved.get()).isTrue();
@@ -224,11 +223,11 @@ class EnvSettingTest {
     @Test
     @DisplayName("reset the value for all environments")
     void resetTheValues() {
-        InMemoryStorageFactory prodStorageFactory = InMemoryStorageFactory.newInstance();
-        MemoizingStorageFactory testingStorageFactory = new MemoizingStorageFactory();
-        InMemoryStorageFactory localStorageFactory = InMemoryStorageFactory.newInstance();
+        var prodStorageFactory = InMemoryStorageFactory.newInstance();
+        var testingStorageFactory = new MemoizingStorageFactory();
+        var localStorageFactory = InMemoryStorageFactory.newInstance();
 
-        EnvSetting<StorageFactory> storageFactory = new EnvSetting<>();
+        var storageFactory = new EnvSetting<StorageFactory>();
         storageFactory.use(prodStorageFactory, Production.class);
         storageFactory.use(testingStorageFactory, Tests.class);
         storageFactory.use(localStorageFactory, Local.class);
@@ -243,9 +242,9 @@ class EnvSettingTest {
     @Test
     @DisplayName("run an operation against a value if it's present")
     void runThrowableConsumer() throws Exception {
-        MemoizingStorageFactory storageFactory = new MemoizingStorageFactory();
+        var storageFactory = new MemoizingStorageFactory();
 
-        EnvSetting<StorageFactory> storageSetting = new EnvSetting<>();
+        var storageSetting = new EnvSetting<StorageFactory>();
 
         storageSetting.use(storageFactory, Production.class);
         storageSetting.ifPresentForEnvironment(Production.class, AutoCloseable::close);
@@ -256,11 +255,11 @@ class EnvSettingTest {
     @Test
     @DisplayName("run an operation for all present values")
     void runOperationForAll() throws Exception {
-        MemoizingStorageFactory prodStorageFactory = new MemoizingStorageFactory();
-        MemoizingStorageFactory testingStorageFactory = new MemoizingStorageFactory();
-        MemoizingStorageFactory localStorageFactory = new MemoizingStorageFactory();
+        var prodStorageFactory = new MemoizingStorageFactory();
+        var testingStorageFactory = new MemoizingStorageFactory();
+        var localStorageFactory = new MemoizingStorageFactory();
 
-        EnvSetting<StorageFactory> storageSetting = new EnvSetting<>();
+        var storageSetting = new EnvSetting<StorageFactory>();
 
         storageSetting.use(prodStorageFactory, Production.class);
         storageSetting.use(testingStorageFactory, Tests.class);
@@ -271,6 +270,5 @@ class EnvSettingTest {
         assertThat(prodStorageFactory.isClosed()).isTrue();
         assertThat(testingStorageFactory.isClosed()).isTrue();
         assertThat(localStorageFactory.isClosed()).isTrue();
-
     }
 }

--- a/server/src/test/java/io/spine/server/Given.java
+++ b/server/src/test/java/io/spine/server/Given.java
@@ -72,7 +72,6 @@ import io.spine.test.subscriptionservice.command.SendReport;
 import io.spine.test.subscriptionservice.event.ReportSent;
 import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.testing.core.given.GivenUserId;
-import io.spine.time.LocalDate;
 import io.spine.time.Now;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -96,20 +95,20 @@ public class Given {
 
         static AggTaskAdded taskAdded(ProjectId id) {
             return AggTaskAdded.newBuilder()
-                               .setProjectId(id)
-                               .build();
+                    .setProjectId(id)
+                    .build();
         }
 
         static AggProjectCreated projectCreated(ProjectId id) {
             return AggProjectCreated.newBuilder()
-                                    .setProjectId(id)
-                                    .build();
+                    .setProjectId(id)
+                    .build();
         }
 
         static AggProjectStarted projectStarted(ProjectId id) {
             return AggProjectStarted.newBuilder()
-                                    .setProjectId(id)
-                                    .build();
+                    .setProjectId(id)
+                    .build();
         }
     }
 
@@ -119,15 +118,13 @@ public class Given {
         }
 
         public static AggCreateProject createProject(ProjectId id) {
-            return AggCreateProject
-                    .newBuilder()
+            return AggCreateProject.newBuilder()
                     .setProjectId(id)
                     .build();
         }
 
         public static SendReport sendReport() {
-            return SendReport
-                    .newBuilder()
+            return SendReport.newBuilder()
                     .setId(ReportId.generate())
                     .vBuild();
         }
@@ -152,12 +149,11 @@ public class Given {
         private static Command create(io.spine.base.CommandMessage command,
                                       UserId userId,
                                       Timestamp when) {
-            TenantId generatedTenantId = TenantId.newBuilder()
-                                                 .setValue(newUuid())
-                                                 .build();
-            TestActorRequestFactory factory =
-                    new TestActorRequestFactory(userId, generatedTenantId);
-            Command result = factory.createCommand(command, when);
+            var generatedTenantId = TenantId.newBuilder()
+                    .setValue(newUuid())
+                    .build();
+            var factory = new TestActorRequestFactory(userId, generatedTenantId);
+            var result = factory.createCommand(command, when);
             return result;
         }
 
@@ -170,37 +166,32 @@ public class Given {
         }
 
         private static Command createProject(UserId userId, ProjectId projectId, Timestamp when) {
-            AggCreateProject command = CommandMessage.createProject(projectId);
+            var command = CommandMessage.createProject(projectId);
             return create(command, userId, when);
         }
 
         static Command createCustomer() {
-            LocalDate localDate = Now.get()
-                                     .asLocalDate();
-            CustomerId customerId = CustomerId
-                    .newBuilder()
+            var localDate = Now.get().asLocalDate();
+            var customerId = CustomerId.newBuilder()
                     .setRegistrationDate(localDate)
                     .setNumber(customerNumber.get())
                     .build();
             customerNumber.incrementAndGet();
-            PersonName personName = PersonName
-                    .newBuilder()
+            var personName = PersonName.newBuilder()
                     .setGivenName("Kreat")
                     .setFamilyName("C'Ustomer")
                     .setHonorificSuffix("Cmd")
                     .build();
-            Customer customer = Customer
-                    .newBuilder()
+            var customer = Customer.newBuilder()
                     .setId(customerId)
                     .setName(personName)
                     .build();
-            io.spine.base.CommandMessage msg = CreateCustomer
-                    .newBuilder()
+            io.spine.base.CommandMessage msg = CreateCustomer.newBuilder()
                     .setCustomerId(customerId)
                     .setCustomer(customer)
                     .build();
-            UserId userId = GivenUserId.of(Identifier.newUuid());
-            Command result = create(msg, userId, currentTime());
+            var userId = GivenUserId.of(Identifier.newUuid());
+            var result = create(msg, userId, currentTime());
             return result;
         }
 
@@ -219,14 +210,14 @@ public class Given {
 
         static Query readAllProjects() {
             // DO NOT replace the type name with another Project class.
-            Query result = requestFactory.query()
-                                         .all(io.spine.test.projection.Project.class);
+            var result = requestFactory.query()
+                                       .all(io.spine.test.projection.Project.class);
             return result;
         }
 
         static Query readUnknownType() {
-            Query result = requestFactory.query()
-                                         .all(Task.class);
+            var result = requestFactory.query()
+                                       .all(Task.class);
             return result;
         }
     }
@@ -260,7 +251,7 @@ public class Given {
 
         @Assign
         List<AggProjectStarted> handle(AggStartProject cmd, CommandContext ctx) {
-            AggProjectStarted message = EventMessage.projectStarted(cmd.getProjectId());
+            var message = EventMessage.projectStarted(cmd.getProjectId());
             return ImmutableList.of(message);
         }
 
@@ -341,8 +332,7 @@ public class Given {
 
         @Assign
         CustomerCreated handle(CreateCustomer cmd, CommandContext ctx) {
-            CustomerCreated event = CustomerCreated
-                    .newBuilder()
+            var event = CustomerCreated.newBuilder()
                     .setCustomerId(cmd.getCustomerId())
                     .setCustomer(cmd.getCustomer())
                     .build();
@@ -360,6 +350,8 @@ public class Given {
      ***************************************************/
 
     static final String PROJECTS_CONTEXT_NAME = "Projects";
+
+    static final String CUSTOMERS_CONTEXT_NAME = "Customers";
 
     static class ProjectDetailsRepository
             extends ProjectionRepository<io.spine.test.projection.ProjectId,

--- a/server/src/test/java/io/spine/server/GrpcContainerTest.java
+++ b/server/src/test/java/io/spine/server/GrpcContainerTest.java
@@ -25,9 +25,7 @@
  */
 package io.spine.server;
 
-import com.google.common.collect.ImmutableSet;
 import io.grpc.BindableService;
-import io.grpc.Server;
 import io.grpc.ServerServiceDefinition;
 import io.spine.server.given.transport.TestGrpcServer;
 import io.spine.testing.logging.mute.MuteLogging;
@@ -57,8 +55,7 @@ class GrpcContainerTest {
 
     @BeforeEach
     void setUp() {
-        grpcContainer = GrpcContainer.inProcess(randomString())
-                                     .build();
+        grpcContainer = GrpcContainer.inProcess(randomString()).build();
         grpcContainer.injectServer(new TestGrpcServer());
     }
 
@@ -66,20 +63,20 @@ class GrpcContainerTest {
     @Test
     @DisplayName("add and remove parameters from builder")
     void setParamsInBuilder() {
-        int port = 60;
-        GrpcContainer.Builder builder = GrpcContainer
+        var port = 60;
+        var builder = GrpcContainer
                 .atPort(port);
 
         assertThat(builder.port()).hasValue(port);
 
-        int count = 3;
-        for (int i = 0; i < count; i++) {
+        var count = 3;
+        for (var i = 0; i < count; i++) {
             BindableService service = CommandService.newBuilder()
                                                     .build();
             builder.addService(service);
         }
 
-        ImmutableSet<ServerServiceDefinition> services = builder.services();
+        var services = builder.services();
 
         // Perform removal and check that the return value is builder itself.
         assertEquals(builder, builder.removeService(services.iterator().next()));
@@ -87,7 +84,7 @@ class GrpcContainerTest {
         Set<ServerServiceDefinition> serviceSet = builder.services();
         assertThat(serviceSet).hasSize(count - 1);
 
-        GrpcContainer container = builder.build();
+        var container = builder.build();
         assertNotNull(container);
     }
 
@@ -114,7 +111,7 @@ class GrpcContainerTest {
     void shutdownItself() throws IOException {
         grpcContainer.start();
 
-        Server server = grpcContainer.grpcServer();
+        var server = grpcContainer.grpcServer();
         grpcContainer.shutdown();
 
         assertThat(server.isShutdown())
@@ -136,8 +133,7 @@ class GrpcContainerTest {
     @MuteLogging
     @DisplayName("stop properly upon application shutdown")
     void stopUponAppShutdown() throws IOException {
-        GrpcContainer container = GrpcContainer.inProcess(randomString())
-                                               .build();
+        var container = GrpcContainer.inProcess(randomString()).build();
         container.addShutdownHook();
 
         container.start();
@@ -148,7 +144,7 @@ class GrpcContainerTest {
     }
 
     @Nested
-    @DisplayName("throw ISE if performing")
+    @DisplayName("throw `ISE` if performing")
     class NotPerformTwice {
 
         @Test

--- a/server/src/test/java/io/spine/server/GrpcContainerTest.java
+++ b/server/src/test/java/io/spine/server/GrpcContainerTest.java
@@ -64,15 +64,13 @@ class GrpcContainerTest {
     @DisplayName("add and remove parameters from builder")
     void setParamsInBuilder() {
         var port = 60;
-        var builder = GrpcContainer
-                .atPort(port);
+        var builder = GrpcContainer.atPort(port);
 
         assertThat(builder.port()).hasValue(port);
 
         var count = 3;
         for (var i = 0; i < count; i++) {
-            BindableService service = CommandService.newBuilder()
-                                                    .build();
+            var service = CommandService.newBuilder().build();
             builder.addService(service);
         }
 

--- a/server/src/test/java/io/spine/server/QueryServiceTest.java
+++ b/server/src/test/java/io/spine/server/QueryServiceTest.java
@@ -69,8 +69,8 @@ class QueryServiceTest {
 
     @AfterEach
     void tearDown() throws Exception {
-        for (var boundedContext : boundedContexts) {
-            boundedContext.close();
+        for (var c : boundedContexts) {
+            c.close();
         }
     }
 

--- a/server/src/test/java/io/spine/server/ServerEnvironmentConfigTest.java
+++ b/server/src/test/java/io/spine/server/ServerEnvironmentConfigTest.java
@@ -77,9 +77,9 @@ class ServerEnvironmentConfigTest {
     }
 
     @Test
-    @DisplayName("reject `null` arguments")
+    @DisplayName("its parts rejecting `null` arguments")
     void nullCheck() {
-        ServerEnvironment.TypeConfigurator configurator = when(Tests.class);
+        var configurator = when(Tests.class);
         new NullPointerTester().testAllPublicInstanceMethods(configurator);
     }
 
@@ -154,7 +154,7 @@ class ServerEnvironmentConfigTest {
             @Test
             @DisplayName("returning a configured instance")
             void ok() {
-                InMemoryTransportFactory factory = InMemoryTransportFactory.newInstance();
+                var factory = InMemoryTransportFactory.newInstance();
                 when(Local.class).use(factory);
                 assertValue(factory);
             }
@@ -164,7 +164,7 @@ class ServerEnvironmentConfigTest {
         @DisplayName("via function")
         void viaFn() {
             TransportFactory factory = new StubTransportFactory();
-            ReturnValue<TransportFactory> fn = new ReturnValue<>(factory);
+            var fn = new ReturnValue<>(factory);
 
             when(Tests.class).useTransportFactory(fn);
 
@@ -200,14 +200,14 @@ class ServerEnvironmentConfigTest {
         @Test
         @DisplayName("to default back to `Local` if no delivery is set")
         void defaultsToLocal() {
-            Delivery delivery = serverEnvironment.delivery();
+            var delivery = serverEnvironment.delivery();
             assertThat(delivery).isNotNull();
         }
 
         @Test
         @DisplayName("to a custom mechanism")
         void customValue() {
-            Delivery customDelivery = customDelivery();
+            var customDelivery = customDelivery();
             when(currentType).use(customDelivery);
 
             assertValue(customDelivery);
@@ -216,8 +216,8 @@ class ServerEnvironmentConfigTest {
         @Test
         @DisplayName("via a function")
         void viaFn() {
-            Delivery valueFromFunction = customDelivery();
-            ReturnValue<Delivery> fn = new ReturnValue<>(valueFromFunction);
+            var valueFromFunction = customDelivery();
+            var fn = new ReturnValue<>(valueFromFunction);
             when(currentType).useDelivery(fn);
 
             assertValue(valueFromFunction);
@@ -227,8 +227,8 @@ class ServerEnvironmentConfigTest {
 
         private Delivery customDelivery() {
             return Delivery.newBuilder()
-                           .setStrategy(UniformAcrossAllShards.forNumber(42))
-                           .build();
+                    .setStrategy(UniformAcrossAllShards.forNumber(42))
+                    .build();
         }
     }
 
@@ -316,7 +316,7 @@ class ServerEnvironmentConfigTest {
         @DisplayName("via a function")
         void viaFn() {
             TracerFactory factory = new MemoizingTracerFactory();
-            ReturnValue<TracerFactory> fn = new ReturnValue<>(factory);
+            var fn = new ReturnValue<>(factory);
 
             when(Tests.class).useTracerFactory(fn);
             assertTracer(factory);
@@ -334,7 +334,7 @@ class ServerEnvironmentConfigTest {
         }
 
         private void assertDelegateIs(StorageFactory factory) {
-            StorageFactory delegate = systemAwareFactory().delegate();
+            var delegate = systemAwareFactory().delegate();
             assertThat(delegate)
                     .isEqualTo(factory);
         }
@@ -367,10 +367,10 @@ class ServerEnvironmentConfigTest {
             void testsFactory() {
                 environment.setTo(Tests.class);
 
-                StorageFactory factory = serverEnvironment.storageFactory();
+                var factory = serverEnvironment.storageFactory();
                 assertThat(factory)
                         .isInstanceOf(SystemAwareStorageFactory.class);
-                StorageFactory delegate = systemAwareFactory().delegate();
+                var delegate = systemAwareFactory().delegate();
                 assertThat(delegate)
                         .isInstanceOf(InMemoryStorageFactory.class);
             }
@@ -408,7 +408,7 @@ class ServerEnvironmentConfigTest {
             @Test
             @DisplayName("returning a configured wrapped instance")
             void returnConfiguredStorageFactory() {
-                InMemoryStorageFactory inMemory = InMemoryStorageFactory.newInstance();
+                var inMemory = InMemoryStorageFactory.newInstance();
                 when(Local.class).use(inMemory);
 
                 assertDelegateIs(inMemory);
@@ -419,7 +419,7 @@ class ServerEnvironmentConfigTest {
         @DisplayName("via a function")
         void viaFn() {
             StorageFactory factory = new MemoizingStorageFactory();
-            ReturnValue<StorageFactory> fn = new ReturnValue<>(factory);
+            var fn = new ReturnValue<>(factory);
 
             when(Tests.class).useStorageFactory(fn);
 

--- a/server/src/test/java/io/spine/server/ServerEnvironmentTest.java
+++ b/server/src/test/java/io/spine/server/ServerEnvironmentTest.java
@@ -72,11 +72,11 @@ class ServerEnvironmentTest {
     @Test
     @DisplayName("allow to customize delivery mechanism")
     void allowToCustomizeDeliveryStrategy() {
-        Delivery newDelivery = Delivery.newBuilder()
-                                       .setStrategy(UniformAcrossAllShards.forNumber(42))
-                                       .build();
-        ServerEnvironment environment = serverEnvironment;
-        Delivery defaultValue = environment.delivery();
+        var newDelivery = Delivery.newBuilder()
+                .setStrategy(UniformAcrossAllShards.forNumber(42))
+                .build();
+        var environment = serverEnvironment;
+        var defaultValue = environment.delivery();
         ServerEnvironment.when(Tests.class)
                          .use(newDelivery);
         assertEquals(newDelivery, environment.delivery());

--- a/server/src/test/java/io/spine/server/StatusesTest.java
+++ b/server/src/test/java/io/spine/server/StatusesTest.java
@@ -28,7 +28,6 @@ package io.spine.server;
 
 import com.google.common.testing.NullPointerTester;
 import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 import io.spine.base.Error;
 import io.spine.grpc.MetadataConverter;
 import io.spine.server.event.UnsupportedEventException;
@@ -60,12 +59,11 @@ class StatusesTest extends UtilityClassTest<Statuses> {
     @Test
     @DisplayName("create invalid argument status exception")
     void createInvalidArgumentStatusEx() {
-        MessageError rejection =
-                new UnsupportedEventException(Sample.messageOfType(ProjectCreated.class));
-        StatusRuntimeException statusRuntimeEx = invalidArgumentWithCause(rejection);
+        var rejection = new UnsupportedEventException(Sample.messageOfType(ProjectCreated.class));
+        var statusRuntimeEx = invalidArgumentWithCause(rejection);
         @SuppressWarnings("OptionalGetWithoutIsPresent")
-        Error actualError = MetadataConverter.toError(statusRuntimeEx.getTrailers())
-                                             .get();
+        var actualError = MetadataConverter.toError(statusRuntimeEx.getTrailers())
+                                           .get();
         assertEquals(Status.INVALID_ARGUMENT.getCode(), statusRuntimeEx.getStatus()
                                                                        .getCode());
         assertEquals(rejection, statusRuntimeEx.getCause());

--- a/server/src/test/java/io/spine/server/VisibilityGuardTest.java
+++ b/server/src/test/java/io/spine/server/VisibilityGuardTest.java
@@ -44,7 +44,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Set;
 
 import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -56,11 +55,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * See `client/spine/test/option/entity_options_should.proto` for definition of messages
  * used for aggregates and repositories in this test.
  */
-@DisplayName("VisibilityGuard should")
+@DisplayName("`VisibilityGuard` should")
 class VisibilityGuardTest {
 
     private VisibilityGuard guard;
-    private List<Repository> repositories;
+    private List<Repository<?, ?>> repositories;
     private BoundedContext boundedContext;
 
     @BeforeEach
@@ -74,7 +73,7 @@ class VisibilityGuardTest {
         register(new HiddenRepository());
     }
 
-    private void register(Repository repository) {
+    private void register(Repository<?, ?> repository) {
         guard.register(repository);
         repositories.add(repository);
     }
@@ -114,15 +113,15 @@ class VisibilityGuardTest {
     @Test
     @DisplayName("obtain repos by visibility")
     void obtainByVisibility() {
-        Set<TypeName> full = guard.entityStateTypes(Visibility.FULL);
+        var full = guard.entityStateTypes(Visibility.FULL);
         assertEquals(1, full.size());
         assertTrue(full.contains(TypeName.of(FullAccessAggregate.class)));
 
-        Set<TypeName> subscribable = guard.entityStateTypes(Visibility.SUBSCRIBE);
+        var subscribable = guard.entityStateTypes(Visibility.SUBSCRIBE);
         assertEquals(1, subscribable.size());
         assertTrue(subscribable.contains(TypeName.of(SubscribableAggregate.class)));
 
-        Set<TypeName> hidden = guard.entityStateTypes(Visibility.NONE);
+        var hidden = guard.entityStateTypes(Visibility.NONE);
         assertEquals(1, hidden.size());
         assertTrue(hidden.contains(TypeName.of(HiddenAggregate.class)));
     }
@@ -132,7 +131,7 @@ class VisibilityGuardTest {
     void shutdownRepositories() {
         guard.shutDownRepositories();
 
-        for (Repository repository : repositories) {
+        for (var repository : repositories) {
             assertFalse(repository.isOpen());
         }
     }

--- a/server/src/test/java/io/spine/server/aggregate/AggregateCommandEndpointTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateCommandEndpointTest.java
@@ -45,15 +45,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
-
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
 import static io.spine.server.aggregate.given.Given.ACommand.addTask;
 import static io.spine.server.aggregate.given.Given.ACommand.createProject;
 import static io.spine.server.aggregate.given.Given.ACommand.startProject;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("AggregateCommandEndpoint should")
+@DisplayName("`AggregateCommandEndpoint` should")
 class AggregateCommandEndpointTest {
 
     private BoundedContext context;
@@ -88,10 +86,10 @@ class AggregateCommandEndpointTest {
     @Test
     @DisplayName("post events on command dispatching")
     void postEventsOnCommandDispatching() {
-        CommandEnvelope cmd = CommandEnvelope.of(createProject(projectId));
+        var cmd = CommandEnvelope.of(createProject(projectId));
 
         repository.dispatch(cmd);
-        AggProjectCreated msg = subscriber.remembered;
+        var msg = subscriber.remembered;
         assertThat(msg.getProjectId())
                 .isEqualTo(projectId);
     }
@@ -99,14 +97,14 @@ class AggregateCommandEndpointTest {
     @Test
     @DisplayName("store aggregate on command dispatching")
     void storeAggregateOnCommandDispatching() {
-        CommandEnvelope cmd = CommandEnvelope.of(createProject(projectId));
-        AggCreateProject msg = (AggCreateProject) cmd.message();
+        var cmd = CommandEnvelope.of(createProject(projectId));
+        var msg = (AggCreateProject) cmd.message();
 
         repository.dispatch(cmd);
-        Optional<ProjectAggregate> optional = repository.find(projectId);
+        var optional = repository.find(projectId);
         assertTrue(optional.isPresent());
 
-        ProjectAggregate aggregate = optional.get();
+        var aggregate = optional.get();
         assertThat(aggregate.id()).isEqualTo(projectId);
 
         Truth.assertThat(aggregate.state().getName())
@@ -134,7 +132,7 @@ class AggregateCommandEndpointTest {
     @SuppressWarnings("CheckReturnValue")
     // ignore ID of the aggregate returned by the repository
     private void assertDispatches(Command cmd) {
-        CommandEnvelope envelope = CommandEnvelope.of(cmd);
+        var envelope = CommandEnvelope.of(cmd);
         repository.dispatch(envelope);
         ProjectAggregate.assertHandled(cmd);
     }

--- a/server/src/test/java/io/spine/server/aggregate/AggregatePartTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregatePartTest.java
@@ -29,7 +29,6 @@ package io.spine.server.aggregate;
 import com.google.common.testing.NullPointerTester;
 import io.spine.base.CommandMessage;
 import io.spine.base.EntityState;
-import io.spine.client.Query;
 import io.spine.client.QueryResponse;
 import io.spine.grpc.MemoizingObserver;
 import io.spine.server.BoundedContext;
@@ -64,7 +63,7 @@ import static io.spine.server.aggregate.given.aggregate.AggregatePartTestEnv.cre
 import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
 import static java.util.stream.Collectors.toList;
 
-@DisplayName("AggregatePart should")
+@DisplayName("`AggregatePart` should")
 class AggregatePartTest {
 
     private static final TestActorRequestFactory factory =
@@ -86,7 +85,7 @@ class AggregatePartTest {
         taskCommentsPart = new TaskCommentsPart(root);
         taskRepository = new TaskRepository();
         taskCommentsRepository = new TaskCommentsRepository();
-        BoundedContext.InternalAccess contextAccess = context.internalAccess();
+        var contextAccess = context.internalAccess();
         contextAccess.register(taskRepository);
         contextAccess.register(taskCommentsRepository);
         prepareAggregatePart();
@@ -117,20 +116,19 @@ class AggregatePartTest {
     @DisplayName("return aggregate part state by class")
     void returnAggregatePartStateByClass() {
         taskRepository.store(taskPart);
-        AggTask task = taskCommentsPart.partState(AggTask.class);
+        var task = taskCommentsPart.partState(AggTask.class);
         assertThat(task.getAssignee())
                 .isEqualTo(ASSIGNEE);
     }
 
     private void assertEntityCount(Class<? extends EntityState<?>> stateType, int expectedCount) {
-        Collection<? extends EntityState<?>> entityStates = queryEntities(stateType);
+        var entityStates = queryEntities(stateType);
         assertThat(entityStates).hasSize(expectedCount);
     }
 
     private Collection<? extends EntityState<?>>
     queryEntities(Class<? extends EntityState<?>> entityClass) {
-        Query query = factory.query()
-                             .all(entityClass);
+        var query = factory.query().all(entityClass);
         MemoizingObserver<QueryResponse> observer = memoizingObserver();
         context.stand()
                .execute(query, observer);
@@ -142,9 +140,9 @@ class AggregatePartTest {
     }
 
     private NullPointerTester createNullPointerTester() throws NoSuchMethodException {
-        Constructor<AnAggregateRoot> constructor =
+        var constructor =
                 AnAggregateRoot.class.getDeclaredConstructor(BoundedContext.class, ProjectId.class);
-        NullPointerTester tester = new NullPointerTester();
+        var tester = new NullPointerTester();
         tester.setDefault(Constructor.class, constructor)
               .setDefault(BoundedContext.class, context)
               .setDefault(AggregateRoot.class, root);

--- a/server/src/test/java/io/spine/server/aggregate/AggregateQueryingTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateQueryingTest.java
@@ -34,7 +34,6 @@ import io.spine.client.CommandFactory;
 import io.spine.client.DeletedColumn;
 import io.spine.client.Query;
 import io.spine.client.QueryFactory;
-import io.spine.core.Command;
 import io.spine.server.BoundedContext;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.aggregate.given.query.AggregateQueryingTestEnv.InvisibleSound;
@@ -43,7 +42,6 @@ import io.spine.server.entity.EntityRecord;
 import io.spine.test.aggregate.query.MRPhoto;
 import io.spine.test.aggregate.query.MRPhotoId;
 import io.spine.test.aggregate.query.MRSoundRecord;
-import io.spine.test.aggregate.query.command.MRUploadPhoto;
 import io.spine.testing.client.TestActorRequestFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -51,7 +49,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -87,8 +84,7 @@ class AggregateQueryingTest {
         context = BoundedContextBuilder.assumingTests(false)
                                        .add(repository)
                                        .build();
-        TestActorRequestFactory requestFactory =
-                new TestActorRequestFactory(AggregateQueryingTest.class);
+        var requestFactory = new TestActorRequestFactory(AggregateQueryingTest.class);
         queries = requestFactory.query();
         commands = requestFactory.command();
         givenPhotos = givenPhotos();
@@ -101,13 +97,13 @@ class AggregateQueryingTest {
 
         @Override
         void checkRead(Query query, MRPhoto... expected) {
-            List<? extends EntityState<?>> readMessages = execute(query);
+            var readMessages = execute(query);
             assertThat(readMessages).containsExactlyElementsIn(expected);
         }
 
         @Override
         void checkReadsNothing(Query query) {
-            List<? extends EntityState<?>> readMessages = execute(query);
+            var readMessages = execute(query);
             assertThat(readMessages).isEmpty();
         }
 
@@ -118,9 +114,9 @@ class AggregateQueryingTest {
 
         @Override
         List<? extends EntityState<?>> execute(Query query) {
-            Iterator<EntityRecord> records = repository.findRecords(query.filters(),
-                                                                    query.responseFormat());
-            ImmutableList<EntityRecord> asList = ImmutableList.copyOf(records);
+            var records = repository.findRecords(query.filters(),
+                                                 query.responseFormat());
+            var asList = ImmutableList.copyOf(records);
             List<? extends EntityState<?>> result =
                     asList.stream()
                           .map(EntityRecord::getState)
@@ -137,13 +133,13 @@ class AggregateQueryingTest {
 
         @Override
         void checkRead(MRPhoto.Query query, MRPhoto... expected) {
-            List<? extends EntityState<?>> readMessages = execute(query);
+            var readMessages = execute(query);
             assertThat(readMessages).containsExactlyElementsIn(expected);
         }
 
         @Override
         void checkReadsNothing(MRPhoto.Query query) {
-            List<? extends EntityState<?>> readMessages = execute(query);
+            var readMessages = execute(query);
             assertThat(readMessages).isEmpty();
         }
 
@@ -154,8 +150,8 @@ class AggregateQueryingTest {
 
         @Override
         List<? extends EntityState<?>> execute(MRPhoto.Query query) {
-            Iterator<MRPhoto> records = repository.findStates(query);
-            ImmutableList<MRPhoto> result = ImmutableList.copyOf(records);
+            var records = repository.findStates(query);
+            var result = ImmutableList.copyOf(records);
             return result;
         }
     }
@@ -164,8 +160,8 @@ class AggregateQueryingTest {
     @DisplayName("throw `IllegalStateException` if an invisible Aggregate is queried" +
             " via Proto `Query`")
     void prohibitQueryingForInvisible() {
-        Query query = MRSoundRecord.query()
-                                   .build(transformWith(queries));
+        var query = MRSoundRecord.query()
+                                 .build(transformWith(queries));
         assertThrows(IllegalStateException.class,
                      () -> InvisibleSound.repository()
                                          .findRecords(query.filters(), query.responseFormat()));
@@ -175,8 +171,7 @@ class AggregateQueryingTest {
     @DisplayName("throw `IllegalStateException` if an invisible Aggregate " +
             "is queried via `EntityQuery`")
     void prohibitEntityQueryingForInvisible() {
-        MRSoundRecord.Query entityQuery = MRSoundRecord.query()
-                                                       .build();
+        var entityQuery = MRSoundRecord.query().build();
         assertThrows(IllegalStateException.class,
                      () -> InvisibleSound.repository()
                                          .findStates(entityQuery));
@@ -218,26 +213,25 @@ class AggregateQueryingTest {
         @Test
         @DisplayName("all instances")
         void includeAll() {
-            Query query = MRPhoto.query()
-                                 .build(transformWith(queries));
-            List<? extends EntityState<?>> readMessages = execute(query);
+            var query = MRPhoto.query().build(transformWith(queries));
+            var readMessages = execute(query);
             assertThat(readMessages).containsExactlyElementsIn(givenPhotos);
         }
 
         @Test
         @DisplayName("an instance by ID")
         void byId() {
-            MRPhoto target = onePhoto();
+            var target = onePhoto();
             readAndCheck(target);
         }
 
         @Test
         @DisplayName("an instance by its ID in case this aggregate instance is archived")
         void archivedInstance() {
-            MRPhoto target = onePhoto();
+            var target = onePhoto();
             archiveItem(target);
-            MRPhotoId targetId = target.getId();
-            Q query = toQuery(
+            var targetId = target.getId();
+            var query = toQuery(
                     MRPhoto.query()
                            .id().is(targetId)
                            .where(ArchivedColumn.is(), true));
@@ -247,10 +241,10 @@ class AggregateQueryingTest {
         @Test
         @DisplayName("an instance by its ID in case this aggregate instance is deleted")
         void deletedInstance() {
-            MRPhoto target = onePhoto();
+            var target = onePhoto();
             deleteItem(target);
-            MRPhotoId targetId = target.getId();
-            Q query = toQuery(
+            var targetId = target.getId();
+            var query = toQuery(
                     MRPhoto.query()
                            .id().is(targetId)
                            .where(DeletedColumn.is(), true));
@@ -260,11 +254,11 @@ class AggregateQueryingTest {
         @Test
         @DisplayName("all archived instances")
         void allArchived() {
-            MRPhoto firstPhoto = onePhoto();
-            MRPhoto secondPhoto = anotherPhoto();
+            var firstPhoto = onePhoto();
+            var secondPhoto = anotherPhoto();
             archiveItem(firstPhoto);
             archiveItem(secondPhoto);
-            Q query = toQuery(
+            var query = toQuery(
                     MRPhoto.query()
                            .where(ArchivedColumn.is(), true)
                            .where(DeletedColumn.is(), false));
@@ -274,11 +268,11 @@ class AggregateQueryingTest {
         @Test
         @DisplayName("all deleted instances")
         void allDeleted() {
-            MRPhoto firstPhoto = onePhoto();
-            MRPhoto secondPhoto = anotherPhoto();
+            var firstPhoto = onePhoto();
+            var secondPhoto = anotherPhoto();
             deleteItem(firstPhoto);
             deleteItem(secondPhoto);
-            Q query = toQuery(
+            var query = toQuery(
                     MRPhoto.query()
                            .where(ArchivedColumn.is(), false)
                            .where(DeletedColumn.is(), true));
@@ -288,12 +282,12 @@ class AggregateQueryingTest {
         @Test
         @DisplayName("instances matching them by the a single entity column")
         void bySingleEntityColumn() {
-            Q queryForNothing =
+            var queryForNothing =
                     toQuery(MRPhoto.query()
                                    .height().isLessThan(20));
             checkReadsNothing(queryForNothing);
 
-            Q queryForOneElement = toQuery(
+            var queryForOneElement = toQuery(
                     MRPhoto.query()
                            .height().isLessThan(201)
             );
@@ -303,7 +297,7 @@ class AggregateQueryingTest {
         @Test
         @DisplayName("instances matching them by the two entity columns joined with `AND`")
         void byTwoEntityColumnsWithAndOperator() {
-            Q query = toQuery(
+            var query = toQuery(
                     MRPhoto.query()
                            .height().isGreaterOrEqualTo(7000)
                            .width().isGreaterThan(6999)
@@ -314,7 +308,7 @@ class AggregateQueryingTest {
         @Test
         @DisplayName("instances matching them by the two entity columns joined with `OR`")
         void byTwoEntityColumnsWithOrOperator() {
-            Q query = toQuery(
+            var query = toQuery(
                     MRPhoto.query()
                            .either(q -> q.width().isLessOrEqualTo(200),
                                    q -> q.height().isGreaterThan(6999))
@@ -327,7 +321,7 @@ class AggregateQueryingTest {
                 "by the two parameters for the same columns with `OR` " +
                 "and by one more column joined with `AND`")
         void byCombinationAndOr() {
-            Q query = toQuery(
+            var query = toQuery(
                     MRPhoto.query()
                            .either(q -> q.sourceType().is(CROP_FRAME),
                                    q -> q.sourceType().is(FULL_FRAME))
@@ -340,7 +334,7 @@ class AggregateQueryingTest {
         @DisplayName("instances matching them by both entity and lifecycle columns")
         void byEntityAndLifecycleCols() {
             archiveItem(projectLogo1000by800());
-            Q query = toQuery(
+            var query = toQuery(
                     MRPhoto.query()
                            .either(q -> q.where(ArchivedColumn.is(), true),
                                    q -> q.height().isGreaterThan(1000))
@@ -351,21 +345,21 @@ class AggregateQueryingTest {
         }
 
         private void readAndCheck(MRPhoto target) {
-            MRPhotoId targetId = target.getId();
-            Q query = toQuery(MRPhoto.query()
-                                     .id().is(targetId));
+            var targetId = target.getId();
+            var query = toQuery(MRPhoto.query()
+                                       .id().is(targetId));
             checkRead(query, target);
         }
 
         private MRPhoto onePhoto() {
-            MRPhoto target = givenPhotos.stream()
+            var target = givenPhotos.stream()
                                         .findFirst()
                                         .orElseGet(() -> fail("No test data."));
             return target;
         }
 
         private MRPhoto anotherPhoto() {
-            MRPhoto target = givenPhotos.stream()
+            var target = givenPhotos.stream()
                                         .skip(1)
                                         .findFirst()
                                         .orElseGet(() -> fail(
@@ -383,9 +377,9 @@ class AggregateQueryingTest {
         }
 
         private List<? extends EntityState<?>> execute(Query query) {
-            Iterator<EntityRecord> records = repository.findRecords(query.filters(),
-                                                                    query.responseFormat());
-            ImmutableList<EntityRecord> asList = ImmutableList.copyOf(records);
+            var records = repository.findRecords(query.filters(),
+                                                 query.responseFormat());
+            var asList = ImmutableList.copyOf(records);
             List<? extends EntityState<?>> result =
                     asList.stream()
                           .map(EntityRecord::getState)
@@ -397,14 +391,14 @@ class AggregateQueryingTest {
     }
 
     private void prepareAggregates(Collection<MRPhoto> aggregateStates) {
-        for (MRPhoto state : aggregateStates) {
-            MRUploadPhoto upload = upload(state);
+        for (var state : aggregateStates) {
+            var upload = upload(state);
             dispatchCommand(upload);
         }
     }
 
     private void dispatchCommand(CommandMessage message) {
-        Command command = commands.create(message);
+        var command = commands.create(message);
         context.commandBus()
                .post(command, noOpObserver());
     }

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryViewsTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryViewsTest.java
@@ -27,7 +27,6 @@
 package io.spine.server.aggregate;
 
 import io.spine.client.ActorRequestFactory;
-import io.spine.core.Command;
 import io.spine.grpc.StreamObservers;
 import io.spine.server.BoundedContext;
 import io.spine.server.BoundedContextBuilder;
@@ -44,7 +43,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("AggregateRepository views should")
+@DisplayName("`AggregateRepository` views should")
 class AggregateRepositoryViewsTest {
 
     /** The Aggregate ID used in all tests. */
@@ -76,7 +75,7 @@ class AggregateRepositoryViewsTest {
      * for being processed by the repository.
      */
     private void postCommand(String cmd) {
-        Command command =
+        var command =
                 requestFactory.command()
                               .create(RepoOfAggregateWithLifecycle.createCommandMessage(id, cmd));
         context.commandBus()
@@ -89,7 +88,7 @@ class AggregateRepositoryViewsTest {
         aggregate = repository.find(id);
 
         assertTrue(aggregate.isPresent());
-        AggregateWithLifecycle agg = aggregate.get();
+        var agg = aggregate.get();
         assertFalse(agg.isArchived());
         assertFalse(agg.isDeleted());
     }
@@ -102,7 +101,7 @@ class AggregateRepositoryViewsTest {
         aggregate = repository.find(id);
 
         assertTrue(aggregate.isPresent());
-        AggregateWithLifecycle agg = aggregate.get();
+        var agg = aggregate.get();
         assertTrue(agg.isArchived());
         assertFalse(agg.isDeleted());
     }
@@ -115,7 +114,7 @@ class AggregateRepositoryViewsTest {
         aggregate = repository.find(id);
 
         assertTrue(aggregate.isPresent());
-        AggregateWithLifecycle agg = aggregate.get();
+        var agg = aggregate.get();
         assertFalse(agg.isArchived());
         assertTrue(agg.isDeleted());
     }

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRootTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRootTest.java
@@ -47,7 +47,7 @@ import java.lang.reflect.Constructor;
 import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisplayName("AggregateRoot should")
+@DisplayName("`AggregateRoot` should")
 class AggregateRootTest {
 
     private AggregateRootTestEnv.ProjectRoot aggregateRoot;
@@ -57,9 +57,9 @@ class AggregateRootTest {
     void setUp() {
         ModelTests.dropAllModels();
         context = BoundedContextBuilder.assumingTests().build();
-        ProjectId projectId = ProjectId.generate();
+        var projectId = ProjectId.generate();
         aggregateRoot = new AggregateRootTestEnv.ProjectRoot(context, projectId);
-        BoundedContext.InternalAccess contextAccess = context.internalAccess();
+        var contextAccess = context.internalAccess();
         contextAccess.register(new ProjectDefinitionRepository());
         contextAccess.register(new ProjectLifeCycleRepository());
     }
@@ -67,7 +67,7 @@ class AggregateRootTest {
     @Test
     @DisplayName(NOT_ACCEPT_NULLS)
     void passNullToleranceCheck() throws NoSuchMethodException {
-        Constructor<AnAggregateRoot> ctor =
+        var ctor =
                 AnAggregateRoot.class.getDeclaredConstructor(BoundedContext.class, String.class);
         new NullPointerTester()
                 .setDefault(Constructor.class, ctor)
@@ -78,10 +78,10 @@ class AggregateRootTest {
     @Test
     @DisplayName("obtain part state by its class")
     void returnPartStateByClass() {
-        EntityState definitionPart = aggregateRoot.partState(ProjectDefinition.class);
+        EntityState<?> definitionPart = aggregateRoot.partState(ProjectDefinition.class);
         assertNotNull(definitionPart);
 
-        EntityState lifeCyclePart = aggregateRoot.partState(ProjectLifecycle.class);
+        EntityState<?> lifeCyclePart = aggregateRoot.partState(ProjectLifecycle.class);
         assertNotNull(lifeCyclePart);
     }
 }

--- a/server/src/test/java/io/spine/server/aggregate/AggregateTransactionTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateTransactionTest.java
@@ -25,7 +25,6 @@
  */
 package io.spine.server.aggregate;
 
-import com.google.protobuf.Message;
 import io.spine.core.Event;
 import io.spine.core.Version;
 import io.spine.server.dispatch.DispatchOutcome;
@@ -42,7 +41,7 @@ import org.junit.jupiter.api.Test;
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.protobuf.AnyPacker.unpack;
 
-@DisplayName("AggregateTransaction should")
+@DisplayName("`AggregateTransaction` should")
 class AggregateTransactionTest
         extends TransactionTest<Id,
                                 Aggregate<Id, AggregateState, AggregateState.Builder>,
@@ -76,8 +75,7 @@ class AggregateTransactionTest
                           AggregateState.Builder>
     createTx(Aggregate<Id, AggregateState, AggregateState.Builder> entity,
              TransactionListener<Id> listener) {
-        AggregateTransaction<Id, AggregateState, AggregateState.Builder> transaction =
-                new AggregateTransaction<>(entity);
+        var transaction = new AggregateTransaction<>(entity);
         transaction.setListener(listener);
         return transaction;
     }
@@ -99,8 +97,8 @@ class AggregateTransactionTest
     @Override
     protected void checkEventReceived(Aggregate<Id, AggregateState, AggregateState.Builder> entity,
                                       Event event) {
-        TxAggregate aggregate = (TxAggregate) entity;
-        Message actualMessage = unpack(event.getMessage());
+        var aggregate = (TxAggregate) entity;
+        var actualMessage = unpack(event.getMessage());
 
         assertThat(aggregate.receivedEvents())
                 .contains(actualMessage);
@@ -109,8 +107,8 @@ class AggregateTransactionTest
     @SuppressWarnings("rawtypes")   // for simplicity.
     @Override
     protected DispatchOutcome applyEvent(Transaction tx, Event event) {
-        AggregateTransaction cast = (AggregateTransaction) tx;
-        EventEnvelope envelope = EventEnvelope.of(event);
+        var cast = (AggregateTransaction) tx;
+        var envelope = EventEnvelope.of(event);
         return cast.play(envelope);
     }
 

--- a/server/src/test/java/io/spine/server/aggregate/ApplyAllowImportTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/ApplyAllowImportTest.java
@@ -71,8 +71,7 @@ class ApplyAllowImportTest {
     @Test
     @DisplayName("use event appliers in a traditional way")
     void normalApply() {
-        ObjectId id = ObjectId
-                .newBuilder()
+        var id = ObjectId.newBuilder()
                 .setValue("Луноход-1")
                 .build();
 
@@ -85,8 +84,7 @@ class ApplyAllowImportTest {
     @Test
     @DisplayName("use event appliers for import")
     void importingApply() {
-        ObjectId id = ObjectId
-                .newBuilder()
+        var id = ObjectId.newBuilder()
                 .setValue("LRV")
                 .build();
 

--- a/server/src/test/java/io/spine/server/aggregate/EventImportTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/EventImportTest.java
@@ -38,7 +38,6 @@ import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
 import io.spine.testing.server.TestEventFactory;
 import io.spine.testing.server.blackbox.BlackBox;
-import io.spine.testing.server.entity.EntitySubject;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -52,7 +51,7 @@ import static com.google.common.truth.Truth.assertThat;
 /**
  * Test support of event import in {@link AggregateRepository}.
  */
-@DisplayName("For event import AggregateRepository should")
+@DisplayName("For event import, `AggregateRepository` should")
 class EventImportTest {
 
     private EngineRepository repository;
@@ -97,22 +96,20 @@ class EventImportTest {
      * @return generated event wrapped into the envelope
      */
     EventEnvelope createEvent(EventMessage eventMessage, @Nullable EngineId producerId) {
-        TestEventFactory eventFactory = producerId == null
-                                        ? TestEventFactory.newInstance(getClass())
-                                        : TestEventFactory.newInstance(producerId, getClass());
-        EventEnvelope result = EventEnvelope.of(eventFactory.createEvent(eventMessage));
+        var eventFactory = producerId == null
+                           ? TestEventFactory.newInstance(getClass())
+                           : TestEventFactory.newInstance(producerId, getClass());
+        var result = EventEnvelope.of(eventFactory.createEvent(eventMessage));
         return result;
     }
-    
+
     @Test
     @DisplayName("Obtain importable event classes")
     void importableEventClasses() {
         createRepository(false);
-        Set<EventClass> importableEventClasses =
-                repository().importableEvents();
-        Set<EventClass> exposedByAggregateClass =
-                repository().aggregateClass()
-                            .importableEvents();
+        Set<EventClass> importableEventClasses = repository().importableEvents();
+        Set<EventClass> exposedByAggregateClass = repository().aggregateClass()
+                                                              .importableEvents();
         assertThat(importableEventClasses)
                 .isEqualTo(exposedByAggregateClass);
     }
@@ -134,7 +131,7 @@ class EventImportTest {
             createRepository(false);
 
             // Create event with producer ID, which is the target aggregate ID.
-            EventEnvelope event = createEvent(eventMessage, engineId);
+            var event = createEvent(eventMessage, engineId);
 
             assertImports(event);
         }
@@ -145,7 +142,7 @@ class EventImportTest {
             createRepository(true);
 
             // Create event with producer ID, which is NOT the target aggregate ID.
-            EventEnvelope event = createEvent(eventMessage, null);
+            var event = createEvent(eventMessage, null);
 
             assertImports(event);
         }
@@ -181,7 +178,7 @@ class EventImportTest {
             createRepository(false);
 
             // Create event with the producer ID of the target aggregate.
-            EventEnvelope event = createEvent(eventMessage, engineId);
+            var event = createEvent(eventMessage, engineId);
 
             // Apply routing to the generated event.
             assertRouted(event);
@@ -193,7 +190,7 @@ class EventImportTest {
             createRepository(true);
 
             // Create event with the producer ID, which is NOT the target aggregate ID.
-            EventEnvelope event = createEvent(eventMessage, null);
+            var event = createEvent(eventMessage, null);
 
             assertRouted(event);
         }
@@ -202,7 +199,7 @@ class EventImportTest {
          * Asserts that the import routing resulted in {@link #engineId}.
          */
         private void assertRouted(EventEnvelope event) {
-            EntitySubject assertEntity =
+            var assertEntity =
                     context().importsEvent(event.outerObject())
                              .assertEntity(engineId, EngineAggregate.class);
             assertEntity.exists();
@@ -214,12 +211,11 @@ class EventImportTest {
     void importUnsupported() {
         createRepository(false);
 
-        EngineId id = engineId("AGR");
-        UnsupportedEngineEvent eventMessage = UnsupportedEngineEvent
-                .newBuilder()
+        var id = engineId("AGR");
+        var eventMessage = UnsupportedEngineEvent.newBuilder()
                 .setId(id)
                 .build();
-        EventEnvelope unsupported = createEvent(eventMessage, id);
+        var unsupported = createEvent(eventMessage, id);
 
         context().importsEvent(unsupported.outerObject())
                  .assertEvents()

--- a/server/src/test/java/io/spine/server/aggregate/IdempotencyGuardTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/IdempotencyGuardTest.java
@@ -37,8 +37,6 @@ import io.spine.server.BoundedContext;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.aggregate.given.aggregate.IgTestAggregate;
 import io.spine.server.aggregate.given.aggregate.IgTestAggregateRepository;
-import io.spine.server.commandbus.CommandBus;
-import io.spine.server.event.EventBus;
 import io.spine.server.type.CommandEnvelope;
 import io.spine.server.type.EventEnvelope;
 import io.spine.test.aggregate.ProjectId;
@@ -63,7 +61,7 @@ import static io.spine.server.aggregate.given.IdempotencyGuardTestEnv.startProje
 import static io.spine.server.aggregate.given.IdempotencyGuardTestEnv.taskStarted;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("IdempotencyGuard should")
+@DisplayName("`IdempotencyGuard` should")
 class IdempotencyGuardTest {
 
     private BoundedContext context;
@@ -98,15 +96,15 @@ class IdempotencyGuardTest {
         @Test
         @DisplayName("throw DuplicateCommandException when command was handled since last snapshot")
         void throwExceptionForDuplicateCommand() {
-            Command createCommand = command(createProject(projectId));
+            var createCommand = command(createProject(projectId));
 
             post(createCommand);
 
-            IgTestAggregate aggregate = repository.loadAggregate(projectId);
-            IdempotencyGuard guard = new IdempotencyGuard(aggregate);
-            Optional<Error> error = check(guard, createCommand);
+            var aggregate = repository.loadAggregate(projectId);
+            var guard = new IdempotencyGuard(aggregate);
+            var error = check(guard, createCommand);
             assertTrue(error.isPresent());
-            Error actualError = error.get();
+            var actualError = error.get();
             assertThat(actualError.getType())
                     .isEqualTo(CommandValidationError.class.getSimpleName());
             assertThat(actualError.getCode()).isEqualTo(DUPLICATE_COMMAND_VALUE);
@@ -116,50 +114,50 @@ class IdempotencyGuardTest {
         @DisplayName("not throw exception when command was handled but snapshot was made")
         void notThrowForCommandHandledAfterSnapshot() {
             repository.setSnapshotTrigger(1);
-            Command createCommand = command(createProject(projectId));
+            var createCommand = command(createProject(projectId));
             post(createCommand);
 
-            IgTestAggregate aggregate = aggregate();
+            var aggregate = aggregate();
 
-            IdempotencyGuard guard = new IdempotencyGuard(aggregate);
-            Optional<Error> error = check(guard, createCommand);
+            var guard = new IdempotencyGuard(aggregate);
+            var error = check(guard, createCommand);
             assertThat(error).isEmpty();
         }
 
         @Test
         @DisplayName("not throw exception if command was not handled")
         void notThrowForCommandNotHandled() {
-            Command createCommand = command(createProject(projectId));
-            IgTestAggregate aggregate = new IgTestAggregate(projectId);
+            var createCommand = command(createProject(projectId));
+            var aggregate = new IgTestAggregate(projectId);
 
-            IdempotencyGuard guard = new IdempotencyGuard(aggregate);
-            Optional<Error> error = guard.check(CommandEnvelope.of(createCommand));
+            var guard = new IdempotencyGuard(aggregate);
+            var error = guard.check(CommandEnvelope.of(createCommand));
             assertThat(error).isEmpty();
         }
 
         @Test
         @DisplayName("not throw exception if another command was handled")
         void notThrowIfAnotherCommandHandled() {
-            Command createCommand = command(createProject(projectId));
-            Command startCommand = command(startProject(projectId));
+            var createCommand = command(createProject(projectId));
+            var startCommand = command(startProject(projectId));
 
             post(createCommand);
 
-            IgTestAggregate aggregate = aggregate();
+            var aggregate = aggregate();
 
-            IdempotencyGuard guard = new IdempotencyGuard(aggregate);
-            Optional<Error> error = check(guard, startCommand);
+            var guard = new IdempotencyGuard(aggregate);
+            var error = check(guard, startCommand);
             assertThat(error).isEmpty();
         }
 
         private void post(Command command) {
-            CommandBus commandBus = context.commandBus();
+            var commandBus = context.commandBus();
             StreamObserver<Ack> noOpObserver = noOpObserver();
             commandBus.post(command, noOpObserver);
         }
 
         private Optional<Error> check(IdempotencyGuard guard, Command command) {
-            CommandEnvelope envelope = CommandEnvelope.of(command);
+            var envelope = CommandEnvelope.of(command);
             return guard.check(envelope);
         }
     }
@@ -177,14 +175,14 @@ class IdempotencyGuardTest {
         @Test
         @DisplayName("throw DuplicateEventException when event was handled since last snapshot")
         void throwExceptionForDuplicateCommand() {
-            Event event = event(taskStarted(projectId));
+            var event = event(taskStarted(projectId));
             post(event);
 
-            IgTestAggregate aggregate = repository.loadAggregate(projectId);
-            IdempotencyGuard guard = new IdempotencyGuard(aggregate);
-            Optional<Error> error = check(guard, event);
+            var aggregate = repository.loadAggregate(projectId);
+            var guard = new IdempotencyGuard(aggregate);
+            var error = check(guard, event);
             assertTrue(error.isPresent());
-            Error actualError = error.get();
+            var actualError = error.get();
             assertThat(actualError.getType()).isEqualTo(EventValidationError.class.getSimpleName());
         }
 
@@ -193,39 +191,39 @@ class IdempotencyGuardTest {
         void notThrowForCommandHandledAfterSnapshot() {
             repository.setSnapshotTrigger(1);
 
-            Event event = event(taskStarted(projectId));
+            var event = event(taskStarted(projectId));
             post(event);
 
-            IgTestAggregate aggregate = repository.loadAggregate(projectId);
-            IdempotencyGuard guard = new IdempotencyGuard(aggregate);
-            Optional<Error> error = check(guard, event);
+            var aggregate = repository.loadAggregate(projectId);
+            var guard = new IdempotencyGuard(aggregate);
+            var error = check(guard, event);
             assertThat(error).isEmpty();
         }
 
         @Test
         @DisplayName("not throw exception if event was not handled")
         void notThrowForCommandNotHandled() {
-            Event event = event(taskStarted(projectId));
-            IgTestAggregate aggregate = new IgTestAggregate(projectId);
+            var event = event(taskStarted(projectId));
+            var aggregate = new IgTestAggregate(projectId);
 
-            IdempotencyGuard guard = new IdempotencyGuard(aggregate);
-            Optional<Error> error = check(guard, event);
+            var guard = new IdempotencyGuard(aggregate);
+            var error = check(guard, event);
             assertThat(error).isEmpty();
         }
 
         @Test
         @DisplayName("not throw exception if another event was handled")
         void notThrowIfAnotherCommandHandled() {
-            Event taskEvent = event(taskStarted(projectId));
-            Event projectEvent = event(projectPaused(projectId));
+            var taskEvent = event(taskStarted(projectId));
+            var projectEvent = event(projectPaused(projectId));
 
-            EventBus eventBus = context.eventBus();
+            var eventBus = context.eventBus();
             eventBus.post(taskEvent);
 
-            IgTestAggregate aggregate = repository.loadAggregate(projectId);
+            var aggregate = repository.loadAggregate(projectId);
 
-            IdempotencyGuard guard = new IdempotencyGuard(aggregate);
-            Optional<Error> error = check(guard, projectEvent);
+            var guard = new IdempotencyGuard(aggregate);
+            var error = check(guard, projectEvent);
             assertThat(error).isEmpty();
         }
 
@@ -235,7 +233,7 @@ class IdempotencyGuardTest {
         }
 
         private Optional<Error> check(IdempotencyGuard guard, Event event) {
-            EventEnvelope envelope = EventEnvelope.of(event);
+            var envelope = EventEnvelope.of(event);
             return guard.check(envelope);
         }
     }

--- a/server/src/test/java/io/spine/server/aggregate/InMemoryRootDirectoryTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/InMemoryRootDirectoryTest.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.aggregate;
 
-import com.google.common.truth.OptionalSubject;
 import io.spine.server.aggregate.given.part.TaskRepository;
 import io.spine.server.aggregate.given.part.TaskRoot;
 import io.spine.test.aggregate.task.AggTask;
@@ -38,7 +37,7 @@ import java.util.Optional;
 
 import static com.google.common.truth.Truth8.assertThat;
 
-@DisplayName("In memory AggregateRootDirectory should")
+@DisplayName("In-memory `AggregateRootDirectory` should")
 class InMemoryRootDirectoryTest {
 
     private AggregateRootDirectory directory;
@@ -56,7 +55,7 @@ class InMemoryRootDirectoryTest {
         directory.register(repository);
         Optional<? extends AggregatePartRepository<?, ?, ?, ?>> found =
                 directory.findPart(TaskRoot.class, AggTask.class);
-        OptionalSubject assertRepository = assertThat(found);
+        var assertRepository = assertThat(found);
         assertRepository.isPresent();
         assertRepository.hasValue(repository);
     }
@@ -66,7 +65,7 @@ class InMemoryRootDirectoryTest {
     void notFindRepository() {
         Optional<? extends AggregatePartRepository<?, ?, ?, ?>> found =
                 directory.findPart(TaskRoot.class, AggTask.class);
-        OptionalSubject assertRepository = assertThat(found);
+        var assertRepository = assertThat(found);
         assertRepository.isEmpty();
     }
 }

--- a/server/src/test/java/io/spine/server/aggregate/ReadOperationTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/ReadOperationTest.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.aggregate;
 
-import io.spine.core.Event;
 import io.spine.server.ContextSpec;
 import io.spine.server.aggregate.given.ReadOperationTestEnv.TestAggregate;
 import io.spine.server.storage.StorageFactory;
@@ -36,9 +35,6 @@ import io.spine.test.storage.StgProjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.core.BoundedContextNames.assumingTestsValue;
@@ -67,15 +63,15 @@ class ReadOperationTest {
     @Test
     @DisplayName("read all events if there are a few")
     void readAll() {
-        int eventCount = 10;
+        var eventCount = 10;
         fillEvents(eventCount);
-        ReadOperation<StgProjectId, StgProject> operation = new ReadOperation<>(storage, ID, 100);
-        Optional<AggregateHistory> record = operation.perform();
+        var operation = new ReadOperation<>(storage, ID, 100);
+        var record = operation.perform();
         assertTrue(record.isPresent());
-        AggregateHistory stateRecord = record.get();
+        var stateRecord = record.get();
 
         assertFalse(stateRecord.hasSnapshot());
-        List<Event> events = stateRecord.getEventList();
+        var events = stateRecord.getEventList();
         assertThat(events).hasSize(eventCount);
     }
 
@@ -83,10 +79,10 @@ class ReadOperationTest {
     @DisplayName("read snapshot if present")
     void readSnapshot() {
         fillEventsWithSnapshot(5);
-        ReadOperation<StgProjectId, StgProject> operation = new ReadOperation<>(storage, ID, 100);
-        Optional<AggregateHistory> record = operation.perform();
+        var operation = new ReadOperation<>(storage, ID, 100);
+        var record = operation.perform();
         assertTrue(record.isPresent());
-        AggregateHistory stateRecord = record.get();
+        var stateRecord = record.get();
 
         assertTrue(stateRecord.hasSnapshot());
     }
@@ -96,31 +92,29 @@ class ReadOperationTest {
     void trimBeforeSnapshot() {
         fillEvents(3);
         fillEventsWithSnapshot(5);
-        int expectedEventCount = 7;
+        var expectedEventCount = 7;
         fillEvents(expectedEventCount);
 
-        ReadOperation<StgProjectId, StgProject> operation = new ReadOperation<>(storage, ID, BATCH_SIZE);
-        Optional<AggregateHistory> record = operation.perform();
+        var operation = new ReadOperation<>(storage, ID, BATCH_SIZE);
+        var record = operation.perform();
         assertTrue(record.isPresent());
-        AggregateHistory stateRecord = record.get();
+        var stateRecord = record.get();
 
         assertTrue(stateRecord.hasSnapshot());
         assertThat(stateRecord.getEventList()).hasSize(expectedEventCount);
     }
 
     private void fillEvents(int count) {
-        List<Event> events = events(count);
-        storage.write(ID, AggregateHistory
-                .newBuilder()
+        var events = events(count);
+        storage.write(ID, AggregateHistory.newBuilder()
                 .addAllEvent(events)
                 .build());
     }
 
     private void fillEventsWithSnapshot(int count) {
-        List<Event> events = events(count);
-        Snapshot snapshot = snapshot();
-        storage.write(ID, AggregateHistory
-                .newBuilder()
+        var events = events(count);
+        var snapshot = snapshot();
+        storage.write(ID, AggregateHistory.newBuilder()
                 .addAllEvent(events)
                 .setSnapshot(snapshot)
                 .build());
@@ -128,7 +122,7 @@ class ReadOperationTest {
 
     private static StgProjectId sampleId() {
         return StgProjectId.newBuilder()
-                           .setId("ReadOperationTest-ID")
-                           .vBuild();
+                .setId("ReadOperationTest-ID")
+                .vBuild();
     }
 }

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregateRootTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregateRootTestEnv.java
@@ -63,10 +63,10 @@ public class AggregateRootTestEnv {
 
         @Assign
         AggProjectCreated handle(AggCreateProject msg) {
-            AggProjectCreated result = AggProjectCreated.newBuilder()
-                                                        .setProjectId(msg.getProjectId())
-                                                        .setName(msg.getName())
-                                                        .build();
+            var result = AggProjectCreated.newBuilder()
+                    .setProjectId(msg.getProjectId())
+                    .setName(msg.getName())
+                    .build();
             return result;
         }
 
@@ -95,9 +95,9 @@ public class AggregateRootTestEnv {
 
         @Assign
         AggProjectStarted handle(AggStartProject msg) {
-            AggProjectStarted result = AggProjectStarted.newBuilder()
-                                                        .setProjectId(msg.getProjectId())
-                                                        .build();
+            var result = AggProjectStarted.newBuilder()
+                    .setProjectId(msg.getProjectId())
+                    .build();
             return result;
         }
 

--- a/server/src/test/java/io/spine/server/aggregate/given/Given.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/Given.java
@@ -111,17 +111,17 @@ public class Given {
         public static Command createProject(UserId userId,
                                             ProjectId projectId,
                                             Timestamp when) {
-            AggCreateProject command = CommandMessage.createProject(projectId);
+            var command = CommandMessage.createProject(projectId);
             return create(command, userId, when);
         }
 
         public static Command addTask(ProjectId id) {
-            AggAddTask command = CommandMessage.addTask(id);
+            var command = CommandMessage.addTask(id);
             return create(command, USER_ID, currentTime());
         }
 
         public static Command startProject(ProjectId id) {
-            AggStartProject command = CommandMessage.startProject(id);
+            var command = CommandMessage.startProject(id);
             return create(command, USER_ID, currentTime());
         }
 
@@ -133,7 +133,7 @@ public class Given {
         public static Command create(io.spine.base.CommandMessage command,
                                      UserId userId,
                                      Timestamp when) {
-            Command result = new TestActorRequestFactory(userId).createCommand(command, when);
+            var result = new TestActorRequestFactory(userId).createCommand(command, when);
             return result;
         }
     }
@@ -144,33 +144,33 @@ public class Given {
         }
 
         public static AggCreateProject createProject(ProjectId id) {
-            AggCreateProject.Builder builder = AggCreateProject.newBuilder()
-                                                               .setProjectId(id)
-                                                               .setName(projectName(id));
+            var builder = AggCreateProject.newBuilder()
+                    .setProjectId(id)
+                    .setName(projectName(id));
             return builder.build();
         }
 
         public static AggPauseProject pauseProject(ProjectId id) {
-            AggPauseProject.Builder builder = AggPauseProject.newBuilder()
-                                                             .setProjectId(id);
+            var builder = AggPauseProject.newBuilder()
+                    .setProjectId(id);
             return builder.build();
         }
 
         public static AggCancelProject cancelProject(ProjectId id) {
-            AggCancelProject.Builder builder = AggCancelProject.newBuilder()
-                                                               .setProjectId(id);
+            var builder = AggCancelProject.newBuilder()
+                    .setProjectId(id);
             return builder.build();
         }
 
         public static AggAddTask addTask(ProjectId id) {
-            AggAddTask.Builder builder = AggAddTask.newBuilder()
-                                                   .setProjectId(id);
+            var builder = AggAddTask.newBuilder()
+                    .setProjectId(id);
             return builder.build();
         }
 
         public static AggStartProject startProject(ProjectId id) {
-            AggStartProject.Builder builder = AggStartProject.newBuilder()
-                                                             .setProjectId(id);
+            var builder = AggStartProject.newBuilder()
+                    .setProjectId(id);
             return builder.build();
         }
     }

--- a/server/src/test/java/io/spine/server/aggregate/given/ReadOperationTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/ReadOperationTestEnv.java
@@ -63,18 +63,15 @@ public final class ReadOperationTestEnv {
     }
 
     private static Event newEvent() {
-        EventId id = EventId
-                .newBuilder()
+        var id = EventId.newBuilder()
                 .setValue(newUuid())
                 .build();
         version = increment(version);
-        EventContext context = EventContext
-                .newBuilder()
+        var context = EventContext.newBuilder()
                 .setTimestamp(currentTime())
                 .setVersion(version)
                 .build();
-        return Event
-                .newBuilder()
+        return Event.newBuilder()
                 .setId(id)
                 .setContext(context)
                 .setMessage(pack(StgProjectCreated.getDefaultInstance()))
@@ -83,8 +80,7 @@ public final class ReadOperationTestEnv {
 
     public static Snapshot snapshot() {
         version = increment(version);
-        return Snapshot
-                .newBuilder()
+        return Snapshot.newBuilder()
                 .setTimestamp(currentTime())
                 .setVersion(version)
                 .build();
@@ -92,6 +88,7 @@ public final class ReadOperationTestEnv {
 
     public static final class TestAggregate
             extends Aggregate<StgProjectId, StgProject, StgProject.Builder> {
+
         private TestAggregate(StgProjectId id) {
             super(id);
         }

--- a/server/src/test/java/io/spine/server/aggregate/given/StorageRecords.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/StorageRecords.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.aggregate.given;
 
-import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
 import io.spine.base.EventMessage;
 import io.spine.base.Identifier;
@@ -63,12 +62,10 @@ public class StorageRecords {
     /** Creates new builder for an aggregate event record and sets the passed timestamp. */
     private static <I> AggregateEventRecord.Builder
     newRecordWith(EventId eventId, I aggregateId, Timestamp timestamp) {
-        AggregateEventRecordId recordId = AggregateEventRecordId
-                .newBuilder()
+        var recordId = AggregateEventRecordId.newBuilder()
                 .setValue(eventId.getValue())
                 .vBuild();
-        return AggregateEventRecord
-                .newBuilder()
+        return AggregateEventRecord.newBuilder()
                 .setId(recordId)
                 .setAggregateId(Identifier.pack(aggregateId))
                 .setTimestamp(timestamp);
@@ -79,7 +76,7 @@ public class StorageRecords {
      */
     public static <I> AggregateEventRecord create(I aggregateId, Timestamp timestamp) {
         EventMessage eventMessage = Sample.messageOfType(AggProjectCreated.class);
-        Event event = eventFactory.createEvent(eventMessage);
+        var event = eventFactory.createEvent(eventMessage);
         return newRecordWith(event.getId(), aggregateId, timestamp)
                 .setEvent(event)
                 .build();
@@ -109,24 +106,20 @@ public class StorageRecords {
      *         the timestamp of first record.
      */
     public static List<AggregateEventRecord> sequenceFor(ProjectId id, Timestamp start) {
-        Duration delta = seconds(10);
-        Timestamp timestamp2 = add(start, delta);
-        Timestamp timestamp3 = add(timestamp2, delta);
+        var delta = seconds(10);
+        var timestamp2 = add(start, delta);
+        var timestamp3 = add(timestamp2, delta);
 
-        TestEventFactory eventFactory = newInstance(Given.class);
+        var factory = newInstance(Given.class);
 
-        Event e1 = eventFactory.createEvent(projectCreated(id, Given.projectName(id)),
-                                            null,
-                                            start);
-        AggregateEventRecord record1 = create(id, start, e1);
+        var e1 = factory.createEvent(projectCreated(id, Given.projectName(id)), null, start);
+        var record1 = create(id, start, e1);
 
-        Event e2 = eventFactory.createEvent(taskAdded(id), null, timestamp2);
-        AggregateEventRecord record2 = create(id, timestamp2, e2);
+        var e2 = factory.createEvent(taskAdded(id), null, timestamp2);
+        var record2 = create(id, timestamp2, e2);
 
-        Event e3 = eventFactory.createEvent(Given.EventMessage.projectStarted(id),
-                                            null,
-                                            timestamp3);
-        AggregateEventRecord record3 = create(id, timestamp3, e3);
+        var e3 = factory.createEvent(Given.EventMessage.projectStarted(id), null, timestamp3);
+        var record3 = create(id, timestamp3, e3);
 
         return newArrayList(record1, record2, record3);
     }

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/AbstractAggregateTestRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/AbstractAggregateTestRepository.java
@@ -32,17 +32,18 @@ import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.AggregateRepository;
 import io.spine.server.tenant.TenantAwareRunner;
 
-import java.util.Optional;
-
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * A test repository which can load an aggregate by its ID and fail the test if the
  * aggregate with such ID is not found.
  *
- * @param <I> the type of aggregate identifiers
- * @param <A> the type of aggregates
- * @param <S> the type of aggregate state
+ * @param <I>
+ *         the type of aggregate identifiers
+ * @param <A>
+ *         the type of aggregates
+ * @param <S>
+ *         the type of aggregate state
  */
 public class AbstractAggregateTestRepository<I,
                                              A extends Aggregate<I, S, ?>,
@@ -50,16 +51,16 @@ public class AbstractAggregateTestRepository<I,
         extends AggregateRepository<I, A, S> {
 
     public A loadAggregate(I id) {
-        Optional<A> optional = find(id);
-        if (!optional.isPresent()) {
+        var optional = find(id);
+        if (optional.isEmpty()) {
             fail("Aggregate not found.");
         }
         return optional.get();
     }
 
     public A loadAggregate(TenantId tenantId, I id) {
-        TenantAwareRunner runner = TenantAwareRunner.with(tenantId);
-        A result = runner.evaluate(() -> loadAggregate(id));
+        var runner = TenantAwareRunner.with(tenantId);
+        var result = runner.evaluate(() -> loadAggregate(id));
         return result;
     }
 }

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/AggregatePartTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/AggregatePartTestEnv.java
@@ -57,8 +57,7 @@ public final class AggregatePartTestEnv {
     }
 
     public static AggCreateTask createTask() {
-        AggCreateTask command = AggCreateTask
-                .newBuilder()
+        var command = AggCreateTask.newBuilder()
                 .setTaskId(ID)
                 .setAssignee(ASSIGNEE)
                 .build();
@@ -66,8 +65,7 @@ public final class AggregatePartTestEnv {
     }
 
     public static AggAddComment commentTask() {
-        AggAddComment command = AggAddComment
-                .newBuilder()
+        var command = AggAddComment.newBuilder()
                 .setTaskId(ID)
                 .setAuthor(COMMENT_AUTHOR)
                 .setText("ASAP")

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/AmishAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/AmishAggregate.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.aggregate.given.aggregate;
 
-import com.google.common.collect.Lists;
 import io.spine.base.EventMessage;
 import io.spine.core.CommandContext;
 import io.spine.server.aggregate.Aggregate;
@@ -41,6 +40,7 @@ import io.spine.test.aggregate.event.AggProjectPaused;
 
 import java.util.List;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static io.spine.server.aggregate.given.Given.EventMessage.projectCancelled;
 import static io.spine.server.aggregate.given.Given.EventMessage.projectPaused;
 
@@ -58,15 +58,15 @@ public class AmishAggregate extends Aggregate<ProjectId, AggProject, AggProject.
 
     @Assign
     AggProjectPaused handle(AggPauseProject cmd, CommandContext ctx) {
-        AggProjectPaused event = projectPaused(cmd.getProjectId());
+        var event = projectPaused(cmd.getProjectId());
         return event;
     }
 
     @Assign
     List<EventMessage> handle(AggCancelProject cmd, CommandContext ctx) {
-        AggProjectPaused firstPaused = projectPaused(cmd.getProjectId());
-        AggProjectCancelled thenCancelled = projectCancelled(cmd.getProjectId());
-        return Lists.newArrayList(firstPaused, thenCancelled);
+        var firstPaused = projectPaused(cmd.getProjectId());
+        var thenCancelled = projectCancelled(cmd.getProjectId());
+        return newArrayList(firstPaused, thenCancelled);
     }
 
     @Apply

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/IgTestAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/IgTestAggregate.java
@@ -59,14 +59,14 @@ public class IgTestAggregate
 
     @Assign
     AggProjectCreated handle(AggCreateProject cmd) {
-        AggProjectCreated event = projectCreated(cmd.getProjectId(),
-                                                       cmd.getName());
+        var event = projectCreated(cmd.getProjectId(),
+                                   cmd.getName());
         return event;
     }
 
     @Assign
     AggProjectStarted handle(AggStartProject cmd) {
-        AggProjectStarted message = projectStarted(cmd.getProjectId());
+        var message = projectStarted(cmd.getProjectId());
         return message;
     }
 

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/TaskAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/TaskAggregate.java
@@ -68,11 +68,11 @@ public class TaskAggregate extends Aggregate<AggTaskId, AggTask, AggTask.Builder
      */
     @Assign
     Pair<AggTaskCreated, Optional<AggTaskAssigned>> handle(AggCreateTask command) {
-        AggTaskId id = command.getTaskId();
-        AggTaskCreated createdEvent = taskCreated(id);
+        var id = command.getTaskId();
+        var createdEvent = taskCreated(id);
 
-        UserId assignee = command.getAssignee();
-        AggTaskAssigned assignedEvent = taskAssignedOrNull(id, assignee);
+        var assignee = command.getAssignee();
+        var assignedEvent = taskAssignedOrNull(id, assignee);
 
         return Pair.withNullable(createdEvent, assignedEvent);
     }
@@ -88,43 +88,42 @@ public class TaskAggregate extends Aggregate<AggTaskId, AggTask, AggTask.Builder
      * {@linkplain UserId assignee} is a default empty instance returns {@code null}.
      */
     private static @Nullable AggTaskAssigned taskAssignedOrNull(AggTaskId id, UserId assignee) {
-        UserId emptyUserId = UserId.getDefaultInstance();
+        var emptyUserId = UserId.getDefaultInstance();
         if (assignee.equals(emptyUserId)) {
             return null;
         }
-        AggTaskAssigned event = AggTaskAssigned.newBuilder()
-                                               .setTaskId(id)
-                                               .setNewAssignee(assignee)
-                                               .build();
+        var event = AggTaskAssigned.newBuilder()
+                .setTaskId(id)
+                .setNewAssignee(assignee)
+                .build();
         return event;
     }
 
     @Assign
     AggTaskAssigned handle(AggAssignTask command) {
-        AggTaskId id = command.getTaskId();
-        UserId newAssignee = command.getAssignee();
-        UserId previousAssignee = state().getAssignee();
+        var id = command.getTaskId();
+        var newAssignee = command.getAssignee();
+        var previousAssignee = state().getAssignee();
 
-        AggTaskAssigned event = taskAssigned(id, previousAssignee, newAssignee);
+        var event = taskAssigned(id, previousAssignee, newAssignee);
         return event;
     }
 
     @Assign
     AggTaskAssigned handle(AggReassignTask command)
             throws AggCannotReassignUnassignedTask {
-        AggTaskId id = command.getTaskId();
-        UserId newAssignee = command.getAssignee();
-        UserId previousAssignee = state().getAssignee();
+        var id = command.getTaskId();
+        var newAssignee = command.getAssignee();
+        var previousAssignee = state().getAssignee();
 
         if (previousAssignee.equals(EMPTY_USER_ID)) {
-            throw AggCannotReassignUnassignedTask
-                    .newBuilder()
+            throw AggCannotReassignUnassignedTask.newBuilder()
                     .setTaskId(id)
                     .setUserId(previousAssignee)
                     .build();
         }
 
-        AggTaskAssigned event = taskAssigned(id, previousAssignee, newAssignee);
+        var event = taskAssigned(id, previousAssignee, newAssignee);
         return event;
     }
 
@@ -132,10 +131,10 @@ public class TaskAggregate extends Aggregate<AggTaskId, AggTask, AggTask.Builder
                                                 UserId previousAssignee,
                                                 UserId newAssignee) {
         return AggTaskAssigned.newBuilder()
-                              .setTaskId(id)
-                              .setPreviousAssignee(previousAssignee)
-                              .setNewAssignee(newAssignee)
-                              .build();
+                .setTaskId(id)
+                .setPreviousAssignee(previousAssignee)
+                .setNewAssignee(newAssignee)
+                .build();
     }
 
     @Apply
@@ -151,11 +150,11 @@ public class TaskAggregate extends Aggregate<AggTaskId, AggTask, AggTask.Builder
     @React
     Pair<AggUserNotified, Optional<AggUserNotified>>
     on(AggTaskAssigned event) {
-        AggTaskId taskId = event.getTaskId();
-        UserId previousAssignee = event.getPreviousAssignee();
-        AggUserNotified previousAssigneeNotified = userNotifiedOrNull(taskId, previousAssignee);
-        UserId newAssignee = event.getNewAssignee();
-        AggUserNotified newAssigneeNotified = userNotified(taskId, newAssignee);
+        var taskId = event.getTaskId();
+        var previousAssignee = event.getPreviousAssignee();
+        var previousAssigneeNotified = userNotifiedOrNull(taskId, previousAssignee);
+        var newAssignee = event.getNewAssignee();
+        var newAssigneeNotified = userNotified(taskId, newAssignee);
         return Pair.withNullable(newAssigneeNotified, previousAssigneeNotified);
     }
 
@@ -163,23 +162,23 @@ public class TaskAggregate extends Aggregate<AggTaskId, AggTask, AggTask.Builder
         if (userId.equals(EMPTY_USER_ID)) {
             return null;
         }
-        AggUserNotified event = userNotified(taskId, userId);
+        var event = userNotified(taskId, userId);
         return event;
     }
 
     private static AggUserNotified userNotified(AggTaskId taskId, UserId userId) {
-        AggUserNotified event = AggUserNotified.newBuilder()
-                                               .setTaskId(taskId)
-                                               .setUserId(userId)
-                                               .build();
+        var event = AggUserNotified.newBuilder()
+                .setTaskId(taskId)
+                .setUserId(userId)
+                .build();
         return event;
     }
 
     @React
     Pair<AggUserNotified, Optional<AggUserNotified>>
     on(Rejections.AggCannotReassignUnassignedTask rejection) {
-        AggUserNotified event = userNotified(rejection.getTaskId(),
-                                             rejection.getUserId());
+        var event = userNotified(rejection.getTaskId(),
+                                 rejection.getUserId());
         return Pair.withNullable(event, null);
     }
 

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/TestAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/TestAggregate.java
@@ -87,14 +87,14 @@ public class TestAggregate
     @Assign
     AggProjectCreated handle(AggCreateProject cmd, CommandContext ctx) {
         createProjectCommandHandled = true;
-        AggProjectCreated event = projectCreated(cmd.getProjectId(), cmd.getName());
+        var event = projectCreated(cmd.getProjectId(), cmd.getName());
         return event;
     }
 
     @Assign
     AggTaskAdded handle(AggAddTask cmd) {
         addTaskCommandHandled = true;
-        AggTaskAdded event = taskAdded(cmd.getProjectId());
+        var event = taskAdded(cmd.getProjectId());
         return event.toBuilder()
                     .setTask(cmd.getTask())
                     .build();
@@ -103,7 +103,7 @@ public class TestAggregate
     @Assign
     List<AggProjectStarted> handle(AggStartProject cmd) {
         startProjectCommandHandled = true;
-        AggProjectStarted message = projectStarted(cmd.getProjectId());
+        var message = projectStarted(cmd.getProjectId());
         return ImmutableList.of(message);
     }
 
@@ -157,7 +157,7 @@ public class TestAggregate
 
     @VisibleForTesting
     public void dispatchCommands(Command... commands) {
-        for (Command cmd : commands) {
+        for (var cmd : commands) {
             AggregateMessageDispatcher.dispatchCommand(this, env(cmd));
         }
     }

--- a/server/src/test/java/io/spine/server/aggregate/given/dispatch/AggregateBuilder.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/dispatch/AggregateBuilder.java
@@ -38,9 +38,12 @@ import io.spine.validate.ValidatingBuilder;
 /**
  * Utility class for building aggregates for tests.
  *
- * @param <A> the type of the aggregate to build
- * @param <I> the type of aggregate IDs
- * @param <S> the type of the aggregate state
+ * @param <A>
+ *         the type of the aggregate to build
+ * @param <I>
+ *         the type of aggregate IDs
+ * @param <S>
+ *         the type of the aggregate state
  */
 @VisibleForTesting
 public class AggregateBuilder<A extends Aggregate<I, S, ?>,
@@ -53,17 +56,17 @@ public class AggregateBuilder<A extends Aggregate<I, S, ?>,
         // Have the constructor for easier location of usages.
     }
 
-    @CanIgnoreReturnValue
     @Override
+    @CanIgnoreReturnValue
     public AggregateBuilder<A, I, S> setResultClass(Class<A> entityClass) {
         super.setResultClass(entityClass);
         return this;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})    /* To avoid massive generics hell. */
     protected void setState(A result, S state, Version version) {
-        TestAggregateTransaction tx = new TestAggregateTransaction(result, state, version);
+        var tx = new TestAggregateTransaction(result, state, version);
         tx.commit();
     }
 

--- a/server/src/test/java/io/spine/server/aggregate/given/dispatch/AggregateMessageDispatcher.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/dispatch/AggregateMessageDispatcher.java
@@ -91,7 +91,7 @@ public class AggregateMessageDispatcher {
     dispatchCommand(Aggregate<?, ?, ?> aggregate, Command command) {
         checkNotNull(aggregate);
         checkNotNull(command);
-        CommandEnvelope ce = CommandEnvelope.of(command);
+        var ce = CommandEnvelope.of(command);
         return AggregateTestSupport
                 .dispatchCommand(new TestAggregateRepository<>(), aggregate, ce);
     }
@@ -122,7 +122,7 @@ public class AggregateMessageDispatcher {
     dispatchEvent(Aggregate<?, ?, ?> aggregate, Event event) {
         checkNotNull(aggregate);
         checkNotNull(event);
-        EventEnvelope env = EventEnvelope.of(event);
+        var env = EventEnvelope.of(event);
         return AggregateTestSupport.dispatchEvent(new TestAggregateRepository<>(), aggregate, env);
     }
 

--- a/server/src/test/java/io/spine/server/aggregate/given/dispatch/AggregatePartBuilder.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/dispatch/AggregatePartBuilder.java
@@ -78,13 +78,13 @@ public class AggregatePartBuilder<A extends AggregatePart<I, S, ?, R>,
 
     @Override
     protected A createEntity(I id) {
-        A result = entityClass().create(aggregateRoot);
+        var result = entityClass().create(aggregateRoot);
         return result;
     }
 
     @Override
     protected Constructor<A> constructor() {
-        Constructor<A> constructor = entityClass().constructor();
+        var constructor = entityClass().constructor();
         return constructor;
     }
 }

--- a/server/src/test/java/io/spine/server/aggregate/given/fibonacci/FibonacciAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/fibonacci/FibonacciAggregate.java
@@ -43,8 +43,7 @@ public final class FibonacciAggregate extends Aggregate<SequenceId, Sequence, Se
 
     @Assign
     StartingNumbersSet handle(SetStartingNumbers cmd) {
-        StartingNumbersSet event = StartingNumbersSet
-                .newBuilder()
+        var event = StartingNumbersSet.newBuilder()
                 .setId(cmd.getId())
                 .setNumberOne(cmd.getNumberOne())
                 .setNumberTwo(cmd.getNumberTwo())
@@ -54,8 +53,7 @@ public final class FibonacciAggregate extends Aggregate<SequenceId, Sequence, Se
 
     @Assign
     SequenceMoved handle(MoveSequence cmd) {
-        SequenceMoved event = SequenceMoved
-                .newBuilder()
+        var event = SequenceMoved.newBuilder()
                 .setId(cmd.getId())
                 .vBuild();
         return event;
@@ -63,8 +61,8 @@ public final class FibonacciAggregate extends Aggregate<SequenceId, Sequence, Se
 
     @Apply
     private void on(StartingNumbersSet event) {
-        int numberOne = event.getNumberOne();
-        int numberTwo = event.getNumberTwo();
+        var numberOne = event.getNumberOne();
+        var numberTwo = event.getNumberTwo();
         builder().setId(event.getId())
                  .setCurrentNumberOne(numberOne)
                  .setCurrentNumberTwo(numberTwo);
@@ -74,9 +72,9 @@ public final class FibonacciAggregate extends Aggregate<SequenceId, Sequence, Se
 
     @Apply
     private void on(SequenceMoved event) {
-        int numberOne = builder().getCurrentNumberOne();
-        int numberTwo = builder().getCurrentNumberTwo();
-        int sum = numberOne + numberTwo;
+        var numberOne = builder().getCurrentNumberOne();
+        var numberTwo = builder().getCurrentNumberTwo();
+        var sum = numberOne + numberTwo;
         builder().setId(event.getId())
                  .setCurrentNumberOne(numberTwo)
                  .setCurrentNumberTwo(sum);

--- a/server/src/test/java/io/spine/server/aggregate/given/importado/Dot.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/importado/Dot.java
@@ -42,15 +42,15 @@ final class Dot extends Aggregate<ObjectId, Point, Point.Builder> {
     @Assign
     Moved on(Move command) {
         return Moved.newBuilder()
-                    .setObject(command.getObject())
-                    .setDirection(command.getDirection())
-                    .setCurrentPosition(move(state(), command.getDirection()))
-                    .build();
+                .setObject(command.getObject())
+                .setDirection(command.getDirection())
+                .setCurrentPosition(move(state(), command.getDirection()))
+                .build();
     }
 
     @Apply(allowImport = true)
     private void event(Moved event) {
-        Point newPosition = move(state(), event.getDirection());
+        var newPosition = move(state(), event.getDirection());
 
         builder().setId(event.getObject())
                  .setX(newPosition.getX())
@@ -58,8 +58,7 @@ final class Dot extends Aggregate<ObjectId, Point, Point.Builder> {
     }
 
     private static Point move(Point p, Direction direction) {
-        Point.Builder result = Point
-                .newBuilder()
+        var result = Point.newBuilder()
                 .setX(p.getX())
                 .setY(p.getY());
         switch (direction) {

--- a/server/src/test/java/io/spine/server/aggregate/given/klasse/EngineAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/klasse/EngineAggregate.java
@@ -54,10 +54,9 @@ public class EngineAggregate extends Aggregate<EngineId, Engine, Engine.Builder>
 
     @Assign
     EngineStarted handle(StartEngine command) throws EngineAlreadyStarted {
-        EngineId id = command.getId();
+        var id = command.getId();
         if (state().getStatus() == STARTED) {
-            throw EngineAlreadyStarted
-                    .newBuilder()
+            throw EngineAlreadyStarted.newBuilder()
                     .setId(id)
                     .build();
         }
@@ -71,10 +70,9 @@ public class EngineAggregate extends Aggregate<EngineId, Engine, Engine.Builder>
 
     @Assign
     EngineStopped handle(StopEngine command) throws EngineAlreadyStopped {
-        EngineId id = command.getId();
+        var id = command.getId();
         if (state().getStatus() == STOPPED) {
-            throw EngineAlreadyStopped
-                    .newBuilder()
+            throw EngineAlreadyStopped.newBuilder()
                     .setId(id)
                     .build();
         }
@@ -151,14 +149,14 @@ public class EngineAggregate extends Aggregate<EngineId, Engine, Engine.Builder>
 
     private static EngineStarted start(EngineId id) {
         return EngineStarted.newBuilder()
-                            .setId(id)
-                            .build();
+                .setId(id)
+                .build();
     }
 
     private static EngineStopped stop(EngineId id) {
         return EngineStopped.newBuilder()
-                            .setId(id)
-                            .build();
+                .setId(id)
+                .build();
     }
 
     private void setStarted() {

--- a/server/src/test/java/io/spine/server/aggregate/given/klasse/IndecisiveEngineAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/klasse/IndecisiveEngineAggregate.java
@@ -36,7 +36,7 @@ public class IndecisiveEngineAggregate extends Aggregate<EngineId, Engine, Engin
 
     @Assign
     EngineStarted handle(StartEngine command) {
-        EngineId id = command.getId();
+        var id = command.getId();
         return EngineStarted.newBuilder()
                 .setId(id)
                 .build();

--- a/server/src/test/java/io/spine/server/aggregate/given/part/TaskCommentsPart.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/part/TaskCommentsPart.java
@@ -49,8 +49,7 @@ public class TaskCommentsPart
 
     @Assign
     AggCommentAdded handle(AggAddComment command) {
-        AggCommentAdded event = AggCommentAdded
-                .newBuilder()
+        var event = AggCommentAdded.newBuilder()
                 .setTaskId(command.getTaskId())
                 .setAuthor(command.getAuthor())
                 .setText(command.getText())
@@ -60,8 +59,7 @@ public class TaskCommentsPart
 
     @Apply
     private void apply(AggCommentAdded event) {
-        Comment comment = Comment
-                .newBuilder()
+        var comment = Comment.newBuilder()
                 .setAuthor(event.getAuthor())
                 .setText(event.getText())
                 .build();

--- a/server/src/test/java/io/spine/server/aggregate/given/part/TaskPart.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/part/TaskPart.java
@@ -50,12 +50,10 @@ public class TaskPart
 
     @Assign
     Pair<AggTaskCreated, AggTaskAssigned> handle(AggCreateTask command) {
-        AggTaskCreated created = AggTaskCreated
-                .newBuilder()
+        var created = AggTaskCreated.newBuilder()
                 .setTaskId(command.getTaskId())
                 .build();
-        AggTaskAssigned assigned = AggTaskAssigned
-                .newBuilder()
+        var assigned = AggTaskAssigned.newBuilder()
                 .setTaskId(command.getTaskId())
                 .setNewAssignee(command.getAssignee())
                 .build();

--- a/server/src/test/java/io/spine/server/aggregate/given/query/AggregateQueryingTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/query/AggregateQueryingTestEnv.java
@@ -40,7 +40,6 @@ import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.AggregateRepository;
 import io.spine.server.aggregate.Apply;
 import io.spine.server.command.Assign;
-import io.spine.server.entity.Repository;
 import io.spine.test.aggregate.query.MRPhoto;
 import io.spine.test.aggregate.query.MRPhotoId;
 import io.spine.test.aggregate.query.MRPhotoType;
@@ -108,16 +107,13 @@ public final class AggregateQueryingTestEnv {
                                     String altText,
                                     int width,
                                     int height) {
-        Url fullSizeUrl = Url
-                .newBuilder()
+        var fullSizeUrl = Url.newBuilder()
                 .setSpec(url)
                 .buildPartial();
-        Url thumbnail = Url
-                .newBuilder()
+        var thumbnail = Url.newBuilder()
                 .setSpec(url + "-thumbnail")
                 .buildPartial();
-        MRPhoto photo = MRPhoto
-                .newBuilder()
+        var photo = MRPhoto.newBuilder()
                 .setId(MRPhotoId.generate())
                 .setFullSizeUrl(fullSizeUrl)
                 .setThumbnailUrl(thumbnail)
@@ -130,12 +126,10 @@ public final class AggregateQueryingTestEnv {
     }
 
     public static MessageId cause() {
-        EventId causeOfChange = EventId
-                .newBuilder()
+        var causeOfChange = EventId.newBuilder()
                 .setValue("For tests")
                 .build();
-        MessageId messageId = MessageId
-                .newBuilder()
+        var messageId = MessageId.newBuilder()
                 .setId(AnyPacker.pack(causeOfChange))
                 .setVersion(Versions.zero())
                 .setTypeUrl("example.org/test.Type")
@@ -150,13 +144,12 @@ public final class AggregateQueryingTestEnv {
     // This suppression makes sense only to Error Prone.
     @SuppressWarnings("unchecked")  // as per declaration of the `DefaultRepository`;
     public static AggregateRepository<MRPhotoId, PhotoAggregate, MRPhoto> newPhotosRepository() {
-        Repository<MRPhotoId, PhotoAggregate> repo = DefaultRepository.of(PhotoAggregate.class);
+        var repo = DefaultRepository.of(PhotoAggregate.class);
         return (AggregateRepository<MRPhotoId, PhotoAggregate, MRPhoto>) repo;
     }
 
     public static MRUploadPhoto upload(MRPhoto state) {
-        return MRUploadPhoto
-                .newBuilder()
+        return MRUploadPhoto.newBuilder()
                 .setId(state.getId())
                 .setFullSizeUrl(state.getFullSizeUrl())
                 .setThumbnailUrl(state.getThumbnailUrl())
@@ -169,22 +162,21 @@ public final class AggregateQueryingTestEnv {
 
     public static MRArchivePhoto archive(MRPhoto photo) {
         return MRArchivePhoto.newBuilder()
-                             .setId(photo.getId())
-                             .vBuild();
+                .setId(photo.getId())
+                .vBuild();
     }
 
     public static MRDeletePhoto delete(MRPhoto photo) {
         return MRDeletePhoto.newBuilder()
-                            .setId(photo.getId())
-                            .vBuild();
+                .setId(photo.getId())
+                .vBuild();
     }
 
     public static class PhotoAggregate extends Aggregate<MRPhotoId, MRPhoto, MRPhoto.Builder> {
 
         @Assign
         MRPhotoUploaded handle(MRUploadPhoto cmd) {
-            MRPhotoUploaded event = MRPhotoUploaded
-                    .newBuilder()
+            var event = MRPhotoUploaded.newBuilder()
                     .setId(cmd.getId())
                     .setFullSizeUrl(cmd.getFullSizeUrl())
                     .setThumbnailUrl(cmd.getThumbnailUrl())
@@ -210,8 +202,8 @@ public final class AggregateQueryingTestEnv {
         @Assign
         MRPhotoArchived handle(MRArchivePhoto photo) {
             return MRPhotoArchived.newBuilder()
-                                  .setId(photo.getId())
-                                  .vBuild();
+                    .setId(photo.getId())
+                    .vBuild();
         }
 
         @Apply
@@ -222,8 +214,8 @@ public final class AggregateQueryingTestEnv {
         @Assign
         MRPhotoDeleted handle(MRDeletePhoto photo) {
             return MRPhotoDeleted.newBuilder()
-                                 .setId(photo.getId())
-                                 .vBuild();
+                    .setId(photo.getId())
+                    .vBuild();
         }
 
         @Apply
@@ -255,8 +247,8 @@ public final class AggregateQueryingTestEnv {
         @Assign
         MRSoundUploaded handle(MRUploadSound cmd) {
             return MRSoundUploaded.newBuilder()
-                                  .setId(cmd.getId())
-                                  .vBuild();
+                    .setId(cmd.getId())
+                    .vBuild();
         }
 
         @Apply

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/AggregateRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/AggregateRepositoryTestEnv.java
@@ -80,28 +80,28 @@ public class AggregateRepositoryTestEnv {
     }
 
     public static ProjectAggregate givenStoredAggregate() {
-        ProjectId id = Sample.messageOfType(ProjectId.class);
-        ProjectAggregate aggregate = givenAggregate().withUncommittedEvents(id);
+        var id = Sample.messageOfType(ProjectId.class);
+        var aggregate = givenAggregate().withUncommittedEvents(id);
 
         repository.storeAggregate(aggregate);
         return aggregate;
     }
 
     public static void givenStoredAggregateWithId(String id) {
-        ProjectId projectId = givenAggregateId(id);
-        ProjectAggregate aggregate = givenAggregate().withUncommittedEvents(projectId);
+        var projectId = givenAggregateId(id);
+        var aggregate = givenAggregate().withUncommittedEvents(projectId);
 
         repository.storeAggregate(aggregate);
     }
 
     private static TestActorRequestFactory newRequestFactory() {
-        TestActorRequestFactory requestFactory =
+        var requestFactory =
                 new TestActorRequestFactory(AggregateRepositoryTestEnv.class);
         return requestFactory;
     }
 
     private static BoundedContext newBoundedContext() {
-        BoundedContext context = BoundedContextBuilder.assumingTests().build();
+        var context = BoundedContextBuilder.assumingTests().build();
         return context;
     }
 

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/AggregateWithLifecycle.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/AggregateWithLifecycle.java
@@ -44,8 +44,8 @@ public class AggregateWithLifecycle
 
     @Assign
     Evaluated handle(Evaluate commandMessage) {
-        String command = commandMessage.getCmd();
-        String result = command + 'd';
+        var command = commandMessage.getCmd();
+        var result = command + 'd';
         return Evaluated
                 .newBuilder()
                 .setCmd(result)
@@ -54,7 +54,7 @@ public class AggregateWithLifecycle
 
     @Apply
     private void on(Evaluated eventMessage) {
-        String msg = RepoOfAggregateWithLifecycle.getMessage(eventMessage);
+        var msg = RepoOfAggregateWithLifecycle.getMessage(eventMessage);
         if (namedAfterColumn(msg, ArchivedColumn.instance())) {
             setArchived(true);
         }

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/FailingAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/FailingAggregate.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.aggregate.given.repo;
 
-import com.google.protobuf.Timestamp;
 import io.spine.base.EventMessage;
 import io.spine.base.Identifier;
 import io.spine.base.Time;
@@ -63,7 +62,7 @@ class FailingAggregate extends Aggregate<Long, LongIdAggregate, LongIdAggregate.
 
     @SuppressWarnings("NumericCastThatLosesPrecision") // Int. part as ID.
     static long toId(FloatEncountered message) {
-        float floatValue = message.getNumber();
+        var floatValue = message.getNumber();
         return (long) Math.abs(floatValue);
     }
 
@@ -96,9 +95,9 @@ class FailingAggregate extends Aggregate<Long, LongIdAggregate, LongIdAggregate.
 
     @React
     NumberPassed on(FloatEncountered value) {
-        float floatValue = value.getNumber();
+        var floatValue = value.getNumber();
         if (floatValue < 0) {
-            long longValue = toId(value);
+            var longValue = toId(value);
             // Complain only if the passed value represents ID of this aggregate.
             // This would allow other aggregates react on this message.
             if (longValue == id()) {
@@ -110,7 +109,7 @@ class FailingAggregate extends Aggregate<Long, LongIdAggregate, LongIdAggregate.
 
     @Apply
     private void apply(NumberPassed event) {
-        int whichSecond = TimestampTemporal
+        var whichSecond = TimestampTemporal
                 .from(event.getWhen())
                 .toInstant()
                 .get(ChronoField.MILLI_OF_SECOND);
@@ -118,9 +117,8 @@ class FailingAggregate extends Aggregate<Long, LongIdAggregate, LongIdAggregate.
     }
 
     private static NumberPassed now() {
-        Timestamp time = Time.currentTime();
-        return NumberPassed
-                .newBuilder()
+        var time = Time.currentTime();
+        return NumberPassed.newBuilder()
                 .setWhen(time)
                 .build();
     }

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/FailingAggregateRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/FailingAggregateRepository.java
@@ -54,13 +54,13 @@ public final class FailingAggregateRepository
         super.setupCommandRouting(routing);
         routing.replaceDefault(
                 // Simplistic routing function that takes absolute value as ID.
-                new CommandRoute<Long, CommandMessage>() {
+                new CommandRoute<>() {
                     private static final long serialVersionUID = 0L;
 
                     @Override
                     public Long apply(CommandMessage message, CommandContext context) {
                         if (message instanceof RejectNegativeInt) {
-                            RejectNegativeInt event = (RejectNegativeInt) message;
+                            var event = (RejectNegativeInt) message;
                             return (long) Math.abs(event.getNumber());
                         }
                         return 0L;
@@ -73,17 +73,18 @@ public final class FailingAggregateRepository
     protected void setupEventRouting(EventRouting<Long> routing) {
         super.setupEventRouting(routing);
         routing.replaceDefault(
-                new EventRoute<Long, EventMessage>() {
+                new EventRoute<>() {
                     private static final long serialVersionUID = 0L;
 
                     /**
                      * Returns several entity identifiers to check error isolation.
+                     *
                      * @see io.spine.server.aggregate.given.repo.FailingAggregate#on(io.spine.test.aggregate.number.FloatEncountered)
                      */
                     @Override
                     public Set<Long> apply(EventMessage message, EventContext context) {
                         if (message instanceof FloatEncountered) {
-                            long absValue = FailingAggregate.toId((FloatEncountered) message);
+                            var absValue = FailingAggregate.toId((FloatEncountered) message);
                             return ImmutableSet.of(absValue, absValue + 100, absValue + 200);
                         }
                         return ImmutableSet.of(1L, 2L);

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/GivenAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/GivenAggregate.java
@@ -57,7 +57,7 @@ public class GivenAggregate {
     }
 
     public ProjectAggregate withUncommittedEvents(ProjectId id) {
-        ProjectAggregate givenProject =
+        var givenProject =
                 Given.aggregateOfClass(ProjectAggregate.class)
                      .withId(id)
                      .build();

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/ProjectAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/ProjectAggregate.java
@@ -57,9 +57,9 @@ public class ProjectAggregate
     @Assign
     AggProjectCreated handle(AggCreateProject msg) {
         return AggProjectCreated.newBuilder()
-                                .setProjectId(msg.getProjectId())
-                                .setName(msg.getName())
-                                .build();
+                .setProjectId(msg.getProjectId())
+                .setName(msg.getName())
+                .build();
     }
 
     @Apply
@@ -71,9 +71,9 @@ public class ProjectAggregate
     @Assign
     AggTaskAdded handle(AggAddTask msg) {
         return AggTaskAdded.newBuilder()
-                           .setProjectId(msg.getProjectId())
-                           .setTask(msg.getTask())
-                           .build();
+                .setProjectId(msg.getProjectId())
+                .setTask(msg.getTask())
+                .build();
     }
 
     @Apply
@@ -85,8 +85,8 @@ public class ProjectAggregate
     @Assign
     AggProjectStarted handle(AggStartProject msg) {
         return AggProjectStarted.newBuilder()
-                                .setProjectId(msg.getProjectId())
-                                .build();
+                .setProjectId(msg.getProjectId())
+                .build();
     }
 
     @Apply
@@ -104,8 +104,7 @@ public class ProjectAggregate
     Optional<AggProjectArchived> on(AggProjectArchived event) {
         if (event.getChildProjectIdList()
                  .contains(id())) {
-            AggProjectArchived reaction = AggProjectArchived
-                    .newBuilder()
+            var reaction = AggProjectArchived.newBuilder()
                     .setProjectId(id())
                     .build();
             return Optional.of(reaction);
@@ -129,8 +128,7 @@ public class ProjectAggregate
     Optional<AggProjectDeleted> on(AggProjectDeleted event) {
         if (event.getChildProjectIdList()
                  .contains(id())) {
-            AggProjectDeleted reaction = AggProjectDeleted
-                    .newBuilder()
+            var reaction = AggProjectDeleted.newBuilder()
                     .setProjectId(id())
                     .build();
             return Optional.of(reaction);

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/ReactingAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/ReactingAggregate.java
@@ -50,15 +50,16 @@ public class ReactingAggregate
     }
 
     /**
-     * Emits {@link io.spine.test.aggregate.event.AggProjectArchived} if the event is from the parent project.
-     * Otherwise returns empty iterable.
+     * Emits {@link io.spine.test.aggregate.event.AggProjectArchived} if the event is from
+     * the parent project.
+     *
+     * <p>Otherwise returns empty iterable.
      */
     @React
     Optional<AggProjectArchived> on(AggProjectArchived event) {
         if (event.getChildProjectIdList()
                  .contains(id())) {
-            AggProjectArchived reaction = AggProjectArchived
-                    .newBuilder()
+            var reaction = AggProjectArchived.newBuilder()
                     .setProjectId(id())
                     .build();
             return Optional.of(reaction);
@@ -68,15 +69,16 @@ public class ReactingAggregate
     }
 
     /**
-     * Emits {@link io.spine.test.aggregate.event.AggProjectDeleted} if the event is from the parent project.
-     * Otherwise returns empty iterable.
+     * Emits {@link io.spine.test.aggregate.event.AggProjectDeleted} if the event is from
+     * the parent project.
+     *
+     * <p>Otherwise returns empty iterable.
      */
     @React
     Optional<AggProjectDeleted> on(AggProjectDeleted event) {
         if (event.getChildProjectIdList()
                  .contains(id())) {
-            AggProjectDeleted reaction = AggProjectDeleted
-                    .newBuilder()
+            var reaction = AggProjectDeleted.newBuilder()
                     .setProjectId(id())
                     .build();
             return Optional.of(reaction);

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/RejectionReactingAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/RejectionReactingAggregate.java
@@ -34,7 +34,6 @@ import io.spine.test.aggregate.ProjectId;
 import io.spine.test.aggregate.event.AggProjectArchived;
 import io.spine.test.aggregate.rejection.Rejections;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -52,11 +51,11 @@ public class RejectionReactingAggregate
 
     @React
     Optional<AggProjectArchived> on(Rejections.AggCannotStartArchivedProject rejection) {
-        List<ProjectId> childIdList = rejection.getChildProjectIdList();
+        var childIdList = rejection.getChildProjectIdList();
         if (childIdList.contains(id())) {
-            AggProjectArchived event = AggProjectArchived.newBuilder()
-                                                         .setProjectId(id())
-                                                         .build();
+            var event = AggProjectArchived.newBuilder()
+                    .setProjectId(id())
+                    .build();
             return Optional.of(event);
         } else {
             return Optional.empty();

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/RepoOfAggregateWithLifecycle.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/RepoOfAggregateWithLifecycle.java
@@ -28,7 +28,6 @@ package io.spine.server.aggregate.given.repo;
 
 import com.google.common.base.Splitter;
 import io.spine.base.CommandMessage;
-import io.spine.core.CommandContext;
 import io.spine.server.aggregate.AggregateRepository;
 import io.spine.server.route.CommandRoute;
 import io.spine.server.route.CommandRouting;
@@ -52,16 +51,7 @@ public class RepoOfAggregateWithLifecycle
      * Custom {@code IdCommandFunction} that parses an aggregate ID from {@code StringValue}.
      */
     private static final CommandRoute<Long, CommandMessage> parsingRoute =
-            new CommandRoute<Long, CommandMessage>() {
-
-                private static final long serialVersionUID = 0L;
-
-                @Override
-                public Long apply(CommandMessage message, CommandContext context) {
-                    Long result = getId((Evaluate) message);
-                    return result;
-                }
-            };
+            (msg, ctx) -> getId((Evaluate) msg);
 
     @Override
     protected void setupCommandRouting(CommandRouting<Long> routing) {
@@ -77,8 +67,8 @@ public class RepoOfAggregateWithLifecycle
      */
     public static Evaluate createCommandMessage(Long id, String msg) {
         return Evaluate.newBuilder()
-                       .setCmd(format("%d%s%s", id, SEPARATOR, msg))
-                       .build();
+                .setCmd(format("%d%s%s", id, SEPARATOR, msg))
+                .build();
     }
 
     private static Long getId(Evaluate commandMessage) {

--- a/server/src/test/java/io/spine/server/aggregate/given/thermometer/SafeThermometer.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/thermometer/SafeThermometer.java
@@ -45,20 +45,17 @@ public final class SafeThermometer extends Aggregate<ThermometerId, Thermometer,
 
     @React
     Optional<TermTemperatureChanged> on(@External TemperatureChanged e) {
-        double temperature = e.getFahrenheit();
+        var temperature = e.getFahrenheit();
         if (!withinBounds(temperature)) {
             return Optional.empty();
         }
+        var change = TemperatureChange.newBuilder()
+                .setNewValue(temperature)
+                .setPreviousValue(state().getFahrenheit());
         return Optional.of(
-                TermTemperatureChanged
-                        .newBuilder()
+                TermTemperatureChanged.newBuilder()
                         .setThermometer(id())
-                        .setChange(
-                                TemperatureChange
-                                        .newBuilder()
-                                        .setNewValue(temperature)
-                                        .setPreviousValue(state().getFahrenheit())
-                        )
+                        .setChange(change)
                         .vBuild()
         );
     }

--- a/server/src/test/java/io/spine/server/aggregate/model/AggregatePartClassTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/model/AggregatePartClassTest.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.aggregate.model;
 
-import io.spine.server.BoundedContext;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.aggregate.given.part.AnAggregatePart;
 import io.spine.server.aggregate.given.part.AnAggregateRoot;
@@ -53,8 +52,8 @@ class AggregatePartClassTest {
     @BeforeEach
     void setUp() {
         ModelTests.dropAllModels();
-        BoundedContext boundedContext = BoundedContextBuilder.assumingTests().build();
-        ProjectId projectId = ProjectId.generate();
+        var boundedContext = BoundedContextBuilder.assumingTests().build();
+        var projectId = ProjectId.generate();
         root = new AnAggregateRoot(boundedContext, projectId);
     }
 
@@ -67,15 +66,14 @@ class AggregatePartClassTest {
     @Test
     @DisplayName("throw exception when aggregate part does not have appropriate constructor")
     void throwOnNoProperCtorAvailable() {
-        AggregatePartClass<WrongAggregatePart> wrongPartClass =
-                asAggregatePartClass(WrongAggregatePart.class);
+        var wrongPartClass = asAggregatePartClass(WrongAggregatePart.class);
         assertThrows(ModelError.class, wrongPartClass::constructor);
     }
 
     @Test
     @DisplayName("create aggregate part entity")
     void createAggregatePartEntity() {
-        AnAggregatePart part = partClass.create(root);
+        var part = partClass.create(root);
 
         assertNotNull(part);
         assertEquals(root.id(), part.id());

--- a/server/src/test/java/io/spine/server/bc/given/ProjectAggregate.java
+++ b/server/src/test/java/io/spine/server/bc/given/ProjectAggregate.java
@@ -61,7 +61,7 @@ public class ProjectAggregate
 
     @Assign
     List<BcProjectStarted> handle(BcStartProject cmd, CommandContext ctx) {
-        BcProjectStarted message = Given.EventMessage.projectStarted(cmd.getProjectId());
+        var message = Given.EventMessage.projectStarted(cmd.getProjectId());
         return Lists.newArrayList(message);
     }
 

--- a/server/src/test/java/io/spine/server/bus/BusBuilderTest.java
+++ b/server/src/test/java/io/spine/server/bus/BusBuilderTest.java
@@ -66,10 +66,10 @@ public abstract class BusBuilderTest<B extends BusBuilder<?, T, E, ?, ?>,
         BusFilter<E> first = new StubFilter<>();
         BusFilter<E> second = new StubFilter<>();
 
-        B builder = builder();
+        var builder = builder();
         builder.appendFilter(first)
                .appendFilter(second);
-        Iterable<BusFilter<E>> filters = builder.filters();
+        var filters = builder.filters();
 
         assertThat(filters)
                 .containsExactly(first, second);

--- a/server/src/test/java/io/spine/server/bus/DispatchingQueueSynchronisationTest.java
+++ b/server/src/test/java/io/spine/server/bus/DispatchingQueueSynchronisationTest.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.bus;
 
-import com.google.common.collect.ImmutableList;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.bus.given.stock.JowDonsIndex;
 import io.spine.server.bus.given.stock.ShareAggregate;
@@ -54,32 +53,29 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class DispatchingQueueSynchronisationTest {
 
     @Test
-    @DisplayName("Bus should not lock with its system counterpart")
+    @DisplayName("`Bus` should not lock with its system counterpart")
     void deadlock() throws InterruptedException {
-        ThreadPoolExecutor executor = (ThreadPoolExecutor) newFixedThreadPool(10);
-        BlackBox context = BlackBox.from(
+        var executor = (ThreadPoolExecutor) newFixedThreadPool(10);
+        var context = BlackBox.from(
                 BoundedContextBuilder.assumingTests()
                                      .add(ShareAggregate.class)
                                      .add(new JowDonsIndex.Repository())
         );
-        int taskCount = 10;
-        ImmutableList<ShareId> shares =
-                Stream.generate(() -> ShareId
-                        .newBuilder()
+        var taskCount = 10;
+        var shares =
+                Stream.generate(() -> ShareId.newBuilder()
                         .setValue(newUuid())
                         .vBuild())
                       .limit(taskCount)
                       .collect(toImmutableList());
         shares.forEach(share -> executor.execute(() -> {
-            Buy buy = Buy
-                    .newBuilder()
+            var buy = Buy.newBuilder()
                     .setShare(share)
                     .setAmount(42)
                     .vBuild();
             context.receivesCommand(buy);
             sleepUninterruptibly(Duration.ofSeconds(1));
-            Sell sell = Sell
-                    .newBuilder()
+            var sell = Sell.newBuilder()
                     .setShare(share)
                     .setAmount(12)
                     .vBuild();

--- a/server/src/test/java/io/spine/server/bus/FilterChainTest.java
+++ b/server/src/test/java/io/spine/server/bus/FilterChainTest.java
@@ -39,7 +39,7 @@ class FilterChainTest {
     @Test
     @DisplayName("not allow closing twice")
     void notAllowClosingTwice() throws Exception {
-        FilterChain<EventEnvelope> chain = new FilterChain<>(ImmutableList.of());
+        var chain = new FilterChain<EventEnvelope>(ImmutableList.of());
 
         chain.close();
         assertThrows(IllegalStateException.class, chain::close);

--- a/server/src/test/java/io/spine/server/bus/given/stock/ShareAggregate.java
+++ b/server/src/test/java/io/spine/server/bus/given/stock/ShareAggregate.java
@@ -31,7 +31,6 @@ import io.spine.server.aggregate.Apply;
 import io.spine.server.command.Assign;
 import io.spine.server.tuple.Pair;
 import io.spine.test.bus.Buy;
-import io.spine.test.bus.Price;
 import io.spine.test.bus.PriceDropped;
 import io.spine.test.bus.PriceRaised;
 import io.spine.test.bus.Sell;
@@ -42,21 +41,19 @@ import io.spine.test.bus.ShareTraded;
 import java.math.BigDecimal;
 
 import static java.lang.Math.max;
-import static java.math.BigDecimal.ROUND_UP;
+import static java.math.RoundingMode.CEILING;
 
 public final class ShareAggregate extends Aggregate<ShareId, Share, Share.Builder> {
 
     @Assign
     Pair<ShareTraded, PriceRaised> handle(Buy command) {
-        int amount = command.getAmount();
-        ShareTraded traded = ShareTraded
-                .newBuilder()
+        var amount = command.getAmount();
+        var traded = ShareTraded.newBuilder()
                 .setShare(id())
                 .setAmount(amount)
                 .vBuild();
-        float percent = max(amount / 100.0f, 50.0f);
-        PriceRaised raised = PriceRaised
-                .newBuilder()
+        var percent = max(amount / 100.0f, 50.0f);
+        var raised = PriceRaised.newBuilder()
                 .setShare(id())
                 .setPercent(percent)
                 .build();
@@ -65,15 +62,13 @@ public final class ShareAggregate extends Aggregate<ShareId, Share, Share.Builde
 
     @Assign
     Pair<ShareTraded, PriceDropped> handle(Sell command) {
-        int amount = command.getAmount();
-        ShareTraded traded = ShareTraded
-                .newBuilder()
+        var amount = command.getAmount();
+        var traded = ShareTraded.newBuilder()
                 .setShare(id())
                 .setAmount(amount)
                 .vBuild();
-        float percent = max(amount / 100.0f, 50.0f);
-        PriceDropped raised = PriceDropped
-                .newBuilder()
+        var percent = max(amount / 100.0f, 50.0f);
+        var raised = PriceDropped.newBuilder()
                 .setShare(id())
                 .setPercent(percent)
                 .build();
@@ -87,26 +82,24 @@ public final class ShareAggregate extends Aggregate<ShareId, Share, Share.Builde
 
     @Apply
     private void event(PriceRaised event) {
-        Price.Builder priceBuilder = builder().getPriceBuilder();
-        float oldPrice = priceBuilder.getUsd();
-        float newPrice = oldPrice + percentage(oldPrice, event.getPercent());
+        var priceBuilder = builder().getPriceBuilder();
+        var oldPrice = priceBuilder.getUsd();
+        var newPrice = oldPrice + percentage(oldPrice, event.getPercent());
         priceBuilder.setUsd(newPrice);
     }
 
     @Apply
     private void event(PriceDropped event) {
-        Price.Builder priceBuilder = builder().getPriceBuilder();
-        float oldPrice = priceBuilder.getUsd();
-        float newPrice = oldPrice - percentage(oldPrice, event.getPercent());
+        var priceBuilder = builder().getPriceBuilder();
+        var oldPrice = priceBuilder.getUsd();
+        var newPrice = oldPrice - percentage(oldPrice, event.getPercent());
         priceBuilder.setUsd(newPrice);
     }
 
     private static float percentage(float value, float percent) {
-        float raise = (value * percent / 100.0f);
-        BigDecimal decimalRaise = BigDecimal.valueOf(raise);
-        return decimalRaise.setScale(2, ROUND_UP)
+        var raise = (value * percent / 100.0f);
+        var decimalRaise = BigDecimal.valueOf(raise);
+        return decimalRaise.setScale(2, CEILING)
                            .floatValue();
     }
-
-
 }

--- a/server/src/test/java/io/spine/server/command/AbstractCommanderTest.java
+++ b/server/src/test/java/io/spine/server/command/AbstractCommanderTest.java
@@ -61,7 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("OverlyCoupledClass")
-@DisplayName("AbstractCommander should")
+@DisplayName("`AbstractCommander` should")
 class AbstractCommanderTest {
 
     private final CommandFactory commandFactory = new TestActorRequestFactory(getClass()).command();
@@ -92,8 +92,7 @@ class AbstractCommanderTest {
     @Test
     @DisplayName("create a command in response to a command")
     void commandOnCommand() {
-        CmdCreateProject commandMessage = CmdCreateProject
-                .newBuilder()
+        var commandMessage = CmdCreateProject.newBuilder()
                 .setProjectId(newProjectId())
                 .build();
         createCommandAndPost(commandMessage);
@@ -104,8 +103,7 @@ class AbstractCommanderTest {
     @Test
     @DisplayName("create a command on an event")
     void commandOnEvent() {
-        CmdTaskAdded eventMessage = CmdTaskAdded
-                .newBuilder()
+        var eventMessage = CmdTaskAdded.newBuilder()
                 .setProjectId(newProjectId())
                 .setTask(Task.newBuilder()
                              .setTaskId(newTaskId())
@@ -141,49 +139,44 @@ class AbstractCommanderTest {
      *******************************/
 
     private static ProjectId newProjectId() {
-        return ProjectId
-                .newBuilder()
+        return ProjectId.newBuilder()
                 .setId(newUuid())
                 .build();
     }
 
     private static TaskId newTaskId() {
-        return TaskId
-                .newBuilder()
+        return TaskId.newBuilder()
                 .setId(random(1, 100))
                 .build();
     }
 
     private static UserId newUserId() {
-        return UserId
-                .newBuilder()
+        return UserId.newBuilder()
                 .setValue(newUuid())
                 .build();
 
     }
 
     private void createCommandAndPost(CommandMessage commandMessage) {
-        io.spine.core.Command command = commandFactory.create(commandMessage);
+        var command = commandFactory.create(commandMessage);
         context.commandBus()
                .post(command, StreamObservers.noOpObserver());
     }
 
     private void createEventAndPost(EventMessage eventMessage) {
-        io.spine.core.Event event = eventFactory.createEvent(eventMessage, null);
+        var event = eventFactory.createEvent(eventMessage, null);
         context.eventBus()
                .post(event);
     }
 
     private void postCreateTaskCommand(boolean startTask) {
-        TaskId taskId = newTaskId();
-        UserId userId = newUserId();
-        Task task = Task
-                .newBuilder()
+        var taskId = newTaskId();
+        var userId = newUserId();
+        var task = Task.newBuilder()
                 .setTaskId(taskId)
                 .setAssignee(userId)
                 .build();
-        CmdCreateTask commandMessage = CmdCreateTask
-                .newBuilder()
+        var commandMessage = CmdCreateTask.newBuilder()
                 .setTaskId(taskId)
                 .setTask(task)
                 .setStart(startTask)
@@ -198,16 +191,14 @@ class AbstractCommanderTest {
 
         @Command
         FirstCmdCreateProject on(CmdCreateProject command) {
-            return FirstCmdCreateProject
-                    .newBuilder()
+            return FirstCmdCreateProject.newBuilder()
                     .setId(command.getProjectId())
                     .build();
         }
 
         @Command
         CmdSetTaskDescription on(CmdTaskAdded event) {
-            return CmdSetTaskDescription
-                    .newBuilder()
+            return CmdSetTaskDescription.newBuilder()
                     .setTaskId(event.getTask()
                                     .getTaskId())
                     .setDescription("Testing command creation on event")
@@ -216,20 +207,18 @@ class AbstractCommanderTest {
 
         @Command
         Pair<CmdAssignTask, Optional<CmdStartTask>> on(CmdCreateTask command) {
-            TaskId taskId = command.getTaskId();
-            UserId assignee = command.getTask()
-                                     .getAssignee();
-            CmdAssignTask cmdAssignTask = CmdAssignTask
-                    .newBuilder()
+            var taskId = command.getTaskId();
+            var assignee = command.getTask()
+                                  .getAssignee();
+            var cmdAssignTask = CmdAssignTask.newBuilder()
                     .setTaskId(taskId)
                     .setAssignee(assignee)
                     .build();
-            CmdStartTask cmdStartTask = command.getStart()
-                                        ? CmdStartTask
-                                                .newBuilder()
-                                                .setTaskId(taskId)
-                                                .build()
-                                        : null;
+            var cmdStartTask = command.getStart()
+                               ? CmdStartTask.newBuilder()
+                                       .setTaskId(taskId)
+                                       .build()
+                               : null;
             return Pair.withNullable(cmdAssignTask, cmdStartTask);
         }
     }

--- a/server/src/test/java/io/spine/server/command/CommandHandlingEntityTest.java
+++ b/server/src/test/java/io/spine/server/command/CommandHandlingEntityTest.java
@@ -49,7 +49,7 @@ class CommandHandlingEntityTest {
     @Test
     @DisplayName("assign own version to created mismatches")
     void assignVersionToMismatches() {
-        int version = entity.version().getNumber();
+        var version = entity.version().getNumber();
 
         assertEquals(version, entity.expectedDefault(msg(), msg()).getVersion());
         assertEquals(version, entity.expectedNotDefault(msg()).getVersion());

--- a/server/src/test/java/io/spine/server/command/CommandHistory.java
+++ b/server/src/test/java/io/spine/server/command/CommandHistory.java
@@ -58,9 +58,9 @@ public final class CommandHistory {
         Message message = command.enclosedMessage();
 
         if (messages.contains(message)) {
-            int messageIndex = messages.indexOf(message);
-            CommandContext actualContext = command.context();
-            CommandContext storedContext = contexts.get(messageIndex);
+            var messageIndex = messages.indexOf(message);
+            var actualContext = command.context();
+            var storedContext = contexts.get(messageIndex);
             return actualContext.equals(storedContext);
         }
 
@@ -78,9 +78,9 @@ public final class CommandHistory {
     }
 
     public void assertHandled(Command expected) {
-        String cmdName = expected.enclosedMessage()
-                                 .getClass()
-                                 .getName();
+        var cmdName = expected.enclosedMessage()
+                              .getClass()
+                              .getName();
         assertTrue(contains(expected), "Expected but wasn't handled, command: " + cmdName);
     }
 }

--- a/server/src/test/java/io/spine/server/command/model/CommandHandlerMethodTest.java
+++ b/server/src/test/java/io/spine/server/command/model/CommandHandlerMethodTest.java
@@ -36,8 +36,6 @@ import io.spine.base.Identifier;
 import io.spine.base.RejectionThrowable;
 import io.spine.core.Command;
 import io.spine.core.CommandContext;
-import io.spine.core.Event;
-import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.given.dispatch.AggregateMessageDispatcher;
 import io.spine.server.command.AbstractCommandHandler;
 import io.spine.server.command.model.given.handler.HandlerReturnsEmptyList;
@@ -52,11 +50,8 @@ import io.spine.server.command.model.given.handler.ValidHandlerTwoParams;
 import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.model.IllegalOutcomeException;
 import io.spine.server.model.ModelError;
-import io.spine.server.procman.ProcessManager;
 import io.spine.server.procman.given.dispatch.PmDispatcher;
 import io.spine.server.type.CommandEnvelope;
-import io.spine.test.reflect.ProjectId;
-import io.spine.test.reflect.command.RefCreateProject;
 import io.spine.test.reflect.event.RefProjectCreated;
 import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.testing.logging.mute.MuteLogging;
@@ -65,10 +60,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-
-import java.lang.reflect.Method;
-import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.base.Throwables.getRootCause;
 import static com.google.common.truth.Truth.assertThat;
@@ -120,44 +111,42 @@ class CommandHandlerMethodTest {
         @Test
         @DisplayName("one `Message`")
         void returningMessage() {
-            ValidHandlerTwoParams handlerObject = new ValidHandlerTwoParams();
+            var handlerObject = new ValidHandlerTwoParams();
 
-            Optional<CommandHandlerMethod> createdMethod =
+            var createdMethod =
                     new CommandHandlerSignature().classify(handlerObject.method());
             assertTrue(createdMethod.isPresent());
-            CommandHandlerMethod handler = createdMethod.get();
-            RefCreateProject cmd = createProject();
-            CommandEnvelope envelope = envelope(cmd);
+            var handler = createdMethod.get();
+            var cmd = createProject();
+            var envelope = envelope(cmd);
 
-            DispatchOutcome outcome = handler.invoke(handlerObject, envelope);
-            List<Event> events = outcome.getSuccess().getProducedEvents().getEventList();
+            var outcome = handler.invoke(handlerObject, envelope);
+            var events = outcome.getSuccess().getProducedEvents().getEventList();
 
             assertThat(handlerObject.handledCommands())
                     .containsExactly(cmd);
             assertEquals(1, events.size());
-            RefProjectCreated event = (RefProjectCreated) events.get(0).enclosedMessage();
+            var event = (RefProjectCreated) events.get(0).enclosedMessage();
             assertEquals(cmd.getProjectId(), event.getProjectId());
         }
 
         @Test
         @DisplayName("`Message` list")
         void returningMessageList() {
-            ValidHandlerOneParamReturnsList handlerObject =
-                    new ValidHandlerOneParamReturnsList();
-            Optional<CommandHandlerMethod> method =
-                    new CommandHandlerSignature().classify(handlerObject.method());
+            var handlerObject = new ValidHandlerOneParamReturnsList();
+            var method = new CommandHandlerSignature().classify(handlerObject.method());
             assertTrue(method.isPresent());
-            CommandHandlerMethod handler = method.get();
-            RefCreateProject cmd = createProject();
-            CommandEnvelope envelope = envelope(cmd);
+            var handler = method.get();
+            var cmd = createProject();
+            var envelope = envelope(cmd);
 
-            DispatchOutcome outcome = handler.invoke(handlerObject, envelope);
-            List<Event> events = outcome.getSuccess().getProducedEvents().getEventList();
+            var outcome = handler.invoke(handlerObject, envelope);
+            var events = outcome.getSuccess().getProducedEvents().getEventList();
 
             assertThat(handlerObject.handledCommands())
                     .containsExactly(cmd);
             assertEquals(1, events.size());
-            RefProjectCreated event = (RefProjectCreated) events.get(0).enclosedMessage();
+            var event = (RefProjectCreated) events.get(0).enclosedMessage();
             assertEquals(cmd.getProjectId(), event.getProjectId());
         }
     }
@@ -169,14 +158,13 @@ class CommandHandlerMethodTest {
         @Test
         @DisplayName("no events")
         void noEvents() {
-            HandlerReturnsEmptyList handlerObject = new HandlerReturnsEmptyList();
-            Optional<CommandHandlerMethod> method =
-                    new CommandHandlerSignature().classify(handlerObject.method());
+            var handlerObject = new HandlerReturnsEmptyList();
+            var method = new CommandHandlerSignature().classify(handlerObject.method());
             assertTrue(method.isPresent());
-            CommandHandlerMethod handler = method.get();
-            RefCreateProject cmd = createProject();
-            CommandEnvelope envelope = envelope(cmd);
-            DispatchOutcome outcome = handler.invoke(handlerObject, envelope);
+            var handler = method.get();
+            var cmd = createProject();
+            var envelope = envelope(cmd);
+            var outcome = handler.invoke(handlerObject, envelope);
             assertTrue(outcome.hasError());
             assertThat(outcome.getError().getType())
                     .isEqualTo(IllegalOutcomeException.class.getCanonicalName());
@@ -185,35 +173,31 @@ class CommandHandlerMethodTest {
         @Test
         @DisplayName("`Nothing` event")
         void nothingEvent() {
-            HandlerReturnsNothing handlerObject = new HandlerReturnsNothing();
-            Optional<CommandHandlerMethod> method =
-                    new CommandHandlerSignature().classify(handlerObject.method());
+            var handlerObject = new HandlerReturnsNothing();
+            var method = new CommandHandlerSignature().classify(handlerObject.method());
             assertTrue(method.isPresent());
-            CommandHandlerMethod handler = method.get();
-            RefCreateProject cmd = createProject();
-            CommandEnvelope envelope = envelope(cmd);
+            var handler = method.get();
+            var cmd = createProject();
+            var envelope = envelope(cmd);
 
-            DispatchOutcome outcome = handler.invoke(handlerObject, envelope);
+            var outcome = handler.invoke(handlerObject, envelope);
             checkIllegalOutcome(outcome, envelope.command());
         }
 
         @Test
         @DisplayName("`Nothing` event from PM")
         void nothingEventInPm() {
-            RefCreateProject commandMessage = createProject();
-            ProcessManager<String, ?, ?> entity =
-                    new ProcessManagerDoingNothing(commandMessage.getProjectId()
-                                                                 .getId());
-            CommandEnvelope cmd = newCommand(commandMessage);
-            DispatchOutcome outcome = PmDispatcher.dispatch(entity, cmd);
+            var commandMessage = createProject();
+            var entity = new ProcessManagerDoingNothing(commandMessage.getProjectId().getId());
+            var cmd = newCommand(commandMessage);
+            var outcome = PmDispatcher.dispatch(entity, cmd);
             checkIllegalOutcome(outcome, cmd.command());
         }
 
         private void checkIllegalOutcome(DispatchOutcome outcome, Command command) {
-            Error.Builder error =
-                    Error.newBuilder()
-                         .setType(IllegalOutcomeException.class.getCanonicalName());
-            DispatchOutcome expected = DispatchOutcome.newBuilder()
+            var error = Error.newBuilder()
+                    .setType(IllegalOutcomeException.class.getCanonicalName());
+            var expected = DispatchOutcome.newBuilder()
                     .setPropagatedSignal(command.messageId())
                     .setError(error)
                     .buildPartial();
@@ -230,7 +214,7 @@ class CommandHandlerMethodTest {
         @Test
         @DisplayName("no annotation")
         void noAnnotation() {
-            Method handler = new InvalidHandlerNoAnnotation().method();
+            var handler = new InvalidHandlerNoAnnotation().method();
             assertFalse(new CommandHandlerSignature().matches(handler));
         }
     }
@@ -244,7 +228,7 @@ class CommandHandlerMethodTest {
         @DisplayName("command handler")
         void onDispatchToHandler() {
             AbstractCommandHandler handler = new RejectingHandler();
-            CommandEnvelope envelope = newCommand(createProject());
+            var envelope = newCommand(createProject());
             try {
                 handler.dispatch(envelope);
             } catch (IllegalStateException e) {
@@ -256,10 +240,9 @@ class CommandHandlerMethodTest {
         @Test
         @DisplayName("entity")
         void onDispatchToEntity() {
-            RefCreateProject commandMessage = createProject();
-            Aggregate<ProjectId, ?, ?> entity =
-                    new RejectingAggregate(commandMessage.getProjectId());
-            CommandEnvelope cmd = newCommand(commandMessage);
+            var commandMessage = createProject();
+            var entity = new RejectingAggregate(commandMessage.getProjectId());
+            var cmd = newCommand(commandMessage);
             try {
                 AggregateMessageDispatcher.dispatchCommand(entity, cmd);
             } catch (IllegalStateException e) {
@@ -268,10 +251,10 @@ class CommandHandlerMethodTest {
         }
 
         private void assertCauseAndId(Throwable e, Object handlerId) {
-            Throwable cause = getRootCause(e);
+            var cause = getRootCause(e);
 
             assertTrue(cause instanceof RejectionThrowable);
-            RejectionThrowable thrown = (RejectionThrowable) cause;
+            var thrown = (RejectionThrowable) cause;
 
             assertTrue(thrown.producerId()
                              .isPresent());
@@ -284,18 +267,17 @@ class CommandHandlerMethodTest {
     @DisplayName("throw `ModelError` when dispatching command of non-handled type")
     void notDispatchNonHandledCmd() {
         AbstractCommandHandler handler = new ValidHandlerOneParam();
-        CommandEnvelope cmd = newCommand(startProject());
+        var cmd = newCommand(startProject());
 
         assertThrows(ModelError.class, () -> handler.dispatch(cmd));
     }
 
     private static CommandEnvelope envelope(Message commandMessage) {
-        Any cmd = pack(commandMessage);
-        Command command = Command
-                .newBuilder()
+        var cmd = pack(commandMessage);
+        var command = Command.newBuilder()
                 .setMessage(cmd)
                 .build();
-        CommandEnvelope envelope = CommandEnvelope.of(command);
+        var envelope = CommandEnvelope.of(command);
         return envelope;
     }
 }

--- a/server/src/test/java/io/spine/server/command/model/CommandHandlerMethodTest.java
+++ b/server/src/test/java/io/spine/server/command/model/CommandHandlerMethodTest.java
@@ -113,8 +113,7 @@ class CommandHandlerMethodTest {
         void returningMessage() {
             var handlerObject = new ValidHandlerTwoParams();
 
-            var createdMethod =
-                    new CommandHandlerSignature().classify(handlerObject.method());
+            var createdMethod = new CommandHandlerSignature().classify(handlerObject.method());
             assertTrue(createdMethod.isPresent());
             var handler = createdMethod.get();
             var cmd = createProject();

--- a/server/src/test/java/io/spine/server/command/model/CommandReactionMethodTest.java
+++ b/server/src/test/java/io/spine/server/command/model/CommandReactionMethodTest.java
@@ -26,18 +26,14 @@
 
 package io.spine.server.command.model;
 
-import com.google.common.truth.IterableSubject;
-import io.spine.base.CommandMessage;
 import io.spine.base.EventMessage;
 import io.spine.core.Command;
-import io.spine.core.Event;
 import io.spine.server.command.model.given.reaction.ReEitherWithNothing;
 import io.spine.server.command.model.given.reaction.ReOneParam;
 import io.spine.server.command.model.given.reaction.ReOptionalResult;
 import io.spine.server.command.model.given.reaction.ReTwoParams;
 import io.spine.server.command.model.given.reaction.TestCommandReactor;
 import io.spine.server.dispatch.DispatchOutcome;
-import io.spine.server.dispatch.Success;
 import io.spine.server.event.EventReceiver;
 import io.spine.server.type.EventEnvelope;
 import io.spine.test.command.CmdAddTask;
@@ -50,8 +46,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
-import java.util.List;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -59,8 +53,8 @@ import static io.spine.base.Identifier.newUuid;
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisplayName("`CommandReactionMethod` should")
 @SuppressWarnings("InnerClassMayBeStatic")
-@DisplayName("CommandReactionMethod should")
 class CommandReactionMethodTest {
 
     private static final
@@ -77,14 +71,14 @@ class CommandReactionMethodTest {
         @Test
         @DisplayName("one event message parameter")
         void oneParam() {
-            Method method = new ReOneParam().getMethod();
+            var method = new ReOneParam().getMethod();
             assertValid(method, true);
         }
 
         @Test
         @DisplayName("event message and context")
         void twoParams() {
-            Method method = new ReTwoParams().getMethod();
+            var method = new ReTwoParams().getMethod();
             assertValid(method, true);
         }
     }
@@ -102,12 +96,12 @@ class CommandReactionMethodTest {
         void setUp() {
             target = new ReOneParam();
             rawMethod = ((TestCommandReactor) target).getMethod();
-            Optional<CommandReactionMethod> result = signature.classify(rawMethod);
+            var result = signature.classify(rawMethod);
             assertTrue(result.isPresent());
             this.method = result.get();
             id = ProjectId.newBuilder()
-                          .setId(newUuid())
-                          .build();
+                    .setId(newUuid())
+                    .build();
         }
 
         @Test
@@ -125,8 +119,8 @@ class CommandReactionMethodTest {
         @Test
         @DisplayName("when returning value")
         void returnValue() {
-            CmdProjectCreated message = createInitEvent(id);
-            DispatchOutcome outcome = method.invoke(target, envelope(message));
+            var message = createInitEvent(id);
+            var outcome = method.invoke(target, envelope(message));
             assertResult(outcome, this.id);
         }
     }
@@ -162,7 +156,7 @@ class CommandReactionMethodTest {
         @Test
         @DisplayName("in predicate")
         void inPredicate() {
-            boolean result = signature.matches(rawMethod);
+            var result = signature.matches(rawMethod);
             assertThat(result).isTrue();
         }
 
@@ -175,27 +169,26 @@ class CommandReactionMethodTest {
         @Test
         @DisplayName("when returning value")
         void returnValue() {
-            ProjectId givenId = this.id;
-            CmdProjectCreated message = createInitEvent(givenId);
+            var givenId = this.id;
+            var message = createInitEvent(givenId);
 
-            DispatchOutcome outcome = method.invoke(target, envelope(message));
+            var outcome = method.invoke(target, envelope(message));
 
             assertResult(outcome, givenId);
         }
 
         @Test
         void returnEmpty() {
-            CmdProjectCreated message = createVoidEvent(id);
+            var message = createVoidEvent(id);
 
-            DispatchOutcome outcome = method.invoke(target, envelope(message));
+            var outcome = method.invoke(target, envelope(message));
 
             assertThat(outcome.getSuccess().hasCommands())
                     .isFalse();
         }
 
         private static CmdProjectCreated createVoidEvent(ProjectId givenId) {
-            return CmdProjectCreated
-                    .newBuilder()
+            return CmdProjectCreated.newBuilder()
                     .setProjectId(givenId)
                     .setInitialize(false) // This will make the method return `Optional.empty()`.
                     .build();
@@ -238,8 +231,7 @@ class CommandReactionMethodTest {
      * Creates the event message which will cause the handling method return non-empty result.
      */
     private static CmdProjectCreated createInitEvent(ProjectId givenId) {
-        return CmdProjectCreated
-                .newBuilder()
+        return CmdProjectCreated.newBuilder()
                 .setProjectId(givenId)
                 .setInitialize(true) // This will make the method return result with a value.
                 .build();
@@ -249,28 +241,26 @@ class CommandReactionMethodTest {
      * Asserts that the result has a message with correct type and passed field value.
      */
     private static void assertResult(DispatchOutcome outcome, ProjectId id) {
-        CmdAddTask expected = CmdAddTask
-                .newBuilder()
+        var expected = CmdAddTask.newBuilder()
                 .setProjectId(id)
                 .build();
         assertTrue(outcome.hasSuccess());
-        Success success = outcome.getSuccess();
+        var success = outcome.getSuccess();
         assertTrue(success.hasCommands());
-        List<Command> commands = success.getProducedCommands()
-                                        .getCommandList();
-        List<CommandMessage> commandMessages = commands
-                .stream()
+        var commands = success.getProducedCommands()
+                              .getCommandList();
+        var commandMessages = commands.stream()
                 .map(Command::enclosedMessage)
                 .collect(toList());
-        IterableSubject assertThat = assertThat(commandMessages);
+        var assertThat = assertThat(commandMessages);
         assertThat.hasSize(1);
         assertThat.containsExactly(expected);
     }
 
     private static EventEnvelope envelope(EventMessage eventMessage) {
-        TestEventFactory factory = TestEventFactory.newInstance(CommandReactionMethodTest.class);
-        Event event = factory.createEvent(eventMessage);
-        EventEnvelope envelope = EventEnvelope.of(event);
+        var factory = TestEventFactory.newInstance(CommandReactionMethodTest.class);
+        var event = factory.createEvent(eventMessage);
+        var envelope = EventEnvelope.of(event);
         return envelope;
     }
 }

--- a/server/src/test/java/io/spine/server/command/model/given/handler/TestCommandHandler.java
+++ b/server/src/test/java/io/spine/server/command/model/given/handler/TestCommandHandler.java
@@ -52,9 +52,7 @@ public abstract class TestCommandHandler extends AbstractCommandHandler {
 
     protected TestCommandHandler() {
         super();
-        BoundedContext context = BoundedContextBuilder
-                .assumingTests(true)
-                .build();
+        var context = BoundedContextBuilder.assumingTests(true).build();
         registerWith(context);
     }
 

--- a/server/src/test/java/io/spine/server/commandbus/AbstractCommandBusTestSuite.java
+++ b/server/src/test/java/io/spine/server/commandbus/AbstractCommandBusTestSuite.java
@@ -26,21 +26,17 @@
 
 package io.spine.server.commandbus;
 
-import com.google.protobuf.Any;
 import io.spine.base.CommandMessage;
-import io.spine.base.Error;
 import io.spine.base.Identifier;
 import io.spine.client.ActorRequestFactory;
 import io.spine.core.Ack;
 import io.spine.core.Command;
 import io.spine.core.CommandContext;
-import io.spine.core.CommandId;
 import io.spine.core.CommandValidationError;
 import io.spine.core.Status;
 import io.spine.core.TenantId;
 import io.spine.grpc.MemoizingObserver;
 import io.spine.server.BoundedContext;
-import io.spine.server.BoundedContextBuilder;
 import io.spine.server.ServerEnvironment;
 import io.spine.server.command.AbstractCommandHandler;
 import io.spine.server.command.Assign;
@@ -104,10 +100,10 @@ abstract class AbstractCommandBusTestSuite {
     }
 
     static Command newCommandWithoutContext() {
-        Command cmd = createProject();
-        Command invalidCmd = cmd.toBuilder()
-                                .setContext(CommandContext.getDefaultInstance())
-                                .build();
+        var cmd = createProject();
+        var invalidCmd = cmd.toBuilder()
+                .setContext(CommandContext.getDefaultInstance())
+                .build();
         return invalidCmd;
     }
 
@@ -125,12 +121,12 @@ abstract class AbstractCommandBusTestSuite {
                                   CommandValidationError validationError,
                                   String errorType,
                                   Command cmd) {
-        Status status = sendingResult.getStatus();
+        var status = sendingResult.getStatus();
         assertEquals(status.getStatusCase(), Status.StatusCase.ERROR);
-        CommandId commandId = cmd.getId();
+        var commandId = cmd.getId();
         assertEquals(commandId, unpack(sendingResult.getMessageId()));
 
-        Error error = status.getError();
+        var error = status.getError();
         assertEquals(errorType,
                      error.getType());
         assertEquals(validationError.getNumber(), error.getCode());
@@ -144,8 +140,8 @@ abstract class AbstractCommandBusTestSuite {
     }
 
     protected static Command newCommandWithoutTenantId() {
-        Command cmd = createProject();
-        Command.Builder commandBuilder = cmd.toBuilder();
+        var cmd = createProject();
+        var commandBuilder = cmd.toBuilder();
         commandBuilder
                 .getContextBuilder()
                 .getActorContextBuilder()
@@ -154,7 +150,7 @@ abstract class AbstractCommandBusTestSuite {
     }
 
     protected static Command clearTenantId(Command cmd) {
-        Command.Builder result = cmd.toBuilder();
+        var result = cmd.toBuilder();
         result.getContextBuilder()
               .getActorContextBuilder()
               .clearTenantId();
@@ -172,14 +168,13 @@ abstract class AbstractCommandBusTestSuite {
 
         context = createContext();
 
-        BoundedContext.InternalAccess contextAccess = context.internalAccess();
+        var contextAccess = context.internalAccess();
         tenantIndex = contextAccess.tenantIndex();
         systemWriteSide = NoOpSystemWriteSide.INSTANCE;
 
         eventBus = context.eventBus();
         watcher = new MemoizingCommandFlowWatcher();
-        commandBus = CommandBus
-                .newBuilder()
+        commandBus = CommandBus.newBuilder()
                 .setMultitenant(this.multitenant)
                 .injectContext(context)
                 .injectSystem(systemWriteSide)
@@ -196,12 +191,11 @@ abstract class AbstractCommandBusTestSuite {
     }
 
     private BoundedContext createContext() {
-        Class<? extends AbstractCommandBusTestSuite> cls = getClass();
-        String name = cls.getSimpleName();
-        BoundedContextBuilder builder =
-                multitenant
-                ? BoundedContext.multitenant(name)
-                : BoundedContext.singleTenant(name);
+        var cls = getClass();
+        var name = cls.getSimpleName();
+        var builder = multitenant
+                      ? BoundedContext.multitenant(name)
+                      : BoundedContext.singleTenant(name);
         return builder.build();
     }
 
@@ -213,8 +207,8 @@ abstract class AbstractCommandBusTestSuite {
     @Test
     @DisplayName("post commands in bulk")
     void postCommandsInBulk() {
-        Command first = newCommand();
-        Command second = newCommand();
+        var first = newCommand();
+        var second = newCommand();
         List<Command> commands = newArrayList(first, second);
 
         // Some derived test suite classes may register the handler in setUp().
@@ -236,8 +230,8 @@ abstract class AbstractCommandBusTestSuite {
     protected void checkResult(Command cmd) {
         assertNull(observer.getError());
         assertTrue(observer.isCompleted());
-        Ack ack = observer.firstResponse();
-        Any messageId = ack.getMessageId();
+        var ack = observer.firstResponse();
+        var messageId = ack.getMessageId();
         assertEquals(cmd.getId(), Identifier.unpack(messageId));
     }
 

--- a/server/src/test/java/io/spine/server/commandbus/AckRejectionPublisherTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/AckRejectionPublisherTest.java
@@ -26,15 +26,9 @@
 
 package io.spine.server.commandbus;
 
-import io.spine.base.RejectionThrowable;
-import io.spine.core.Ack;
-import io.spine.core.Command;
 import io.spine.core.CommandId;
-import io.spine.core.Event;
-import io.spine.server.BoundedContext;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.bus.Listener;
-import io.spine.server.event.EventBus;
 import io.spine.server.event.RejectionFactory;
 import io.spine.server.type.EventEnvelope;
 import io.spine.test.commandbus.CmdBusCaffetteriaId;
@@ -59,24 +53,23 @@ class AckRejectionPublisherTest {
     @BeforeEach
     void createPublisher() {
         listener = new MemoizingListener();
-        BoundedContext context = BoundedContextBuilder
+        var context = BoundedContextBuilder
                 .assumingTests()
                 .addEventListener(listener)
                 .build();
-        EventBus eventBus = context.eventBus();
+        var eventBus = context.eventBus();
         publisher = new AckRejectionPublisher(eventBus);
     }
 
     @Test
     @DisplayName("publish the passed rejection to event bus")
     void publishRejection() {
-        TestActorRequestFactory requestFactory =
-                new TestActorRequestFactory(AckRejectionPublisherTest.class);
-        Command command = requestFactory.generateCommand();
+        var requestFactory = new TestActorRequestFactory(AckRejectionPublisherTest.class);
+        var command = requestFactory.generateCommand();
 
-        RejectionThrowable throwable = stubThrowable();
-        Event rejection = RejectionFactory.reject(command, throwable);
-        Ack ack = reject(CommandId.generate(), rejection);
+        var throwable = stubThrowable();
+        var rejection = RejectionFactory.reject(command, throwable);
+        var ack = reject(CommandId.generate(), rejection);
         publisher.onNext(ack);
         assertThat(listener.lastReceived)
                 .isNotNull();
@@ -85,8 +78,7 @@ class AckRejectionPublisherTest {
     }
 
     private static CmdBusEntryDenied stubThrowable() {
-        CmdBusEntryDenied throwable = CmdBusEntryDenied
-                .newBuilder()
+        var throwable = CmdBusEntryDenied.newBuilder()
                 .setId(CmdBusCaffetteriaId.generate())
                 .setVisitorCount(15)
                 .setReason("Test command bus rejection.")
@@ -97,7 +89,7 @@ class AckRejectionPublisherTest {
     @Test
     @DisplayName("ignore non-rejection `Ack`s")
     void ignoreNonRejection() {
-        Ack ack = acknowledge(CommandId.generate());
+        var ack = acknowledge(CommandId.generate());
         publisher.onNext(ack);
         assertThat(listener.lastReceived)
                 .isNull();
@@ -106,8 +98,8 @@ class AckRejectionPublisherTest {
     @Test
     @DisplayName("re-throw an error passed to `onError` as `IllegalStateException`")
     void rethrowError() {
-        RuntimeException exception = new RuntimeException("Test Ack publisher exception.");
-        IllegalStateException thrown = assertIllegalState(() -> publisher.onError(exception));
+        var exception = new RuntimeException("Test Ack publisher exception.");
+        var thrown = assertIllegalState(() -> publisher.onError(exception));
         assertThat(thrown.getCause())
                 .isEqualTo(exception);
     }

--- a/server/src/test/java/io/spine/server/commandbus/CommandBusBuilderTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandBusBuilderTest.java
@@ -38,8 +38,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
-
 import static io.spine.testing.TestValues.nullRef;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -48,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("DuplicateStringLiteralInspection") // Common test display names.
-@DisplayName("CommandBus Builder should")
+@DisplayName("`CommandBus.Builder` should")
 class CommandBusBuilderTest
         extends BusBuilderTest<CommandBus.Builder, CommandEnvelope, Command> {
 
@@ -65,7 +63,7 @@ class CommandBusBuilderTest
 
     @BeforeEach
     void setUp() {
-        BoundedContext context =
+        var context =
                 BoundedContext.multitenant(getClass().getSimpleName())
                               .build();
         tenantIndex = context.internalAccess()
@@ -75,8 +73,7 @@ class CommandBusBuilderTest
     @Test
     @DisplayName("create new CommandBus instance")
     void createNewInstance() {
-        CommandBus commandBus = CommandBus
-                .newBuilder()
+        var commandBus = CommandBus.newBuilder()
                 .injectTenantIndex(tenantIndex)
                 .injectSystem(SYSTEM_WRITE_SIDE)
                 .build();
@@ -95,8 +92,8 @@ class CommandBusBuilderTest
     void neverOmitCommandStore() {
         assertThrows(IllegalStateException.class,
                      () -> CommandBus.newBuilder()
-                                     .injectSystem(SYSTEM_WRITE_SIDE)
-                                     .build());
+                             .injectSystem(SYSTEM_WRITE_SIDE)
+                             .build());
     }
 
     @Test
@@ -104,8 +101,8 @@ class CommandBusBuilderTest
     void neverOmitSystem() {
         assertThrows(IllegalStateException.class,
                      () -> CommandBus.newBuilder()
-                                     .injectTenantIndex(tenantIndex)
-                                     .build());
+                             .injectTenantIndex(tenantIndex)
+                             .build());
     }
 
     @Nested
@@ -127,8 +124,8 @@ class CommandBusBuilderTest
         @DisplayName("system write side")
         void system() {
             SystemWriteSide systemWriteSide = NoOpSystemWriteSide.INSTANCE;
-            CommandBus.Builder builder = builder().injectSystem(systemWriteSide);
-            Optional<SystemWriteSide> actual = builder.system();
+            var builder = builder().injectSystem(systemWriteSide);
+            var actual = builder.system();
             assertTrue(actual.isPresent());
             assertSame(systemWriteSide, actual.get());
         }
@@ -136,9 +133,9 @@ class CommandBusBuilderTest
         @Test
         @DisplayName("tenant index")
         void tenantIndex() {
-            TenantIndex index = TenantIndex.singleTenant();
-            CommandBus.Builder builder = builder().injectTenantIndex(index);
-            Optional<TenantIndex> actual = builder.tenantIndex();
+            var index = TenantIndex.singleTenant();
+            var builder = builder().injectTenantIndex(index);
+            var actual = builder.tenantIndex();
             assertTrue(actual.isPresent());
             assertSame(index, actual.get());
         }

--- a/server/src/test/java/io/spine/server/commandbus/CommandDispatcherRegistryTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandDispatcherRegistryTest.java
@@ -46,13 +46,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
-
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("CommandDispatcherRegistry should")
+@DisplayName("`CommandDispatcherRegistry` should")
 class CommandDispatcherRegistryTest {
 
     /**
@@ -68,21 +66,21 @@ class CommandDispatcherRegistryTest {
     }
 
     @SafeVarargs
-    private final void assertSupported(Class<? extends CommandMessage>... cmdClasses) {
-        Set<CommandClass> supportedClasses = registry.registeredMessageClasses();
+    private void assertSupported(Class<? extends CommandMessage>... cmdClasses) {
+        var supportedClasses = registry.registeredMessageClasses();
 
-        for (Class<? extends CommandMessage> cls : cmdClasses) {
-            CommandClass cmdClass = CommandClass.from(cls);
+        for (var cls : cmdClasses) {
+            var cmdClass = CommandClass.from(cls);
             assertTrue(supportedClasses.contains(cmdClass));
         }
     }
 
     @SafeVarargs
-    private final void assertNotSupported(Class<? extends CommandMessage>... cmdClasses) {
-        Set<CommandClass> supportedClasses = registry.registeredMessageClasses();
+    private void assertNotSupported(Class<? extends CommandMessage>... cmdClasses) {
+        var supportedClasses = registry.registeredMessageClasses();
 
-        for (Class<? extends CommandMessage> cls : cmdClasses) {
-            CommandClass cmdClass = CommandClass.from(cls);
+        for (var cls : cmdClasses) {
+            var cmdClass = CommandClass.from(cls);
             assertFalse(supportedClasses.contains(cmdClass));
         }
     }
@@ -132,7 +130,7 @@ class CommandDispatcherRegistryTest {
         @Test
         @DisplayName("command handler")
         void commandHandler() {
-            AllCommandHandler handler = new AllCommandHandler();
+            var handler = new AllCommandHandler();
 
             registry.register(handler);
             registry.unregister(handler);
@@ -182,7 +180,7 @@ class CommandDispatcherRegistryTest {
     @Test
     @DisplayName("accept empty process manager repository dispatcher")
     void acceptEmptyProcessManagerRepository() {
-        NoCommandsDispatcherRepo pmRepo = new NoCommandsDispatcherRepo();
+        var pmRepo = new NoCommandsDispatcherRepo();
         registry.register(DelegatingCommandDispatcher.of(pmRepo));
     }
 

--- a/server/src/test/java/io/spine/server/commandbus/CommandHandlerTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandHandlerTest.java
@@ -31,13 +31,11 @@ import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Message;
 import io.spine.core.Command;
-import io.spine.server.BoundedContext;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.commandbus.given.CommandHandlerTestEnv.EventCatcher;
 import io.spine.server.commandbus.given.CommandHandlerTestEnv.TestCommandHandler;
 import io.spine.server.event.EventBus;
 import io.spine.server.type.CommandEnvelope;
-import io.spine.server.type.EventEnvelope;
 import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.testing.server.model.ModelTests;
 import org.junit.jupiter.api.AfterEach;
@@ -46,12 +44,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
 
-@DisplayName("CommandHandler should")
+@DisplayName("`CommandHandler` should")
 class CommandHandlerTest {
 
     private static final TestActorRequestFactory requestFactory =
@@ -64,7 +60,7 @@ class CommandHandlerTest {
     @BeforeEach
     void setUp() {
         ModelTests.dropAllModels();
-        BoundedContext context = BoundedContextBuilder
+        var context = BoundedContextBuilder
                 .assumingTests(true)
                 .build();
         commandBus = context.commandBus();
@@ -113,19 +109,19 @@ class CommandHandlerTest {
     }
 
     @Test
-    @DisplayName("post generated events to EventBus")
+    @DisplayName("post generated events to `EventBus`")
     void postGeneratedEventsToBus() {
-        Command cmd = Given.ACommand.startProject();
+        var cmd = Given.ACommand.startProject();
 
-        EventCatcher eventCatcher = new EventCatcher();
+        var eventCatcher = new EventCatcher();
         eventBus.register(eventCatcher);
 
         handler.handle(cmd);
 
         ImmutableList<? extends Message> expectedMessages = handler.getEventsOnStartProjectCmd();
-        List<EventEnvelope> actualEvents = eventCatcher.dispatched();
-        for (int i = 0; i < expectedMessages.size(); i++) {
-            Message expected = expectedMessages.get(i);
+        var actualEvents = eventCatcher.dispatched();
+        for (var i = 0; i < expectedMessages.size(); i++) {
+            var expected = expectedMessages.get(i);
             Message actual = actualEvents.get(i)
                                          .outerObject()
                                          .enclosedMessage();
@@ -135,35 +131,35 @@ class CommandHandlerTest {
     }
 
     @Nested
-    @DisplayName("post Pair of events")
+    @DisplayName("post `Pair` of events")
     class PostPair {
 
         @Test
-        @DisplayName("with two non-null values")
+        @DisplayName("with two non-`null` values")
         void withBothValues() {
-            Command cmd = Given.ACommand.createTask(true);
+            var cmd = Given.ACommand.createTask(true);
 
-            EventCatcher eventCatcher = new EventCatcher();
+            var eventCatcher = new EventCatcher();
             eventBus.register(eventCatcher);
 
             handler.handle(cmd);
 
-            List<EventEnvelope> dispatchedEvents = eventCatcher.dispatched();
+            var dispatchedEvents = eventCatcher.dispatched();
             assertThat(dispatchedEvents)
                     .hasSize(2);
         }
 
         @Test
-        @DisplayName("with null second value")
+        @DisplayName("with `null` second value")
         void withNullSecondValue() {
-            Command cmd = Given.ACommand.createTask(false);
+            var cmd = Given.ACommand.createTask(false);
 
-            EventCatcher eventCatcher = new EventCatcher();
+            var eventCatcher = new EventCatcher();
             eventBus.register(eventCatcher);
 
             handler.handle(cmd);
 
-            List<EventEnvelope> dispatchedEvents = eventCatcher.dispatched();
+            var dispatchedEvents = eventCatcher.dispatched();
             assertThat(dispatchedEvents)
                     .hasSize(1);
         }

--- a/server/src/test/java/io/spine/server/commandbus/CommandReceivedTapTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandReceivedTapTest.java
@@ -46,7 +46,7 @@ import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
 import static io.spine.base.Identifier.newUuid;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-@DisplayName("CommandReceivedTap should")
+@DisplayName("`CommandReceivedTap` should")
 class CommandReceivedTapTest {
 
     private MemoizingWriteSide writeSide;
@@ -72,59 +72,55 @@ class CommandReceivedTapTest {
     }
 
     @Test
-    @DisplayName("post MarkCommandAsReceived on command")
+    @DisplayName("post `MarkCommandAsReceived` on command")
     void postSystemCommand() {
-        Command command = command(commandMessage(), null);
+        var command = command(commandMessage(), null);
         postAndCheck(command);
     }
 
     @Test
-    @DisplayName("post MarkCommandAsReceived to specific tenant")
+    @DisplayName("post `MarkCommandAsReceived` to specific tenant")
     void postIfMultitenant() {
         initMultitenant();
 
-        TenantId expectedTenant = tenantId();
-        Command command = command(commandMessage(), expectedTenant);
+        var expectedTenant = tenantId();
+        var command = command(commandMessage(), expectedTenant);
         postAndCheck(command);
 
-        TenantId actualTenant = writeSide.lastSeenEvent()
-                                         .tenant();
+        var actualTenant = writeSide.lastSeenEvent().tenant();
         assertThat(actualTenant)
                 .isEqualTo(expectedTenant);
     }
 
     private void postAndCheck(Command command) {
-        CommandEnvelope envelope = CommandEnvelope.of(command);
+        var envelope = CommandEnvelope.of(command);
 
         Optional<?> ack = filter.filter(envelope);
         assertFalse(ack.isPresent());
 
-        CommandReceived systemEvent = (CommandReceived) writeSide.lastSeenEvent()
-                                                                 .message();
+        var systemEvent = (CommandReceived) writeSide.lastSeenEvent().message();
         assertThat(systemEvent.getId())
                 .isEqualTo(envelope.id());
     }
 
     private static TenantId tenantId() {
-        TenantId tenant = TenantId
-                .newBuilder()
+        var tenant = TenantId.newBuilder()
                 .setValue(CommandReceivedTapTest.class.getSimpleName())
                 .build();
         return tenant;
     }
 
     private static Command command(CommandMessage message, @Nullable TenantId tenantId) {
-        TestActorRequestFactory requestFactory =
+        var requestFactory =
                 tenantId == null
                 ? new TestActorRequestFactory(CommandReceivedTapTest.class)
                 : new TestActorRequestFactory(CommandReceivedTapTest.class, tenantId);
-        Command command = requestFactory.createCommand(message);
+        var command = requestFactory.createCommand(message);
         return command;
     }
 
     private static CommandMessage commandMessage() {
-        return CmdCreateProject
-                .newBuilder()
+        return CmdCreateProject.newBuilder()
                 .setId(newUuid())
                 .build();
     }

--- a/server/src/test/java/io/spine/server/commandbus/CommandSchedulingTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandSchedulingTest.java
@@ -26,11 +26,8 @@
 
 package io.spine.server.commandbus;
 
-import com.google.protobuf.Duration;
-import com.google.protobuf.Timestamp;
 import io.spine.base.CommandMessage;
 import io.spine.core.Command;
-import io.spine.core.CommandContext;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.test.commandbus.ProjectId;
 import io.spine.test.commandbus.command.CmdBusStartProject;
@@ -49,8 +46,8 @@ import static io.spine.time.testing.Past.minutesAgo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SuppressWarnings("DuplicateStringLiteralInspection") // Common test display names.
 @DisplayName("Command scheduling mechanism should")
+@SuppressWarnings("DuplicateStringLiteralInspection") // Common test display names.
 class CommandSchedulingTest extends AbstractCommandBusTestSuite {
 
     CommandSchedulingTest() {
@@ -58,10 +55,10 @@ class CommandSchedulingTest extends AbstractCommandBusTestSuite {
     }
 
     @Test
-    @DisplayName("store scheduled command to CommandStore and return `OK`")
+    @DisplayName("return `OK`")
     void storeScheduledCommand() {
         commandBus.register(createProjectHandler);
-        Command cmd = createProject(/*delay=*/minutes(1));
+        var cmd = createProject(/*delay=*/minutes(1));
 
         commandBus.post(cmd, observer);
 
@@ -72,7 +69,7 @@ class CommandSchedulingTest extends AbstractCommandBusTestSuite {
     @DisplayName("schedule command if delay is set")
     void scheduleIfDelayIsSet() {
         commandBus.register(createProjectHandler);
-        Command cmd = createProject(/*delay=*/minutes(1));
+        var cmd = createProject(/*delay=*/minutes(1));
 
         commandBus.post(cmd, observer);
     }
@@ -80,11 +77,11 @@ class CommandSchedulingTest extends AbstractCommandBusTestSuite {
     @Test
     @DisplayName("not schedule command if no scheduling options are set")
     void notScheduleWithoutOptions() {
-        CreateProjectHandler handler = new CreateProjectHandler();
+        var handler = new CreateProjectHandler();
         handler.registerWith(BoundedContextBuilder.assumingTests().build());
         commandBus.register(handler);
 
-        Command command = createProject();
+        var command = createProject();
         commandBus.post(command, observer);
 
         checkResult(command);
@@ -94,7 +91,7 @@ class CommandSchedulingTest extends AbstractCommandBusTestSuite {
     @DisplayName("post previously scheduled command")
     void postPreviouslyScheduled() {
         commandBus.register(createProjectHandler);
-        Command command = createScheduledCommand();
+        var command = createScheduledCommand();
 
         commandBus.postPreviouslyScheduled(command);
 
@@ -105,7 +102,7 @@ class CommandSchedulingTest extends AbstractCommandBusTestSuite {
     @Test
     @DisplayName("reject previously scheduled command if no endpoint is found")
     void rejectPreviouslyScheduledWithoutEndpoint() {
-        Command command = createScheduledCommand();
+        var command = createScheduledCommand();
         assertThrows(IllegalStateException.class,
                      () -> commandBus.postPreviouslyScheduled(command));
     }
@@ -117,13 +114,13 @@ class CommandSchedulingTest extends AbstractCommandBusTestSuite {
         @Test
         @DisplayName("scheduling options")
         void schedulingOptions() {
-            Command cmd = createCommand();
-            Timestamp schedulingTime = currentTime();
-            Duration delay = minutes(5);
+            var cmd = createCommand();
+            var schedulingTime = currentTime();
+            var delay = minutes(5);
 
-            Command cmdUpdated = setSchedule(cmd, delay, schedulingTime);
-            CommandContext.Schedule schedule = cmdUpdated.context()
-                                                         .getSchedule();
+            var cmdUpdated = setSchedule(cmd, delay, schedulingTime);
+            var schedule = cmdUpdated.context()
+                                     .getSchedule();
 
             assertEquals(delay, schedule.getDelay());
             assertEquals(schedulingTime, cmdUpdated.getSystemProperties()
@@ -133,34 +130,31 @@ class CommandSchedulingTest extends AbstractCommandBusTestSuite {
         @Test
         @DisplayName("scheduling time")
         void schedulingTime() {
-            Command cmd = createCommand();
-            Timestamp schedulingTime = currentTime();
+            var cmd = createCommand();
+            var schedulingTime = currentTime();
 
-            Command cmdUpdated = CommandScheduler.setSchedulingTime(cmd, schedulingTime);
+            var cmdUpdated = CommandScheduler.setSchedulingTime(cmd, schedulingTime);
 
             assertEquals(schedulingTime, cmdUpdated.getSystemProperties()
                                                    .getSchedulingTime());
         }
 
         private Command createCommand() {
-            ProjectId id = ProjectId
-                    .newBuilder()
+            var id = ProjectId.newBuilder()
                     .setId(newUuid())
                     .build();
-            CmdBusStartProject command = CmdBusStartProject
-                    .newBuilder()
+            var command = CmdBusStartProject.newBuilder()
                     .setProjectId(id)
                     .build();
-            CommandMessage commandMessage = toMessage(command, CommandMessage.class);
-            Command cmd = requestFactory.command()
-                                        .create(commandMessage);
+            var commandMessage = toMessage(command, CommandMessage.class);
+            var cmd = requestFactory.command().create(commandMessage);
             return cmd;
         }
     }
 
     private static Command createScheduledCommand() {
-        Timestamp schedulingTime = minutesAgo(3);
-        Duration delayPrimary = minutes(5);
+        var schedulingTime = minutesAgo(3);
+        var delayPrimary = minutes(5);
         return setSchedule(createProject(), delayPrimary, schedulingTime);
     }
 }

--- a/server/src/test/java/io/spine/server/commandbus/CommandValidatorViolationCheckTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandValidatorViolationCheckTest.java
@@ -27,8 +27,6 @@
 package io.spine.server.commandbus;
 
 import com.google.common.truth.Correspondence;
-import com.google.common.truth.IterableSubject;
-import com.google.protobuf.Any;
 import io.spine.base.Time;
 import io.spine.core.Command;
 import io.spine.core.CommandContext;
@@ -51,7 +49,7 @@ import static io.spine.server.commandbus.CommandValidator.inspect;
 import static io.spine.server.commandbus.Given.CommandMessage.createProjectMessage;
 import static io.spine.testing.core.given.GivenCommandContext.withRandomActor;
 
-@DisplayName("CommandValidator violation check should")
+@DisplayName("`CommandValidator` violation check should")
 class CommandValidatorViolationCheckTest {
 
     private static final Correspondence<@NonNull ConstraintViolation, @NonNull String>
@@ -63,9 +61,9 @@ class CommandValidatorViolationCheckTest {
     @Test
     @DisplayName("validate command and return empty violations list if command is valid")
     void returnNothingForValidCmd() {
-        Command cmd = Given.ACommand.createProject();
+        var cmd = Given.ACommand.createProject();
 
-        List<ConstraintViolation> violations = inspectCommand(cmd);
+        var violations = inspectCommand(cmd);
 
         assertThat(violations)
                 .isEmpty();
@@ -74,31 +72,29 @@ class CommandValidatorViolationCheckTest {
     @Test
     @DisplayName("not allow commands without IDs")
     void notAllowDefaultId() {
-        Command cmd = Given.ACommand.createProject();
-        Command unidentifiableCommand = cmd
-                .toBuilder()
+        var cmd = Given.ACommand.createProject();
+        var unidentifiableCommand = cmd.toBuilder()
                 .setId(CommandId.getDefaultInstance())
                 .build();
-        List<ConstraintViolation> violations = inspectCommand(unidentifiableCommand);
+        var violations = inspectCommand(unidentifiableCommand);
 
         assertThat(violations)
                 .hasSize(1);
     }
 
     @Test
-    @DisplayName("return violations if command has invalid Message")
+    @DisplayName("return violations if command has invalid `Message`")
     void notAllowInvalidMessage() {
-        Any invalidMessagePacked = AnyPacker.pack(CmdBusCreateProject.getDefaultInstance());
-        Command commandWithEmptyMessage = Command
-                .newBuilder()
+        var invalidMessagePacked = AnyPacker.pack(CmdBusCreateProject.getDefaultInstance());
+        var commandWithEmptyMessage = Command.newBuilder()
                 .setId(CommandId.generate())
                 .setMessage(invalidMessagePacked)
                 .setContext(withRandomActor())
                 .build();
 
-        List<ConstraintViolation> violations = inspectCommand(commandWithEmptyMessage);
+        var violations = inspectCommand(commandWithEmptyMessage);
 
-        IterableSubject assertViolations = assertThat(violations);
+        var assertViolations = assertThat(violations);
         assertViolations
                 .hasSize(2);
     }
@@ -106,14 +102,13 @@ class CommandValidatorViolationCheckTest {
     @Test
     @DisplayName("return violations if command has invalid context")
     void notAllowInvalidContext() {
-        TestActorRequestFactory factory = new TestActorRequestFactory(getClass());
-        Command command = factory.createCommand(createProjectMessage(), Time.currentTime());
-        Command commandWithoutContext = command
-                .toBuilder()
+        var factory = new TestActorRequestFactory(getClass());
+        var command = factory.createCommand(createProjectMessage(), Time.currentTime());
+        var commandWithoutContext = command.toBuilder()
                 .setContext(CommandContext.getDefaultInstance())
                 .build();
 
-        List<ConstraintViolation> violations = inspectCommand(commandWithoutContext);
+        var violations = inspectCommand(commandWithoutContext);
         assertThat(violations)
                 .hasSize(1);
     }
@@ -121,9 +116,9 @@ class CommandValidatorViolationCheckTest {
     @Test
     @DisplayName("allow empty command messages")
     void emptyMessage() {
-        TestActorRequestFactory factory = new TestActorRequestFactory(getClass());
-        Command emptyCommand = factory.createCommand(CmdEmpty.getDefaultInstance());
-        List<ConstraintViolation> violations = inspectCommand(emptyCommand);
+        var factory = new TestActorRequestFactory(getClass());
+        var emptyCommand = factory.createCommand(CmdEmpty.getDefaultInstance());
+        var violations = inspectCommand(emptyCommand);
         assertThat(violations)
                 .comparingElementsUsing(messageFormatContains)
                 .doesNotContain("command target ID");
@@ -132,15 +127,14 @@ class CommandValidatorViolationCheckTest {
     @Test
     @DisplayName("allow messages without an ID as a first field")
     void noId() {
-        TestActorRequestFactory factory = new TestActorRequestFactory(getClass());
-        CmdBusCreateLabels msg = CmdBusCreateLabels
-                .newBuilder()
+        var factory = new TestActorRequestFactory(getClass());
+        var msg = CmdBusCreateLabels.newBuilder()
                 .addLabel("red")
                 .addLabel("green")
                 .addLabel("blue")
                 .vBuild();
-        Command command = factory.createCommand(msg);
-        List<ConstraintViolation> violations = inspectCommand(command);
+        var command = factory.createCommand(msg);
+        var violations = inspectCommand(command);
         assertThat(violations)
                 .isEmpty();
     }

--- a/server/src/test/java/io/spine/server/commandbus/ExecutorCommandSchedulerTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/ExecutorCommandSchedulerTest.java
@@ -58,7 +58,7 @@ import static io.spine.server.commandbus.Given.CommandMessage.addTask;
 import static io.spine.server.commandbus.Given.CommandMessage.createProjectMessage;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@DisplayName("ExecutorCommandScheduler should")
+@DisplayName("`ExecutorCommandScheduler` should")
 class ExecutorCommandSchedulerTest {
 
     private static final long DELAY_MS = 1100;
@@ -103,8 +103,7 @@ class ExecutorCommandSchedulerTest {
     @Test
     @DisplayName("schedule command if delay is set")
     void scheduleCmdIfDelaySet() {
-        Command command =
-                commandFactory.createBasedOnContext(createProjectMessage(), commandContext);
+        var command = commandFactory.createBasedOnContext(createProjectMessage(), commandContext);
         scheduler.schedule(command);
 
         assertScheduledExactly(command);
@@ -113,15 +112,15 @@ class ExecutorCommandSchedulerTest {
     @Test
     @DisplayName("not schedule command with same ID twice")
     void notScheduleCmdWithSameId() {
-        String id = newUuid();
+        var id = newUuid();
 
-        Command firstCommand = commandFactory.createBasedOnContext(createProjectMessage(id),
-                                                                   commandContext);
+        var firstCommand = commandFactory.createBasedOnContext(createProjectMessage(id),
+                                                               commandContext);
 
-        Command extraCommand = commandFactory.createBasedOnContext(addTask(id), commandContext)
-                                             .toBuilder()
-                                             .setId(firstCommand.getId())
-                                             .build();
+        var extraCommand = commandFactory.createBasedOnContext(addTask(id), commandContext)
+                .toBuilder()
+                .setId(firstCommand.getId())
+                .build();
 
         scheduler.schedule(firstCommand);
         scheduler.schedule(extraCommand);
@@ -135,15 +134,14 @@ class ExecutorCommandSchedulerTest {
     void recoverFromPostFail() throws Exception {
 
         // Inject a throwing executor service so the `post` operation fails.
-        ScheduledExecutorService service = Executors.newScheduledThreadPool(5);
-        ThrowingScheduledExecutor throwingExecutor = new ThrowingScheduledExecutor(service);
-        ExecutorCommandScheduler scheduler = new ExecutorCommandScheduler(throwingExecutor);
+        var service = Executors.newScheduledThreadPool(5);
+        var throwingExecutor = new ThrowingScheduledExecutor(service);
+        var scheduler = new ExecutorCommandScheduler(throwingExecutor);
 
         scheduler.setCommandBus(commandBus);
         scheduler.setWatcher(watcher);
 
-        Command cmd1 =
-                commandFactory.createBasedOnContext(createProjectMessage(), this.commandContext);
+        var cmd1 = commandFactory.createBasedOnContext(createProjectMessage(), this.commandContext);
         scheduler.schedule(cmd1);
 
         waitForCommandProcessed();
@@ -151,8 +149,7 @@ class ExecutorCommandSchedulerTest {
         assertThat(throwingExecutor.throwScheduled())
                 .isTrue();
 
-        Command cmd2 =
-                commandFactory.createBasedOnContext(createProjectMessage(), this.commandContext);
+        var cmd2 = commandFactory.createBasedOnContext(createProjectMessage(), this.commandContext);
         scheduler.schedule(cmd2);
 
         assertScheduled(cmd2);
@@ -178,9 +175,9 @@ class ExecutorCommandSchedulerTest {
         assertThat(watcher.scheduled())
                 .hasSize(1);
 
-        Command scheduled = watcher.scheduled()
-                                   .get(0);
-        Command expectedCmd =
+        var scheduled = watcher.scheduled()
+                               .get(0);
+        var expectedCmd =
                 CommandScheduler.setSchedulingTime(expected, getSchedulingTime(scheduled));
         assertThat(scheduled)
                 .isEqualTo(expectedCmd);
@@ -189,7 +186,7 @@ class ExecutorCommandSchedulerTest {
     private void assertScheduled(Command expected) {
         BinaryPredicate<Command, Command> isScheduled =
                 ExecutorCommandSchedulerTest::isEqualToScheduled;
-        Correspondence<Command, Command> correspondence =
+        var correspondence =
                 Correspondence.from(isScheduled, "is the scheduled command");
         assertThat(watcher.scheduled())
                 .comparingElementsUsing(correspondence)
@@ -197,14 +194,14 @@ class ExecutorCommandSchedulerTest {
     }
 
     private static boolean isEqualToScheduled(Command scheduled, Command command) {
-        Command withSchedulingTime =
+        var withSchedulingTime =
                 CommandScheduler.setSchedulingTime(command, getSchedulingTime(scheduled));
         return withSchedulingTime.equals(scheduled);
     }
 
     private static Timestamp getSchedulingTime(Command cmd) {
-        Timestamp time = cmd.getSystemProperties()
-                            .getSchedulingTime();
+        var time = cmd.getSystemProperties()
+                      .getSchedulingTime();
         return time;
     }
 

--- a/server/src/test/java/io/spine/server/commandbus/Given.java
+++ b/server/src/test/java/io/spine/server/commandbus/Given.java
@@ -28,9 +28,7 @@ package io.spine.server.commandbus;
 
 import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
-import io.spine.client.CommandFactory;
 import io.spine.core.Command;
-import io.spine.core.CommandContext;
 import io.spine.core.TenantId;
 import io.spine.core.UserId;
 import io.spine.test.commandbus.ProjectId;
@@ -41,8 +39,6 @@ import io.spine.test.commandbus.command.CmdBusCreateProject;
 import io.spine.test.commandbus.command.CmdBusCreateTask;
 import io.spine.test.commandbus.command.CmdBusRemoveTask;
 import io.spine.test.commandbus.command.CmdBusStartProject;
-import io.spine.test.commandbus.command.FirstCmdBusCreateProject;
-import io.spine.test.commandbus.command.SecondCmdBusStartProject;
 import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.testing.core.given.GivenCommandContext;
 import io.spine.testing.core.given.GivenUserId;
@@ -58,9 +54,8 @@ public class Given {
     }
 
     private static ProjectId newProjectId() {
-        String uuid = newUuid();
-        return ProjectId
-                .newBuilder()
+        var uuid = newUuid();
+        return ProjectId.newBuilder()
                 .setId(uuid)
                 .build();
     }
@@ -81,13 +76,11 @@ public class Given {
          */
         private static Command create(io.spine.base.CommandMessage command, UserId userId,
                                       Timestamp when) {
-            TenantId generatedTenantId = TenantId
-                    .newBuilder()
+            var generatedTenantId = TenantId.newBuilder()
                     .setValue(newUuid())
                     .build();
-            TestActorRequestFactory factory =
-                    new TestActorRequestFactory(userId, generatedTenantId);
-            Command result = factory.createCommand(command, when);
+            var factory = new TestActorRequestFactory(userId, generatedTenantId);
+            var result = factory.createCommand(command, when);
             return result;
         }
 
@@ -103,28 +96,18 @@ public class Given {
             return addTask(USER_ID, PROJECT_ID, currentTime());
         }
 
-        static Command secondStartProject() {
-            SecondCmdBusStartProject command = CommandMessage.secondStartProject(newProjectId());
-            return create(command, USER_ID, currentTime());
-        }
-
-        static Command firstCreateProject() {
-            FirstCmdBusCreateProject command = CommandMessage.firstCreateProject(newProjectId());
-            return create(command, USER_ID, currentTime());
-        }
-
         static Command createTask(TaskId taskId, UserId userId, boolean startTask) {
-            CmdBusCreateTask command = CommandMessage.createTask(taskId, userId, startTask);
+            var command = CommandMessage.createTask(taskId, userId, startTask);
             return create(command, userId, currentTime());
         }
 
         static Command addTask(UserId userId, ProjectId projectId, Timestamp when) {
-            CmdBusAddTask command = CommandMessage.addTask(projectId);
+            var command = CommandMessage.addTask(projectId);
             return create(command, userId, when);
         }
 
         static Command removeTask() {
-            CmdBusRemoveTask command = CommandMessage.removeTask(PROJECT_ID);
+            var command = CommandMessage.removeTask(PROJECT_ID);
             return create(command, USER_ID, currentTime());
         }
 
@@ -139,15 +122,15 @@ public class Given {
 
         static Command createProject(Duration delay) {
 
-            CmdBusCreateProject projectMessage = CommandMessage.createProjectMessage();
-            CommandContext commandContext = GivenCommandContext.withScheduledDelayOf(delay);
-            CommandFactory commandFactory = new TestActorRequestFactory(ACommand.class).command();
-            Command cmd = commandFactory.createBasedOnContext(projectMessage, commandContext);
+            var projectMessage = CommandMessage.createProjectMessage();
+            var commandContext = GivenCommandContext.withScheduledDelayOf(delay);
+            var commandFactory = new TestActorRequestFactory(ACommand.class).command();
+            var cmd = commandFactory.createBasedOnContext(projectMessage, commandContext);
             return cmd;
         }
 
         static Command createProject(UserId userId, ProjectId projectId, Timestamp when) {
-            CmdBusCreateProject command = CommandMessage.createProjectMessage(projectId);
+            var command = CommandMessage.createProjectMessage(projectId);
             return create(command, userId, when);
         }
 
@@ -156,14 +139,13 @@ public class Given {
         }
 
         static Command startProject(UserId userId, ProjectId projectId, Timestamp when) {
-            CmdBusStartProject command = CommandMessage.startProject(projectId);
+            var command = CommandMessage.startProject(projectId);
             return create(command, userId, when);
         }
 
         private static TaskId newTaskId() {
-            int id = random(1, 100);
-            return TaskId
-                    .newBuilder()
+            var id = random(1, 100);
+            return TaskId.newBuilder()
                     .setId(id)
                     .build();
         }
@@ -176,13 +158,11 @@ public class Given {
         }
 
         static CmdBusCreateTask createTask(TaskId taskId, UserId userId, boolean startTask) {
-            Task task = Task
-                    .newBuilder()
+            var task = Task.newBuilder()
                     .setTaskId(taskId)
                     .setAssignee(userId)
                     .build();
-            return CmdBusCreateTask
-                    .newBuilder()
+            return CmdBusCreateTask.newBuilder()
                     .setTaskId(taskId)
                     .setTask(task)
                     .setStart(startTask)
@@ -191,20 +171,20 @@ public class Given {
 
         static CmdBusAddTask addTask(String projectId) {
             return addTask(ProjectId.newBuilder()
-                                    .setId(projectId)
-                                    .build());
+                                   .setId(projectId)
+                                   .build());
         }
 
         static CmdBusAddTask addTask(ProjectId id) {
             return CmdBusAddTask.newBuilder()
-                                .setProjectId(id)
-                                .build();
+                    .setProjectId(id)
+                    .build();
         }
 
         static CmdBusRemoveTask removeTask(ProjectId projectId) {
             return CmdBusRemoveTask.newBuilder()
-                                   .setProjectId(projectId)
-                                   .build();
+                    .setProjectId(projectId)
+                    .build();
         }
 
         public static CmdBusCreateProject createProjectMessage() {
@@ -220,28 +200,14 @@ public class Given {
 
         static CmdBusCreateProject createProjectMessage(String projectId) {
             return createProjectMessage(ProjectId.newBuilder()
-                                                 .setId(projectId)
-                                                 .build());
+                                                .setId(projectId)
+                                                .build());
         }
 
         static CmdBusStartProject startProject(ProjectId id) {
             return CmdBusStartProject
                     .newBuilder()
                     .setProjectId(id)
-                    .build();
-        }
-
-        static FirstCmdBusCreateProject firstCreateProject(ProjectId projectId) {
-            return FirstCmdBusCreateProject
-                    .newBuilder()
-                    .setId(projectId)
-                    .build();
-        }
-
-        static SecondCmdBusStartProject secondStartProject(ProjectId projectId) {
-            return SecondCmdBusStartProject
-                    .newBuilder()
-                    .setId(projectId)
                     .build();
         }
     }

--- a/server/src/test/java/io/spine/server/commandbus/MultiTenantCommandBusTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/MultiTenantCommandBusTest.java
@@ -40,8 +40,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
-
 import static io.spine.core.CommandValidationError.TENANT_UNKNOWN;
 import static io.spine.core.CommandValidationError.UNSUPPORTED_COMMAND;
 import static io.spine.core.Status.StatusCase.ERROR;
@@ -52,8 +50,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisplayName("Multitenant `CommandBus` should")
 @SuppressWarnings("DuplicateStringLiteralInspection") // Common test display names.
-@DisplayName("Multitenant CommandBus should")
 class MultiTenantCommandBusTest extends AbstractCommandBusTestSuite {
 
     MultiTenantCommandBusTest() {
@@ -80,7 +78,7 @@ class MultiTenantCommandBusTest extends AbstractCommandBusTestSuite {
     @DisplayName("verify tenant ID attribute if is multitenant")
     void requireTenantId() {
         commandBus.register(createProjectHandler);
-        Command cmd = newCommandWithoutTenantId();
+        var cmd = newCommandWithoutTenantId();
 
         commandBus.post(cmd, observer);
 
@@ -93,7 +91,7 @@ class MultiTenantCommandBusTest extends AbstractCommandBusTestSuite {
     @Test
     @DisplayName("state command not supported when there is neither handler nor dispatcher for it")
     void requireHandlerOrDispatcher() {
-        Command command = addTask();
+        var command = addTask();
         commandBus.post(command, observer);
 
         checkCommandError(observer.firstResponse(),
@@ -120,7 +118,7 @@ class MultiTenantCommandBusTest extends AbstractCommandBusTestSuite {
         @Test
         @DisplayName("command handler")
         void commandHandler() {
-            CreateProjectHandler handler = new CreateProjectHandler();
+            var handler = new CreateProjectHandler();
             commandBus.register(handler);
             handler.registerWith(context);
 
@@ -164,7 +162,7 @@ class MultiTenantCommandBusTest extends AbstractCommandBusTestSuite {
         }
 
         CreateProjectHandler newCommandHandler() {
-            CreateProjectHandler handler = new CreateProjectHandler();
+            var handler = new CreateProjectHandler();
             handler.registerWith(context);
             return handler;
         }
@@ -175,7 +173,7 @@ class MultiTenantCommandBusTest extends AbstractCommandBusTestSuite {
     void postCommand() {
         commandBus.register(createProjectHandler);
 
-        Command command = createProject();
+        var command = createProject();
         commandBus.post(command, observer);
 
         checkResult(command);
@@ -198,7 +196,7 @@ class MultiTenantCommandBusTest extends AbstractCommandBusTestSuite {
         @Test
         @DisplayName("command dispatcher")
         void commandDispatcher() {
-            AddTaskDispatcher dispatcher = new AddTaskDispatcher();
+            var dispatcher = new AddTaskDispatcher();
             commandBus.register(dispatcher);
 
             commandBus.post(addTask(), observer);
@@ -213,7 +211,7 @@ class MultiTenantCommandBusTest extends AbstractCommandBusTestSuite {
         commandBus.register(createProjectHandler);
         commandBus.register(new AddTaskDispatcher());
 
-        Set<CommandClass> cmdClasses = commandBus.registeredCommandClasses();
+        var cmdClasses = commandBus.registeredCommandClasses();
 
         assertTrue(cmdClasses.contains(CommandClass.from(CmdBusCreateProject.class)));
         assertTrue(cmdClasses.contains(CommandClass.from(CmdBusAddTask.class)));

--- a/server/src/test/java/io/spine/server/commandbus/RejectionInFilterTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/RejectionInFilterTest.java
@@ -40,28 +40,26 @@ import io.spine.testing.server.blackbox.BlackBox;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("Command bus, when a `Rejection` is thrown from a bus filter, should")
+@DisplayName("`CommandBus`, when a `Rejection` is thrown from a bus filter, should")
 class RejectionInFilterTest {
 
     @Test
     @DisplayName("post this rejection to `EventBus`")
     void postRejection() {
-        BlackBox context = BlackBox.from(
+        var context = BlackBox.from(
                 BoundedContextBuilder.assumingTests()
                                      .add(OrderAggregate.class)
                                      .add(new CaffetteriaStatsRepository())
                                      .addCommandFilter(new BeachCustomerFilter())
         );
-        CmdBusCaffetteriaId caffetteria = CmdBusCaffetteriaId.generate();
-        int allowedCount = 2;
-        Visitors visitorsAllowedToEnter = Visitors
-                .newBuilder()
+        var caffetteria = CmdBusCaffetteriaId.generate();
+        var allowedCount = 2;
+        var visitorsAllowedToEnter = Visitors.newBuilder()
                 .setCount(allowedCount)
                 .setBringOwnFood(false)
                 .build();
-        int deniedCount = 4;
-        Visitors visitorsDeniedEntrance = Visitors
-                .newBuilder()
+        var deniedCount = 4;
+        var visitorsDeniedEntrance = Visitors.newBuilder()
                 .setCount(deniedCount)
                 .setBringOwnFood(true)
                 .build();
@@ -76,8 +74,7 @@ class RejectionInFilterTest {
                .hasStateThat()
                .comparingExpectedFieldsOnly()
                .isEqualTo(
-                       CmdBusCaffetteriaStats
-                               .newBuilder()
+                       CmdBusCaffetteriaStats.newBuilder()
                                .setVisitorCount(allowedCount)
                                .setEntryDenied(deniedCount)
                                .build()
@@ -86,8 +83,7 @@ class RejectionInFilterTest {
 
     private static CmdBusAllocateTable allocateTableForVisitors(CmdBusCaffetteriaId caffetteria,
                                                                 Visitors visitorsDenied) {
-        return CmdBusAllocateTable
-                .newBuilder()
+        return CmdBusAllocateTable.newBuilder()
                 .setId(CmdBusOrderId.generate())
                 .setCaffetteria(caffetteria)
                 .setVisitors(visitorsDenied)

--- a/server/src/test/java/io/spine/server/commandbus/SingleTenantCommandBusTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/SingleTenantCommandBusTest.java
@@ -31,9 +31,7 @@ import io.spine.core.Ack;
 import io.spine.core.Command;
 import io.spine.core.CommandValidationError;
 import io.spine.grpc.MemoizingObserver;
-import io.spine.server.bus.EnvelopeValidator;
 import io.spine.server.commandbus.given.SingleTenantCommandBusTestEnv.FaultyHandler;
-import io.spine.server.type.CommandEnvelope;
 import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.testing.logging.mute.MuteLogging;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("Single tenant CommandBus should")
+@DisplayName("Single-tenant `CommandBus` should")
 class SingleTenantCommandBusTest extends AbstractCommandBusTestSuite {
 
     private static final TestActorRequestFactory requestFactory =
@@ -84,7 +82,7 @@ class SingleTenantCommandBusTest extends AbstractCommandBusTestSuite {
         @Test
         @DisplayName("invalid command")
         void invalidCmd() {
-            Command cmd = newCommandWithoutContext();
+            var cmd = newCommandWithoutContext();
 
             commandBus.post(cmd, observer);
 
@@ -99,7 +97,7 @@ class SingleTenantCommandBusTest extends AbstractCommandBusTestSuite {
         @DisplayName("multitenant command in single tenant context")
         void multitenantCmdIfSingleTenant() {
             // Create a multi-tenant command.
-            Command cmd = createProject();
+            var cmd = createProject();
 
             commandBus.post(cmd, observer);
 
@@ -114,14 +112,14 @@ class SingleTenantCommandBusTest extends AbstractCommandBusTestSuite {
     @Test
     @DisplayName("do not propagate dispatching errors")
     void doNotPropagateExceptions() {
-        FaultyHandler faultyHandler = FaultyHandler.initializedHandler();
+        var faultyHandler = FaultyHandler.initializedHandler();
         commandBus.register(faultyHandler);
 
-        Command remoteTaskCommand = clearTenantId(removeTask());
+        var remoteTaskCommand = clearTenantId(removeTask());
         MemoizingObserver<Ack> observer = memoizingObserver();
         commandBus.post(remoteTaskCommand, observer);
 
-        Ack ack = observer.firstResponse();
+        var ack = observer.firstResponse();
         assertTrue(ack.getStatus()
                       .hasOk());
     }
@@ -129,7 +127,7 @@ class SingleTenantCommandBusTest extends AbstractCommandBusTestSuite {
     @Test
     @DisplayName("create validator once")
     void createValidatorOnce() {
-        EnvelopeValidator<CommandEnvelope> validator = commandBus.validator();
+        var validator = commandBus.validator();
         assertNotNull(validator);
         assertSame(validator, commandBus.validator());
     }

--- a/server/src/test/java/io/spine/server/commandbus/given/CommandDispatcherRegistryTestEnv.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/CommandDispatcherRegistryTestEnv.java
@@ -81,10 +81,10 @@ public class CommandDispatcherRegistryTestEnv {
         }
 
         private void handleProjectCreated(ProjectId projectId) {
-            Project newState = state().toBuilder()
-                                      .setId(projectId)
-                                      .setStatus(Project.Status.CREATED)
-                                      .build();
+            var newState = state().toBuilder()
+                    .setId(projectId)
+                    .setStatus(Project.Status.CREATED)
+                    .build();
             builder().mergeFrom(newState);
         }
 
@@ -92,12 +92,12 @@ public class CommandDispatcherRegistryTestEnv {
         void on(CmdBusTaskAdded event) {
             keep(event);
 
-            Task task = event.getTask();
+            var task = event.getTask();
             handleTaskAdded(task);
         }
 
         private void handleTaskAdded(Task task) {
-            Project newState = state().toBuilder()
+            var newState = state().toBuilder()
                                       .addTask(task)
                                       .build();
             builder().mergeFrom(newState);
@@ -111,9 +111,9 @@ public class CommandDispatcherRegistryTestEnv {
         }
 
         private void handleProjectStarted() {
-            Project newState = state().toBuilder()
-                                      .setStatus(Project.Status.STARTED)
-                                      .build();
+            var newState = state().toBuilder()
+                    .setStatus(Project.Status.STARTED)
+                    .build();
             builder().mergeFrom(newState);
         }
     }

--- a/server/src/test/java/io/spine/server/commandbus/given/CommandHandlerTestEnv.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/CommandHandlerTestEnv.java
@@ -41,7 +41,6 @@ import io.spine.server.type.CommandEnvelope;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
 import io.spine.test.commandbus.ProjectId;
-import io.spine.test.commandbus.TaskId;
 import io.spine.test.commandbus.command.CmdBusAddTask;
 import io.spine.test.commandbus.command.CmdBusCreateProject;
 import io.spine.test.commandbus.command.CmdBusCreateTask;
@@ -110,7 +109,7 @@ public class CommandHandlerTestEnv {
         @SuppressWarnings("CheckReturnValue")
         // Can ignore the returned ID of the command handler in these tests.
         public void handle(Command cmd) {
-            CommandEnvelope commandEnvelope = CommandEnvelope.of(cmd);
+            var commandEnvelope = CommandEnvelope.of(cmd);
             dispatch(commandEnvelope);
         }
 
@@ -144,31 +143,27 @@ public class CommandHandlerTestEnv {
         }
 
         private ImmutableList<EventMessage> createEventsOnStartProjectCmd() {
-            ProjectId id = ProjectId
-                    .newBuilder()
+            var id = ProjectId.newBuilder()
                     .setId(id())
                     .build();
-            CmdBusProjectStarted startedEvent = CmdBusProjectStarted
-                    .newBuilder()
+            var startedEvent = CmdBusProjectStarted.newBuilder()
                     .setProjectId(id)
                     .build();
-            CmdBusProjectStarted defaultEvent = CmdBusProjectStarted.getDefaultInstance();
+            var defaultEvent = CmdBusProjectStarted.getDefaultInstance();
             return ImmutableList.of(startedEvent, defaultEvent);
         }
 
         private static Pair<CmdBusTaskAssigned, Optional<CmdBusTaskStarted>>
         createEventsOnCreateTaskCmd(CmdBusCreateTask msg) {
-            TaskId taskId = msg.getTaskId();
-            CmdBusTaskAssigned cmdTaskAssigned = CmdBusTaskAssigned
-                    .newBuilder()
+            var taskId = msg.getTaskId();
+            var cmdTaskAssigned = CmdBusTaskAssigned.newBuilder()
                     .setTaskId(taskId)
                     .build();
-            CmdBusTaskStarted cmdTaskStarted = msg.getStart()
-                                               ? CmdBusTaskStarted
-                                                       .newBuilder()
-                                                       .setTaskId(taskId)
-                                                       .build()
-                                               : null;
+            var cmdTaskStarted = msg.getStart()
+                                 ? CmdBusTaskStarted.newBuilder()
+                                         .setTaskId(taskId)
+                                         .build()
+                                 : null;
             return Pair.withNullable(cmdTaskAssigned, cmdTaskStarted);
         }
     }

--- a/server/src/test/java/io/spine/server/commandbus/given/SingleTenantCommandBusTestEnv.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/SingleTenantCommandBusTestEnv.java
@@ -29,7 +29,6 @@ package io.spine.server.commandbus.given;
 import com.google.protobuf.Message;
 import io.spine.core.Command;
 import io.spine.core.CommandContext;
-import io.spine.server.BoundedContext;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.command.AbstractCommandHandler;
 import io.spine.server.command.Assign;
@@ -67,7 +66,7 @@ public class SingleTenantCommandBusTestEnv {
         }
 
         public static FaultyHandler initializedHandler() {
-            FaultyHandler handler = new FaultyHandler();
+            var handler = new FaultyHandler();
             handler.registerWith(BoundedContextBuilder.assumingTests().build());
             return handler;
         }
@@ -108,16 +107,6 @@ public class SingleTenantCommandBusTestEnv {
             super();
             this.commandBus = commandBus;
             this.commandToPost = commandToPost;
-        }
-
-        public static CommandPostingHandler
-        initializedHandler(CommandBus commandBus, Command commandToPost) {
-            CommandPostingHandler handler = new CommandPostingHandler(commandBus, commandToPost);
-            BoundedContext context = BoundedContextBuilder
-                    .assumingTests()
-                    .build();
-            handler.registerWith(context);
-            return handler;
         }
 
         @Assign

--- a/server/src/test/java/io/spine/server/commandbus/given/caffetteria/BeachCustomerFilter.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/caffetteria/BeachCustomerFilter.java
@@ -40,16 +40,15 @@ public final class BeachCustomerFilter implements CommandFilter {
 
     @Override
     public Optional<Ack> filter(CommandEnvelope envelope) {
-        CmdBusAllocateTable command =
+        var command =
                 unpack(envelope.command()
                                .getMessage(), CmdBusAllocateTable.class);
-        boolean withOwnFood = command.getVisitors()
-                                     .getBringOwnFood();
+        var withOwnFood = command.getVisitors()
+                                 .getBringOwnFood();
         if (!withOwnFood) {
             return letPass();
         }
-        CmdBusEntryDenied rejection = CmdBusEntryDenied
-                .newBuilder()
+        var rejection = CmdBusEntryDenied.newBuilder()
                 .setId(command.getCaffetteria())
                 .setVisitorCount(command.getVisitors()
                                         .getCount())

--- a/server/src/test/java/io/spine/server/delivery/AbstractDeliveryTest.java
+++ b/server/src/test/java/io/spine/server/delivery/AbstractDeliveryTest.java
@@ -52,7 +52,7 @@ abstract class AbstractDeliveryTest {
     }
 
     static void changeShardCountTo(int shards) {
-        Delivery newDelivery = Delivery.localWithShardsAndWindow(shards, Durations.ZERO);
+        var newDelivery = Delivery.localWithShardsAndWindow(shards, Durations.ZERO);
         ServerEnvironment.when(Tests.class)
                          .use(newDelivery);
     }

--- a/server/src/test/java/io/spine/server/delivery/AbstractStationTest.java
+++ b/server/src/test/java/io/spine/server/delivery/AbstractStationTest.java
@@ -63,11 +63,11 @@ abstract class AbstractStationTest {
     @Test
     @DisplayName("do nothing on an empty conveyor")
     void doNothingOnEmptyConveyor() {
-        MemoizingAction action = new MemoizingAction();
-        Station station = newStation(action);
-        Conveyor emptyConveyor = new Conveyor(new ArrayList<>(), new DeliveredMessages());
+        var action = new MemoizingAction();
+        var station = newStation(action);
+        var emptyConveyor = new Conveyor(new ArrayList<>(), new DeliveredMessages());
 
-        Station.Result result = station.process(emptyConveyor);
+        var result = station.process(emptyConveyor);
         assertDeliveredCount(result, 0);
 
         assertThat(action.passedMessages()).isNull();
@@ -99,7 +99,7 @@ abstract class AbstractStationTest {
 
     static void assertKeptForLonger(InboxMessageId id,
                                     Map<InboxMessageId, InboxMessage> remaindersById) {
-        InboxMessage message = remaindersById.get(id);
+        var message = remaindersById.get(id);
         assertThat(
                 compare(message.getKeepUntil(), message.getWhenReceived())
         ).isGreaterThan(0);
@@ -107,7 +107,7 @@ abstract class AbstractStationTest {
 
     static void assertNotKeptForLonger(InboxMessageId id,
                                     Map<InboxMessageId, InboxMessage> remaindersById) {
-        InboxMessage message = remaindersById.get(id);
+        var message = remaindersById.get(id);
         assertThat(message.getKeepUntil()).isEqualTo(Timestamp.getDefaultInstance());
     }
 }

--- a/server/src/test/java/io/spine/server/delivery/CatchUpStationTest.java
+++ b/server/src/test/java/io/spine/server/delivery/CatchUpStationTest.java
@@ -28,7 +28,6 @@ package io.spine.server.delivery;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.protobuf.Timestamp;
 import io.spine.type.TypeUrl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -36,8 +35,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Streams.stream;
@@ -70,18 +67,18 @@ class CatchUpStationTest extends AbstractStationTest {
     @Test
     @DisplayName("remove live messages which correspond to a started `CatchUpJob`")
     void removeLiveMessagesIfCatchUpStarted() {
-        InboxMessage toDeliver = toDeliver(targetOne, type);
-        InboxMessage anotherToDeliver = copyWithNewId(toDeliver);
-        InboxMessage delivered = delivered(targetOne, type);
-        InboxMessage differentTarget = delivered(targetTwo, type);
-        Conveyor conveyor = new Conveyor(
+        var toDeliver = toDeliver(targetOne, type);
+        var anotherToDeliver = copyWithNewId(toDeliver);
+        var delivered = delivered(targetOne, type);
+        var differentTarget = delivered(targetTwo, type);
+        var conveyor = new Conveyor(
                 ImmutableList.of(toDeliver, anotherToDeliver, delivered, differentTarget),
                 new DeliveredMessages()
         );
 
-        CatchUp job = catchUpJob(type, IN_PROGRESS, currentTime(), ImmutableList.of(targetOne));
-        CatchUpStation station = new CatchUpStation(MemoizingAction.empty(), ImmutableList.of(job));
-        Station.Result result = station.process(conveyor);
+        var job = catchUpJob(type, IN_PROGRESS, currentTime(), ImmutableList.of(targetOne));
+        var station = new CatchUpStation(MemoizingAction.empty(), ImmutableList.of(job));
+        var result = station.process(conveyor);
 
         assertDeliveredCount(result, 0);
 
@@ -98,20 +95,20 @@ class CatchUpStationTest extends AbstractStationTest {
     @DisplayName("deliver the messages in `CATCH_UP` status " +
             "which correspond to a started `CatchUpJob` and remove duplicates")
     void matchAndRunDeliveryAction() {
-        InboxMessage toCatchUp = catchingUp(targetOne, type);
-        InboxMessage duplicateCopy = copyWithNewId(toCatchUp);
-        InboxMessage anotherToCatchUp = catchingUp(targetOne, type);
-        InboxMessage alreadyDelivered = delivered(targetOne, type);
-        InboxMessage differentTarget = catchingUp(targetTwo, type);
+        var toCatchUp = catchingUp(targetOne, type);
+        var duplicateCopy = copyWithNewId(toCatchUp);
+        var anotherToCatchUp = catchingUp(targetOne, type);
+        var alreadyDelivered = delivered(targetOne, type);
+        var differentTarget = catchingUp(targetTwo, type);
 
-        ImmutableList<InboxMessage> initialContents =
+        var initialContents =
                 ImmutableList.of(toCatchUp, anotherToCatchUp, duplicateCopy,
                                  alreadyDelivered, differentTarget);
-        Conveyor conveyor = new Conveyor(initialContents, new DeliveredMessages());
+        var conveyor = new Conveyor(initialContents, new DeliveredMessages());
 
-        CatchUp job = catchUpJob(type, IN_PROGRESS, currentTime(), ImmutableList.of(targetOne));
-        CatchUpStation station = new CatchUpStation(MemoizingAction.empty(), ImmutableList.of(job));
-        Station.Result result = station.process(conveyor);
+        var job = catchUpJob(type, IN_PROGRESS, currentTime(), ImmutableList.of(targetOne));
+        var station = new CatchUpStation(MemoizingAction.empty(), ImmutableList.of(job));
+        var result = station.process(conveyor);
 
         assertDeliveredCount(result, 2);
 
@@ -135,18 +132,18 @@ class CatchUpStationTest extends AbstractStationTest {
     @DisplayName("mark as `CATCH_UP` those live messages " +
             "which correspond to a finalizing `CatchUpJob`")
     void markLiveMessagesCatchUpIfJobFinalizing() {
-        InboxMessage toDeliver = toDeliver(targetOne, type);
-        InboxMessage anotherToDeliver = copyWithNewId(toDeliver);
-        InboxMessage delivered = delivered(targetOne, type);
-        InboxMessage differentTarget = delivered(targetTwo, type);
-        Conveyor conveyor = new Conveyor(
+        var toDeliver = toDeliver(targetOne, type);
+        var anotherToDeliver = copyWithNewId(toDeliver);
+        var delivered = delivered(targetOne, type);
+        var differentTarget = delivered(targetTwo, type);
+        var conveyor = new Conveyor(
                 ImmutableList.of(toDeliver, anotherToDeliver, delivered, differentTarget),
                 new DeliveredMessages()
         );
 
-        CatchUp job = catchUpJob(type, FINALIZING, currentTime(), ImmutableList.of(targetOne));
-        CatchUpStation station = new CatchUpStation(MemoizingAction.empty(), ImmutableList.of(job));
-        Station.Result result = station.process(conveyor);
+        var job = catchUpJob(type, FINALIZING, currentTime(), ImmutableList.of(targetOne));
+        var station = new CatchUpStation(MemoizingAction.empty(), ImmutableList.of(job));
+        var result = station.process(conveyor);
         assertDeliveredCount(result, 0);
 
         assertContainsExactly(conveyor.iterator(),
@@ -162,21 +159,21 @@ class CatchUpStationTest extends AbstractStationTest {
             "if the respective `CatchUpJob` is completed, " +
             "keeping the `CATCH_UP` messages in their storage for a bit longer")
     void deduplicateAndDeliverWhenJobCompleted() {
-        InboxMessage toCatchUp = catchingUp(targetOne, type);
-        InboxMessage moreToCatchUp = catchingUp(targetOne, type);
-        InboxMessage toDeliver = toDeliver(targetOne, type);
-        InboxMessage duplicateToCatchUp = copyWithNewId(toCatchUp);
-        InboxMessage duplicateToDeliver = copyWithStatus(copyWithNewId(toCatchUp), TO_DELIVER);
-        Conveyor conveyor = new Conveyor(
+        var toCatchUp = catchingUp(targetOne, type);
+        var moreToCatchUp = catchingUp(targetOne, type);
+        var toDeliver = toDeliver(targetOne, type);
+        var duplicateToCatchUp = copyWithNewId(toCatchUp);
+        var duplicateToDeliver = copyWithStatus(copyWithNewId(toCatchUp), TO_DELIVER);
+        var conveyor = new Conveyor(
                 ImmutableList.of(toCatchUp, moreToCatchUp, toDeliver,
                                  duplicateToCatchUp, duplicateToDeliver),
                 new DeliveredMessages()
         );
 
-        CatchUp job = catchUpJob(type, COMPLETED, currentTime(), ImmutableList.of(targetOne));
-        MemoizingAction action = MemoizingAction.empty();
-        CatchUpStation station = new CatchUpStation(action, ImmutableList.of(job));
-        Station.Result result = station.process(conveyor);
+        var job = catchUpJob(type, COMPLETED, currentTime(), ImmutableList.of(targetOne));
+        var action = MemoizingAction.empty();
+        var station = new CatchUpStation(action, ImmutableList.of(job));
+        var result = station.process(conveyor);
         assertDeliveredCount(result, 2);
 
         Collection<InboxMessage> deliveredMessages = checkNotNull(action.passedMessages());
@@ -186,7 +183,7 @@ class CatchUpStationTest extends AbstractStationTest {
                               moreToCatchUp
         );
 
-        Map<InboxMessageId, InboxMessage> remaindersById =
+        var remaindersById =
                 stream(conveyor.iterator()).collect(toMap(InboxMessage::getId, message -> message));
         assertThat(remaindersById).hasSize(3);
 
@@ -199,27 +196,27 @@ class CatchUpStationTest extends AbstractStationTest {
     @DisplayName("run the delivery action " +
             "for the messages in `CATCH_UP` status sorting them beforehand")
     void sortCatchUpMessagesBeforeCallingToAction() {
-        Timestamp now = currentTime();
-        Timestamp secondBefore = subtract(now, fromSeconds(1));
-        Timestamp twoSecondsBefore = subtract(now, fromSeconds(2));
-        Timestamp threeSecondsBefore = subtract(now, fromSeconds(3));
+        var now = currentTime();
+        var secondBefore = subtract(now, fromSeconds(1));
+        var twoSecondsBefore = subtract(now, fromSeconds(2));
+        var threeSecondsBefore = subtract(now, fromSeconds(3));
 
-        InboxMessage toCatchUp1 = catchingUp(targetOne, type, threeSecondsBefore);
-        InboxMessage toCatchUp2 = catchingUp(targetOne, type, twoSecondsBefore);
-        InboxMessage toCatchUp3 = catchingUp(targetOne, type, secondBefore);
-        InboxMessage toCatchUp4 = catchingUp(targetOne, type, now);
-        Conveyor conveyor = new Conveyor(
+        var toCatchUp1 = catchingUp(targetOne, type, threeSecondsBefore);
+        var toCatchUp2 = catchingUp(targetOne, type, twoSecondsBefore);
+        var toCatchUp3 = catchingUp(targetOne, type, secondBefore);
+        var toCatchUp4 = catchingUp(targetOne, type, now);
+        var conveyor = new Conveyor(
                 ImmutableList.of(toCatchUp3, toCatchUp2, toCatchUp4, toCatchUp1),
                 new DeliveredMessages()
         );
 
-        CatchUp job = catchUpJob(type, IN_PROGRESS, currentTime(), ImmutableList.of(targetOne));
-        MemoizingAction action = MemoizingAction.empty();
-        CatchUpStation station = new CatchUpStation(action, ImmutableList.of(job));
-        Station.Result result = station.process(conveyor);
+        var job = catchUpJob(type, IN_PROGRESS, currentTime(), ImmutableList.of(targetOne));
+        var action = MemoizingAction.empty();
+        var station = new CatchUpStation(action, ImmutableList.of(job));
+        var result = station.process(conveyor);
         assertDeliveredCount(result, 4);
 
-        List<InboxMessage> deliveredMessages = checkNotNull(action.passedMessages());
+        var deliveredMessages = checkNotNull(action.passedMessages());
         assertThat(deliveredMessages).containsExactlyElementsIn(
                 ImmutableList.of(toCatchUp1, toCatchUp2, toCatchUp3, toCatchUp4)
         );
@@ -232,8 +229,8 @@ class CatchUpStationTest extends AbstractStationTest {
         @Test
         @DisplayName("by a particular target ID of the `CatchUpJob`")
         void byId() {
-            ImmutableSet<InboxMessage> messages = messagesToTargetOneOf(type);
-            CatchUp job = catchUpJob(type, IN_PROGRESS, currentTime(), ImmutableList.of(targetOne));
+            var messages = messagesToTargetOneOf(type);
+            var job = catchUpJob(type, IN_PROGRESS, currentTime(), ImmutableList.of(targetOne));
             assertMatchesEvery(messages, job);
         }
 
@@ -241,13 +238,13 @@ class CatchUpStationTest extends AbstractStationTest {
         @DisplayName("when the `CatchUpJob` matches all the targets of type " +
                 "to which `InboxMessage` is dispatched")
         void allByType() {
-            ImmutableSet<InboxMessage> messages = messagesToTargetOneOf(type);
-            CatchUp job = catchUpJob(type, IN_PROGRESS, currentTime(), null);
+            var messages = messagesToTargetOneOf(type);
+            var job = catchUpJob(type, IN_PROGRESS, currentTime(), null);
             assertMatchesEvery(messages, job);
         }
 
         private void assertMatchesEvery(ImmutableSet<InboxMessage> messages, CatchUp job) {
-            for (InboxMessage message : messages) {
+            for (var message : messages) {
                 assertThat(job.matches(message))
                         .isTrue();
             }
@@ -261,8 +258,8 @@ class CatchUpStationTest extends AbstractStationTest {
         @Test
         @DisplayName("when the target type of the `InboxMessage` and the `CatchUpJob` differs")
         void whenTargetTypeDiffers() {
-            ImmutableSet<InboxMessage> messages = messagesToTargetOneOf(anotherType);
-            CatchUp job = catchUpJob(type, IN_PROGRESS, currentTime(), null);
+            var messages = messagesToTargetOneOf(anotherType);
+            var job = catchUpJob(type, IN_PROGRESS, currentTime(), null);
             assertMatchesNone(messages, job);
         }
 
@@ -270,13 +267,13 @@ class CatchUpStationTest extends AbstractStationTest {
         @DisplayName("when the target ID of the `InboxMessage` " +
                 "does not match the IDs enumerated in the `CatchUpJob`")
         void whenIdDoesNotMatch() {
-            ImmutableSet<InboxMessage> messages = messagesToTargetOneOf(type);
-            CatchUp job = catchUpJob(type, IN_PROGRESS, currentTime(), ImmutableSet.of(targetTwo));
+            var messages = messagesToTargetOneOf(type);
+            var job = catchUpJob(type, IN_PROGRESS, currentTime(), ImmutableSet.of(targetTwo));
             assertMatchesNone(messages, job);
         }
 
         private void assertMatchesNone(ImmutableSet<InboxMessage> messages, CatchUp job) {
-            for (InboxMessage message : messages) {
+            for (var message : messages) {
                 assertThat(job.matches(message))
                         .isFalse();
             }

--- a/server/src/test/java/io/spine/server/delivery/CleanupStationTest.java
+++ b/server/src/test/java/io/spine/server/delivery/CleanupStationTest.java
@@ -50,17 +50,17 @@ class CleanupStationTest extends AbstractStationTest {
     @Test
     @DisplayName("remove the messages in `DELIVERED` status")
     void removeDeliveredMessages() {
-        InboxMessage delivered = delivered(targetOne, type);
-        InboxMessage deliveredToAnotherTarget = delivered(targetTwo, type);
-        InboxMessage catchingUp = catchingUp(targetTwo, type);
-        InboxMessage toDeliver = toDeliver(targetOne, type);
-        Conveyor conveyor = new Conveyor(
+        var delivered = delivered(targetOne, type);
+        var deliveredToAnotherTarget = delivered(targetTwo, type);
+        var catchingUp = catchingUp(targetTwo, type);
+        var toDeliver = toDeliver(targetOne, type);
+        var conveyor = new Conveyor(
                 ImmutableList.of(delivered, deliveredToAnotherTarget, catchingUp, toDeliver),
                 new DeliveredMessages()
         );
 
         Station station = new CleanupStation();
-        Station.Result result = station.process(conveyor);
+        var result = station.process(conveyor);
 
         assertDeliveredCount(result, 0);
 
@@ -77,19 +77,19 @@ class CleanupStationTest extends AbstractStationTest {
     @DisplayName("keep the messages in `DELIVERED` status if they have `keep_until` in future" +
             "and remove `DELIVERED` messages if their `keep_until` is in the past")
     void considerKeepUntilWhenRemoving() {
-        InboxMessage deliveredKeepTillFuture = keepUntil(
+        var deliveredKeepTillFuture = keepUntil(
                 delivered(targetOne, type), add(currentTime(), fromSeconds(10))
         );
-        InboxMessage deliveredKeepUntilPastTime = keepUntil(
+        var deliveredKeepUntilPastTime = keepUntil(
                 delivered(targetTwo, type), subtract(currentTime(), fromSeconds(5))
         );
-        Conveyor conveyor = new Conveyor(
+        var conveyor = new Conveyor(
                 ImmutableList.of(deliveredKeepTillFuture, deliveredKeepUntilPastTime),
                 new DeliveredMessages()
         );
 
         Station station = new CleanupStation();
-        Station.Result result = station.process(conveyor);
+        var result = station.process(conveyor);
         assertDeliveredCount(result, 0);
 
         assertContainsExactly(conveyor.removals(),

--- a/server/src/test/java/io/spine/server/delivery/DeliveryBuilderTest.java
+++ b/server/src/test/java/io/spine/server/delivery/DeliveryBuilderTest.java
@@ -116,7 +116,7 @@ class DeliveryBuilderTest {
         @Test
         @DisplayName("delivery strategy")
         void strategy() {
-            DeliveryStrategy strategy = UniformAcrossAllShards.forNumber(42);
+            var strategy = UniformAcrossAllShards.forNumber(42);
             assertThat(builder().setStrategy(strategy).strategy())
                   .hasValue(strategy);
         }
@@ -124,7 +124,7 @@ class DeliveryBuilderTest {
         @Test
         @DisplayName("Inbox storage")
         void inboxStorage() {
-            InboxStorage storage = new InboxStorage(factory, false);
+            var storage = new InboxStorage(factory, false);
             assertThat(builder().setInboxStorage(storage).inboxStorage())
                   .hasValue(storage);
         }
@@ -132,7 +132,7 @@ class DeliveryBuilderTest {
         @Test
         @DisplayName("Catch-up storage")
         void catchUpStorage() {
-            CatchUpStorage storage = new CatchUpStorage(factory, false);
+            var storage = new CatchUpStorage(factory, false);
             assertThat(builder().setCatchUpStorage(storage).catchUpStorage())
                   .hasValue(storage);
         }
@@ -140,7 +140,7 @@ class DeliveryBuilderTest {
         @Test
         @DisplayName("work registry")
         void workRegistry() {
-            InMemoryShardedWorkRegistry registry = new InMemoryShardedWorkRegistry();
+            var registry = new InMemoryShardedWorkRegistry();
             assertThat(builder().setWorkRegistry(registry)
                                        .workRegistry())
                   .hasValue(registry);
@@ -149,7 +149,7 @@ class DeliveryBuilderTest {
         @Test
         @DisplayName("deduplication window")
         void deduplicationWindow() {
-            Duration duration = fromMinutes(123);
+            var duration = fromMinutes(123);
             assertThat(builder().setDeduplicationWindow(duration).deduplicationWindow())
                     .hasValue(duration);
         }
@@ -157,7 +157,7 @@ class DeliveryBuilderTest {
         @Test
         @DisplayName("delivery monitor")
         void deliveryMonitor() {
-            DeliveryMonitor monitor = DeliveryMonitor.alwaysContinue();
+            var monitor = DeliveryMonitor.alwaysContinue();
             assertThat(builder().setMonitor(monitor).deliveryMonitor())
                     .hasValue(monitor);
         }
@@ -165,7 +165,7 @@ class DeliveryBuilderTest {
         @Test
         @DisplayName("page size")
         void pageSize() {
-            int pageSize = 42;
+            var pageSize = 42;
             assertThat(builder().setPageSize(pageSize).pageSize())
                     .hasValue(pageSize);
         }
@@ -173,7 +173,7 @@ class DeliveryBuilderTest {
         @Test
         @DisplayName("catch-up page size")
         void catchUpPageSize() {
-            int catchUpPageSize = 499;
+            var catchUpPageSize = 499;
             assertThat(builder().setCatchUpPageSize(catchUpPageSize).catchUpPageSize())
                     .hasValue(catchUpPageSize);
         }

--- a/server/src/test/java/io/spine/server/delivery/DeliveryDefaultsTest.java
+++ b/server/src/test/java/io/spine/server/delivery/DeliveryDefaultsTest.java
@@ -41,20 +41,20 @@ class DeliveryDefaultsTest {
     @Test
     @DisplayName("initialize the `InboxStorage` in a single-tenant mode")
     void createSingleTenantInboxStorage() {
-        InboxStorage storage = defaultDelivery().inboxStorage();
+        var storage = defaultDelivery().inboxStorage();
         assertSingleTenant(storage);
     }
 
     @Test
     @DisplayName("initialize the `CatchUp` in a single-tenant mode")
     void createSingleTenantCatchUpStorage() {
-        CatchUpStorage storage = defaultDelivery().catchUpStorage();
+        var storage = defaultDelivery().catchUpStorage();
         assertSingleTenant(storage);
     }
 
     private static Delivery defaultDelivery() {
         return Delivery.newBuilder()
-                       .build();
+                .build();
     }
 
     private static void assertSingleTenant(Storage<?, ?> storage) {

--- a/server/src/test/java/io/spine/server/delivery/DeliveryErrorsTest.java
+++ b/server/src/test/java/io/spine/server/delivery/DeliveryErrorsTest.java
@@ -36,13 +36,13 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisplayName("DeliveryErrors should")
+@DisplayName("`DeliveryErrors` should")
 class DeliveryErrorsTest {
 
     @Test
     @DisplayName(NOT_ACCEPT_NULLS)
     void nulls() {
-        DeliveryErrors.Builder builder = DeliveryErrors.newBuilder();
+        var builder = DeliveryErrors.newBuilder();
         new NullPointerTester()
                 .testInstanceMethods(builder, PACKAGE);
     }
@@ -50,12 +50,12 @@ class DeliveryErrorsTest {
     @Test
     @DisplayName("accept model errors")
     void acceptErrors() {
-        DeliveryErrors.Builder builder = DeliveryErrors.newBuilder();
-        ModelError mockError = new ModelError("boo!");
+        var builder = DeliveryErrors.newBuilder();
+        var mockError = new ModelError("boo!");
         builder.addError(mockError);
-        DeliveryErrors errors = builder.build();
+        var errors = builder.build();
 
-        ModelError error = assertThrows(ModelError.class, errors::throwIfAny);
+        var error = assertThrows(ModelError.class, errors::throwIfAny);
         assertThat(error)
                 .isEqualTo(mockError);
     }
@@ -63,13 +63,13 @@ class DeliveryErrorsTest {
     @Test
     @DisplayName("accept runtime exceptions")
     void acceptExceptions() {
-        DeliveryErrors.Builder builder = DeliveryErrors.newBuilder();
+        var builder = DeliveryErrors.newBuilder();
         RuntimeException mockException = new IllegalArgumentException("42");
         builder.addException(mockException);
-        DeliveryErrors errors = builder.build();
+        var errors = builder.build();
 
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                                                          errors::throwIfAny);
+        var exception = assertThrows(IllegalArgumentException.class,
+                                     errors::throwIfAny);
         assertThat(exception)
                 .isEqualTo(mockException);
     }
@@ -77,16 +77,16 @@ class DeliveryErrorsTest {
     @Test
     @DisplayName("throw exceptions with suppressed throwables")
     void throwWithSuppressed() {
-        DeliveryErrors.Builder builder = DeliveryErrors.newBuilder();
-        ModelError mockError = new ModelError("model is wrong");
-        ModelError anotherMockError = new ModelError("completely");
+        var builder = DeliveryErrors.newBuilder();
+        var mockError = new ModelError("model is wrong");
+        var anotherMockError = new ModelError("completely");
         RuntimeException mockException = new IllegalArgumentException("3.14");
         builder.addError(mockError);
         builder.addError(anotherMockError);
         builder.addException(mockException);
 
-        DeliveryErrors errors = builder.build();
-        ModelError error = assertThrows(ModelError.class, errors::throwIfAny);
+        var errors = builder.build();
+        var error = assertThrows(ModelError.class, errors::throwIfAny);
         assertThat(error)
                 .isEqualTo(mockError);
         assertThat(error.getSuppressed())

--- a/server/src/test/java/io/spine/server/delivery/DeliveryFactoryTest.java
+++ b/server/src/test/java/io/spine/server/delivery/DeliveryFactoryTest.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.delivery;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -39,15 +38,15 @@ class DeliveryFactoryTest {
     @DisplayName("create an instance of `Delivery` " +
             "which delivers the messages from their shards asynchronously")
     void createLocalAsync(){
-        Delivery delivery = Delivery.localAsync();
+        var delivery = Delivery.localAsync();
 
-        ImmutableList<ShardObserver> observers = delivery.shardObservers();
+        var observers = delivery.shardObservers();
         assertThat(observers).hasSize(1);
 
-        ShardObserver observer = observers.get(0);
+        var observer = observers.get(0);
         assertThat(observer).isInstanceOf(LocalDispatchingObserver.class);
 
-        LocalDispatchingObserver localObserver = (LocalDispatchingObserver) observer;
+        var localObserver = (LocalDispatchingObserver) observer;
         assertThat(localObserver.isAsync()).isTrue();
     }
 }

--- a/server/src/test/java/io/spine/server/delivery/DispatchingIdTest.java
+++ b/server/src/test/java/io/spine/server/delivery/DispatchingIdTest.java
@@ -48,18 +48,17 @@ class DispatchingIdTest {
     @Test
     @DisplayName("support equality")
     void supportEquality() {
-        Timestamp now = Time.currentTime();
-        Timestamp inPast = subtract(now, fromSeconds(1));
-        Command commandA = command("Target A");
-        Command commandB = command("Target B");
+        var now = Time.currentTime();
+        var inPast = subtract(now, fromSeconds(1));
+        var commandA = command("Target A");
+        var commandB = command("Target B");
 
+        var messageOne = new DispatchingId(toDeliver(commandA, now));
+        var anotherMessageOne = new DispatchingId(toDeliver(commandA, now));
+        var messageOneFromPast = new DispatchingId(toDeliver(commandA, inPast));
 
-        DispatchingId messageOne = new DispatchingId(toDeliver(commandA, now));
-        DispatchingId anotherMessageOne = new DispatchingId(toDeliver(commandA, now));
-        DispatchingId messageOneFromPast = new DispatchingId(toDeliver(commandA, inPast));
-
-        DispatchingId messageTwo = new DispatchingId(toDeliver(commandB, now));
-        DispatchingId messageTwoFromPast = new DispatchingId(toDeliver(commandB, inPast));
+        var messageTwo = new DispatchingId(toDeliver(commandB, now));
+        var messageTwoFromPast = new DispatchingId(toDeliver(commandB, inPast));
 
         new EqualsTester().addEqualityGroup(messageOne, anotherMessageOne, messageOneFromPast)
                           .addEqualityGroup(messageTwo, messageTwoFromPast)

--- a/server/src/test/java/io/spine/server/delivery/EndpointsTest.java
+++ b/server/src/test/java/io/spine/server/delivery/EndpointsTest.java
@@ -34,8 +34,6 @@ import io.spine.time.ZoneIds;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
-
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.server.delivery.InboxLabel.HANDLE_COMMAND;
 import static io.spine.server.delivery.InboxLabel.REACT_UPON_EVENT;
@@ -46,21 +44,21 @@ class EndpointsTest {
     @Test
     @DisplayName("be empty by default")
     void beEmpty() {
-        Endpoints<String, CommandEnvelope> endpoints = new Endpoints<>();
+        var endpoints = new Endpoints<String, CommandEnvelope>();
         assertThat(endpoints.isEmpty()).isTrue();
     }
 
     @Test
     @DisplayName("allow to append endpoint providers and remember the last one per label")
     void appendEndpoint() {
-        Endpoints<String, CommandEnvelope> endpoints = new Endpoints<>();
+        var endpoints = new Endpoints<String, CommandEnvelope>();
 
-        MessageEndpoint<String, CommandEnvelope> first = noOpEndpoint();
-        MessageEndpoint<String, CommandEnvelope> second = noOpEndpoint();
+        var first = noOpEndpoint();
+        var second = noOpEndpoint();
         LazyEndpoint<String, CommandEnvelope> firstProvider = envelope -> first;
         LazyEndpoint<String, CommandEnvelope> secondProvider = envelope -> second;
 
-        InboxLabel label = HANDLE_COMMAND;
+        var label = HANDLE_COMMAND;
 
         endpoints.add(label, firstProvider);
         checkContains(endpoints, label, first);
@@ -72,8 +70,8 @@ class EndpointsTest {
     @Test
     @DisplayName("return `Optional.empty()` if no endpoint providers configured for the label")
     void returnEmpty() {
-        Endpoints<String, CommandEnvelope> endpoints = new Endpoints<>();
-        Optional<MessageEndpoint<String, CommandEnvelope>> result =
+        var endpoints = new Endpoints<String, CommandEnvelope>();
+        var result =
                 endpoints.get(REACT_UPON_EVENT, cmdEnvelope());
         assertThat(result.isPresent()).isFalse();
     }
@@ -82,15 +80,15 @@ class EndpointsTest {
     private static void checkContains(Endpoints<String, CommandEnvelope> endpoints,
                                       InboxLabel label,
                                       MessageEndpoint<String, CommandEnvelope> endpoint) {
-        CommandEnvelope someCmdEnvelope = cmdEnvelope();
-        Optional<MessageEndpoint<String, CommandEnvelope>> cmdEndpoint =
+        var someCmdEnvelope = cmdEnvelope();
+        var cmdEndpoint =
                 endpoints.get(label, someCmdEnvelope);
         assertThat(cmdEndpoint.isPresent()).isTrue();
         assertThat(cmdEndpoint.get()).isEqualTo(endpoint);
     }
 
     private static CommandEnvelope cmdEnvelope() {
-        TestActorRequestFactory commandFactory =
+        var commandFactory =
                 new TestActorRequestFactory(GivenUserId.generated(), ZoneIds.systemDefault());
         return CommandEnvelope.of(commandFactory.generateCommand());
     }

--- a/server/src/test/java/io/spine/server/delivery/InboxContents.java
+++ b/server/src/test/java/io/spine/server/delivery/InboxContents.java
@@ -46,15 +46,15 @@ final class InboxContents {
      * Fetches the contents of the {@code Inbox}es for each of the {@code ShardIndex}es.
      */
     static ImmutableMap<ShardIndex, ImmutableList<InboxMessage>> get() {
-        Delivery delivery = ServerEnvironment.instance()
-                                             .delivery();
-        InboxStorage storage = delivery.inboxStorage();
-        int shardCount = delivery.shardCount();
+        var delivery = ServerEnvironment.instance()
+                                        .delivery();
+        var storage = delivery.inboxStorage();
+        var shardCount = delivery.shardCount();
         ImmutableMap.Builder<ShardIndex, ImmutableList<InboxMessage>> builder =
                 ImmutableMap.builder();
-        for (int shardIndex = 0; shardIndex < shardCount; shardIndex++) {
-            ShardIndex index = DeliveryStrategy.newIndex(shardIndex, shardCount);
-            Page<InboxMessage> page = with(TenantId.getDefaultInstance())
+        for (var shardIndex = 0; shardIndex < shardCount; shardIndex++) {
+            var index = DeliveryStrategy.newIndex(shardIndex, shardCount);
+            var page = with(TenantId.getDefaultInstance())
                     .evaluate(() -> storage.readAll(index, Integer.MAX_VALUE));
             builder.put(index, page.contents());
         }

--- a/server/src/test/java/io/spine/server/delivery/InboxStorageTest.java
+++ b/server/src/test/java/io/spine/server/delivery/InboxStorageTest.java
@@ -29,11 +29,9 @@ package io.spine.server.delivery;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import com.google.common.collect.UnmodifiableIterator;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Timestamp;
 import io.spine.base.Time;
-import io.spine.core.Command;
 import io.spine.server.ServerEnvironment;
 import io.spine.server.storage.AbstractStorageTest;
 import io.spine.test.delivery.AddNumber;
@@ -46,9 +44,7 @@ import org.junit.jupiter.api.Test;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -93,51 +89,51 @@ public class InboxStorageTest
 
     @Override
     protected InboxMessageId newId() {
-        ShardIndex index = newIndex(4, 2020);
+        var index = newIndex(4, 2020);
         return InboxMessageMixin.generateIdWith(index);
     }
 
     @Test
     @DisplayName("write and read `InboxMessage`s")
     void writeAndReadRecords() {
-        ShardIndex index = newIndex(1, 100);
+        var index = newIndex(1, 100);
         assertStorageEmpty(index);
 
-        ImmutableList<InboxMessage> messages = generateMessages(index, 256);
+        var messages = generateMessages(index, 256);
 
-        InboxMessage firstMessage = messages.get(0);
+        var firstMessage = messages.get(0);
 
         storage().write(firstMessage);
-        Page<InboxMessage> pageWithSingleRecord = readContents(index);
+        var pageWithSingleRecord = readContents(index);
         assertThat(pageWithSingleRecord.contents()
                                        .size()).isEqualTo(1);
         assertThat(pageWithSingleRecord.contents()
                                        .get(0)).isEqualTo(firstMessage);
 
         storage().writeBatch(messages.subList(1, messages.size()));
-        Page<InboxMessage> pageWithAllRecords = readContents(index);
+        var pageWithAllRecords = readContents(index);
         assertSameContent(messages, pageWithAllRecords);
     }
 
     @Test
     @DisplayName("read `InboxMessage`s page by page starting from the older messages")
     void readRecordsPageByPage() {
-        ShardIndex index = newIndex(8, 2019);
-        int totalMessages = 79;
-        int pageSize = 13;
+        var index = newIndex(8, 2019);
+        var totalMessages = 79;
+        var pageSize = 13;
 
-        ImmutableList<InboxMessage> messages = generateMessages(index, totalMessages);
+        var messages = generateMessages(index, totalMessages);
         storage().writeBatch(messages);
         storage().writeBatch(generateMessages(newIndex(19, 2019), 19));
         storage().writeBatch(generateMessages(newIndex(21, 2019), 23));
 
-        List<List<InboxMessage>> expected = Lists.partition(messages, pageSize);
-        Page<InboxMessage> actualPage = storage().readAll(index, pageSize);
-        for (Iterator<List<InboxMessage>> iterator = expected.iterator(); iterator.hasNext(); ) {
-            List<InboxMessage> expectedPage = iterator.next();
+        var expected = Lists.partition(messages, pageSize);
+        var actualPage = storage().readAll(index, pageSize);
+        for (var iterator = expected.iterator(); iterator.hasNext(); ) {
+            var expectedPage = iterator.next();
             assertSameContent(expectedPage, actualPage);
 
-            Optional<Page<InboxMessage>> maybeNext = actualPage.next();
+            var maybeNext = actualPage.next();
             if (iterator.hasNext()) {
                 assertThat(maybeNext).isPresent();
                 actualPage = maybeNext.get();
@@ -150,21 +146,21 @@ public class InboxStorageTest
     @Test
     @DisplayName("remove selected `InboxMessage` instances")
     void removeMessages() {
-        ShardIndex index = newIndex(6, 7);
-        ImmutableList<InboxMessage> messages = generate(20, index);
-        InboxStorage storage = storage();
+        var index = newIndex(6, 7);
+        var messages = generate(20, index);
+        var storage = storage();
         storage.writeBatch(messages);
 
         readAllAndCompare(storage, index, messages);
 
-        UnmodifiableIterator<InboxMessage> iterator = messages.iterator();
-        InboxMessage first = iterator.next();
-        InboxMessage second = iterator.next();
+        var iterator = messages.iterator();
+        var first = iterator.next();
+        var second = iterator.next();
 
         storage.removeBatch(ImmutableList.of(first, second));
 
         // Make a `List` from the rest of the elements. Those deleted aren't included.
-        ImmutableList<InboxMessage> remainder = ImmutableList.copyOf(iterator);
+        var remainder = ImmutableList.copyOf(iterator);
 
         readAllAndCompare(storage, index, remainder);
 
@@ -176,11 +172,11 @@ public class InboxStorageTest
     @DisplayName("do nothing if removing inexistent `InboxMessage` instances")
     void doNothingIfRemovingInexistentMessages() {
 
-        InboxStorage storage = storage();
-        ShardIndex index = newIndex(6, 7);
+        var storage = storage();
+        var index = newIndex(6, 7);
         checkEmpty(storage, index);
 
-        ImmutableList<InboxMessage> messages = generate(40, index);
+        var messages = generate(40, index);
         storage.removeBatch(messages);
 
         checkEmpty(storage, index);
@@ -189,42 +185,41 @@ public class InboxStorageTest
     @Test
     @DisplayName("mark messages delivered")
     void markMessagedDelivered() {
-        ShardIndex index = newIndex(3, 71);
-        ImmutableList<InboxMessage> messages = generate(10, index);
-        InboxStorage storage = storage();
+        var index = newIndex(3, 71);
+        var messages = generate(10, index);
+        var storage = storage();
         storage.writeBatch(messages);
 
-        ImmutableList<InboxMessage> nonDelivered = readAllAndCompare(storage, index, messages);
+        var nonDelivered = readAllAndCompare(storage, index, messages);
         nonDelivered.iterator()
                     .forEachRemaining((m) -> assertEquals(TO_DELIVER, m.getStatus()));
 
         // Leave the first one in `TO_DELIVER` status and mark the rest as `DELIVERED`.
-        UnmodifiableIterator<InboxMessage> iterator = messages.iterator();
-        InboxMessage remainingNonDelivered = iterator.next();
-        ImmutableList<InboxMessage> toMarkDelivered = ImmutableList.copyOf(iterator);
-        List<InboxMessage> markedDelivered = markDelivered(toMarkDelivered);
+        var iterator = messages.iterator();
+        var remainingNonDelivered = iterator.next();
+        var toMarkDelivered = ImmutableList.copyOf(iterator);
+        var markedDelivered = markDelivered(toMarkDelivered);
 
         storage.writeBatch(markedDelivered);
-        ImmutableList<InboxMessage> originalMarkedDelivered =
-                toMarkDelivered.stream()
-                               .map(m -> m.toBuilder()
-                                          .setStatus(DELIVERED)
-                                          .vBuild())
-                               .collect(toImmutableList());
+        var originalMarkedDelivered = toMarkDelivered.stream()
+                .map(m -> m.toBuilder()
+                        .setStatus(DELIVERED)
+                        .vBuild())
+                .collect(toImmutableList());
 
         // Check that both `TO_DELIVER` message and those marked `DELIVERED` are stored as expected.
-        ImmutableList<InboxMessage> readResult = storage.readAll(index, Integer.MAX_VALUE)
-                                                        .contents();
+        var readResult = storage.readAll(index, Integer.MAX_VALUE)
+                                .contents();
         assertTrue(readResult.contains(remainingNonDelivered));
         assertTrue(readResult.containsAll(originalMarkedDelivered));
     }
 
     private static List<InboxMessage> markDelivered(ImmutableList<InboxMessage> toMarkDelivered) {
         return toMarkDelivered.stream()
-                              .map(m -> m.toBuilder()
-                                         .setStatus(DELIVERED)
-                                         .vBuild())
-                              .collect(toList());
+                .map(m -> m.toBuilder()
+                        .setStatus(DELIVERED)
+                        .vBuild())
+                .collect(toList());
     }
 
     /*
@@ -257,7 +252,7 @@ public class InboxStorageTest
     }
 
     private void assertStorageEmpty(ShardIndex index) {
-        Page<InboxMessage> page = readContents(index);
+        var page = readContents(index);
         assertThat(page.contents()
                        .isEmpty()).isTrue();
         assertThat(page.next()).isEmpty();
@@ -268,15 +263,13 @@ public class InboxStorageTest
     }
 
     private InboxMessage newCommandInInbox(InboxMessageId id, String targetId) {
-        Command command = factory.createCommand(AddNumber.newBuilder()
+        var command = factory.createCommand(AddNumber.newBuilder()
                                                          .setCalculatorId(targetId)
                                                          .setValue(random.nextInt())
                                                          .vBuild());
-        InboxId inboxId = InboxIds.wrap(targetId, TypeUrl.of(Calc.class));
-        InboxSignalId signalId = newSignalId(targetId, command.getId()
-                                                              .value());
-        return InboxMessage
-                .newBuilder()
+        var inboxId = InboxIds.wrap(targetId, TypeUrl.of(Calc.class));
+        var signalId = newSignalId(targetId, command.getId().value());
+        return InboxMessage.newBuilder()
                 .setId(id)
                 .setSignalId(signalId)
                 .setInboxId(inboxId)
@@ -290,27 +283,19 @@ public class InboxStorageTest
     @CanIgnoreReturnValue
     private static ImmutableList<InboxMessage>
     readAllAndCompare(InboxStorage storage, ShardIndex idx, ImmutableList<InboxMessage> expected) {
-        Page<InboxMessage> page = storage.readAll(idx, Integer.MAX_VALUE);
+        var page = storage.readAll(idx, Integer.MAX_VALUE);
         assertEquals(expected.size(), page.size());
 
-        ImmutableList<InboxMessage> contents = page.contents();
+        var contents = page.contents();
         assertEquals(ImmutableSet.copyOf(expected), ImmutableSet.copyOf(contents));
         return contents;
     }
 
     private static void checkEmpty(InboxStorage storage, ShardIndex index) {
-        Page<InboxMessage> emptyPage = storage.readAll(index, 10);
+        var emptyPage = storage.readAll(index, 10);
         assertEquals(0, emptyPage.size());
         assertThat(emptyPage.contents()).isEmpty();
         assertThat(emptyPage.next()).isEmpty();
-    }
-
-    private static void readAndCompare(InboxStorage storage, InboxMessage msg) {
-        Optional<InboxMessage> optional = storage.read(msg.getId());
-        assertTrue(optional.isPresent());
-
-        InboxMessage readResult = optional.get();
-        assertEquals(msg, readResult);
     }
 
     /**
@@ -321,17 +306,15 @@ public class InboxStorageTest
      */
     public static InboxMessage generate(int shardIndex, int totalShards, Timestamp whenReceived) {
         checkNotNull(whenReceived);
-        InboxMessage message = toDeliver("target-entity-id", TypeUrl.of(Calc.class), whenReceived);
+        var message = toDeliver("target-entity-id", TypeUrl.of(Calc.class), whenReceived);
 
-        InboxMessageId modifiedId =
-                message.getId()
-                       .toBuilder()
-                       .setIndex(newIndex(shardIndex, totalShards))
-                       .vBuild();
-        InboxMessage result =
-                message.toBuilder()
-                       .setId(modifiedId)
-                       .vBuild();
+        var modifiedId = message.getId()
+                .toBuilder()
+                .setIndex(newIndex(shardIndex, totalShards))
+                .vBuild();
+        var result = message.toBuilder()
+                .setId(modifiedId)
+                .vBuild();
         return result;
     }
 
@@ -343,9 +326,9 @@ public class InboxStorageTest
      */
     public static ImmutableList<InboxMessage> generate(int totalMessages, ShardIndex index) {
         ImmutableList.Builder<InboxMessage> builder = ImmutableList.builder();
-        for (int msgCounter = 0; msgCounter < totalMessages; msgCounter++) {
+        for (var msgCounter = 0; msgCounter < totalMessages; msgCounter++) {
 
-            InboxMessage msg = generate(index.getIndex(), index.getOfTotal(), currentTime());
+            var msg = generate(index.getIndex(), index.getOfTotal(), currentTime());
             builder.add(msg);
         }
         return builder.build();

--- a/server/src/test/java/io/spine/server/delivery/ShardedWorkRegistryTest.java
+++ b/server/src/test/java/io/spine/server/delivery/ShardedWorkRegistryTest.java
@@ -28,9 +28,7 @@ package io.spine.server.delivery;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import com.google.protobuf.Duration;
 import com.google.protobuf.util.Durations;
-import io.spine.server.NodeId;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -60,13 +58,13 @@ public abstract class ShardedWorkRegistryTest {
     @Test
     @DisplayName("pick up the shard if it is not picked up previously and allow to complete it")
     void testPickUp() {
-        ShardedWorkRegistry registry = registry();
+        var registry = registry();
 
-        ShardIndex index = newIndex(1, 42);
-        NodeId node = generateNodeId();
+        var index = newIndex(1, 42);
+        var node = generateNodeId();
 
-        Optional<ShardProcessingSession> session = registry.pickUp(index, node);
-        ShardProcessingSession actualSession = assertSession(session, index);
+        var session = registry.pickUp(index, node);
+        var actualSession = assertSession(session, index);
 
         assertThat(registry.pickUp(index, node))
                 .isEmpty();
@@ -74,19 +72,19 @@ public abstract class ShardedWorkRegistryTest {
                 .isEmpty();
 
         actualSession.complete();
-        Optional<ShardProcessingSession> newSession = registry.pickUp(index, generateNodeId());
+        var newSession = registry.pickUp(index, generateNodeId());
         assertSession(newSession, index);
     }
 
     @Test
     @DisplayName("release the shards which sessions expired")
     void testReleaseExpired() {
-        ShardedWorkRegistry registry = registry();
+        var registry = registry();
 
-        int totalShards = 35;
+        var totalShards = 35;
 
-        ImmutableSet<ShardIndex> indexes = pickUp(registry, totalShards, totalShards);
-        Iterable<ShardIndex> releasedIndexes =
+        var indexes = pickUp(registry, totalShards, totalShards);
+        var releasedIndexes =
                 registry.releaseExpiredSessions(Durations.fromSeconds(100));
         assertThat(releasedIndexes.iterator()
                                   .hasNext()).isFalse();
@@ -95,9 +93,9 @@ public abstract class ShardedWorkRegistryTest {
         releasedIndexes = registry.releaseExpiredSessions(Durations.fromMillis(100));
         assertThat(releasedIndexes).containsExactlyElementsIn(indexes);
 
-        for (ShardIndex shardIndex : indexes) {
-            NodeId anotherNode = generateNodeId();
-            Optional<ShardProcessingSession> newSession = registry.pickUp(shardIndex, anotherNode);
+        for (var shardIndex : indexes) {
+            var anotherNode = generateNodeId();
+            var newSession = registry.pickUp(shardIndex, anotherNode);
             assertSession(newSession, shardIndex);
         }
     }
@@ -105,31 +103,31 @@ public abstract class ShardedWorkRegistryTest {
     @Test
     @DisplayName("release a shard only if it's blocked")
     void testOnlyReleaseBlocked() {
-        ShardedWorkRegistry registry = registry();
+        var registry = registry();
 
-        int totalShards = 12;
+        var totalShards = 12;
 
-        Duration expirationPeriod = Durations.fromMillis(1);
+        var expirationPeriod = Durations.fromMillis(1);
         pickUp(registry, totalShards, totalShards);
         sleepUninterruptibly(ofSeconds(1));
         registry.releaseExpiredSessions(expirationPeriod);
 
         // Pick up half of the shards and leave another half empty.
-        ImmutableSet<ShardIndex> newIndexes =
+        var newIndexes =
                 pickUp(registry, totalShards, totalShards / 2);
         sleepUninterruptibly(ofSeconds(1));
-        Iterable<ShardIndex> releasedIndexes = registry.releaseExpiredSessions(expirationPeriod);
+        var releasedIndexes = registry.releaseExpiredSessions(expirationPeriod);
         assertThat(releasedIndexes).containsExactlyElementsIn(newIndexes);
     }
 
     private static ImmutableSet<ShardIndex>
     pickUp(ShardedWorkRegistry registry, int outOfTotal, int howMany) {
-        ImmutableSet<ShardIndex> indexes = range(1, howMany)
+        var indexes = range(1, howMany)
                 .mapToObj(i -> {
-                    NodeId newNode = generateNodeId();
-                    ShardIndex newIndex = newIndex(i, outOfTotal);
+                    var newNode = generateNodeId();
+                    var newIndex = newIndex(i, outOfTotal);
 
-                    Optional<ShardProcessingSession> session = registry.pickUp(newIndex, newNode);
+                    var session = registry.pickUp(newIndex, newNode);
                     assertSession(session, newIndex);
                     return newIndex;
                 })
@@ -143,7 +141,7 @@ public abstract class ShardedWorkRegistryTest {
     assertSession(Optional<ShardProcessingSession> session, ShardIndex index) {
         assertThat(session)
                 .isPresent();
-        ShardProcessingSession actualSession = session.get();
+        var actualSession = session.get();
         assertThat(actualSession.shardIndex()).isEqualTo(index);
         return actualSession;
     }

--- a/server/src/test/java/io/spine/server/delivery/ShardedWorkRegistryTest.java
+++ b/server/src/test/java/io/spine/server/delivery/ShardedWorkRegistryTest.java
@@ -113,8 +113,7 @@ public abstract class ShardedWorkRegistryTest {
         registry.releaseExpiredSessions(expirationPeriod);
 
         // Pick up half of the shards and leave another half empty.
-        var newIndexes =
-                pickUp(registry, totalShards, totalShards / 2);
+        var newIndexes = pickUp(registry, totalShards, totalShards / 2);
         sleepUninterruptibly(ofSeconds(1));
         var releasedIndexes = registry.releaseExpiredSessions(expirationPeriod);
         assertThat(releasedIndexes).containsExactlyElementsIn(newIndexes);

--- a/server/src/test/java/io/spine/server/delivery/TestRoutines.java
+++ b/server/src/test/java/io/spine/server/delivery/TestRoutines.java
@@ -30,9 +30,7 @@ import io.spine.server.projection.Projection;
 import io.spine.server.projection.ProjectionRepository;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
@@ -48,15 +46,15 @@ public final class TestRoutines {
 
     public static <P extends Projection<String, ?, ?>> P
     findView(ProjectionRepository<String, P, ?> repo, String id) {
-        Optional<P> view = repo.find(id);
+        var view = repo.find(id);
         assertThat(view).isPresent();
         return view.get();
     }
 
     public static void post(List<Callable<Object>> jobs, int threads) throws InterruptedException {
-        ExecutorService service = newFixedThreadPool(threads);
+        var service = newFixedThreadPool(threads);
         service.invokeAll(jobs);
-        List<Runnable> leftovers = service.shutdownNow();
+        var leftovers = service.shutdownNow();
         assertThat(leftovers).isEmpty();
     }
 }

--- a/server/src/test/java/io/spine/server/delivery/TurbulenceTest.java
+++ b/server/src/test/java/io/spine/server/delivery/TurbulenceTest.java
@@ -28,7 +28,6 @@ package io.spine.server.delivery;
 
 import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Duration;
-import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Durations;
 import io.spine.base.Time;
 import org.junit.jupiter.api.DisplayName;
@@ -53,14 +52,14 @@ class TurbulenceTest {
     @DisplayName("define the turbulence start time " +
             "by counting back its duration from the current time")
     void defineStartTime() {
-        Duration duration = Durations.fromSeconds(10);
-        Turbulence turbulence = Turbulence.of(duration);
-        Timestamp actual = turbulence.whenStarts();
+        var duration = Durations.fromSeconds(10);
+        var turbulence = Turbulence.of(duration);
+        var actual = turbulence.whenStarts();
 
-        Timestamp currentTime = Time.currentTime();
-        Timestamp approximateExpected = subtract(currentTime, duration);
+        var currentTime = Time.currentTime();
+        var approximateExpected = subtract(currentTime, duration);
 
-        long difference = Math.abs(toMillis(actual) - toMillis(approximateExpected));
+        var difference = Math.abs(toMillis(actual) - toMillis(approximateExpected));
         assertThat(difference).isLessThan(50 /* ms */);
     }
 }

--- a/server/src/test/java/io/spine/server/delivery/UniformStrategyTest.java
+++ b/server/src/test/java/io/spine/server/delivery/UniformStrategyTest.java
@@ -33,35 +33,35 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("`UniformAcrossAllShards should")
-public class UniformStrategyTest {
+class UniformStrategyTest {
 
     @Test
     @DisplayName("return single shard strategy")
-    public void singleShard() {
-        DeliveryStrategy strategy = UniformAcrossAllShards.singleShard();
+    void singleShard() {
+        var strategy = UniformAcrossAllShards.singleShard();
         assertThat(strategy.shardCount())
                 .isEqualTo(1);
     }
 
     @Test
     @DisplayName("allow to create a strategy with the given number of shards")
-    public void customShardNumber() {
-        int shards = 42;
-        DeliveryStrategy strategy = UniformAcrossAllShards.forNumber(shards);
+    void customShardNumber() {
+        var shards = 42;
+        var strategy = UniformAcrossAllShards.forNumber(shards);
         assertThat(strategy.shardCount())
                 .isEqualTo(shards);
     }
 
     @Test
     @DisplayName("not accept a negative shard number")
-    public void negativeNumberOfShards() {
+    void negativeNumberOfShards() {
         assertThrows(IllegalArgumentException.class,
                      () -> UniformAcrossAllShards.forNumber(-7));
     }
 
     @Test
     @DisplayName("not accept a zero number of shards")
-    public void zeroShards() {
+    void zeroShards() {
         assertThrows(IllegalArgumentException.class,
                      () -> UniformAcrossAllShards.forNumber(0));
     }

--- a/server/src/test/java/io/spine/server/delivery/given/CalcAggregate.java
+++ b/server/src/test/java/io/spine/server/delivery/given/CalcAggregate.java
@@ -43,28 +43,27 @@ public class CalcAggregate extends Aggregate<String, Calc, Calc.Builder> {
 
     @Assign
     NumberAdded handle(AddNumber command) {
-        int value = command.getValue();
+        var value = command.getValue();
         return NumberAdded.newBuilder()
-                          .setValue(value)
-                          .vBuild();
+                .setValue(value)
+                .vBuild();
     }
 
     @Apply
     private void on(NumberAdded event) {
-        int currentSum = builder().getSum();
+        var currentSum = builder().getSum();
         builder().setSum(currentSum + event.getValue());
     }
 
     @Apply(allowImport = true)
     private void on(NumberImported event) {
-        int currentSum = builder().getSum();
+        var currentSum = builder().getSum();
         builder().setSum(currentSum + event.getValue());
     }
 
     @React
     NumberAdded on(NumberReacted event) {
-        return NumberAdded
-                .newBuilder()
+        return NumberAdded.newBuilder()
                 .setCalculatorId(event.getCalculatorId())
                 .setValue(event.getValue())
                 .vBuild();

--- a/server/src/test/java/io/spine/server/delivery/given/ConsecutiveNumberProcess.java
+++ b/server/src/test/java/io/spine/server/delivery/given/ConsecutiveNumberProcess.java
@@ -43,22 +43,20 @@ public final class ConsecutiveNumberProcess
 
     @Assign
     Pair<PositiveNumberEmitted, NegativeNumberEmitted> handle(EmitNextNumber cmd) {
-        String id = cmd.getId();
+        var id = cmd.getId();
         builder().setId(id);
-        int iteration = state().getIteration();
-        int nextValue = iteration + 1;
+        var iteration = state().getIteration();
+        var nextValue = iteration + 1;
         builder().setIteration(nextValue);
-        PositiveNumberEmitted positiveNumberEmitted =
-                PositiveNumberEmitted.newBuilder()
-                                     .setId(id)
-                                     .setValue(nextValue)
-                                     .vBuild();
+        var positiveNumberEmitted = PositiveNumberEmitted.newBuilder()
+                .setId(id)
+                .setValue(nextValue)
+                .vBuild();
 
-        NegativeNumberEmitted negativeNumberEmitted =
-                NegativeNumberEmitted.newBuilder()
-                                     .setId(id)
-                                     .setValue(-1 * nextValue)
-                                     .vBuild();
+        var negativeNumberEmitted = NegativeNumberEmitted.newBuilder()
+                .setId(id)
+                .setValue(-1 * nextValue)
+                .vBuild();
         return Pair.of(positiveNumberEmitted, negativeNumberEmitted);
     }
 }

--- a/server/src/test/java/io/spine/server/delivery/given/ConsecutiveProjection.java
+++ b/server/src/test/java/io/spine/server/delivery/given/ConsecutiveProjection.java
@@ -90,10 +90,10 @@ public class ConsecutiveProjection
 
         mode.validate(newValue);
 
-        int lastValue = state().getLastValue();
-        int difference = abs(newValue) - abs(lastValue);
+        var lastValue = state().getLastValue();
+        var difference = abs(newValue) - abs(lastValue);
         if (difference != 1) {
-            String message =
+            var message =
                     format("`ConsecutiveNumberProjection` with ID `%s` got wrong value. " +
                                    "Current value is %d, but got `%d`.",
                            id, lastValue, newValue);
@@ -115,7 +115,7 @@ public class ConsecutiveProjection
         }
 
         void validate(int incoming) {
-            Boolean valid = validator.apply(incoming);
+            var valid = validator.apply(incoming);
             if (!valid) {
                 throw newIllegalArgumentException(
                         "The mode `%s` does not accept the supplied `%d` value.",

--- a/server/src/test/java/io/spine/server/delivery/given/CounterView.java
+++ b/server/src/test/java/io/spine/server/delivery/given/CounterView.java
@@ -55,7 +55,7 @@ public final class CounterView extends Projection<String, DCounter, DCounter.Bui
     @Subscribe
     @SuppressWarnings("unused")
     void on(NumberAdded event, EventContext context) {
-        DCounter.Builder builder = builder();
+        var builder = builder();
         builder.setTotal(builder.getTotal() + weight);
     }
 

--- a/server/src/test/java/io/spine/server/delivery/given/DeliveryTestEnv.java
+++ b/server/src/test/java/io/spine/server/delivery/given/DeliveryTestEnv.java
@@ -109,7 +109,7 @@ public class DeliveryTestEnv {
 
         @Override
         protected void doStore(CalcAggregate aggregate) {
-            String id = aggregate.id();
+            var id = aggregate.id();
             incrementByKey(id, storeCalls);
             super.doStore(aggregate);
         }
@@ -157,8 +157,7 @@ public class DeliveryTestEnv {
                 packed = update.getEvent()
                                .getMessage();
             }
-            CalculatorSignal msg =
-                    (CalculatorSignal) AnyPacker.unpack(packed);
+            var msg = (CalculatorSignal) AnyPacker.unpack(packed);
             signals.put(msg.getCalculatorId(), msg);
         }
 

--- a/server/src/test/java/io/spine/server/delivery/given/TaskAssignment.java
+++ b/server/src/test/java/io/spine/server/delivery/given/TaskAssignment.java
@@ -43,12 +43,12 @@ public class TaskAssignment
 
     @React
     DTaskAssigned on(DTaskCreated event) {
-        String rawId = event.getId();
+        var rawId = event.getId();
         builder().setId(rawId);
         return DTaskAssigned.newBuilder()
-                            .setId(rawId)
-                            .setAssignee(GivenUserId.generated())
-                            .vBuild();
+                .setId(rawId)
+                .setAssignee(GivenUserId.generated())
+                .vBuild();
     }
 
     public static class Repository

--- a/server/src/test/java/io/spine/server/delivery/given/TaskView.java
+++ b/server/src/test/java/io/spine/server/delivery/given/TaskView.java
@@ -46,14 +46,14 @@ public class TaskView extends Projection<String, DTaskView, DTaskView.Builder> {
 
     @Subscribe
     void to(DTaskCreated event) {
-        String rawId = event.getId();
+        var rawId = event.getId();
         creationEvents.put(rawId, event);
         builder().setId(rawId);
     }
 
     @Subscribe
     void to(DTaskAssigned event) {
-        String rawId = event.getId();
+        var rawId = event.getId();
         if (!creationEvents.containsKey(rawId)) {
             throw new IllegalStateException("`DTaskCreated` event was" +
                                                     " not dispatched before `DTaskAssigned`.");

--- a/server/src/test/java/io/spine/server/delivery/given/TestCatchUpJobs.java
+++ b/server/src/test/java/io/spine/server/delivery/given/TestCatchUpJobs.java
@@ -65,22 +65,19 @@ public final class TestCatchUpJobs {
                                      CatchUpStatus status,
                                      Timestamp sinceWhen,
                                      @Nullable Collection<Object> ids) {
-        CatchUpId catchUpId = CatchUpId
-                .newBuilder()
+        var catchUpId = CatchUpId.newBuilder()
                 .setUuid(Identifier.newUuid())
                 .setProjectionType(projectionType.value())
                 .build();
-        CatchUp.Request.Builder requestBuilder = CatchUp.Request.newBuilder()
-                                                                .setSinceWhen(sinceWhen);
+        var requestBuilder = CatchUp.Request.newBuilder().setSinceWhen(sinceWhen);
         if (ids != null) {
-            for (Object id : ids) {
+            for (var id : ids) {
                 requestBuilder.addTarget(Identifier.pack(id));
             }
         }
-        CatchUp.Request request = requestBuilder.build();
+        var request = requestBuilder.build();
 
-        CatchUp result = CatchUp
-                .newBuilder()
+        var result = CatchUp.newBuilder()
                 .setId(catchUpId)
                 .setStatus(status)
                 .setRequest(request)

--- a/server/src/test/java/io/spine/server/delivery/given/TestInboxMessages.java
+++ b/server/src/test/java/io/spine/server/delivery/given/TestInboxMessages.java
@@ -39,7 +39,6 @@ import io.spine.server.delivery.InboxMessageId;
 import io.spine.server.delivery.InboxMessageMixin;
 import io.spine.server.delivery.InboxMessageStatus;
 import io.spine.server.delivery.InboxSignalId;
-import io.spine.server.delivery.ShardIndex;
 import io.spine.test.delivery.AddNumber;
 import io.spine.test.delivery.DTask;
 import io.spine.testing.client.TestActorRequestFactory;
@@ -174,15 +173,15 @@ public final class TestInboxMessages {
      * of the passed command in  and sets the receiving time according to the passed value.
      */
     public static InboxMessage toDeliver(Command source, Timestamp whenReceived) {
-        InboxId inboxId = newInboxId("some-target", TypeUrl.of(DTask.class));
-        InboxMessage message = messageReceivedAt(source, TO_DELIVER, inboxId, whenReceived);
+        var inboxId = newInboxId("some-target", TypeUrl.of(DTask.class));
+        var message = messageReceivedAt(source, TO_DELIVER, inboxId, whenReceived);
         return message;
     }
 
     private static InboxMessage newMessage(Object target, TypeUrl type, InboxMessageStatus status) {
-        Command command = generateCommand(target);
-        InboxId inboxId = newInboxId(target, type);
-        InboxMessage message = messageReceivedAt(command, status, inboxId, Time.currentTime());
+        var command = generateCommand(target);
+        var inboxId = newInboxId(target, type);
+        var message = messageReceivedAt(command, status, inboxId, Time.currentTime());
         return message;
     }
 
@@ -190,13 +189,12 @@ public final class TestInboxMessages {
                                                   InboxMessageStatus status,
                                                   InboxId inboxId,
                                                   Timestamp whenReceived) {
-        ShardIndex index = DeliveryStrategy.newIndex(0, 1);
-        InboxMessageId id = InboxMessageMixin.generateIdWith(index);
-        InboxSignalId.Builder signalId = InboxSignalId.newBuilder()
+        var index = DeliveryStrategy.newIndex(0, 1);
+        var id = InboxMessageMixin.generateIdWith(index);
+        var signalId = InboxSignalId.newBuilder()
                                                       .setValue(command.getId()
                                                                        .value());
-        InboxMessage result = InboxMessage
-                .newBuilder()
+        var result = InboxMessage.newBuilder()
                 .setId(id)
                 .setStatus(status)
                 .setCommand(command)
@@ -210,18 +208,18 @@ public final class TestInboxMessages {
 
     private static InboxId newInboxId(Object targetId, TypeUrl targetType) {
         return InboxId.newBuilder()
-                      .setEntityId(EntityId.newBuilder()
-                                           .setId(Identifier.pack(targetId))
-                                           .vBuild())
-                      .setTypeUrl(targetType.value())
-                      .vBuild();
+                .setEntityId(EntityId.newBuilder()
+                                     .setId(Identifier.pack(targetId))
+                                     .vBuild())
+                .setTypeUrl(targetType.value())
+                .vBuild();
     }
 
     private static Command generateCommand(Object targetId) {
-        AddNumber commandMessage = AddNumber.newBuilder()
-                                            .setCalculatorId("some-id-" + targetId)
-                                            .setValue(targetId.hashCode())
-                                            .vBuild();
+        var commandMessage = AddNumber.newBuilder()
+                .setCalculatorId("some-id-" + targetId)
+                .setValue(targetId.hashCode())
+                .vBuild();
         return factory.createCommand(commandMessage);
     }
 }

--- a/server/src/test/java/io/spine/server/delivery/given/TestInboxMessages.java
+++ b/server/src/test/java/io/spine/server/delivery/given/TestInboxMessages.java
@@ -68,8 +68,8 @@ public final class TestInboxMessages {
      */
     public static InboxMessage copyWithNewId(InboxMessage original) {
         return original.toBuilder()
-                       .setId(InboxMessageMixin.generateIdWith(original.shardIndex()))
-                       .vBuild();
+                .setId(InboxMessageMixin.generateIdWith(original.shardIndex()))
+                .vBuild();
     }
 
     /**
@@ -77,8 +77,8 @@ public final class TestInboxMessages {
      */
     public static InboxMessage copyWithStatus(InboxMessage original, InboxMessageStatus newStatus) {
         return original.toBuilder()
-                       .setStatus(newStatus)
-                       .vBuild();
+                .setStatus(newStatus)
+                .vBuild();
     }
 
     /**
@@ -192,8 +192,7 @@ public final class TestInboxMessages {
         var index = DeliveryStrategy.newIndex(0, 1);
         var id = InboxMessageMixin.generateIdWith(index);
         var signalId = InboxSignalId.newBuilder()
-                                                      .setValue(command.getId()
-                                                                       .value());
+                .setValue(command.getId().value());
         var result = InboxMessage.newBuilder()
                 .setId(id)
                 .setStatus(status)

--- a/server/src/test/java/io/spine/server/dispatch/DispatchMixinsTest.java
+++ b/server/src/test/java/io/spine/server/dispatch/DispatchMixinsTest.java
@@ -56,14 +56,12 @@ class DispatchMixinsTest {
     @Test
     @DisplayName("`DispatchOutcomeMixin` should provide a `hasRejection` shortcut")
     void dispatchOutcomeMixinHasRejectionShortcut() {
-        DispatchOutcome noRejectionOutcome = DispatchOutcome.getDefaultInstance();
+        var noRejectionOutcome = DispatchOutcome.getDefaultInstance();
         assertThat(noRejectionOutcome.hasRejection()).isFalse();
-        Success rejectionSuccessOutcome = Success
-                .newBuilder()
+        var rejectionSuccessOutcome = Success.newBuilder()
                 .setRejection(Given.rejectionEvent())
                 .build();
-        DispatchOutcome rejectionOutcome = DispatchOutcome
-                .newBuilder()
+        var rejectionOutcome = DispatchOutcome.newBuilder()
                 .setSuccess(rejectionSuccessOutcome)
                 .build();
         assertThat(rejectionOutcome.hasRejection()).isTrue();

--- a/server/src/test/java/io/spine/server/dispatch/DispatchOutcomeHandlerTest.java
+++ b/server/src/test/java/io/spine/server/dispatch/DispatchOutcomeHandlerTest.java
@@ -45,22 +45,22 @@ import java.util.List;
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
 import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
 
-@DisplayName("DispatchOutcomeHandler should")
+@DisplayName("`DispatchOutcomeHandler` should")
 public final class DispatchOutcomeHandlerTest {
 
     @Test
     @DisplayName("allow default doNothing handlers")
     void allowDefaultHandlers() {
-        DispatchOutcome outcome = DispatchOutcome.getDefaultInstance();
-        DispatchOutcomeHandler handler = DispatchOutcomeHandler.from(outcome);
+        var outcome = DispatchOutcome.getDefaultInstance();
+        var handler = DispatchOutcomeHandler.from(outcome);
         assertThat(handler.handle()).isEqualTo(outcome);
     }
 
     @Test
     @DisplayName(NOT_ACCEPT_NULLS)
     void passNullToleranceCheck() {
-        DispatchOutcome outcome = DispatchOutcome.getDefaultInstance();
-        DispatchOutcomeHandler handler = DispatchOutcomeHandler.from(outcome);
+        var outcome = DispatchOutcome.getDefaultInstance();
+        var handler = DispatchOutcomeHandler.from(outcome);
         new NullPointerTester().testAllPublicInstanceMethods(handler);
     }
 
@@ -71,16 +71,14 @@ public final class DispatchOutcomeHandlerTest {
         @Test
         @DisplayName("error outcome")
         void error() {
-            Error error = Error
-                    .newBuilder()
+            var error = Error.newBuilder()
                     .setCode(1)
                     .build();
-            DispatchOutcome outcome = DispatchOutcome
-                    .newBuilder()
+            var outcome = DispatchOutcome.newBuilder()
                     .setError(error)
                     .build();
             List<Error> errors = new ArrayList<>();
-            DispatchOutcome result = DispatchOutcomeHandler
+            var result = DispatchOutcomeHandler
                     .from(outcome)
                     .onError(errors::add)
                     .handle();
@@ -91,15 +89,12 @@ public final class DispatchOutcomeHandlerTest {
         @Test
         @DisplayName("success outcome")
         void success() {
-            Success success = Success
-                    .newBuilder()
-                    .build();
-            DispatchOutcome outcome = DispatchOutcome
-                    .newBuilder()
+            var success = Success.getDefaultInstance();
+            var outcome = DispatchOutcome.newBuilder()
                     .setSuccess(success)
                     .build();
             List<Success> successes = new ArrayList<>();
-            DispatchOutcome result = DispatchOutcomeHandler
+            var result = DispatchOutcomeHandler
                     .from(outcome)
                     .onSuccess(successes::add)
                     .handle();
@@ -110,20 +105,17 @@ public final class DispatchOutcomeHandlerTest {
         @Test
         @DisplayName("produced events outcome")
         void events() {
-            Event event = Given.event();
-            Success success = Success
-                    .newBuilder()
-                    .setProducedEvents(ProducedEvents
-                                               .newBuilder()
+            var event = Given.event();
+            var success = Success.newBuilder()
+                    .setProducedEvents(ProducedEvents.newBuilder()
                                                .addEvent(event)
                                                .build())
                     .build();
-            DispatchOutcome outcome = DispatchOutcome
-                    .newBuilder()
+            var outcome = DispatchOutcome.newBuilder()
                     .setSuccess(success)
                     .build();
             List<Event> events = new ArrayList<>();
-            DispatchOutcome result = DispatchOutcomeHandler
+            var result = DispatchOutcomeHandler
                     .from(outcome)
                     .onEvents(events::addAll)
                     .handle();
@@ -134,20 +126,18 @@ public final class DispatchOutcomeHandlerTest {
         @Test
         @DisplayName("produced commands outcome")
         void commands() {
-            Command command = Given.command();
-            Success success = Success
-                    .newBuilder()
-                    .setProducedCommands(ProducedCommands
-                                                 .newBuilder()
+            var command = Given.command();
+            var success = Success.newBuilder()
+                    .setProducedCommands(ProducedCommands.newBuilder()
                                                  .addCommand(command)
                                                  .build())
                     .build();
-            DispatchOutcome outcome = DispatchOutcome
+            var outcome = DispatchOutcome
                     .newBuilder()
                     .setSuccess(success)
                     .build();
             List<Command> commands = new ArrayList<>();
-            DispatchOutcome result = DispatchOutcomeHandler
+            var result = DispatchOutcomeHandler
                     .from(outcome)
                     .onCommands(commands::addAll)
                     .handle();
@@ -158,17 +148,16 @@ public final class DispatchOutcomeHandlerTest {
         @Test
         @DisplayName("rejection outcome")
         void rejection() {
-            Event rejection = Given.rejectionEvent();
-            Success error = Success
-                    .newBuilder()
+            var rejection = Given.rejectionEvent();
+            var error = Success.newBuilder()
                     .setRejection(rejection)
                     .build();
-            DispatchOutcome outcome = DispatchOutcome
+            var outcome = DispatchOutcome
                     .newBuilder()
                     .setSuccess(error)
                     .build();
             List<Event> rejections = new ArrayList<>();
-            DispatchOutcome result = DispatchOutcomeHandler
+            var result = DispatchOutcomeHandler
                     .from(outcome)
                     .onRejection(rejections::add)
                     .handle();
@@ -180,20 +169,17 @@ public final class DispatchOutcomeHandlerTest {
         @Test
         @DisplayName("interruption outcome")
         void interruption() {
-            MessageId messageId = MessageId
-                    .newBuilder()
+            var messageId = MessageId.newBuilder()
                     .setId(Identifier.pack(TestValues.randomString()))
                     .build();
-            Interruption interruption = Interruption
-                    .newBuilder()
+            var interruption = Interruption.newBuilder()
                     .setStoppedAt(messageId)
                     .build();
-            DispatchOutcome outcome = DispatchOutcome
-                    .newBuilder()
+            var outcome = DispatchOutcome.newBuilder()
                     .setInterrupted(interruption)
                     .build();
             List<Interruption> interruptions = new ArrayList<>();
-            DispatchOutcome result = DispatchOutcomeHandler
+            var result = DispatchOutcomeHandler
                     .from(outcome)
                     .onInterruption(interruptions::add)
                     .handle();
@@ -204,16 +190,14 @@ public final class DispatchOutcomeHandlerTest {
         @Test
         @DisplayName("ignore outcome")
         void ignore() {
-            Ignore ignore = Ignore
-                    .newBuilder()
+            var ignore = Ignore.newBuilder()
                     .setReason(TestValues.randomString())
                     .build();
-            DispatchOutcome outcome = DispatchOutcome
-                    .newBuilder()
+            var outcome = DispatchOutcome.newBuilder()
                     .setIgnored(ignore)
                     .build();
             List<Ignore> ignored = new ArrayList<>();
-            DispatchOutcome result = DispatchOutcomeHandler
+            var result = DispatchOutcomeHandler
                     .from(outcome)
                     .onIgnored(ignored::add)
                     .handle();

--- a/server/src/test/java/io/spine/server/dispatch/given/Given.java
+++ b/server/src/test/java/io/spine/server/dispatch/given/Given.java
@@ -62,9 +62,9 @@ public final class Given {
     }
 
     public static Event rejectionEvent() {
-        Command cmd = commandFactory.create(createDispatch());
+        var cmd = commandFactory.create(createDispatch());
         RejectionThrowable throwable = new StubRejectionThrowable();
-        Event rejection = reject(cmd, throwable);
+        var rejection = reject(cmd, throwable);
         return rejection;
     }
 

--- a/server/src/test/java/io/spine/server/enrich/EnricherBuilderTest.java
+++ b/server/src/test/java/io/spine/server/enrich/EnricherBuilderTest.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.function.Executable;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisplayName("Enricher Builder should")
+@DisplayName("`Enricher.Builder` should")
 class EnricherBuilderTest {
 
     private EventEnricher.Builder builder;
@@ -56,7 +56,7 @@ class EnricherBuilderTest {
     }
 
     @Nested
-    @DisplayName("build Enricher")
+    @DisplayName("build `Enricher`")
     class BuildEnricher {
 
         @Test
@@ -87,7 +87,7 @@ class EnricherBuilderTest {
                     (e, c) -> StringValue.getDefaultInstance())
                .add(EbtOrderCreated.class, BoolValue.class,
                     (e, c) -> BoolValue.of(true));
-        EventEnricher enricher = builder.build();
+        var enricher = builder.build();
         assertThat(enricher).isNotNull();
     }
 

--- a/server/src/test/java/io/spine/server/enrich/SingularFnTest.java
+++ b/server/src/test/java/io/spine/server/enrich/SingularFnTest.java
@@ -26,9 +26,7 @@
 
 package io.spine.server.enrich;
 
-import com.google.common.truth.extensions.proto.ProtoSubject;
 import com.google.common.truth.extensions.proto.ProtoTruth;
-import io.spine.core.Enrichment;
 import io.spine.core.EventContext;
 import io.spine.server.enrich.given.event.SfnTestEvent;
 import io.spine.server.enrich.given.event.SfnTestStarted;
@@ -39,7 +37,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisplayName("SingularFn should")
+@DisplayName("`SingularFn` should")
 class SingularFnTest {
 
     private final TestEventFactory factory = TestEventFactory.newInstance(getClass());
@@ -53,18 +51,18 @@ class SingularFnTest {
     @Test
     @DisplayName("create Enrichment instance")
     void enrichment() {
-        SingularFn<SfnTestEvent, EventContext> fn = new SingularFn<>(
+        var fn = new SingularFn<SfnTestEvent, EventContext>(
                 (m, c) -> c.getTimestamp()
         );
 
-        EventEnvelope event = EventEnvelope.of(
+        var event = EventEnvelope.of(
                 factory.createEvent(SfnTestStarted.newBuilder()
                                                   .setTestName(getClass().getCanonicalName())
                                                   .build()
                 ));
 
-        Enrichment enrichment = fn.apply((SfnTestEvent) event.message(), event.context());
-        ProtoSubject assertThat = ProtoTruth.assertThat(enrichment);
+        var enrichment = fn.apply((SfnTestEvent) event.message(), event.context());
+        var assertThat = ProtoTruth.assertThat(enrichment);
         assertThat.isNotNull();
         assertThat.hasAllRequiredFields();
     }

--- a/server/src/test/java/io/spine/server/enrich/given/EitEnricherSetup.java
+++ b/server/src/test/java/io/spine/server/enrich/given/EitEnricherSetup.java
@@ -45,8 +45,7 @@ public class EitEnricherSetup {
     public static EventEnricher createEnricher(EitUserRepository users,
                                                EitProjectRepository projects,
                                                EitTaskRepository tasks) {
-        EventEnricher enricher = EventEnricher
-                .newBuilder()
+        var enricher = EventEnricher.newBuilder()
                 .add(EitUserAccountCreated.class, EitUserAccount.class,
                      (e, c) -> find(users, e.getUser()))
                 .add(EitProjectCreated.class, EitProject.class,

--- a/server/src/test/java/io/spine/server/entity/AbstractEntityTest.java
+++ b/server/src/test/java/io/spine/server/entity/AbstractEntityTest.java
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -49,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@DisplayName("AbstractEntity should")
+@DisplayName("`AbstractEntity` should")
 class AbstractEntityTest {
 
     @Nested
@@ -63,9 +62,9 @@ class AbstractEntityTest {
         @Test
         @DisplayName("`updateState`")
         void updateState() throws NoSuchMethodException {
-            Method updateState =
+            var updateState =
                     AbstractEntity.class.getDeclaredMethod("updateState", EntityState.class);
-            int modifiers = updateState.getModifiers();
+            var modifiers = updateState.getModifiers();
             assertTrue(Modifier.isFinal(modifiers));
         }
 
@@ -76,9 +75,9 @@ class AbstractEntityTest {
         @Test
         @DisplayName("`validate`")
         void validate() throws NoSuchMethodException {
-            Method validate =
+            var validate =
                     AbstractEntity.class.getDeclaredMethod("validate", EntityState.class);
-            int modifiers = validate.getModifiers();
+            var modifiers = validate.getModifiers();
             assertTrue(Modifier.isPrivate(modifiers) || Modifier.isFinal(modifiers));
         }
     }
@@ -87,7 +86,7 @@ class AbstractEntityTest {
     @DisplayName("throw InvalidEntityStateException if state is invalid")
     void rejectInvalidState() {
         AbstractEntity<?, NaturalNumber> entity = new NaturalNumberEntity(0);
-        NaturalNumber invalidNaturalNumber = newNaturalNumber(-1);
+        var invalidNaturalNumber = newNaturalNumber(-1);
         try {
             // This should pass.
             entity.updateState(newNaturalNumber(1));
@@ -107,7 +106,7 @@ class AbstractEntityTest {
     @Test
     @DisplayName("not accept null to `checkEntityState`")
     void rejectNullState() {
-        AnEntity entity = new AnEntity(0L);
+        var entity = new AnEntity(0L);
 
         assertThrows(NullPointerException.class, () -> entity.checkEntityState(null));
     }
@@ -115,9 +114,8 @@ class AbstractEntityTest {
     @Test
     @DisplayName("allow valid state")
     void allowValidState() {
-        AnEntity entity = new AnEntity(0L);
-        LongIdAggregate state = LongIdAggregate
-                .newBuilder()
+        var entity = new AnEntity(0L);
+        var state = LongIdAggregate.newBuilder()
                 .setId(entity.id())
                 .build();
         assertTrue(entity.checkEntityState(state)
@@ -127,22 +125,22 @@ class AbstractEntityTest {
     @Test
     @DisplayName("return string ID")
     void returnStringId() {
-        AnEntity entity = new AnEntity(1_234_567L);
+        var entity = new AnEntity(1_234_567L);
 
         assertEquals("1234567", entity.idAsString());
         assertSame(entity.idAsString(), entity.idAsString());
     }
 
-    @SuppressWarnings("MagicNumber")
     @Test
     @DisplayName("support equality")
+    @SuppressWarnings("MagicNumber")
     void supportEquality() {
-        ProjectId id = AvEntity.projectId("88");
-        AvEntity entity = new AvEntity(id);
-        AvEntity similarEntity = new AvEntity(id);
+        var id = AvEntity.projectId("88");
+        var entity = new AvEntity(id);
+        var similarEntity = new AvEntity(id);
         similarEntity.updateState(entity.state(), entity.version());
 
-        AvEntity different = new AvEntity(AvEntity.projectId("42"));
+        var different = new AvEntity(AvEntity.projectId("42"));
         new EqualsTester().addEqualityGroup(entity, similarEntity)
                           .addEqualityGroup(different)
                           .testEquals();
@@ -151,12 +149,12 @@ class AbstractEntityTest {
     @Test
     @DisplayName("have `updateState` method visible to package only")
     void haveUpdateStatePackagePrivate() {
-        boolean methodFound = false;
+        var methodFound = false;
 
-        Method[] methods = AbstractEntity.class.getDeclaredMethods();
-        for (Method method : methods) {
+        var methods = AbstractEntity.class.getDeclaredMethods();
+        for (var method : methods) {
             if ("updateState".equals(method.getName())) {
-                Invokable<?, Object> updateState = Invokable.from(method);
+                var updateState = Invokable.from(method);
                 assertTrue(updateState.isPackagePrivate());
                 methodFound = true;
             }
@@ -174,14 +172,14 @@ class AbstractEntityTest {
 
         static ProjectId projectId(String value) {
             return ProjectId.newBuilder()
-                            .setId(value)
-                            .build();
+                    .setId(value)
+                    .build();
         }
     }
 
     static NaturalNumber newNaturalNumber(int value) {
         return NaturalNumber.newBuilder()
-                            .setValue(value)
-                            .build();
+                .setValue(value)
+                .build();
     }
 }

--- a/server/src/test/java/io/spine/server/entity/AbstractEventSubscriberTest.java
+++ b/server/src/test/java/io/spine/server/entity/AbstractEventSubscriberTest.java
@@ -54,14 +54,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
-
 import static com.google.common.truth.Truth8.assertThat;
 import static io.spine.protobuf.AnyPacker.pack;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("AbstractEventSubscriber should")
+@DisplayName("`AbstractEventSubscriber` should")
 class AbstractEventSubscriberTest {
 
     private TestSubscriber subscriber;
@@ -70,12 +68,8 @@ class AbstractEventSubscriberTest {
 
     @BeforeEach
     void setUp() {
-        groupsContext = BoundedContext
-                .singleTenant("Groups")
-                .build();
-        organizationsContext = BoundedContext
-                .singleTenant("Organizations")
-                .build();
+        groupsContext = BoundedContext.singleTenant("Groups").build();
+        organizationsContext = BoundedContext.singleTenant("Organizations").build();
         subscriber = new TestSubscriber();
         groupsContext.internalAccess()
                      .registerEventDispatcher(subscriber);
@@ -90,16 +84,14 @@ class AbstractEventSubscriberTest {
     @Test
     @DisplayName("receive domestic entity state updates")
     void receiveEntityStateUpdates() {
-        Group.Builder builder = Group
-                .newBuilder()
+        var builder = Group.newBuilder()
                 .setId(GroupId.generate())
                 .setName("Admins")
                 .addParticipant(UserId.getDefaultInstance())
                 .addParticipant(UserId.getDefaultInstance());
-        Group newState = builder.build();
-        Group oldState = builder.setName("Old " + builder.getName()).build();
-        EntityStateChanged event = EntityStateChanged
-                .newBuilder()
+        var newState = builder.build();
+        var oldState = builder.setName("Old " + builder.getName()).build();
+        var event = EntityStateChanged.newBuilder()
                 .setEntity(messageIdWithType(Group.class))
                 .setWhen(Time.currentTime())
                 .setOldState(pack(oldState))
@@ -109,28 +101,26 @@ class AbstractEventSubscriberTest {
         SystemBoundedContexts.systemOf(groupsContext)
                              .eventBus()
                              .post(GivenEvent.withMessage(event));
-        Optional<Group> receivedState = subscriber.domestic();
+        var receivedState = subscriber.domestic();
         assertTrue(receivedState.isPresent());
         assertThat(receivedState)
-              .hasValue(newState);
+                .hasValue(newState);
         assertThat(subscriber.external())
-              .isEmpty();
+                .isEmpty();
     }
 
     @Test
     @DisplayName("receive external entity state updates")
     void receiveExternalEntityStateUpdates() {
-        Organization.Builder builder = Organization
-                .newBuilder()
+        var builder = Organization.newBuilder()
                 .setId(OrganizationId.generate())
                 .setName("Developers")
                 .setHead(UserId.getDefaultInstance())
                 .addMember(UserId.getDefaultInstance())
                 .addMember(UserId.getDefaultInstance());
-        Organization newState = builder.build();
-        Organization oldState = builder.setName("Old " + builder.getName()).build();
-        EntityStateChanged event = EntityStateChanged
-                .newBuilder()
+        var newState = builder.build();
+        var oldState = builder.setName("Old " + builder.getName()).build();
+        var event = EntityStateChanged.newBuilder()
                 .setEntity(messageIdWithType(Organization.class))
                 .setWhen(Time.currentTime())
                 .setOldState(pack(oldState))
@@ -140,7 +130,7 @@ class AbstractEventSubscriberTest {
         SystemBoundedContexts.systemOf(organizationsContext)
                              .eventBus()
                              .post(GivenEvent.withMessage(event));
-        Optional<Organization> receivedState = subscriber.external();
+        var receivedState = subscriber.external();
         assertThat(receivedState)
                 .hasValue(newState);
         assertThat(subscriber.domestic())
@@ -172,8 +162,7 @@ class AbstractEventSubscriberTest {
     }
 
     private static MessageId messageIdWithType(Class<? extends Message> type) {
-        MessageId historyId = MessageId
-                .newBuilder()
+        var historyId = MessageId.newBuilder()
                 .setId(pack(Empty.getDefaultInstance()))
                 .setTypeUrl(TypeUrl.of(type).value())
                 .build();
@@ -181,8 +170,7 @@ class AbstractEventSubscriberTest {
     }
 
     private static MessageId emptyEventId() {
-        return MessageId
-                .newBuilder()
+        return MessageId.newBuilder()
                 .setId(pack(EventId.getDefaultInstance()))
                 .setTypeUrl("example.org/test.Event")
                 .build();

--- a/server/src/test/java/io/spine/server/entity/CompositeEventFilterTest.java
+++ b/server/src/test/java/io/spine/server/entity/CompositeEventFilterTest.java
@@ -28,7 +28,6 @@ package io.spine.server.entity;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
-import com.google.protobuf.Message;
 import io.spine.base.EventMessage;
 import io.spine.core.Event;
 import io.spine.test.entity.event.EntProjectCreated;
@@ -42,30 +41,25 @@ import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("CompositeEventFilter should")
+@DisplayName("`CompositeEventFilter` should")
 class CompositeEventFilterTest {
 
     @Test
     @DisplayName("accept any given event if no filters are provided")
     void acceptIfEmpty() {
-        CompositeEventFilter emptyFilter = CompositeEventFilter
-                .newBuilder()
-                .build();
-        Optional<? extends Message> filtered =
-                emptyFilter.filter(EntProjectCreated.getDefaultInstance());
+        var emptyFilter = CompositeEventFilter.newBuilder().build();
+        var filtered = emptyFilter.filter(EntProjectCreated.getDefaultInstance());
         assertTrue(filtered.isPresent());
     }
 
     @Test
     @DisplayName("accept the given event if all filter accept")
     void acceptIfAllAccept() {
-        CompositeEventFilter filter = CompositeEventFilter
-                .newBuilder()
+        var filter = CompositeEventFilter.newBuilder()
                 .add(Optional::of)
                 .add(Optional::of)
                 .build();
-        Optional<? extends Message> filtered =
-                filter.filter(EntProjectCreated.getDefaultInstance());
+        var filtered = filter.filter(EntProjectCreated.getDefaultInstance());
         assertTrue(filtered.isPresent());
     }
 
@@ -74,15 +68,14 @@ class CompositeEventFilterTest {
     void rejectIfOneRejects() {
         EventMessage eventMessage = EntProjectCreated.getDefaultInstance();
 
-        MockFilter mockFilter = new MockFilter(eventMessage);
+        var mockFilter = new MockFilter(eventMessage);
 
-        CompositeEventFilter filter = CompositeEventFilter
-                .newBuilder()
+        var filter = CompositeEventFilter.newBuilder()
                 .add(anyEvent -> Optional.empty())
                 .add(mockFilter)
                 .build();
 
-        Optional<? extends EventMessage> filtered = filter.filter(eventMessage);
+        var filtered = filter.filter(eventMessage);
 
         assertThat(filtered)
                 .isEmpty();
@@ -102,7 +95,7 @@ class CompositeEventFilterTest {
             this.eventMessage = message;
         }
 
-        boolean called() {
+        private boolean called() {
             return called;
         }
 

--- a/server/src/test/java/io/spine/server/entity/DefaultCommandRouteTest.java
+++ b/server/src/test/java/io/spine/server/entity/DefaultCommandRouteTest.java
@@ -48,15 +48,16 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.spine.testing.TestValues.nullRef;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("DefaultCommandRoute should")
+@DisplayName("`DefaultCommandRoute` should")
 class DefaultCommandRouteTest {
 
     @Test
     @DisplayName("get ID from command message")
     void getIdFromCommand() {
-        EntCreateProject msg = Sample.messageOfType(EntCreateProject.class);
+        var msg = Sample.messageOfType(EntCreateProject.class);
 
         assertTrue(DefaultCommandRoute.exists(msg));
 
@@ -100,12 +101,12 @@ class DefaultCommandRouteTest {
 
         @Override
         public Parser<? extends Message> getParserForType() {
-            return null;
+            return nullRef();
         }
 
         @Override
         public ByteString toByteString() {
-            return null;
+            return nullRef();
         }
 
         @SuppressWarnings("ZeroLengthArrayAllocation")
@@ -126,17 +127,17 @@ class DefaultCommandRouteTest {
 
         @Override
         public Builder newBuilderForType() {
-            return null;
+            return nullRef();
         }
 
         @Override
         public Builder toBuilder() {
-            return null;
+            return nullRef();
         }
 
         @Override
         public Message getDefaultInstanceForType() {
-            return null;
+            return nullRef();
         }
 
         @Override
@@ -146,12 +147,12 @@ class DefaultCommandRouteTest {
 
         @Override
         public List<String> findInitializationErrors() {
-            return null;
+            return nullRef();
         }
 
         @Override
         public String getInitializationErrorString() {
-            return null;
+            return nullRef();
         }
 
         @Override
@@ -163,7 +164,7 @@ class DefaultCommandRouteTest {
 
         @Override
         public Map<Descriptors.FieldDescriptor, Object> getAllFields() {
-            return null;
+            return nullRef();
         }
 
         @Override
@@ -174,7 +175,7 @@ class DefaultCommandRouteTest {
         @Override
         public Descriptors.FieldDescriptor getOneofFieldDescriptor(
                 Descriptors.OneofDescriptor oneof) {
-            return null;
+            return nullRef();
         }
 
         @Override
@@ -184,7 +185,7 @@ class DefaultCommandRouteTest {
 
         @Override
         public Object getField(Descriptors.FieldDescriptor field) {
-            return null;
+            return nullRef();
         }
 
         @Override
@@ -194,12 +195,12 @@ class DefaultCommandRouteTest {
 
         @Override
         public Object getRepeatedField(Descriptors.FieldDescriptor field, int index) {
-            return null;
+            return nullRef();
         }
 
         @Override
         public UnknownFieldSet getUnknownFields() {
-            return null;
+            return nullRef();
         }
     }
 }

--- a/server/src/test/java/io/spine/server/entity/DefaultConverterTest.java
+++ b/server/src/test/java/io/spine/server/entity/DefaultConverterTest.java
@@ -28,11 +28,9 @@ package io.spine.server.entity;
 
 import com.google.common.testing.SerializableTester;
 import com.google.protobuf.FieldMask;
-import io.spine.server.BoundedContext;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.given.organizations.Organization;
 import io.spine.server.given.organizations.OrganizationId;
-import io.spine.type.TypeUrl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,15 +45,12 @@ class DefaultConverterTest {
 
     @BeforeEach
     void setUp() {
-        BoundedContext context =
-                BoundedContextBuilder.assumingTests()
-                                     .build();
+        var context = BoundedContextBuilder.assumingTests().build();
         RecordBasedRepository<OrganizationId, TestEntity, Organization> repo = new TestRepository();
         context.internalAccess()
                .register(repo);
 
-        TypeUrl stateType = repo.entityModelClass()
-                                .stateTypeUrl();
+        var stateType = repo.entityModelClass().stateTypeUrl();
         converter = forAllFields(stateType, repo.entityFactory());
     }
 
@@ -66,20 +61,19 @@ class DefaultConverterTest {
     }
 
     @Test
-    @DisplayName("create instance with FieldMask")
+    @DisplayName("create instance with `FieldMask`")
     void createWithFieldMask() {
-        FieldMask fieldMask = FieldMask.newBuilder()
-                                       .addPaths("foo.bar")
-                                       .build();
+        var fieldMask = FieldMask.newBuilder()
+                .addPaths("foo.bar")
+                .build();
 
-        StorageConverter<OrganizationId, TestEntity, Organization> withMasks =
-                converter.withFieldMask(fieldMask);
+        var withMasks = converter.withFieldMask(fieldMask);
 
         assertEquals(fieldMask, withMasks.fieldMask());
     }
 
     private static TestEntity createEntity(OrganizationId id, Organization state) {
-        TestEntity result = new TestEntity(id);
+        var result = new TestEntity(id);
         result.setState(state);
         return result;
     }
@@ -87,17 +81,15 @@ class DefaultConverterTest {
     @Test
     @DisplayName("convert forward and backward")
     void convertForwardAndBackward() {
-        OrganizationId id = OrganizationId.generate();
-        Organization entityState = Organization
-                .newBuilder()
+        var id = OrganizationId.generate();
+        var entityState = Organization.newBuilder()
                 .setName("back and forth")
                 .setId(id)
                 .vBuild();
-        TestEntity entity = createEntity(id, entityState);
+        var entity = createEntity(id, entityState);
 
-        EntityRecord out = converter.convert(entity);
-        TestEntity back = converter.reverse()
-                                   .convert(out);
+        var out = converter.convert(entity);
+        var back = converter.reverse().convert(out);
         assertEquals(entity, back);
     }
 

--- a/server/src/test/java/io/spine/server/entity/EntityBuilder.java
+++ b/server/src/test/java/io/spine/server/entity/EntityBuilder.java
@@ -131,12 +131,12 @@ public abstract class EntityBuilder<E extends AbstractEntity<I, S>, I, S extends
 
     @Override
     public E build() {
-        I id = id();
-        E result = createEntity(id);
-        S state = state();
-        Timestamp timestamp = timestamp();
+        var id = id();
+        var result = createEntity(id);
+        var state = state();
+        var timestamp = timestamp();
 
-        Version version = Versions.newVersion(this.version, timestamp);
+        var version = Versions.newVersion(this.version, timestamp);
         setState(result, state, version);
         return result;
     }
@@ -161,7 +161,7 @@ public abstract class EntityBuilder<E extends AbstractEntity<I, S>, I, S extends
         }
         checkNotNull(entityClass, "Entity class is not set");
         @SuppressWarnings("unchecked") // The cast is preserved by generic params of this class.
-        S result = (S) entityClass.defaultState();
+        var result = (S) entityClass.defaultState();
         return result;
     }
 
@@ -176,7 +176,7 @@ public abstract class EntityBuilder<E extends AbstractEntity<I, S>, I, S extends
 
     @Override
     protected Constructor<E> constructor() {
-        Constructor<E> constructor = entityClass().constructor();
+        var constructor = entityClass().constructor();
         constructor.setAccessible(true);
         return constructor;
     }
@@ -185,7 +185,7 @@ public abstract class EntityBuilder<E extends AbstractEntity<I, S>, I, S extends
      * Creates an empty entity instance.
      */
     protected E createEntity(I id) {
-        E result = entityClass().create(id);
+        var result = entityClass().create(id);
         return result;
     }
 }

--- a/server/src/test/java/io/spine/server/entity/EntityIdFunctionTest.java
+++ b/server/src/test/java/io/spine/server/entity/EntityIdFunctionTest.java
@@ -28,42 +28,39 @@ package io.spine.server.entity;
 
 import com.google.protobuf.StringValue;
 import io.spine.client.EntityId;
+import io.spine.server.entity.RecordBasedRepository.EntityIdFunction;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.function.Function;
 
 import static io.spine.protobuf.TypeConverter.toAny;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisplayName("EntityIdFunction should")
+@DisplayName("`EntityIdFunction` should")
 class EntityIdFunctionTest {
 
     @Test
     @DisplayName("not accept wrong ID type")
     void rejectWrongIdType() {
-        Function<EntityId, StringValue> func =
-                new RecordBasedRepository.EntityIdFunction<>(StringValue.class);
+        var func = new EntityIdFunction<>(StringValue.class);
 
-        EntityId wrongType = EntityId.newBuilder()
-                                     .setId(toAny(100L))
-                                     .build();
+        var wrongType = EntityId.newBuilder()
+                .setId(toAny(100L))
+                .build();
         assertThrows(IllegalStateException.class, () -> func.apply(wrongType));
     }
 
     @Test
     @DisplayName("accept proper ID type")
     void acceptProperIdType() {
-        Function<EntityId, StringValue> func =
-                new RecordBasedRepository.EntityIdFunction<>(StringValue.class);
+        var func = new EntityIdFunction<>(StringValue.class);
 
-        String value = "abcd";
-        EntityId type = EntityId.newBuilder()
-                                .setId(toAny(value))
-                                .build();
-        StringValue result = func.apply(type);
+        var value = "abcd";
+        var type = EntityId.newBuilder()
+                .setId(toAny(value))
+                .build();
+        var result = func.apply(type);
         assertNotNull(result);
         assertEquals(value, result.getValue());
     }

--- a/server/src/test/java/io/spine/server/entity/EntityLifecycleTest.java
+++ b/server/src/test/java/io/spine/server/entity/EntityLifecycleTest.java
@@ -38,7 +38,6 @@ import io.spine.protobuf.AnyPacker;
 import io.spine.server.aggregate.model.AggregateClass;
 import io.spine.server.entity.given.entity.TestAggregate;
 import io.spine.server.entity.model.EntityClass;
-import io.spine.system.server.MemoizedSystemMessage;
 import io.spine.system.server.MemoizingWriteSide;
 import io.spine.system.server.NoOpSystemWriteSide;
 import io.spine.system.server.event.EntityCreated;
@@ -55,7 +54,7 @@ import static io.spine.protobuf.AnyPacker.pack;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-@DisplayName("EntityLifecycle should")
+@DisplayName("`EntityLifecycle` should")
 class EntityLifecycleTest {
 
     private static final EntityClass<?> TEST_ENTITY_CLASS =
@@ -71,10 +70,9 @@ class EntityLifecycleTest {
     }
 
     @Test
-    @DisplayName("be created with a default EventFilter")
+    @DisplayName("be created with a default `EventFilter`")
     void allowCreationWithoutEventFilter() {
-        EntityLifecycle lifecycle = EntityLifecycle
-                .newBuilder()
+        var lifecycle = EntityLifecycle.newBuilder()
                 .setSystemWriteSide(NoOpSystemWriteSide.INSTANCE)
                 .setEntityType(TEST_ENTITY_CLASS)
                 .setEntityId("sample-id")
@@ -86,44 +84,39 @@ class EntityLifecycleTest {
     @DisplayName("filter system events before posting")
     void filterEventsBeforePosting() {
         EventFilter filter = event -> {
-            boolean stateChanged = event instanceof EntityStateChanged;
+            var stateChanged = event instanceof EntityStateChanged;
             return stateChanged
                    ? Optional.empty()
                    : Optional.of(event);
         };
-        MemoizingWriteSide writeSide = MemoizingWriteSide.singleTenant();
-        int entityId = 42;
-        EntityLifecycle lifecycle = EntityLifecycle
-                .newBuilder()
+        var writeSide = MemoizingWriteSide.singleTenant();
+        var entityId = 42;
+        var lifecycle = EntityLifecycle.newBuilder()
                 .setEntityId(entityId)
                 .setEntityType(TEST_ENTITY_CLASS)
                 .setSystemWriteSide(writeSide)
                 .setEventFilter(filter)
                 .build();
         lifecycle.onEntityCreated(ENTITY);
-        MemoizedSystemMessage lastSeenEvent = writeSide.lastSeenEvent();
+        var lastSeenEvent = writeSide.lastSeenEvent();
         assertThat(lastSeenEvent.message())
                 .isInstanceOf(EntityCreated.class);
 
-        EntityRecord previousRecord = EntityRecord
-                .newBuilder()
+        var previousRecord = EntityRecord.newBuilder()
                 .setEntityId(Identifier.pack(entityId))
                 .setState(pack(Timestamp.getDefaultInstance()))
                 .build();
-        EntityRecord newRecord = previousRecord
-                .toBuilder()
+        var newRecord = previousRecord.toBuilder()
                 .setState(pack(Time.currentTime()))
                 .build();
-        EntityRecordChange change = EntityRecordChange
-                .newBuilder()
+        var change = EntityRecordChange.newBuilder()
                 .setPreviousValue(previousRecord)
                 .setNewValue(newRecord)
                 .build();
-        EventId causeEventId = EventId.newBuilder()
-                            .setValue("test event ID")
-                            .build();
-        MessageId causeMessage = MessageId
-                .newBuilder()
+        var causeEventId = EventId.newBuilder()
+                .setValue("test event ID")
+                .build();
+        var causeMessage = MessageId.newBuilder()
                 .setId(AnyPacker.pack(causeEventId))
                 .setTypeUrl("example.com/test.Event")
                 .buildPartial();

--- a/server/src/test/java/io/spine/server/entity/EntityTest.java
+++ b/server/src/test/java/io/spine/server/entity/EntityTest.java
@@ -29,7 +29,6 @@ package io.spine.server.entity;
 import com.google.common.collect.Range;
 import com.google.common.truth.LongSubject;
 import io.spine.core.UserId;
-import io.spine.core.Version;
 import io.spine.core.Versions;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.entity.given.entity.EntityWithMessageId;
@@ -68,7 +67,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("Entity should")
+@DisplayName("`Entity` should")
 class EntityTest {
 
     private Project state = Sample.messageOfType(Project.class);
@@ -84,9 +83,9 @@ class EntityTest {
         aggregateWithState = TestAggregate.withState();
     }
 
-    @SuppressWarnings("ResultOfObjectAllocationIgnored") // Because we expect the exception.
     @Test
-    @DisplayName("not accept null ID")
+    @DisplayName("not accept `null` ID")
+    @SuppressWarnings("ResultOfObjectAllocationIgnored") // Because we expect the exception.
     void notAcceptNullId() {
         assertThrows(NullPointerException.class, () -> new EntityWithMessageId(nullRef()));
     }
@@ -98,7 +97,7 @@ class EntityTest {
         @Test
         @DisplayName("for single entity")
         void forSingleEntity() {
-            Project state = entityNew.defaultState();
+            var state = entityNew.defaultState();
             assertEquals(Project.getDefaultInstance(), state);
         }
 
@@ -107,8 +106,8 @@ class EntityTest {
         void forDifferentEntities() {
             assertEquals(Project.getDefaultInstance(), entityNew.defaultState());
 
-            EntityWithMessageId entityWithMessageId = new EntityWithMessageId();
-            Project expected = Project.getDefaultInstance();
+            var entityWithMessageId = new EntityWithMessageId();
+            var expected = Project.getDefaultInstance();
             assertEquals(expected, entityWithMessageId.defaultState());
         }
     }
@@ -118,39 +117,39 @@ class EntityTest {
     class AcceptId {
 
         @Test
-        @DisplayName("String")
+        @DisplayName("`String`")
         void ofStringType() {
-            String stringId = "stringId";
-            TestEntityWithIdString entityWithStringId = new TestEntityWithIdString(stringId);
+            var stringId = "stringId";
+            var entityWithStringId = new TestEntityWithIdString(stringId);
 
             assertEquals(stringId, entityWithStringId.id());
         }
 
         @Test
-        @DisplayName("Long")
+        @DisplayName("`Long`")
         void ofLongType() {
             Long longId = 12L;
-            TestEntityWithIdLong entityWithLongId = new TestEntityWithIdLong(longId);
+            var entityWithLongId = new TestEntityWithIdLong(longId);
 
             assertEquals(longId, entityWithLongId.id());
         }
 
         @Test
-        @DisplayName("Integer")
+        @DisplayName("`Integer`")
         void ofIntegerType() {
             Integer integerId = 12;
-            TestEntityWithIdInteger entityWithIntegerId = new TestEntityWithIdInteger(integerId);
+            var entityWithIntegerId = new TestEntityWithIdInteger(integerId);
 
             assertEquals(integerId, entityWithIntegerId.id());
         }
 
         @Test
-        @DisplayName("Message")
+        @DisplayName("`Message`")
         void ofMessageType() {
-            ProjectId messageId = ProjectId.newBuilder()
-                                           .setId("messageId")
-                                           .vBuild();
-            TestEntityWithIdMessage entityWithMessageID = new TestEntityWithIdMessage(messageId);
+            var messageId = ProjectId.newBuilder()
+                    .setId("messageId")
+                    .vBuild();
+            var entityWithMessageID = new TestEntityWithIdMessage(messageId);
 
             assertEquals(messageId, entityWithMessageID.id());
         }
@@ -165,7 +164,7 @@ class EntityTest {
     @Test
     @DisplayName("have state")
     void haveState() {
-        Version ver = Versions.newVersion(3, currentTime());
+        var ver = Versions.newVersion(3, currentTime());
 
         entityNew.updateState(state, ver);
 
@@ -192,27 +191,24 @@ class EntityTest {
     @Test
     @DisplayName("check `(set_once)` on state update")
     void setOnce() {
-        BoundedContextBuilder context = BoundedContextBuilder
+        var context = BoundedContextBuilder
                 .assumingTests()
                 .add(UserAggregate.class);
-        UserId id = UserId.newBuilder()
-                             .setValue(newUuid())
-                             .build();
-        SignUpUser signUpUser = SignUpUser
-                .newBuilder()
+        var id = UserId.newBuilder()
+                .setValue(newUuid())
+                .build();
+        var signUpUser = SignUpUser.newBuilder()
                 .setId(id)
                 .vBuild();
-        ChooseDayOfBirth chooseInitial = ChooseDayOfBirth
-                .newBuilder()
+        var chooseInitial = ChooseDayOfBirth.newBuilder()
                 .setId(id)
                 .setDayOfBirth(LocalDates.of(2000, JANUARY, 1))
                 .vBuild();
-        ChooseDayOfBirth chooseAgain = ChooseDayOfBirth
-                .newBuilder()
+        var chooseAgain = ChooseDayOfBirth.newBuilder()
                 .setId(id)
                 .setDayOfBirth(LocalDates.of(1988, FEBRUARY, 29))
                 .vBuild();
-        BlackBox bbc = BlackBox
+        var bbc = BlackBox
                 .from(context)
                 .receivesCommand(signUpUser)
                 .receivesCommand(chooseInitial)
@@ -229,8 +225,7 @@ class EntityTest {
     @Test
     @DisplayName("have zero version by default")
     void haveZeroVersionByDefault() {
-        assertEquals(0, entityNew.version()
-                                 .getNumber());
+        assertEquals(0, entityNew.version().getNumber());
     }
 
     @Nested
@@ -240,7 +235,7 @@ class EntityTest {
         @Test
         @DisplayName("when told to do so")
         void whenAsked() {
-            int version = entityNew.incrementVersion();
+            var version = entityNew.incrementVersion();
             assertEquals(1, version);
         }
 
@@ -263,9 +258,9 @@ class EntityTest {
         @Test
         @DisplayName("when incrementing version")
         void onVersionIncrement() {
-            long timeBeforeIncrement = TimeTests.currentTimeSeconds();
+            var timeBeforeIncrement = TimeTests.currentTimeSeconds();
             entityNew.incrementVersion();
-            long timeAfterIncrement = TimeTests.currentTimeSeconds();
+            var timeAfterIncrement = TimeTests.currentTimeSeconds();
 
             assertModificationTime()
                     .isIn(Range.closed(timeBeforeIncrement, timeAfterIncrement));
@@ -275,7 +270,7 @@ class EntityTest {
         @DisplayName("when updating state")
         void onStateUpdate() {
             entityNew.incrementState(state);
-            long expectedTimeSec = TimeTests.currentTimeSeconds();
+            var expectedTimeSec = TimeTests.currentTimeSeconds();
             assertModificationTime()
                     .isEqualTo(expectedTimeSec);
         }
@@ -293,7 +288,7 @@ class EntityTest {
         @Test
         @DisplayName("same entities are equal")
         void equalToSame() {
-            TestAggregate another = TestAggregate.copyOf(aggregateWithState);
+            var another = TestAggregate.copyOf(aggregateWithState);
 
             assertEquals(aggregateWithState, another);
         }
@@ -305,13 +300,14 @@ class EntityTest {
         }
 
         @Test
-        @DisplayName("entity is not equal to null")
+        @DisplayName("entity is not equal to `null`")
         void notEqualToNull() {
             assertNotEquals(entityWithState, nullRef());
         }
 
         @Test
         @DisplayName("entity is not equal to object of another class")
+        @SuppressWarnings("AssertBetweenInconvertibleTypes") /* That's the point. */
         void notEqualToOtherClass() {
             assertNotEquals(entityWithState, newUuid());
         }
@@ -319,7 +315,7 @@ class EntityTest {
         @Test
         @DisplayName("entities with different IDs are not equal")
         void notEqualToDifferentId() {
-            TestEntity another = TestEntity.newInstance(newUuid());
+            var another = TestEntity.newInstance(newUuid());
 
             assertNotEquals(entityWithState.id(), another.id());
             assertNotEquals(entityWithState, another);
@@ -328,18 +324,18 @@ class EntityTest {
         @Test
         @DisplayName("entities with different states are not equal")
         void notEqualToDifferentState() {
-            TestEntity another = TestEntity.withStateOf(entityWithState);
+            var another = TestEntity.withStateOf(entityWithState);
             another.updateState(Sample.messageOfType(Project.class), another.version());
 
             assertNotEquals(entityWithState.state(), another.state());
             assertNotEquals(entityWithState, another);
         }
 
-        @SuppressWarnings("CheckReturnValue") // The entity version can be ignored in this test.
         @Test
         @DisplayName("entities with different versions are not equal")
+        @SuppressWarnings("CheckReturnValue") // The entity version can be ignored in this test.
         void notEqualToDifferentVersion() {
-            TestEntity another = TestEntity.withStateOf(entityWithState);
+            var another = TestEntity.withStateOf(entityWithState);
             another.incrementVersion();
 
             assertNotEquals(entityWithState, another);
@@ -358,7 +354,7 @@ class EntityTest {
                                        .trim()
                                        .isEmpty());
 
-            int hashCode = entityWithState.hashCode();
+            var hashCode = entityWithState.hashCode();
 
             assertTrue(hashCode != 0);
         }
@@ -372,7 +368,7 @@ class EntityTest {
         @Test
         @DisplayName("for different instances, unique hash code is generated")
         void uniqueForDifferentInstances() {
-            TestEntity another = TestEntity.withState();
+            var another = TestEntity.withState();
 
             assertNotEquals(entityWithState.hashCode(), another.hashCode());
         }
@@ -437,7 +433,7 @@ class EntityTest {
         @DisplayName("entities with different status are not equal")
         void consideredForEquality() {
             // Create entities with the same ID and the same (default) state.
-            String id = "This very same identifier";
+            var id = "This very same identifier";
             AbstractEntity<?, ?> oneEntity = new TestEntityWithIdString(id);
             AbstractEntity<?, ?> another = new TestEntityWithIdString(id);
 
@@ -449,7 +445,7 @@ class EntityTest {
         @Test
         @DisplayName("status can be assigned")
         void supportAssignment() {
-            LifecycleFlags status = LifecycleFlags.newBuilder()
+            var status = LifecycleFlags.newBuilder()
                                                   .setArchived(true)
                                                   .setDeleted(false)
                                                   .build();

--- a/server/src/test/java/io/spine/server/entity/EntityVisibilityTest.java
+++ b/server/src/test/java/io/spine/server/entity/EntityVisibilityTest.java
@@ -38,8 +38,6 @@ import io.spine.test.entity.UserSignIn;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
-
 import static com.google.common.truth.Truth8.assertThat;
 import static io.spine.option.EntityOption.Visibility.FULL;
 import static io.spine.option.EntityOption.Visibility.NONE;
@@ -48,7 +46,7 @@ import static io.spine.option.EntityOption.Visibility.SUBSCRIBE;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("EntityVisibility should")
+@DisplayName("`EntityVisibility` should")
 class EntityVisibilityTest {
 
     @Test
@@ -59,40 +57,40 @@ class EntityVisibilityTest {
     }
 
     @Test
-    @DisplayName("not accept null `Visibility` values")
+    @DisplayName("not accept `null` `Visibility` values")
     void notAcceptNulls() {
-        Optional<EntityVisibility> value = EntityVisibility.of(Password.class);
+        var value = EntityVisibility.of(Password.class);
         assertThat(value).isPresent();
-        EntityVisibility instance = value.get();
+        var instance = value.get();
         new NullPointerTester()
                 .testAllPublicInstanceMethods(instance);
     }
 
     @Test
-    @DisplayName("report NONE level for `Aggregate`s by default")
+    @DisplayName("report `NONE` level for `Aggregate`s by default")
     void aggregateDefaults() {
-        EntityVisibility actual = assertVisibility(Password.class, NONE);
+        var actual = assertVisibility(Password.class, NONE);
         assertFalse(actual.isNotNone());
     }
 
     @Test
-    @DisplayName("report NONE level for `Process Manager`s by default")
+    @DisplayName("report `NONE` level for `Process Manager`s by default")
     void pmDefaults() {
-        EntityVisibility actual = assertVisibility(UserSignIn.class, NONE);
+        var actual = assertVisibility(UserSignIn.class, NONE);
         assertFalse(actual.isNotNone());
     }
 
     @Test
-    @DisplayName("report FULL level for `Projection`s by default")
+    @DisplayName("report `FULL` level for `Projection`s by default")
     void projectionDefaults() {
-        EntityVisibility actual = assertVisibility(UserFeed.class, FULL);
+        var actual = assertVisibility(UserFeed.class, FULL);
         assertTrue(actual.isNotNone());
     }
 
     @Test
-    @DisplayName("report QUERY level")
+    @DisplayName("report `QUERY` level")
     void findQuery() {
-        EntityVisibility visibility = visibilityOf(AccountDetails.class);
+        var visibility = visibilityOf(AccountDetails.class);
         assertTrue(visibility.is(QUERY));
         assertTrue(visibility.canQuery());
         assertTrue(visibility.isAsLeast(QUERY));
@@ -102,9 +100,9 @@ class EntityVisibilityTest {
     }
 
     @Test
-    @DisplayName("report SUBSCRIBE level")
+    @DisplayName("report `SUBSCRIBE` level")
     void findSubscribe() {
-        EntityVisibility visibility = visibilityOf(UserActivity.class);
+        var visibility = visibilityOf(UserActivity.class);
         assertTrue(visibility.is(SUBSCRIBE));
         assertTrue(visibility.canSubscribe());
         assertTrue(visibility.isAsLeast(SUBSCRIBE));
@@ -114,9 +112,9 @@ class EntityVisibilityTest {
     }
 
     @Test
-    @DisplayName("report FULL level")
+    @DisplayName("report `FULL` level")
     void findFull() {
-        EntityVisibility visibility = visibilityOf(LastSeen.class);
+        var visibility = visibilityOf(LastSeen.class);
         assertTrue(visibility.is(FULL));
         assertTrue(visibility.canQuery());
         assertTrue(visibility.canSubscribe());
@@ -128,13 +126,13 @@ class EntityVisibilityTest {
 
     private static EntityVisibility
     assertVisibility(Class<? extends EntityState<?>> stateClass, EntityOption.Visibility expected) {
-        EntityVisibility actual = visibilityOf(stateClass);
+        var actual = visibilityOf(stateClass);
         assertTrue(actual.is(expected));
         return actual;
     }
 
     private static EntityVisibility visibilityOf(Class<? extends EntityState<?>> stateClass) {
-        Optional<EntityVisibility> visibility = EntityVisibility.of(stateClass);
+        var visibility = EntityVisibility.of(stateClass);
         assertThat(visibility).isPresent();
         return visibility.get();
     }

--- a/server/src/test/java/io/spine/server/entity/EventBlackListTest.java
+++ b/server/src/test/java/io/spine/server/entity/EventBlackListTest.java
@@ -37,15 +37,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-@DisplayName("EventBlackList should")
+
+@DisplayName("`EventBlackList` should")
 class EventBlackListTest {
 
     private static final TestEventFactory eventFactory =
@@ -62,7 +61,7 @@ class EventBlackListTest {
     @DisplayName("allow events of type not from the list")
     void allowArbitrary() {
         EventMessage event = EntProjectCreated.getDefaultInstance();
-        Optional<? extends EventMessage> filtered = blackList.filter(event);
+        var filtered = blackList.filter(event);
         assertTrue(filtered.isPresent());
         assertEquals(event, filtered.get());
     }
@@ -71,17 +70,17 @@ class EventBlackListTest {
     @DisplayName("not allow events of type from the list")
     void notAllowFromList() {
         EventMessage event = EntTaskAdded.getDefaultInstance();
-        Optional<? extends EventMessage> filtered = blackList.filter(event);
+        var filtered = blackList.filter(event);
         assertFalse(filtered.isPresent());
     }
 
     @Test
     @DisplayName("filter out events from bulk")
     void filterOut() {
-        List<Event> events = Stream.<EventMessage>of(EntProjectCreated.getDefaultInstance(),
-                                                     EntTaskAdded.getDefaultInstance())
-                                   .map(eventFactory::createEvent)
-                                   .collect(toList());
+        var events = Stream.<EventMessage>of(EntProjectCreated.getDefaultInstance(),
+                                             EntTaskAdded.getDefaultInstance())
+                           .map(eventFactory::createEvent)
+                           .collect(toList());
         Collection<Event> filtered = blackList.filter(events);
         assertEquals(1, filtered.size());
         assertTrue(events.contains(events.get(0)));

--- a/server/src/test/java/io/spine/server/entity/EventFieldFilterTest.java
+++ b/server/src/test/java/io/spine/server/entity/EventFieldFilterTest.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.entity;
 
-import com.google.protobuf.FieldMask;
 import com.google.protobuf.Message;
 import io.spine.test.entity.ProjectId;
 import io.spine.test.entity.Task;
@@ -43,16 +42,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("EventFieldFilter should")
+@DisplayName("`EventFieldFilter` should")
 class EventFieldFilterTest {
 
     @Test
     @DisplayName("pass event if not specified otherwise")
     void allowByDefault() {
-        EventFieldFilter filter = EventFieldFilter
-                .newBuilder()
-                .build();
-        EntProjectCreated event = EntProjectCreated.getDefaultInstance();
+        var filter = EventFieldFilter.newBuilder().build();
+        var event = EntProjectCreated.getDefaultInstance();
         Optional<? extends Message> filtered = filter.filter(event);
         assertTrue(filtered.isPresent());
         assertEquals(event, filtered.get());
@@ -61,20 +58,17 @@ class EventFieldFilterTest {
     @Test
     @DisplayName("apply mask and pass")
     void applyFieldMask() {
-        FieldMask mask =
-                fromFieldNumbers(EntTaskAdded.class, EntTaskAdded.PROJECT_ID_FIELD_NUMBER);
-        EventFieldFilter filter = EventFieldFilter
-                .newBuilder()
+        var mask = fromFieldNumbers(EntTaskAdded.class, EntTaskAdded.PROJECT_ID_FIELD_NUMBER);
+        var filter = EventFieldFilter.newBuilder()
                 .putMask(EntTaskAdded.class, mask)
                 .build();
-        EntTaskAdded event = EntTaskAdded
-                .newBuilder()
+        var event = EntTaskAdded.newBuilder()
                 .setProjectId(Sample.messageOfType(ProjectId.class))
                 .setTask(Sample.messageOfType(Task.class))
                 .build();
         Optional<? extends Message> filtered = filter.filter(event);
         assertTrue(filtered.isPresent());
-        EntTaskAdded maskedEventMessage = (EntTaskAdded) filtered.get();
+        var maskedEventMessage = (EntTaskAdded) filtered.get();
         assertTrue(maskedEventMessage.hasProjectId());
         assertEquals(event.getProjectId(), maskedEventMessage.getProjectId());
         assertFalse(maskedEventMessage.hasTask());

--- a/server/src/test/java/io/spine/server/entity/EventWhiteListTest.java
+++ b/server/src/test/java/io/spine/server/entity/EventWhiteListTest.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -47,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("EventWhiteList should")
+@DisplayName("`EventWhiteList` should")
 class EventWhiteListTest {
 
     private static final TestEventFactory eventFactory =
@@ -72,10 +71,10 @@ class EventWhiteListTest {
     @Test
     @DisplayName("filter out non-allowed events")
     void filterOut() {
-        List<Event> events = Stream.<EventMessage>of(EntProjectStarted.getDefaultInstance(),
-                                                     EntTaskAdded.getDefaultInstance())
-                                   .map(eventFactory::createEvent)
-                                   .collect(toList());
+        var events = Stream.<EventMessage>of(EntProjectStarted.getDefaultInstance(),
+                                             EntTaskAdded.getDefaultInstance())
+                           .map(eventFactory::createEvent)
+                           .collect(toList());
         Collection<Event> filtered = whiteList.filter(events);
         assertEquals(1, filtered.size());
         assertTrue(events.contains(events.get(0)));
@@ -85,7 +84,7 @@ class EventWhiteListTest {
     @DisplayName("not allow events out from the white list")
     void denyEvents() {
         EventMessage event = EntTaskAdded.getDefaultInstance();
-        Optional<? extends EventMessage> result = whiteList.filter(event);
+        var result = whiteList.filter(event);
         assertFalse(result.isPresent());
     }
 }

--- a/server/src/test/java/io/spine/server/entity/FieldMasksTest.java
+++ b/server/src/test/java/io/spine/server/entity/FieldMasksTest.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
-import java.util.Iterator;
 
 import static com.google.common.collect.Lists.newArrayListWithCapacity;
 import static com.google.common.collect.Lists.newLinkedList;
@@ -51,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-@DisplayName("FieldMasks utility should")
+@DisplayName("`FieldMasks` utility should")
 class FieldMasksTest extends UtilityClassTest<FieldMasks> {
 
     FieldMasksTest() {
@@ -72,13 +71,12 @@ class FieldMasksTest extends UtilityClassTest<FieldMasks> {
         @Test
         @DisplayName("to single message")
         void toSingleMessage() {
-            FieldMask fieldMask =
-                    fromFieldNumbers(AggProject.class,
-                                     AggProject.ID_FIELD_NUMBER,
-                                     AggProject.NAME_FIELD_NUMBER);
-            AggProject original = Given.newProject("some-string-id");
+            var fieldMask = fromFieldNumbers(AggProject.class,
+                                             AggProject.ID_FIELD_NUMBER,
+                                             AggProject.NAME_FIELD_NUMBER);
+            var original = Given.newProject("some-string-id");
 
-            AggProject masked = FieldMasks.applyMask(fieldMask, original);
+            var masked = FieldMasks.applyMask(fieldMask, original);
 
             assertEquals(original.getId(), masked.getId());
             assertEquals(original.getName(), masked.getName());
@@ -89,26 +87,26 @@ class FieldMasksTest extends UtilityClassTest<FieldMasks> {
         @Test
         @DisplayName("to message collection")
         void toMessageCollections() {
-            FieldMask fieldMask = fromFieldNumbers(AggProject.class,
-                                                   AggProject.STATUS_FIELD_NUMBER,
-                                                   AggProject.TASK_FIELD_NUMBER);
-            int count = 5;
+            var fieldMask = fromFieldNumbers(AggProject.class,
+                                             AggProject.STATUS_FIELD_NUMBER,
+                                             AggProject.TASK_FIELD_NUMBER);
+            var count = 5;
 
             Collection<AggProject> original = newArrayListWithCapacity(count);
 
-            for (int i = 0; i < count; i++) {
-                AggProject project = Given.newProject(format("project-%s", i));
+            for (var i = 0; i < count; i++) {
+                var project = Given.newProject(format("project-%s", i));
                 original.add(project);
             }
 
-            Collection<AggProject> masked = FieldMasks.applyMask(fieldMask, original);
+            var masked = FieldMasks.applyMask(fieldMask, original);
 
             assertThat(masked).hasSize(original.size());
 
             // Collection references are not the same
             assertNotSame(original, masked);
 
-            for (AggProject project : masked) {
+            for (var project : masked) {
                 assertMatchesMask(project, fieldMask);
 
                 // Can't check repeated fields with assertMatchesMask
@@ -123,15 +121,15 @@ class FieldMasksTest extends UtilityClassTest<FieldMasks> {
     class NotApplyEmptyMask {
 
         @Test
-        @DisplayName("to single message")
+        @DisplayName("to single `Message`")
         void toSingleMessage() {
-            FieldMask emptyMask = Given.fieldMask();
+            var emptyMask = Given.fieldMask();
 
-            AggProject origin = Given.newProject("read_whole_message");
-            AggProject clone = AggProject.newBuilder(origin)
+            var origin = Given.newProject("read_whole_message");
+            var clone = AggProject.newBuilder(origin)
                                          .build();
 
-            AggProject processed = FieldMasks.applyMask(emptyMask, origin);
+            var processed = FieldMasks.applyMask(emptyMask, origin);
 
             // Check object itself was returned
             assertSame(processed, origin);
@@ -142,19 +140,19 @@ class FieldMasksTest extends UtilityClassTest<FieldMasks> {
 
         @SuppressWarnings("MethodWithMultipleLoops")
         @Test
-        @DisplayName("to message collection")
+        @DisplayName("to `Message` collection")
         void toMessageCollection() {
-            FieldMask emptyMask = Given.fieldMask();
+            var emptyMask = Given.fieldMask();
 
             Collection<AggProject> original = newLinkedList();
-            int count = 5;
+            var count = 5;
 
-            for (int i = 0; i < count; i++) {
-                AggProject project = Given.newProject(format("test-data--%s", i));
+            for (var i = 0; i < count; i++) {
+                var project = Given.newProject(format("test-data--%s", i));
                 original.add(project);
             }
 
-            Collection<AggProject> processed = FieldMasks.applyMask(emptyMask, original);
+            var processed = FieldMasks.applyMask(emptyMask, original);
 
             assertThat(processed).hasSize(original.size());
 
@@ -162,9 +160,9 @@ class FieldMasksTest extends UtilityClassTest<FieldMasks> {
             assertNotSame(original, processed);
 
             // A copy of the argument is returned (Collection type may differ)
-            Iterator<AggProject> processedProjects = processed.iterator();
+            var processedProjects = processed.iterator();
 
-            for (AggProject anOriginal : original) {
+            for (var anOriginal : original) {
                 assertEquals(processedProjects.next(), anOriginal);
             }
         }

--- a/server/src/test/java/io/spine/server/entity/InvalidEntityStateExceptionTest.java
+++ b/server/src/test/java/io/spine/server/entity/InvalidEntityStateExceptionTest.java
@@ -36,16 +36,16 @@ import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisplayName("InvalidEntityStateException should")
+@DisplayName("`InvalidEntityStateException` should")
 class InvalidEntityStateExceptionTest {
 
-    @SuppressWarnings("DuplicateStringLiteralInspection") // Common test case.
     @Test
     @DisplayName("create exception with violations")
+    @SuppressWarnings("DuplicateStringLiteralInspection") // Common test case.
     void createExceptionWithViolations() {
-        AccountDetails entityState = AccountDetails.getDefaultInstance();
+        var entityState = AccountDetails.getDefaultInstance();
 
-        InvalidEntityStateException exception = onConstraintViolations(
+        var exception = onConstraintViolations(
                 entityState,
                 singletonList(ConstraintViolation.getDefaultInstance()));
 

--- a/server/src/test/java/io/spine/server/entity/NoOpEventFilterTest.java
+++ b/server/src/test/java/io/spine/server/entity/NoOpEventFilterTest.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.entity;
 
-import com.google.common.collect.ImmutableCollection;
 import com.google.protobuf.Message;
 import io.spine.base.EventMessage;
 import io.spine.core.Event;
@@ -40,7 +39,6 @@ import io.spine.testing.server.TestEventFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -50,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("NoOpEventFilter should")
+@DisplayName("`NoOpEventFilter` should")
 class NoOpEventFilterTest {
 
     private final EventFilter filter = EventFilter.allowAll();
@@ -78,34 +76,31 @@ class NoOpEventFilterTest {
     @Test
     @DisplayName("allow any bulk of events")
     void allowAnyBulk() {
-        List<Event> events = events().collect(toList());
-        ImmutableCollection<Event> filtered = filter.filter(events);
+        var events = events().collect(toList());
+        var filtered = filter.filter(events);
         assertEquals(events, filtered);
     }
 
     private static Stream<Event> events() {
-        ProjectId projectId = ProjectId
+        var projectId = ProjectId
                 .newBuilder()
                 .setId(newUuid())
                 .build();
-        Stream<Event> result =
-                Stream.<EventMessage>of(EntProjectCreated
-                                                .newBuilder()
-                                                .setProjectId(projectId)
-                                                .build(),
-                                        EntProjectStarted
-                                                .newBuilder()
-                                                .setProjectId(projectId)
-                                                .build(),
-                                        EntTaskAdded
-                                                .newBuilder()
-                                                .setProjectId(projectId)
-                                                .build(),
-                                        StandardRejections.EntityAlreadyArchived
-                                                .newBuilder()
-                                                .setEntityId(AnyPacker.pack(projectId))
-                                                .build())
-                        .map(eventFactory::createEvent);
+        var result =
+                Stream.<EventMessage>of(
+                        EntProjectCreated.newBuilder()
+                                .setProjectId(projectId)
+                                .build(),
+                        EntProjectStarted.newBuilder()
+                                .setProjectId(projectId)
+                                .build(),
+                        EntTaskAdded.newBuilder()
+                                .setProjectId(projectId)
+                                .build(),
+                        StandardRejections.EntityAlreadyArchived.newBuilder()
+                                .setEntityId(AnyPacker.pack(projectId))
+                                .build())
+                      .map(eventFactory::createEvent);
         return result;
     }
 }

--- a/server/src/test/java/io/spine/server/entity/RecordBasedRepositoryTest.java
+++ b/server/src/test/java/io/spine/server/entity/RecordBasedRepositoryTest.java
@@ -27,7 +27,6 @@
 package io.spine.server.entity;
 
 import com.google.common.collect.Lists;
-import com.google.common.truth.IterableSubject;
 import com.google.common.truth.OptionalSubject;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Any;
@@ -38,12 +37,10 @@ import io.spine.base.EntityState;
 import io.spine.base.Identifier;
 import io.spine.client.ArchivedColumn;
 import io.spine.client.CompositeFilter;
-import io.spine.client.Filter;
 import io.spine.client.IdFilter;
 import io.spine.client.ResponseFormat;
 import io.spine.client.TargetFilters;
 import io.spine.server.entity.given.repository.GivenLifecycleFlags;
-import io.spine.server.storage.RecordWithColumns;
 import io.spine.testing.TestValues;
 import io.spine.testing.server.model.ModelTests;
 import io.spine.testing.server.tenant.TenantAwareTest;
@@ -96,7 +93,7 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
     protected abstract E createEntity(I id);
 
     protected final E createEntity(int idValue) {
-        I id = createId(idValue);
+        var id = createId(idValue);
         return createEntity(id);
     }
 
@@ -148,13 +145,13 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
 
     @CanIgnoreReturnValue
     private List<E> createAndStoreEntities(RecordBasedRepository<I, E, S> repo, int count) {
-        List<E> entities = createEntities(count);
+        var entities = createEntities(count);
         storeEntities(repo, entities);
         return entities;
     }
 
     private void storeEntities(RecordBasedRepository<I, E, S> repo, List<E> entities) {
-        for (E entity : entities) {
+        for (var entity : entities) {
             repo.store(entity);
         }
     }
@@ -174,8 +171,8 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
     @Test
     @DisplayName("create entities")
     void createEntities() {
-        I id = createId(5);
-        E projectEntity = repository().create(id);
+        var id = createId(5);
+        var projectEntity = repository().create(id);
         assertNotNull(projectEntity);
         assertEquals(id, projectEntity.id());
     }
@@ -224,7 +221,7 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
         }
 
         private void assertResult(Optional<E> optional) {
-            OptionalSubject assertResult = assertThat(optional);
+            var assertResult = assertThat(optional);
             assertResult.isPresent();
             assertResult.hasValue(entity);
         }
@@ -245,13 +242,13 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
         @Test
         @DisplayName("by IDs")
         void multipleEntitiesByIds() {
-            int count = 10;
-            List<E> entities = createAndStoreEntities(repository(), count);
+            var count = 10;
+            var entities = createAndStoreEntities(repository(), count);
 
             List<I> ids = Lists.newLinkedList();
 
             // Find some of the records (half of them in this case)
-            for (int i = 0; i < count / 2; i++) {
+            for (var i = 0; i < count / 2; i++) {
                 ids.add(entities.get(i)
                                 .id());
             }
@@ -265,30 +262,28 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
         @Test
         @DisplayName("by query")
         void entitiesByQuery() {
-            I id1 = createId(271);
-            I id2 = createId(314);
-            E entity1 = createEntity(id1);
-            E entity2 = createEntity(id2);
+            var id1 = createId(271);
+            var id2 = createId(314);
+            var entity1 = createEntity(id1);
+            var entity2 = createEntity(id2);
             repository().store(entity1);
             repository().store(entity2);
 
-            String fieldPath = "id_string";
-            StringValue fieldValue = StringValue.newBuilder()
-                                                .setValue(id1.toString())
-                                                .build();
-            Filter filter = eq(fieldPath, fieldValue);
-            CompositeFilter aggregatingFilter = CompositeFilter
-                    .newBuilder()
+            var fieldPath = "id_string";
+            var fieldValue = StringValue.newBuilder()
+                    .setValue(id1.toString())
+                    .build();
+            var filter = eq(fieldPath, fieldValue);
+            var aggregatingFilter = CompositeFilter.newBuilder()
                     .addFilter(filter)
                     .setOperator(ALL)
                     .build();
-            TargetFilters filters = TargetFilters
-                    .newBuilder()
+            var filters = TargetFilters.newBuilder()
                     .addFilter(aggregatingFilter)
                     .build();
             Collection<E> found = newArrayList(repository().find(filters, emptyFormat()));
 
-            IterableSubject assertThatFound = assertThat(found);
+            var assertThatFound = assertThat(found);
             assertThatFound.hasSize(1);
             assertThatFound.contains(entity1);
             assertThatFound.doesNotContain(entity2);
@@ -297,20 +292,20 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
         @Test
         @DisplayName("by query and field mask")
         void entitiesByQueryAndFields() {
-            int count = 10;
-            List<E> entities = createAndStoreEntities(repository(), count);
+            var count = 10;
+            var entities = createAndStoreEntities(repository(), count);
 
             // Find some of the entities (half of them in this case).
-            int idsToObtain = count / 2;
-            List<Any> ids = obtainSomeNumberOfEntityIds(entities, idsToObtain);
+            var idsToObtain = count / 2;
+            var ids = obtainSomeNumberOfEntityIds(entities, idsToObtain);
 
-            TargetFilters filters = createIdFilters(ids);
-            FieldMask firstFieldOnly = createFirstFieldOnlyMask(entities);
-            Iterator<E> readEntities = find(filters, firstFieldOnly);
+            var filters = createIdFilters(ids);
+            var firstFieldOnly = createFirstFieldOnlyMask(entities);
+            var readEntities = find(filters, firstFieldOnly);
             Collection<E> foundList = newArrayList(readEntities);
 
             assertThat(foundList).hasSize(ids.size());
-            for (E entity : foundList) {
+            for (var entity : foundList) {
                 assertMatches(entity, firstFieldOnly);
             }
         }
@@ -318,66 +313,63 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
         @Test
         @DisplayName("in ascending order")
         void entitiesInAscendingOrder() {
-            int count = 10;
+            var count = 10;
             // UUIDs are used to produce a collection with the names in a random order.
-            List<E> entities = entitiesWithNames(repository(), count, Identifier::newUuid);
+            var entities = entitiesWithNames(repository(), count, Identifier::newUuid);
 
-            ResponseFormat format = ResponseFormat
-                    .newBuilder()
+            var format = ResponseFormat.newBuilder()
                     .addOrderBy(orderByName(ASCENDING))
                     .vBuild();
-            Iterator<E> readEntities = repository().loadAll(format);
+            var readEntities = repository().loadAll(format);
             Collection<E> foundList = newArrayList(readEntities);
 
-            List<E> expectedList = orderedByName(entities);
+            var expectedList = orderedByName(entities);
             assertThat(foundList).containsExactlyElementsIn(expectedList);
         }
 
         @Test
         @DisplayName("in descending order")
         void entitiesInDescendingOrder() {
-            int count = 10;
+            var count = 10;
             // UUIDs are used to produce a collection with the names in a random order.
-            List<E> entities = entitiesWithNames(repository(), count, Identifier::newUuid);
+            var entities = entitiesWithNames(repository(), count, Identifier::newUuid);
 
-            ResponseFormat format = ResponseFormat
-                    .newBuilder()
+            var format = ResponseFormat.newBuilder()
                     .addOrderBy(orderByName(DESCENDING))
                     .vBuild();
-            Iterator<E> readEntities = repository().loadAll(format);
+            var readEntities = repository().loadAll(format);
             Collection<E> foundList = newArrayList(readEntities);
 
-            List<E> expectedList = reverse(orderedByName(entities));
+            var expectedList = reverse(orderedByName(entities));
             assertThat(foundList).containsExactlyElementsIn(expectedList);
         }
 
         @Test
         @DisplayName("limited number of entities")
         void limitedNumberOfEntities() {
-            int totalCount = 10;
-            int limit = 5;
+            var totalCount = 10;
+            var limit = 5;
             // UUIDs are used to produce a collection with the names in a random order.
-            List<E> entities = entitiesWithNames(repository(), totalCount, Identifier::newUuid);
+            var entities = entitiesWithNames(repository(), totalCount, Identifier::newUuid);
 
-            ResponseFormat format = ResponseFormat
-                    .newBuilder()
+            var format = ResponseFormat.newBuilder()
                     .addOrderBy(orderByName(ASCENDING))
                     .setLimit(limit)
                     .vBuild();
-            Iterator<E> readEntities = repository().loadAll(format);
+            var readEntities = repository().loadAll(format);
             Collection<E> foundList = newArrayList(readEntities);
 
-            List<E> expectedList = orderedByName(entities).subList(0, limit);
+            var expectedList = orderedByName(entities).subList(0, limit);
             assertThat(foundList).containsExactlyElementsIn(expectedList);
         }
 
         @Test
         @DisplayName("all entities")
         void allEntities() {
-            List<E> entities = createAndStoreEntities(repository(), 150);
+            var entities = createAndStoreEntities(repository(), 150);
             Collection<E> found = newArrayList(loadAll());
 
-            IterableSubject assertFoundEntities = assertThat(found);
+            var assertFoundEntities = assertThat(found);
 
             assertFoundEntities.hasSize(entities.size());
 
@@ -387,12 +379,12 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
         @Test
         @DisplayName("all entity records")
         void allEntityRecords() {
-            List<E> entities = createAndStoreEntities(repository, 150);
+            var entities = createAndStoreEntities(repository, 150);
             Collection<EntityRecord> found = newArrayList(loadAllRecords());
             assertThat(found).hasSize(entities.size());
 
-            for (E entity : entities) {
-                RecordWithColumns<I, EntityRecord> record = repository.toRecord(entity);
+            for (var entity : entities) {
+                var record = repository.toRecord(entity);
                 assertThat(found).contains(record.record());
             }
         }
@@ -405,8 +397,7 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
         }
 
         private Iterator<E> find(TargetFilters filters, FieldMask firstFieldOnly) {
-            ResponseFormat format = ResponseFormat
-                    .newBuilder()
+            var format = ResponseFormat.newBuilder()
                     .setFieldMask(firstFieldOnly)
                     .vBuild();
             return repository().find(filters, format);
@@ -414,38 +405,36 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
 
         private List<E> entitiesWithNames(RecordBasedRepository<I, E, S> repo, int count,
                                           Supplier<String> nameSupplier) {
-            List<E> entities = createWithNames(count, nameSupplier);
+            var entities = createWithNames(count, nameSupplier);
             storeEntities(repo, entities);
             return entities;
         }
 
         private List<Any> obtainSomeNumberOfEntityIds(List<E> entities, int count) {
             List<Any> ids = Lists.newLinkedList();
-            for (int i = 0; i < count; i++) {
-                Message entityId = (Message) entities.get(i)
-                                                     .id();
-                Any id = pack(entityId);
+            for (var i = 0; i < count; i++) {
+                var entityId = (Message) entities.get(i)
+                                                 .id();
+                var id = pack(entityId);
                 ids.add(id);
             }
             return ids;
         }
 
         private TargetFilters createIdFilters(List<Any> ids) {
-            IdFilter filter = IdFilter
-                    .newBuilder()
+            var filter = IdFilter.newBuilder()
                     .addAllId(ids)
                     .build();
-            TargetFilters filters = TargetFilters
-                    .newBuilder()
+            var filters = TargetFilters.newBuilder()
                     .setIdFilter(filter)
                     .build();
             return filters;
         }
 
         private FieldMask createFirstFieldOnlyMask(List<E> entities) {
-            E firstEntity = entities.get(0);
-            FieldMask fieldMask = fromFieldNumbers(firstEntity.defaultState()
-                                                              .getClass(), 1);
+            var firstEntity = entities.get(0);
+            var fieldMask = fromFieldNumbers(firstEntity.defaultState()
+                                                        .getClass(), 1);
             return fieldMask;
         }
 
@@ -457,11 +446,11 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
     @Test
     @DisplayName("create entity on `loadOrCreate` if not found")
     void loadOrCreateEntity() {
-        int count = 3;
+        var count = 3;
         createAndStoreEntities(repository(), count);
 
-        I id = createId(count + 1);
-        E entity = loadOrCreate(id);
+        var id = createId(count + 1);
+        var entity = loadOrCreate(id);
 
         assertNotNull(entity);
         assertEquals(id, entity.id());
@@ -470,10 +459,10 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
     @Test
     @DisplayName("handle wrong passed IDs")
     void handleWrongPassedIds() {
-        int count = 10;
-        List<E> entities = createAndStoreEntities(repository(), count);
+        var count = 10;
+        var entities = createAndStoreEntities(repository(), count);
         List<I> ids = Lists.newLinkedList();
-        for (int i = 0; i < count; i++) {
+        for (var i = 0; i < count; i++) {
             ids.add(entities.get(i)
                             .id());
         }
@@ -481,7 +470,7 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
         ids.add(sideEntity.id());
 
         Collection<E> found = newArrayList(loadMany(ids));
-        IterableSubject assertThatFound = assertThat(found);
+        var assertThatFound = assertThat(found);
         assertThatFound.hasSize(ids.size() - 1); // Check we've found all existing items
         assertThatFound.containsExactlyElementsIn(entities);
     }
@@ -493,8 +482,8 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
         @Test
         @DisplayName("archived")
         void archived() {
-            E entity = createEntity(821);
-            I id = entity.id();
+            var entity = createEntity(821);
+            var id = entity.id();
 
             storeEntity(entity);
 
@@ -509,8 +498,8 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
         @Test
         @DisplayName("deleted")
         void deleted() {
-            E entity = createEntity(822);
-            I id = entity.id();
+            var entity = createEntity(822);
+            var id = entity.id();
 
             storeEntity(entity);
 
@@ -523,7 +512,7 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
         }
 
         private OptionalSubject assertFound(I id) {
-            Optional<E> entity = repository().findActive(id);
+            var entity = repository().findActive(id);
             return assertThat(entity);
         }
     }
@@ -531,9 +520,9 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
     @Test
     @DisplayName("exclude non-active records from entity query")
     void excludeNonActiveRecords() {
-        E activeEntity = createEntity(271);
-        E archivedEntity = createEntity(42);
-        E deletedEntity = createEntity(314);
+        var activeEntity = createEntity(271);
+        var archivedEntity = createEntity(42);
+        var deletedEntity = createEntity(314);
         delete(asTxEntity(deletedEntity));
         archive(asTxEntity(archivedEntity));
 
@@ -542,20 +531,20 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
         storeEntity(archivedEntity);
         storeEntity(deletedEntity);
 
-        Iterator<E> found = repository().loadAll(emptyFormat());
+        var found = repository().loadAll(emptyFormat());
         List<E> foundList = newArrayList(found);
         // Check results
         assertThat(foundList).hasSize(1);
-        E actualEntity = foundList.get(0);
+        var actualEntity = foundList.get(0);
         assertEquals(activeEntity, actualEntity);
     }
 
     @Test
     @DisplayName("allow any lifecycle if column is involved in query")
     void ignoreLifecycleForColumns() {
-        E activeEntity = createEntity(42);
-        E archivedEntity = createEntity(314);
-        E deletedEntity = createEntity(271);
+        var activeEntity = createEntity(42);
+        var archivedEntity = createEntity(314);
+        var deletedEntity = createEntity(271);
         delete(asTxEntity(deletedEntity));
         archive(asTxEntity(archivedEntity));
 
@@ -564,16 +553,15 @@ class RecordBasedRepositoryTest<E extends AbstractEntity<I, S>, I, S extends Ent
         storeEntity(archivedEntity);
         storeEntity(deletedEntity);
 
-        CompositeFilter filter = all(eq(ArchivedColumn.instance(), false));
-        TargetFilters filters = TargetFilters
-                .newBuilder()
+        var filter = all(eq(ArchivedColumn.instance(), false));
+        var filters = TargetFilters.newBuilder()
                 .addFilter(filter)
                 .build();
 
-        Iterator<E> found = repository().find(filters, emptyFormat());
+        var found = repository().find(filters, emptyFormat());
         Collection<E> foundList = newArrayList(found);
         // Check result
-        IterableSubject assertFoundList = assertThat(foundList);
+        var assertFoundList = assertThat(foundList);
         assertFoundList.hasSize(2);
         assertFoundList.containsExactly(activeEntity, deletedEntity);
     }

--- a/server/src/test/java/io/spine/server/entity/RepositoryTest.java
+++ b/server/src/test/java/io/spine/server/entity/RepositoryTest.java
@@ -35,7 +35,6 @@ import io.spine.server.entity.given.repository.TestRepo;
 import io.spine.server.entity.storage.EntityRecordStorage;
 import io.spine.server.tenant.TenantAwareOperation;
 import io.spine.server.tenant.TenantAwareRunner;
-import io.spine.test.entity.Project;
 import io.spine.test.entity.ProjectId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("Repository should")
+@DisplayName("`Repository` should")
 class RepositoryTest {
 
     private BoundedContext context;
@@ -63,8 +62,8 @@ class RepositoryTest {
 
     private static ProjectId createId(String value) {
         return ProjectId.newBuilder()
-                        .setId(value)
-                        .build();
+                .setId(value)
+                .build();
     }
 
     @BeforeEach
@@ -120,7 +119,7 @@ class RepositoryTest {
     @Test
     @DisplayName("provide default event filter")
     void provideDefaultEventFilter() {
-        EventFilter filter = repository.eventFilter();
+        var filter = repository.eventFilter();
         assertNotNull(filter);
     }
 
@@ -129,9 +128,9 @@ class RepositoryTest {
     class OverwritingContext {
 
         @Test
-        @DisplayName("throwing ISE")
+        @DisplayName("throwing `ISE`")
         void prohibit() {
-            BoundedContext anotherContext = BoundedContext
+            var anotherContext = BoundedContext
                     .singleTenant("Context-1")
                     .build();
             assertThrows(IllegalStateException.class, () ->
@@ -151,7 +150,7 @@ class RepositoryTest {
     @Test
     @DisplayName("close storage on close")
     void closeStorageOnClose() {
-        EntityRecordStorage<?, ?> storage = (EntityRecordStorage<?, ?>) repository.storage();
+        var storage = (EntityRecordStorage<?, ?>) repository.storage();
         repository.close();
 
         assertTrue(storage.isClosed());
@@ -169,7 +168,7 @@ class RepositoryTest {
      * Creates three entities in the repository.
      */
     private void createAndStoreEntities() {
-        TenantAwareOperation op = new TenantAwareOperation(tenantId) {
+        var op = new TenantAwareOperation(tenantId) {
             @Override
             public void run() {
                 createAndStore("Eins");
@@ -184,7 +183,7 @@ class RepositoryTest {
     @DisplayName("iterate over entities")
     void iterateOverEntities() {
         createAndStoreEntities();
-        int numEntities = size(iteratorAt(tenantId));
+        var numEntities = size(iteratorAt(tenantId));
         assertEquals(3, numEntities);
     }
 
@@ -192,20 +191,20 @@ class RepositoryTest {
     @DisplayName("not allow removal in entities iterator")
     void notAllowRemovalInIterator() {
         createAndStoreEntities();
-        Iterator<ProjectEntity> iterator = iteratorAt(tenantId);
+        var iterator = iteratorAt(tenantId);
         assertThrows(UnsupportedOperationException.class, iterator::remove);
     }
 
     @Test
     @DisplayName("register with a bounded context")
     void registered() {
-        TestRepo repo = new TestRepo();
+        var repo = new TestRepo();
 
         assertFalse(repo.isRegistered());
         repo.checkNotRegistered();
         assertThrows(IllegalStateException.class, repo::checkRegistered);
 
-        BoundedContext context = BoundedContextBuilder
+        var context = BoundedContextBuilder
                 .assumingTests()
                 .build();
         repo.registerWith(context);
@@ -218,10 +217,10 @@ class RepositoryTest {
     @Test
     @DisplayName("register twice with the same context")
     void registerWithSameContext() {
-        TestRepo repo = new TestRepo();
+        var repo = new TestRepo();
 
-        String contextName = "test context";
-        BoundedContext context = BoundedContext.singleTenant(contextName).build();
+        var contextName = "test context";
+        var context = BoundedContext.singleTenant(contextName).build();
         repo.registerWith(context);
 
         assertTrue(repo.isRegistered());
@@ -233,24 +232,23 @@ class RepositoryTest {
     @DisplayName("not register in another context")
     void anotherContext() {
         assertTrue(repository.isRegistered());
-        BoundedContext anotherContext = BoundedContext.singleTenant("another").build();
+        var anotherContext = BoundedContext.singleTenant("another").build();
         assertThrows(IllegalStateException.class, () -> repository.registerWith(anotherContext));
     }
 
     private Iterator<ProjectEntity> iteratorAt(TenantId tenantId) {
-        Iterator<ProjectEntity> result =
-                TenantAwareRunner.with(tenantId)
-                                 .evaluate(() -> repository.iterator(entity -> true));
+        var result = TenantAwareRunner.with(tenantId)
+                                      .evaluate(() -> repository.iterator(entity -> true));
         return result;
     }
 
     private void createAndStore(String idValue) {
-        ProjectId id = createId(idValue);
-        ProjectEntity entity = repository.create(id);
-        Project stateWithVersion = entity.state()
-                                         .toBuilder()
-                                         .setId(id)
-                                         .vBuild();
+        var id = createId(idValue);
+        var entity = repository.create(id);
+        var stateWithVersion = entity.state()
+                .toBuilder()
+                .setId(id)
+                .vBuild();
         TestTransaction.injectState(entity, stateWithVersion, Versions.zero());
         repository.store(entity);
     }

--- a/server/src/test/java/io/spine/server/entity/TestEntity.java
+++ b/server/src/test/java/io/spine/server/entity/TestEntity.java
@@ -38,7 +38,7 @@ public class TestEntity
         implements HasLifecycleColumns<ProjectId, Project> {
 
     static TestEntity newInstance(String id) {
-        TestEntity result = new TestEntityBuilder()
+        var result = new TestEntityBuilder()
                 .setResultClass(TestEntity.class)
                 .withId(newIdWith(id))
                 .build();
@@ -46,7 +46,7 @@ public class TestEntity
     }
 
     static TestEntity withState() {
-        TestEntity result = new TestEntityBuilder()
+        var result = new TestEntityBuilder()
                 .setResultClass(TestEntity.class)
                 .withId(newIdWith(newUuid()))
                 .withState(Sample.messageOfType(Project.class))
@@ -56,7 +56,7 @@ public class TestEntity
     }
 
     static TestEntity withStateOf(TestEntity entity) {
-        TestEntity result = new TestEntityBuilder()
+        var result = new TestEntityBuilder()
                 .setResultClass(TestEntity.class)
                 .withId(entity.id())
                 .withState(entity.state())

--- a/server/src/test/java/io/spine/server/entity/TestTransaction.java
+++ b/server/src/test/java/io/spine/server/entity/TestTransaction.java
@@ -26,7 +26,6 @@
 package io.spine.server.entity;
 
 import io.spine.base.EntityState;
-import io.spine.core.Event;
 import io.spine.core.Version;
 import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.dispatch.Success;
@@ -41,6 +40,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * A utility class providing various test-only methods, which in production mode are allowed
  * with the transactions only.
  */
+@SuppressWarnings("rawtypes")   /* To avoid hell with generic parameters. */
 public class TestTransaction {
 
     /** Prevents instantiation from outside. */
@@ -55,7 +55,7 @@ public class TestTransaction {
      */
     public static void
     injectState(TransactionalEntity entity, EntityState state, Version version) {
-        TestTx tx = new TestTx(entity, state, version);
+        var tx = new TestTx(entity, state, version);
         tx.commit();
     }
 
@@ -66,7 +66,7 @@ public class TestTransaction {
      * <p>To be used in tests only.
      */
     public static void archive(TransactionalEntity entity) {
-        TestTx tx = new TestTx(entity) {
+        var tx = new TestTx(entity) {
 
             @Override
             protected DispatchOutcome dispatch(TransactionalEntity entity, EventEnvelope event) {
@@ -86,7 +86,7 @@ public class TestTransaction {
      * <p>To be used in tests only.
      */
     public static void delete(TransactionalEntity entity) {
-        TestTx tx = new TestTx(entity) {
+        var tx = new TestTx(entity) {
 
             @Override
             protected DispatchOutcome dispatch(TransactionalEntity entity, EventEnvelope event) {
@@ -125,13 +125,13 @@ public class TestTransaction {
             return new NoIncrement(this);
         }
 
-        private void dispatchForTest() {
-            EntProjectCreated eventMessage = EntProjectCreated
+        void dispatchForTest() {
+            var eventMessage = EntProjectCreated
                     .newBuilder()
                     .setProjectId(ProjectId.getDefaultInstance())
                     .buildPartial();
-            TestEventFactory factory = TestEventFactory.newInstance(TestTransaction.class);
-            Event event = factory.createEvent(eventMessage);
+            var factory = TestEventFactory.newInstance(TestTransaction.class);
+            var event = factory.createEvent(eventMessage);
             dispatch(entity(), EventEnvelope.of(event));
         }
     }

--- a/server/src/test/java/io/spine/server/entity/TestTransaction.java
+++ b/server/src/test/java/io/spine/server/entity/TestTransaction.java
@@ -126,8 +126,7 @@ public class TestTransaction {
         }
 
         void dispatchForTest() {
-            var eventMessage = EntProjectCreated
-                    .newBuilder()
+            var eventMessage = EntProjectCreated.newBuilder()
                     .setProjectId(ProjectId.getDefaultInstance())
                     .buildPartial();
             var factory = TestEventFactory.newInstance(TestTransaction.class);

--- a/server/src/test/java/io/spine/server/entity/TransactionTest.java
+++ b/server/src/test/java/io/spine/server/entity/TransactionTest.java
@@ -25,8 +25,6 @@
  */
 package io.spine.server.entity;
 
-import com.google.common.collect.ImmutableList;
-import com.google.protobuf.Descriptors.FieldDescriptor;
 import io.spine.base.EntityState;
 import io.spine.base.EventMessage;
 import io.spine.base.Identifier;
@@ -139,12 +137,12 @@ public abstract class TransactionTest<I,
         @Test
         @DisplayName("from entity")
         void fromEntity() {
-            E entity = createEntity();
-            B expectedBuilder = toBuilder(entity);
-            Version expectedVersion = entity.version();
-            LifecycleFlags expectedLifecycleFlags = entity.lifecycleFlags();
+            var entity = createEntity();
+            var expectedBuilder = toBuilder(entity);
+            var expectedVersion = entity.version();
+            var expectedLifecycleFlags = entity.lifecycleFlags();
 
-            Transaction<I, E, S, B> tx = createTx(entity);
+            var tx = createTx(entity);
             assertNotNull(tx);
 
             assertThat(tx.entity())
@@ -164,16 +162,16 @@ public abstract class TransactionTest<I,
         @Test
         @DisplayName("from entity, state, and version")
         void fromEntityStateAndVersion() {
-            E entity = createEntity();
-            S newState = newState();
-            Version newVersion = newVersion();
+            var entity = createEntity();
+            var newState = newState();
+            var newVersion = newVersion();
 
             assertThat(newState)
                     .isNotEqualTo(entity.state());
             assertThat(newVersion)
                     .isNotEqualTo(entity.version());
 
-            Transaction<I, E, S, B> tx = createTx(entity, newState, newVersion);
+            var tx = createTx(entity, newState, newVersion);
 
             assertThat(tx.builder().build())
                     .isEqualTo(newState);
@@ -197,10 +195,10 @@ public abstract class TransactionTest<I,
     @Test
     @DisplayName("deliver events to handler methods")
     void propagateChangesToAppliers() {
-        E entity = createEntity();
-        Transaction<I, E, S, B> tx = createTx(entity);
+        var entity = createEntity();
+        var tx = createTx(entity);
 
-        Event event = withMessage(createEventMessage());
+        var event = withMessage(createEventMessage());
         applyEvent(tx, event);
 
         checkEventReceived(entity, event);
@@ -209,17 +207,16 @@ public abstract class TransactionTest<I,
     @Test
     @DisplayName("create phase for each dispatched message")
     void createPhaseForAppliedEvent() {
-        E entity = createEntity();
-        Transaction<I, E, S, B> tx = createTx(entity);
+        var entity = createEntity();
+        var tx = createTx(entity);
 
-        Event event = withMessage(createEventMessage());
-        DispatchOutcome outcome = applyEvent(tx, event);
+        var event = withMessage(createEventMessage());
+        var outcome = applyEvent(tx, event);
         assertTrue(outcome.hasSuccess());
         assertThat(tx.phases())
                 .hasSize(1);
 
-        Phase<I> phase = tx.phases()
-                           .get(0);
+        var phase = tx.phases().get(0);
 
         assertThat(phase.messageId()).isEqualTo(event.id());
     }
@@ -227,18 +224,18 @@ public abstract class TransactionTest<I,
     @Test
     @DisplayName("propagate changes to entity when phase is propagated")
     void propagateChangesToEntityOnCommit() {
-        E entity = createEntity();
+        var entity = createEntity();
 
-        S stateBeforePhase = entity.state();
-        Version versionBeforePhase = entity.version();
+        var stateBeforePhase = entity.state();
+        var versionBeforePhase = entity.version();
 
-        Transaction<I, E, S, B> tx = createTx(entity);
-        Event event = withMessage(createEventMessage());
+        var tx = createTx(entity);
+        var event = withMessage(createEventMessage());
 
         applyEvent(tx, event);
 
-        S modifiedState = entity.state();
-        Version modifiedVersion = entity.version();
+        var modifiedState = entity.state();
+        var modifiedVersion = entity.version();
 
         assertThat(modifiedState)
                 .isNotEqualTo(stateBeforePhase);
@@ -249,20 +246,20 @@ public abstract class TransactionTest<I,
     @Test
     @DisplayName("not propagate changes to entity on rollback")
     void notPropagateChangesOnRollback() {
-        E entity = createEntity();
-        S stateBeforeRollback = entity.state();
-        Version versionBeforeRollback = entity.version();
+        var entity = createEntity();
+        var stateBeforeRollback = entity.state();
+        var versionBeforeRollback = entity.version();
 
-        Transaction<I, E, S, B> tx = createTx(entity);
+        var tx = createTx(entity);
 
-        Event event = withMessage(createEventMessage());
-        DispatchOutcome outcome = applyEvent(tx, event);
+        var event = withMessage(createEventMessage());
+        var outcome = applyEvent(tx, event);
         assertTrue(outcome.hasSuccess());
-        RuntimeException exception = new RuntimeException("that triggers rollback");
+        var exception = new RuntimeException("that triggers rollback");
         tx.rollback(fromThrowable(exception));
 
-        S stateAfterRollback = entity.state();
-        Version versionAfterRollback = entity.version();
+        var stateAfterRollback = entity.state();
+        var versionAfterRollback = entity.version();
 
         assertThat(stateAfterRollback)
                 .isEqualTo(stateBeforeRollback);
@@ -273,18 +270,18 @@ public abstract class TransactionTest<I,
     @Test
     @DisplayName("set transaction entity version from event context")
     void setVersionFromEventContext() {
-        E entity = createEntity();
+        var entity = createEntity();
 
-        Transaction<I, E, S, B> tx = createTx(entity);
-        Event event = withMessage(createEventMessage());
+        var tx = createTx(entity);
+        var event = withMessage(createEventMessage());
 
-        Version ctxVersion = event.context()
-                                  .getVersion();
+        var ctxVersion = event.context()
+                              .getVersion();
         assertThat(ctxVersion)
                 .isNotEqualTo(tx.version());
 
         applyEvent(tx, event);
-        Version modifiedVersion = tx.version();
+        var modifiedVersion = tx.version();
         assertThat(tx.version())
                 .isEqualTo(modifiedVersion);
     }
@@ -292,18 +289,18 @@ public abstract class TransactionTest<I,
     @Test
     @DisplayName("notify listener during transaction execution")
     void notifyListenerDuringExecution() {
-        MemoizingTransactionListener<I> listener = new MemoizingTransactionListener<>();
-        E entity = createEntity();
-        Transaction<I, E, S, B> tx = createTx(entity, listener);
-        Event event = withMessage(createEventMessage());
+        var listener = new MemoizingTransactionListener<I>();
+        var entity = createEntity();
+        var tx = createTx(entity, listener);
+        var event = withMessage(createEventMessage());
 
-        DispatchOutcome outcome = applyEvent(tx, event);
+        var outcome = applyEvent(tx, event);
         assertTrue(outcome.hasSuccess());
 
-        ImmutableList<Phase<I>> phases = listener.phasesOnAfter();
+        var phases = listener.phasesOnAfter();
         assertThat(phases)
                 .hasSize(1);
-        Phase<I> phase = phases.get(0);
+        var phase = phases.get(0);
         assertThat(phase.messageId())
                 .isEqualTo(event.getId());
     }
@@ -312,10 +309,10 @@ public abstract class TransactionTest<I,
     @Test
     @DisplayName("not allow injecting state if entity has non-zero version already")
     void notInjectToEntityWithVersion() {
-        E entity = createEntity();
+        var entity = createEntity();
         entity.incrementVersion();
-        S newState = newState();
-        Version newVersion = newVersion();
+        var newState = newState();
+        var newVersion = newVersion();
 
         assertThrows(IllegalStateException.class,
                      () -> createTx(entity, newState, newVersion));
@@ -328,24 +325,24 @@ public abstract class TransactionTest<I,
         @Test
         @DisplayName("`IllegalStateException` on phase failure")
         void onPhaseFailure() {
-            E entity = createEntity();
+            var entity = createEntity();
 
-            Transaction<I, E, S, B> tx = createTx(entity);
+            var tx = createTx(entity);
 
-            Event event = withMessage(failingInHandler());
+            var event = withMessage(failingInHandler());
 
-            DispatchOutcome outcome = applyEvent(tx, event);
+            var outcome = applyEvent(tx, event);
             assertTrue(outcome.hasError());
         }
 
         @Test
         @DisplayName("`InvalidEntityStateException` on state transition failure")
         void onCommitFailure() {
-            E entity = createEntity();
-            Transaction<I, E, S, B> tx = createTx(entity);
-            Event event = withMessage(failingStateTransition());
+            var entity = createEntity();
+            var tx = createTx(entity);
+            var event = withMessage(failingStateTransition());
 
-            DispatchOutcome outcome = applyEvent(tx, event);
+            var outcome = applyEvent(tx, event);
             assertTrue(outcome.hasError());
         }
     }
@@ -357,14 +354,14 @@ public abstract class TransactionTest<I,
         @Test
         @DisplayName("on violation in message handler")
         void ifPhaseFailed() {
-            E entity = createEntity();
-            S originalState = entity.state();
-            Version originalVersion = entity.version();
+            var entity = createEntity();
+            var originalState = entity.state();
+            var originalVersion = entity.version();
 
-            Transaction<I, E, S, B> tx = createTx(entity);
+            var tx = createTx(entity);
 
-            Event event = withMessage(failingInHandler());
-            DispatchOutcome outcome = applyEvent(tx, event);
+            var event = withMessage(failingInHandler());
+            var outcome = applyEvent(tx, event);
             assertTrue(outcome.hasError());
             checkRollback(entity, originalState, originalVersion);
         }
@@ -372,23 +369,23 @@ public abstract class TransactionTest<I,
         @Test
         @DisplayName("on violation at state transition")
         void ifCommitFailed() {
-            E entity = createAndModify();
-            S originalState = entity.state();
-            Version originalVersion = entity.version();
+            var entity = createAndModify();
+            var originalState = entity.state();
+            var originalVersion = entity.version();
 
-            Transaction<I, E, S, B> tx = createTx(entity);
-            Version nextVersion = Versions.increment(entity.version());
-            Event event = withMessageAndVersion(failingStateTransition(), nextVersion);
+            var tx = createTx(entity);
+            var nextVersion = Versions.increment(entity.version());
+            var event = withMessageAndVersion(failingStateTransition(), nextVersion);
 
-            DispatchOutcome outcome = applyEvent(tx, event);
+            var outcome = applyEvent(tx, event);
             assertTrue(outcome.hasError());
             checkRollback(entity, originalState, originalVersion);
         }
 
         private E createAndModify() {
-            E entity = createEntity();
-            Transaction<I, E, S, B> tx = createTx(entity);
-            Event event = withMessage(createEventMessage());
+            var entity = createEntity();
+            var tx = createTx(entity);
+            var event = withMessage(createEventMessage());
             applyEvent(tx, event);
             tx.commit();
             return entity;
@@ -406,9 +403,9 @@ public abstract class TransactionTest<I,
     @Test
     @DisplayName("init builder with the entity ID, if the field is required or assumed required")
     void initBuilderWithId() {
-        E entity = createEntity();
-        Transaction<I, E, S, B> tx = createTx(entity);
-        FieldDescriptor firstField =
+        var entity = createEntity();
+        var tx = createTx(entity);
+        var firstField =
                 entity.state()
                       .getDescriptorForType()
                       .getFields()
@@ -425,15 +422,14 @@ public abstract class TransactionTest<I,
      * @implNote This method uses package-private API of the {@link Transaction} class.
      */
     protected final void advanceVersionFromEvent() {
-        E entity = createEntity();
-        Transaction<I, E, S, B> tx = createTx(entity);
+        var entity = createEntity();
+        var tx = createTx(entity);
         assertThat(tx.version())
                 .isEqualTo(entity.version());
 
-        Event event = withMessage(createEventMessage());
+        var event = withMessage(createEventMessage());
         applyEvent(tx, event);
-        Version versionFromEvent = event.context()
-                                        .getVersion();
+        var versionFromEvent = event.context().getVersion();
         assertThat(tx.version())
                 .isEqualTo(versionFromEvent);
         tx.commit();

--- a/server/src/test/java/io/spine/server/entity/TransactionalEntityTest.java
+++ b/server/src/test/java/io/spine/server/entity/TransactionalEntityTest.java
@@ -43,8 +43,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@SuppressWarnings("rawtypes")   // for simplicity
 @DisplayName("`TransactionalEntity` should")
+@SuppressWarnings("rawtypes")   // for simplicity
 class TransactionalEntityTest {
 
     @Nested
@@ -60,7 +60,7 @@ class TransactionalEntityTest {
         @Test
         @DisplayName("if transaction isn't changed")
         void withUnchangedTx() {
-            TransactionalEntity entity = entityWithActiveTx(false);
+            var entity = entityWithActiveTx(false);
 
             assertFalse(entity.changed());
         }
@@ -73,7 +73,7 @@ class TransactionalEntityTest {
         @Test
         @DisplayName("if transaction state changed")
         void ifTxStateChanged() {
-            TransactionalEntity entity = entityWithActiveTx(true);
+            var entity = entityWithActiveTx(true);
 
             assertTrue(entity.changed());
         }
@@ -108,7 +108,7 @@ class TransactionalEntityTest {
         @Test
         @DisplayName("until transaction started")
         void untilTxStarted() {
-            TransactionalEntity entity = newEntity(false, false);
+            var entity = newEntity(false, false);
 
             assertFalse(entity.isTransactionInProgress());
         }
@@ -117,7 +117,7 @@ class TransactionalEntityTest {
     @Test
     @DisplayName("have transaction in progress when transaction is active")
     void haveTxInProgress() {
-        TransactionalEntity entity = entityWithActiveTx(false);
+        var entity = entityWithActiveTx(false);
 
         assertTrue(entity.isTransactionInProgress());
     }
@@ -138,8 +138,8 @@ class TransactionalEntityTest {
     @Test
     @DisplayName("disallow injecting transaction wrapped around another entity instance")
     void disallowOtherInstanceTx() {
-        TransactionalEntity entity = newEntity(true, false);
-        TransactionalEntity anotherEntity = newEntity(true, false);
+        var entity = newEntity(true, false);
+        var anotherEntity = newEntity(true, false);
         assertThrows(IllegalStateException.class, () ->
                 entity.injectTransaction(anotherEntity.tx()));
     }
@@ -157,7 +157,7 @@ class TransactionalEntityTest {
         @Test
         @DisplayName("with inactive transaction")
         void withInactiveTx() {
-            TransactionalEntity entity = newEntity(false, false);
+            var entity = newEntity(false, false);
             assertThrows(IllegalStateException.class, () -> entity.setArchived(true));
         }
     }
@@ -175,7 +175,7 @@ class TransactionalEntityTest {
         @Test
         @DisplayName("with inactive transaction")
         void withInactiveTx() {
-            TransactionalEntity entity = newEntity(false, false);
+            var entity = newEntity(false, false);
 
             assertThrows(IllegalStateException.class, () -> entity.setDeleted(true));
         }
@@ -184,10 +184,10 @@ class TransactionalEntityTest {
     @Test
     @DisplayName("return transaction `lifecycleFlags` if transaction is active")
     void returnActiveTxFlags() {
-        TransactionalEntity entity = newEntity(true, true);
-        LifecycleFlags originalFlags = entity.lifecycleFlags();
+        var entity = newEntity(true, true);
+        var originalFlags = entity.lifecycleFlags();
 
-        Transaction tx = entity.transaction();
+        var tx = entity.transaction();
 
         assertThat(originalFlags)
                 .isEqualTo(tx.lifecycleFlags());
@@ -216,8 +216,7 @@ class TransactionalEntityTest {
             EntityState originalState = toBuilder(entity)
                     .build();
 
-            EmptyEntity newState = EmptyEntity
-                    .newBuilder()
+            var newState = EmptyEntity.newBuilder()
                     .setId(newUuidValue().getValue())
                     .build();
             assertThat(newState)
@@ -248,5 +247,4 @@ class TransactionalEntityTest {
         entity.injectTransaction(tx);
         return entity;
     }
-
 }

--- a/server/src/test/java/io/spine/server/entity/TransactionalEventPlayerTest.java
+++ b/server/src/test/java/io/spine/server/entity/TransactionalEventPlayerTest.java
@@ -27,7 +27,6 @@
 package io.spine.server.entity;
 
 import io.spine.core.Event;
-import io.spine.core.Version;
 import io.spine.server.dispatch.BatchDispatchOutcome;
 import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.dispatch.Success;
@@ -62,12 +61,12 @@ class TransactionalEventPlayerTest {
     @Test
     @DisplayName("delegate applying events to transaction when playing")
     void delegateEventsToTx() {
-        TxPlayingEntity entity = entityWithActiveTx(false);
-        EventPlayingTransaction txMock = (EventPlayingTransaction) entity.transaction();
+        var entity = entityWithActiveTx(false);
+        var txMock = (EventPlayingTransaction) entity.transaction();
         assertNotNull(txMock);
-        Version v1 = increment(zero());
-        Event firstEvent = withVersion(v1);
-        Event secondEvent = withVersion(increment(v1));
+        var v1 = increment(zero());
+        var firstEvent = withVersion(v1);
+        var secondEvent = withVersion(increment(v1));
 
         entity.play(newArrayList(firstEvent, secondEvent));
 
@@ -77,14 +76,14 @@ class TransactionalEventPlayerTest {
 
     @SuppressWarnings("unchecked")  // OK for the test.
     private static TxPlayingEntity entityWithActiveTx(boolean txChanged) {
-        TxPlayingEntity entity = new TxPlayingEntity();
-        EventPlayingTransaction tx = new StubTransaction(entity, true, txChanged);
+        var entity = new TxPlayingEntity();
+        var tx = new StubTransaction(entity, true, txChanged);
         entity.injectTransaction(tx);
         return entity;
     }
 
     private static void verifyEventApplied(EventPlayingTransaction txMock, Event event) {
-        StubTransaction tx = (StubTransaction) txMock;
+        var tx = (StubTransaction) txMock;
         assertTrue(tx.dispatched(event));
     }
 
@@ -96,7 +95,7 @@ class TransactionalEventPlayerTest {
             implements EventPlayer {
 
         private TxPlayingEntity() {
-            super("TxPlayingEntity ID");
+            super("`TxPlayingEntity` ID");
         }
 
         @Override
@@ -126,10 +125,9 @@ class TransactionalEventPlayerTest {
 
         @Override
         protected DispatchOutcome dispatch(TransactionalEntity entity, EventEnvelope envelope) {
-            Event event = envelope.outerObject();
+            var event = envelope.outerObject();
             dispatchedEvents.add(event);
-            return DispatchOutcome
-                    .newBuilder()
+            return DispatchOutcome.newBuilder()
                     .setPropagatedSignal(event.messageId())
                     .setSuccess(Success.getDefaultInstance())
                     .vBuild();

--- a/server/src/test/java/io/spine/server/entity/given/FieldMasksTestEnv.java
+++ b/server/src/test/java/io/spine/server/entity/given/FieldMasksTestEnv.java
@@ -52,30 +52,30 @@ public class FieldMasksTestEnv {
         }
 
         public static AggProject newProject(String id) {
-            ProjectId projectId = ProjectId.newBuilder()
-                                           .setUuid(id)
-                                           .build();
-            Task first = Task.newBuilder()
-                             .setTaskId(TaskId.newBuilder()
-                                              .setId(1)
-                                              .build())
-                             .setTitle("First Task")
-                             .build();
+            var projectId = ProjectId.newBuilder()
+                    .setUuid(id)
+                    .build();
+            var first = Task.newBuilder()
+                    .setTaskId(TaskId.newBuilder()
+                                       .setId(1)
+                                       .build())
+                    .setTitle("First Task")
+                    .build();
 
-            Task second = Task.newBuilder()
-                              .setTaskId(TaskId.newBuilder()
-                                               .setId(2)
-                                               .build())
-                              .setTitle("Second Task")
-                              .build();
+            var second = Task.newBuilder()
+                    .setTaskId(TaskId.newBuilder()
+                                       .setId(2)
+                                       .build())
+                    .setTitle("Second Task")
+                    .build();
 
-            AggProject project = AggProject.newBuilder()
-                                           .setId(projectId)
-                                           .setName(format("Test project : %s", id))
-                                           .addTask(first)
-                                           .addTask(second)
-                                           .setStatus(Status.CREATED)
-                                           .build();
+            var project = AggProject.newBuilder()
+                    .setId(projectId)
+                    .setName(format("Test project : %s", id))
+                    .addTask(first)
+                    .addTask(second)
+                    .setStatus(Status.CREATED)
+                    .build();
             return project;
         }
 

--- a/server/src/test/java/io/spine/server/entity/given/Given.java
+++ b/server/src/test/java/io/spine/server/entity/given/Given.java
@@ -55,7 +55,7 @@ public class Given {
     public static <A extends Aggregate<I, S, ?>, I, S extends EntityState<I>>
     AggregateBuilder<A, I, S> aggregateOfClass(Class<A> aggregateClass) {
         checkNotNull(aggregateClass);
-        AggregateBuilder<A, I, S> result = new AggregateBuilder<>();
+        var result = new AggregateBuilder<A, I, S>();
         result.setResultClass(aggregateClass);
         return result;
     }
@@ -69,7 +69,7 @@ public class Given {
                    R extends AggregateRoot<I>>
     AggregatePartBuilder<A, I, S, R> aggregatePartOfClass(Class<A> partClass) {
         checkNotNull(partClass);
-        AggregatePartBuilder<A, I, S, R> result = new AggregatePartBuilder<>();
+        var result = new AggregatePartBuilder<A, I, S, R>();
         result.setResultClass(partClass);
         return result;
     }
@@ -83,7 +83,7 @@ public class Given {
                    B extends ValidatingBuilder<S>>
     ProjectionBuilder<P, I, S, B> projectionOfClass(Class<P> projectionClass) {
         checkNotNull(projectionClass);
-        ProjectionBuilder<P, I, S, B> result = new ProjectionBuilder<>();
+        var result = new ProjectionBuilder<P, I, S, B>();
         result.setResultClass(projectionClass);
         return result;
     }

--- a/server/src/test/java/io/spine/server/entity/given/RecordBasedRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/entity/given/RecordBasedRepositoryTestEnv.java
@@ -27,7 +27,6 @@
 package io.spine.server.entity.given;
 
 import com.google.protobuf.FieldMask;
-import io.spine.base.EntityState;
 import io.spine.client.OrderBy;
 import io.spine.client.ResponseFormat;
 import io.spine.server.entity.AbstractEntity;
@@ -44,7 +43,7 @@ public final class RecordBasedRepositoryTestEnv {
 
     public static <E extends AbstractEntity<?, ?>>
     void assertMatches(E entity, FieldMask fieldMask) {
-        EntityState<?> state = entity.state();
+        var state = entity.state();
         assertMatchesMask(state, fieldMask);
     }
 
@@ -53,9 +52,9 @@ public final class RecordBasedRepositoryTestEnv {
      */
     public static OrderBy orderByName(OrderBy.Direction direction) {
         return OrderBy.newBuilder()
-                      .setColumn(ENTITY_NAME_COLUMN)
-                      .setDirection(direction)
-                      .build();
+                .setColumn(ENTITY_NAME_COLUMN)
+                .setDirection(direction)
+                .vBuild();
     }
 
     public static ResponseFormat emptyFormat() {

--- a/server/src/test/java/io/spine/server/entity/given/entity/TestAggregate.java
+++ b/server/src/test/java/io/spine/server/entity/given/entity/TestAggregate.java
@@ -42,7 +42,7 @@ public class TestAggregate
     }
 
     public static TestAggregate copyOf(TestAggregate entity) {
-        TestAggregate result =
+        var result =
                 Given.aggregateOfClass(TestAggregate.class)
                      .withId(entity.id())
                      .withState(entity.state())
@@ -54,12 +54,11 @@ public class TestAggregate
     }
 
     public static TestAggregate withState() {
-        String id = newUuid();
-        EmptyAggregate state = EmptyAggregate
-                .newBuilder()
+        var id = newUuid();
+        var state = EmptyAggregate.newBuilder()
                 .setId(id)
                 .build();
-        TestAggregate result =
+        var result =
                 Given.aggregateOfClass(TestAggregate.class)
                      .withId(id)
                      .withState(state)

--- a/server/src/test/java/io/spine/server/entity/given/tx/TxProjection.java
+++ b/server/src/test/java/io/spine/server/entity/given/tx/TxProjection.java
@@ -74,7 +74,7 @@ public final class TxProjection
      * @see io.spine.server.projection.ProjectionTransactionTest#failingInHandler
      */
     @Subscribe
-    @SuppressWarnings("DoNotCallSuggester") // Does not apply to this test env. class.
+    @SuppressWarnings("DoNotCallSuggester") /* Does not apply to this test env. class. */
     void event(TxErrorRequested e) {
         throw new RuntimeException("that tests the projection tx behaviour");
     }
@@ -97,12 +97,12 @@ public final class TxProjection
     }
 
     private void updateTypeValue() {
-        ProjectionType newTypeValue = typeValueOf(isNullType);
+        var newTypeValue = typeValueOf(isNullType);
         builder().setType(newTypeValue);
     }
 
     private void updateNameLength() {
-        int newLengthValue = calculateLength(builder().getName());
+        var newLengthValue = calculateLength(builder().getName());
         builder().setNameLength(newLengthValue);
     }
 
@@ -113,7 +113,7 @@ public final class TxProjection
     }
 
     public static int calculateLength(String name) {
-        int lengthValue = name.length();
+        var lengthValue = name.length();
         return lengthValue;
     }
 }

--- a/server/src/test/java/io/spine/server/entity/model/EntityClassTest.java
+++ b/server/src/test/java/io/spine/server/entity/model/EntityClassTest.java
@@ -37,7 +37,6 @@ import io.spine.time.testing.Past;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Constructor;
 import java.time.Instant;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -60,31 +59,32 @@ class EntityClassTest {
     @Test
     @DisplayName("obtain entity constructor")
     void getEntityConstructor() {
-        Constructor<TaskEntity> ctor = entityClass.constructor();
+        var ctor = entityClass.constructor();
         assertNotNull(ctor);
     }
 
     @Test
     @DisplayName("create and initialize entity instance")
     void createEntityInstance() {
-        TaskId id = TaskId.generate();
-        Timestamp before = Past.secondsAgo(1);
+        var id = TaskId.generate();
+        var before = Past.secondsAgo(1);
 
         // Create and init the entity.
-        EntityClass<TaskEntity> entityClass = new EntityClass<>(TaskEntity.class);
+        var entityClass = new EntityClass<>(TaskEntity.class);
         AbstractEntity<TaskId, Task> entity = entityClass.create(id);
 
-        Timestamp after = Time.currentTime();
+        var after = Time.currentTime();
 
         // The interval with a much earlier start to allow non-zero interval on faster computers.
-        Range<Instant> whileWeCreate = Range.closed(toInstant(before), toInstant(after));
+        var whileWeCreate = Range.closed(toInstant(before), toInstant(after));
 
         assertThat(entity.id())
                 .isEqualTo(id);
-        assertThat(entity.version().isZero())
+        assertThat(entity.version()
+                         .isZero())
                 .isTrue();
 
-        Instant whenModifier = toInstant(entity.whenModified());
+        var whenModifier = toInstant(entity.whenModified());
         assertTrue(whileWeCreate.contains(whenModifier));
 
         assertThat(entity.state())
@@ -98,6 +98,7 @@ class EntityClassTest {
 
     /** A test entity which defines ID and state. */
     private static class TaskEntity extends AbstractEntity<TaskId, Task> {
+
         private TaskEntity(TaskId id) {
             super(id);
         }

--- a/server/src/test/java/io/spine/server/entity/storage/AssertColumns.java
+++ b/server/src/test/java/io/spine/server/entity/storage/AssertColumns.java
@@ -44,8 +44,8 @@ final class AssertColumns {
     }
 
     static void assertContains(Iterable<? extends Column<?, ?>> columns, String columnName) {
-        ColumnName expectedName = ColumnName.of(columnName);
-        boolean contains = false;
+        var expectedName = ColumnName.of(columnName);
+        var contains = false;
         for (Column<?, ?> column : columns) {
             contains = contains || column.name().equals(expectedName);
         }

--- a/server/src/test/java/io/spine/server/entity/storage/EntityRecordSpecTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/EntityRecordSpecTest.java
@@ -45,9 +45,6 @@ import io.spine.test.entity.TaskViewId;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
-import java.util.Optional;
-
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
@@ -74,8 +71,8 @@ class EntityRecordSpecTest {
     @DisplayName("be extracted from an entity class")
     void beExtractedFromEntityClass() {
         EntityRecordSpec<?, ?, ?> spec = EntityRecordSpec.of(TaskListViewProjection.class);
-        ColumnName columnName = ColumnName.of("description");
-        Optional<Column<?, ?>> descriptionColumn = spec.findColumn(columnName);
+        var columnName = ColumnName.of("description");
+        var descriptionColumn = spec.findColumn(columnName);
 
         assertThat(descriptionColumn).isPresent();
     }
@@ -89,8 +86,8 @@ class EntityRecordSpecTest {
     }
 
     private static void testFindAndCompare(EntityColumn<TaskView, ?> column) {
-        ColumnName columnName = column.name();
-        Class<?> type = column.type();
+        var columnName = column.name();
+        var type = column.type();
 
         assertThat(spec().get(columnName)
                          .type()).isEqualTo(type);
@@ -99,16 +96,16 @@ class EntityRecordSpecTest {
     @Test
     @DisplayName("return all definitions of the columns")
     void returnAllColumns() {
-        ImmutableSet<Column<?, ?>> columns = spec().columns();
-        ImmutableSet<ColumnName> actualNames = toNames(columns);
+        var columns = spec().columns();
+        var actualNames = toNames(columns);
 
-        ImmutableSet<? extends Column<?, ?>> expected =
-                ImmutableSet.<Column<?, ?>>builder()
-                        .addAll(declaredColumns())
-                        .add(ArchivedColumn.instance(), DeletedColumn.instance(),
-                             VersionColumn.instance())
-                        .build();
-        ImmutableSet<ColumnName> expectedNames = toNames(expected);
+        var expected = ImmutableSet.<Column<?, ?>>builder()
+                .addAll(declaredColumns())
+                .add(ArchivedColumn.instance(),
+                     DeletedColumn.instance(),
+                     VersionColumn.instance())
+                .build();
+        var expectedNames = toNames(expected);
 
         assertThat(actualNames).containsExactlyElementsIn(expectedNames);
     }
@@ -124,7 +121,7 @@ class EntityRecordSpecTest {
     @Test
     @DisplayName("throw `IAE` when the column with the specified name is not found")
     void throwOnColumnNotFound() {
-        ColumnName nonExistent = ColumnName.of("non-existent-column");
+        var nonExistent = ColumnName.of("non-existent-column");
 
         assertThrows(IllegalArgumentException.class, () -> spec().get(nonExistent));
     }
@@ -132,8 +129,8 @@ class EntityRecordSpecTest {
     @Test
     @DisplayName("search for a column by name")
     void searchByName() {
-        ColumnName existingColumn = ColumnName.of("name");
-        Optional<Column<?, ?>> column = spec().findColumn(existingColumn);
+        var existingColumn = ColumnName.of("name");
+        var column = spec().findColumn(existingColumn);
 
         assertThat(column).isPresent();
     }
@@ -141,8 +138,8 @@ class EntityRecordSpecTest {
     @Test
     @DisplayName("return empty `Optional` when searching for a non-existent column")
     void returnEmptyOptionalForNonExistent() {
-        ColumnName nonExistent = ColumnName.of("non-existent-column");
-        Optional<Column<?, ?>> result = spec().findColumn(nonExistent);
+        var nonExistent = ColumnName.of("non-existent-column");
+        var result = spec().findColumn(nonExistent);
 
         assertThat(result).isEmpty();
     }
@@ -150,19 +147,19 @@ class EntityRecordSpecTest {
     @Test
     @DisplayName("return the list of columns")
     void returnColumns() {
-        int lifecycleColumnCount = EntityRecordColumn.names()
+        var lifecycleColumnCount = EntityRecordColumn.names()
                                                      .size();
-        int protoColumnCount = 4;
+        var protoColumnCount = 4;
 
-        int expectedSize = lifecycleColumnCount + protoColumnCount;
+        var expectedSize = lifecycleColumnCount + protoColumnCount;
         assertThat(spec().columnCount()).isEqualTo(expectedSize);
     }
 
     @Test
     @DisplayName("extract values from entity")
     void extractColumnValues() {
-        TaskViewProjection projection = new TaskViewProjection();
-        Map<ColumnName, Object> values = spec().valuesIn(projection);
+        var projection = new TaskViewProjection();
+        var values = spec().valuesIn(projection);
 
         assertThat(values).containsExactly(
                 ColumnName.of("archived"), projection.isArchived(),
@@ -182,19 +179,17 @@ class EntityRecordSpecTest {
     @Test
     @DisplayName("extract ID value from `EntityRecord`")
     void extractIdValue() {
-        TaskViewProjection projection = new TaskViewProjection();
-        TaskView state = projection.state();
-        TaskViewId id =
-                TaskViewId.newBuilder()
-                        .setId(93)
-                        .vBuild();
-        EntityRecord record = EntityRecord
-                .newBuilder()
+        var projection = new TaskViewProjection();
+        var state = projection.state();
+        var id = TaskViewId.newBuilder()
+                .setId(93)
+                .vBuild();
+        var record = EntityRecord.newBuilder()
                 .setEntityId(Identifier.pack(id))
                 .setState(AnyPacker.pack(state))
                 .setVersion(Versions.newVersion(3, currentTime()))
                 .vBuild();
-        TaskViewId actual = spec().idFromRecord(record);
+        var actual = spec().idFromRecord(record);
         assertThat(actual).isEqualTo(id);
     }
 }

--- a/server/src/test/java/io/spine/server/entity/storage/EntityRecordWithColumnsTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/EntityRecordWithColumnsTest.java
@@ -42,7 +42,6 @@ import io.spine.server.entity.storage.given.TestEntity;
 import io.spine.server.storage.given.TestColumnMapping;
 import io.spine.test.storage.StgProject;
 import io.spine.test.storage.StgProjectId;
-import io.spine.test.storage.StgTask;
 import io.spine.test.storage.StgTaskId;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -105,8 +104,7 @@ class EntityRecordWithColumnsTest {
     @Test
     @DisplayName("support equality")
     void supportEquality() {
-        ColumnName columnName = ArchivedColumn.instance()
-                                              .name();
+        var columnName = ArchivedColumn.instance().name();
         Object value = false;
         EntityRecordWithColumns<?> emptyFieldsEnvelope =
                 EntityRecordWithColumns.of(sampleEntityRecord());
@@ -125,31 +123,29 @@ class EntityRecordWithColumnsTest {
     @Test
     @DisplayName("return empty names collection if no storage fields are set")
     void returnEmptyColumns() {
-        EntityRecordWithColumns<?> record = sampleRecordWithEmptyColumns();
+        var record = sampleRecordWithEmptyColumns();
         assertFalse(record.hasColumns());
-        ImmutableSet<ColumnName> names = record.columnNames();
+        var names = record.columnNames();
         assertTrue(names.isEmpty());
     }
 
     @Test
     @DisplayName("throw `ISE` on attempt to get value by non-existent name")
     void throwOnNonExistentColumn() {
-        EntityRecordWithColumns<?> record = sampleRecordWithEmptyColumns();
-        ColumnName nonExistentName = ColumnName.of("non-existent-column");
+        var record = sampleRecordWithEmptyColumns();
+        var nonExistentName = ColumnName.of("non-existent-column");
         assertThrows(IllegalStateException.class, () -> record.columnValue(nonExistentName));
     }
 
     @Test
     @DisplayName("have `Entity` lifecycle columns even if the entity does not define custom ones")
     void supportEmptyColumns() {
-        EntityWithoutCustomColumns entity = new EntityWithoutCustomColumns(TASK_ID);
+        var entity = new EntityWithoutCustomColumns(TASK_ID);
 
-        EntityRecordSpec<StgTaskId, StgTask, EntityWithoutCustomColumns> columns =
-                EntityRecordSpec.of(entity);
-        Map<ColumnName, Object> storageFields = columns.valuesIn(entity);
+        var columns = EntityRecordSpec.of(entity);
+        var storageFields = columns.valuesIn(entity);
 
-        EntityRecordWithColumns<?> record =
-                EntityRecordWithColumns.of(sampleEntityRecord(), storageFields);
+        var record = EntityRecordWithColumns.of(sampleEntityRecord(), storageFields);
         assertThat(record.columnNames())
                 .containsExactlyElementsIn(EntityRecordColumn.names());
     }
@@ -157,12 +153,11 @@ class EntityRecordWithColumnsTest {
     @Test
     @DisplayName("return column value by column name")
     void returnColumnValue() {
-        ColumnName columnName = ColumnName.of("some-boolean-column");
-        boolean columnValue = false;
+        var columnName = ColumnName.of("some-boolean-column");
+        var columnValue = false;
         ImmutableMap<ColumnName, Object> storageFields = ImmutableMap.of(columnName, columnValue);
-        EntityRecordWithColumns<?> record =
-                EntityRecordWithColumns.of(sampleEntityRecord(), storageFields);
-        Object value = record.columnValue(columnName);
+        var record = EntityRecordWithColumns.of(sampleEntityRecord(), storageFields);
+        var value = record.columnValue(columnName);
 
         assertThat(value).isEqualTo(columnValue);
     }
@@ -170,13 +165,12 @@ class EntityRecordWithColumnsTest {
     @Test
     @DisplayName("return a column value with the column mapping applied")
     void returnValueWithColumnMapping() {
-        ColumnName columnName = ColumnName.of("some-int-column");
-        int columnValue = 42;
+        var columnName = ColumnName.of("some-int-column");
+        var columnValue = 42;
 
         ImmutableMap<ColumnName, Object> storageFields = ImmutableMap.of(columnName, columnValue);
-        EntityRecordWithColumns<?> record =
-                EntityRecordWithColumns.of(sampleEntityRecord(), storageFields);
-        String value = record.columnValue(columnName, new TestColumnMapping());
+        var record = EntityRecordWithColumns.of(sampleEntityRecord(), storageFields);
+        var value = record.columnValue(columnName, new TestColumnMapping());
 
         assertThat(value).isEqualTo(String.valueOf(columnValue));
     }
@@ -184,12 +178,11 @@ class EntityRecordWithColumnsTest {
     @Test
     @DisplayName("return `null` column value")
     void returnNullValue() {
-        ColumnName columnName = ColumnName.of("the-null-column");
+        var columnName = ColumnName.of("the-null-column");
         Map<ColumnName, Object> storageFields = new HashMap<>();
         storageFields.put(columnName, null);
-        EntityRecordWithColumns<?> record =
-                EntityRecordWithColumns.of(sampleEntityRecord(), storageFields);
-        Object value = record.columnValue(columnName);
+        var record = EntityRecordWithColumns.of(sampleEntityRecord(), storageFields);
+        var value = record.columnValue(columnName);
 
         assertThat(value).isNull();
     }
@@ -201,9 +194,9 @@ class EntityRecordWithColumnsTest {
         @Test
         @DisplayName("an `Entity` identifier and a record")
         void idAndRecord() {
-            EntityRecord rawRecord = sampleEntityRecord();
+            var rawRecord = sampleEntityRecord();
             Long id = 199L;
-            EntityRecordWithColumns<Long> result = EntityRecordWithColumns.create(id, rawRecord);
+            var result = EntityRecordWithColumns.create(id, rawRecord);
             assertThat(result).isNotNull();
             assertThat(result.id()).isEqualTo(id);
             assertThat(result.record()).isEqualTo(rawRecord);
@@ -212,15 +205,14 @@ class EntityRecordWithColumnsTest {
         @Test
         @DisplayName("an `Entity` and a record")
         void entityAndRecord() {
-            TestEntity entity = new TestEntity(PROJECT_ID);
-            EntityRecord rawRecord = sampleEntityRecord();
-            EntityRecordWithColumns<StgProjectId> result =
-                    EntityRecordWithColumns.create(entity, rawRecord);
+            var entity = new TestEntity(PROJECT_ID);
+            var rawRecord = sampleEntityRecord();
+            var result = EntityRecordWithColumns.create(entity, rawRecord);
             assertThat(result).isNotNull();
             assertThat(result.id()).isEqualTo(PROJECT_ID);
             assertThat(result.record()).isEqualTo(rawRecord);
-            ImmutableSet<ColumnName> names = result.columnNames();
-            ImmutableSet<ColumnName> expectedNames =
+            var names = result.columnNames();
+            var expectedNames =
                     StgProject.Column.definitions()
                                      .stream()
                                      .map(RecordColumn::name)
@@ -239,21 +231,20 @@ class EntityRecordWithColumnsTest {
         @Test
         @DisplayName("record")
         void record() {
-            EntityRecordWithColumns<?> recordWithFields = sampleRecordWithEmptyColumns();
-            EntityRecord record = recordWithFields.record();
+            var recordWithFields = sampleRecordWithEmptyColumns();
+            var record = recordWithFields.record();
             assertNotNull(record);
         }
 
         @Test
         @DisplayName("column values")
         void columnValues() {
-            ColumnName columnName = DeletedColumn.instance()
-                                                 .name();
+            var columnName = DeletedColumn.instance()
+                                          .name();
             Object value = false;
-            Map<ColumnName, Object> columnsExpected = singletonMap(columnName, value);
-            EntityRecordWithColumns<?> record =
-                    EntityRecordWithColumns.of(sampleEntityRecord(), columnsExpected);
-            ImmutableSet<ColumnName> columnNames = record.columnNames();
+            var columnsExpected = singletonMap(columnName, value);
+            var record = EntityRecordWithColumns.of(sampleEntityRecord(), columnsExpected);
+            var columnNames = record.columnNames();
             assertThat(columnNames).hasSize(1);
             assertTrue(columnNames.contains(columnName));
             assertThat(value).isEqualTo(record.columnValue(columnName));

--- a/server/src/test/java/io/spine/server/entity/storage/ScannerTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ScannerTest.java
@@ -31,12 +31,8 @@ import io.spine.client.ArchivedColumn;
 import io.spine.client.DeletedColumn;
 import io.spine.client.VersionColumn;
 import io.spine.query.Column;
-import io.spine.query.ColumnName;
-import io.spine.server.entity.model.EntityClass;
 import io.spine.server.entity.storage.given.TaskListViewProjection;
 import io.spine.server.entity.storage.given.TaskViewProjection;
-import io.spine.test.entity.TaskListView;
-import io.spine.test.entity.TaskView;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -51,14 +47,13 @@ class ScannerTest {
     @Test
     @DisplayName("include `Entity` lifecycle columns into the scan results")
     void extractSystemColumns() {
-        EntityClass<TaskViewProjection> entityClass = asEntityClass(TaskViewProjection.class);
-        Scanner<TaskView, TaskViewProjection> scanner = new Scanner<>(entityClass);
-        EntityColumns<TaskViewProjection> columns = scanner.columns();
+        var entityClass = asEntityClass(TaskViewProjection.class);
+        var scanner = new Scanner<>(entityClass);
+        var columns = scanner.columns();
 
-        ImmutableSet<ColumnName> names =
-                columns.stream()
-                       .map(Column::name)
-                       .collect(toImmutableSet());
+        var names = columns.stream()
+                .map(Column::name)
+                .collect(toImmutableSet());
 
         assertThat(names).containsAtLeastElementsIn(
                 ImmutableSet.of(
@@ -72,11 +67,10 @@ class ScannerTest {
     @Test
     @DisplayName("extract the columns declared with `(column)` option in the Protobuf message")
     void extractSimpleColumns() {
-        EntityClass<TaskListViewProjection> entityClass =
-                asEntityClass(TaskListViewProjection.class);
-        Scanner<TaskListView, TaskListViewProjection> scanner = new Scanner<>(entityClass);
+        var entityClass = asEntityClass(TaskListViewProjection.class);
+        var scanner = new Scanner<>(entityClass);
 
-        StateColumns<TaskListView> columns = scanner.stateColumns();
+        var columns = scanner.stateColumns();
 
         assertContains(columns, "description");
     }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@ val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.74")
 val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.76")
 
 /** The version of this library. */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.84")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.85")


### PR DESCRIPTION
This PR is the follow-up to #1427.

It completes the `var` replacement for the half of `server` test sources

Some of the existing warnings were addressed as well. 

The library version is set to `2.0.0-SNAPSHOT.85`.
