### PR TITLE
[2.x] Make `AbstractWorkRegistry` respect the current worker of a node 

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.88`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.89`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -505,12 +505,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 15 17:46:33 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 18:06:28 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.88`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.89`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -975,12 +975,12 @@ This report was generated on **Wed Dec 15 17:46:33 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 15 17:46:34 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 18:06:29 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.88`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.89`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1485,12 +1485,12 @@ This report was generated on **Wed Dec 15 17:46:34 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 15 17:46:35 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 18:06:29 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.88`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.89`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -2095,12 +2095,12 @@ This report was generated on **Wed Dec 15 17:46:35 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 15 17:46:37 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 18:06:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.88`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.89`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2613,12 +2613,12 @@ This report was generated on **Wed Dec 15 17:46:37 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 15 17:46:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 18:06:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.88`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.89`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3175,12 +3175,12 @@ This report was generated on **Wed Dec 15 17:46:39 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 15 17:46:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 18:06:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.88`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.89`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3737,12 +3737,12 @@ This report was generated on **Wed Dec 15 17:46:39 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 15 17:46:40 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 18:06:32 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.88`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.89`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4343,4 +4343,4 @@ This report was generated on **Wed Dec 15 17:46:40 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 15 17:46:45 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 18:06:32 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -505,7 +505,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 08 15:37:50 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 17:46:33 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -975,7 +975,7 @@ This report was generated on **Wed Dec 08 15:37:50 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 08 15:37:51 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 17:46:34 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1485,7 +1485,7 @@ This report was generated on **Wed Dec 08 15:37:51 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 08 15:37:51 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 17:46:35 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2095,7 +2095,7 @@ This report was generated on **Wed Dec 08 15:37:51 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 08 15:37:52 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 17:46:37 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2613,7 +2613,7 @@ This report was generated on **Wed Dec 08 15:37:52 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 08 15:37:53 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 17:46:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3175,7 +3175,7 @@ This report was generated on **Wed Dec 08 15:37:53 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 08 15:37:53 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 17:46:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3737,7 +3737,7 @@ This report was generated on **Wed Dec 08 15:37:53 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 08 15:37:54 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 17:46:40 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4343,4 +4343,4 @@ This report was generated on **Wed Dec 08 15:37:54 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 08 15:37:54 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 17:46:45 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.88</version>
+<version>2.0.0-SNAPSHOT.89</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -62,7 +62,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.78</version>
+    <version>2.0.0-SNAPSHOT.77</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -158,7 +158,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.78</version>
+    <version>2.0.0-SNAPSHOT.77</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.77</version>
+    <version>2.0.0-SNAPSHOT.78</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -158,7 +158,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.77</version>
+    <version>2.0.0-SNAPSHOT.78</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/server/src/main/java/io/spine/server/delivery/AbstractWorkRegistry.java
+++ b/server/src/main/java/io/spine/server/delivery/AbstractWorkRegistry.java
@@ -44,48 +44,65 @@ import static io.spine.base.Time.currentTime;
  * persistence mechanism.
  *
  * @implNote This class is NOT thread safe. Synchronize the atomic persistence operations
- *         as well as the methods implemented in this class make an implementation thread safe.
+ *         as well as the methods implemented in this class to make an implementation thread safe.
  */
 @SPI
 public abstract class AbstractWorkRegistry implements ShardedWorkRegistry {
 
     @Override
-    public Optional<ShardProcessingSession> pickUp(ShardIndex index, NodeId nodeId) {
+    public Optional<ShardProcessingSession> pickUp(ShardIndex index, NodeId node) {
         checkNotNull(index);
-        checkNotNull(nodeId);
+        checkNotNull(node);
 
-        var record = find(index);
-        if (record.isPresent()) {
-            var existingRecord = record.get();
-            if (hasPickedBy(existingRecord)) {
-                return Optional.empty();
-            } else {
-                var updatedRecord = updateNode(existingRecord, nodeId);
-                return Optional.of(asSession(updatedRecord));
-            }
-        } else {
-            var newRecord = createRecord(index, nodeId);
+        var worker = currentWorkerFor(node);
+        var session = pickUp(index, worker);
+
+        return session;
+    }
+
+    private Optional<ShardProcessingSession> pickUp(ShardIndex index, WorkerId worker) {
+        var optionalRecord = find(index);
+        if (optionalRecord.isEmpty()) {
+            var newRecord = createRecord(index, worker);
             return Optional.of(asSession(newRecord));
         }
+
+        var record = optionalRecord.get();
+        if (hasWorker(record)) {
+            return Optional.empty();
+        }
+
+        var updatedRecord = updateNode(record, worker);
+        return Optional.of(asSession(updatedRecord));
     }
 
-    private static boolean hasPickedBy(ShardSessionRecord record) {
-        return !NodeId.getDefaultInstance().equals(record.getPickedBy());
+    /**
+     * Returns an identifier of the current worker that is now going to process the shard.
+     *
+     * <p>An example of such an identifier could be ID of the thread which performs processing.
+     *
+     * @param node
+     *         the node to which the resulted worker belongs
+     */
+    protected abstract WorkerId currentWorkerFor(NodeId node);
+
+    private static boolean hasWorker(ShardSessionRecord record) {
+        return !WorkerId.getDefaultInstance().equals(record.getWorker());
     }
 
-    private ShardSessionRecord createRecord(ShardIndex index, NodeId nodeId) {
+    private ShardSessionRecord createRecord(ShardIndex index, WorkerId worker) {
         var newRecord = ShardSessionRecord.newBuilder()
                 .setIndex(index)
-                .setPickedBy(nodeId)
+                .setWorker(worker)
                 .setWhenLastPicked(currentTime())
                 .vBuild();
         write(newRecord);
         return newRecord;
     }
 
-    private ShardSessionRecord updateNode(ShardSessionRecord record, NodeId nodeId) {
+    private ShardSessionRecord updateNode(ShardSessionRecord record, WorkerId worker) {
         var updatedRecord = record.toBuilder()
-                .setPickedBy(nodeId)
+                .setWorker(worker)
                 .setWhenLastPicked(currentTime())
                 .build();
         write(updatedRecord);
@@ -97,7 +114,7 @@ public abstract class AbstractWorkRegistry implements ShardedWorkRegistry {
         checkNotNull(inactivityPeriod);
         ImmutableSet.Builder<ShardIndex> resultBuilder = ImmutableSet.builder();
         allRecords().forEachRemaining(record -> {
-            if (record.hasPickedBy()) {
+            if (record.hasWorker()) {
                 var whenPicked = record.getWhenLastPicked();
                 var elapsed = between(whenPicked, currentTime());
 
@@ -112,11 +129,11 @@ public abstract class AbstractWorkRegistry implements ShardedWorkRegistry {
     }
 
     /**
-     * Clears the value of {@code ShardSessionRecord.when_last_picked} and stores the session.
+     * Clears the value of {@code ShardSessionRecord.worker} and stores the session.
      */
     protected void clearNode(ShardSessionRecord session) {
         var record = session.toBuilder()
-                .clearPickedBy()
+                .clearWorker()
                 .build();
         write(record);
     }

--- a/server/src/main/java/io/spine/server/delivery/ShardProcessingSession.java
+++ b/server/src/main/java/io/spine/server/delivery/ShardProcessingSession.java
@@ -32,7 +32,7 @@ import io.spine.server.NodeId;
 /**
  * The session of processing the messages, which reside in a shard.
  *
- * <p>Starts by {@linkplain ShardedWorkRegistry#pickUp(ShardIndex, NodeId)} picking up}
+ * <p>Starts by {@linkplain ShardedWorkRegistry#pickUp(ShardIndex, NodeId) picking up}
  * the shard to process.
  */
 @SPI

--- a/server/src/main/java/io/spine/server/delivery/ShardedWorkRegistry.java
+++ b/server/src/main/java/io/spine/server/delivery/ShardedWorkRegistry.java
@@ -54,12 +54,12 @@ public interface ShardedWorkRegistry {
      *
      * @param index
      *         the index of the shard to pick up for processing
-     * @param nodeId
+     * @param node
      *         the identifier of the node for which to pick the shard
      * @return the session of shard processing,
      *         or {@code Optional.empty()} if the shard is not available
      */
-    Optional<ShardProcessingSession> pickUp(ShardIndex index, NodeId nodeId);
+    Optional<ShardProcessingSession> pickUp(ShardIndex index, NodeId node);
 
     /**
      * Clears up the recorded {@code NodeId}s from the session records if there was no activity

--- a/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
+++ b/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
@@ -59,7 +59,7 @@ public final class InMemoryShardedWorkRegistry extends AbstractWorkRegistry {
 
     @Override
     protected WorkerId currentWorkerFor(NodeId node) {
-        WorkerId worker = WorkerId
+        var worker = WorkerId
                 .newBuilder()
                 .setNodeId(node)
                 .setValue(String.valueOf(Thread.currentThread().getId()))

--- a/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
+++ b/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
@@ -59,10 +59,11 @@ public final class InMemoryShardedWorkRegistry extends AbstractWorkRegistry {
 
     @Override
     protected WorkerId currentWorkerFor(NodeId node) {
+        var currentThread = String.valueOf(Thread.currentThread().getId());
         var worker = WorkerId
                 .newBuilder()
                 .setNodeId(node)
-                .setValue(String.valueOf(Thread.currentThread().getId()))
+                .setValue(currentThread)
                 .vBuild();
         return worker;
     }

--- a/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
+++ b/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
@@ -33,6 +33,7 @@ import io.spine.server.delivery.ShardIndex;
 import io.spine.server.delivery.ShardProcessingSession;
 import io.spine.server.delivery.ShardSessionRecord;
 import io.spine.server.delivery.ShardedWorkRegistry;
+import io.spine.server.delivery.WorkerId;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -52,8 +53,18 @@ public final class InMemoryShardedWorkRegistry extends AbstractWorkRegistry {
     private final Map<ShardIndex, ShardSessionRecord> workByNode = newConcurrentMap();
 
     @Override
-    public synchronized Optional<ShardProcessingSession> pickUp(ShardIndex index, NodeId nodeId) {
-        return super.pickUp(index, nodeId);
+    public synchronized Optional<ShardProcessingSession> pickUp(ShardIndex index, NodeId node) {
+        return super.pickUp(index, node);
+    }
+
+    @Override
+    protected WorkerId currentWorkerFor(NodeId node) {
+        WorkerId worker = WorkerId
+                .newBuilder()
+                .setNodeId(node)
+                .setValue(String.valueOf(Thread.currentThread().getId()))
+                .vBuild();
+        return worker;
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
+++ b/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
@@ -67,11 +67,11 @@ public final class InMemoryShardedWorkRegistry extends AbstractWorkRegistry {
      */
     @Override
     protected WorkerId currentWorkerFor(NodeId node) {
-        var currentThread = String.valueOf(Thread.currentThread().getId());
+        var currentThread = Thread.currentThread().getId();
         var worker = WorkerId
                 .newBuilder()
                 .setNodeId(node)
-                .setValue(currentThread)
+                .setValue(String.valueOf(currentThread))
                 .vBuild();
         return worker;
     }

--- a/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
+++ b/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
@@ -57,6 +57,14 @@ public final class InMemoryShardedWorkRegistry extends AbstractWorkRegistry {
         return super.pickUp(index, node);
     }
 
+    /**
+     * Returns an identifier of the current worker that is now going to process the shard.
+     *
+     * <p>This implementation uses an identifier of the current thread as a {@code WorkerId}.
+     *
+     * @param node
+     *         the node to which the resulted worker belongs
+     */
     @Override
     protected WorkerId currentWorkerFor(NodeId node) {
         var currentThread = String.valueOf(Thread.currentThread().getId());

--- a/server/src/main/proto/spine/server/delivery/delivery.proto
+++ b/server/src/main/proto/spine/server/delivery/delivery.proto
@@ -45,7 +45,6 @@ import "spine/server/catchup/catch_up.proto";
 //
 // A value type used across the application. To be potentially used in JavaScript, Go, C++ and
 // other client and server environments, that are split into shards.
-//
 message ShardIndex {
 
     // The zero-based index of the shard.
@@ -61,17 +60,18 @@ message ShardSessionRecord {
     // The index of a shard processed in this session.
     ShardIndex index = 1 [(required) = true];
 
-    // The identifier of an application node, which picked up the index and processes it.
-    //
-    // Unset until a node picks the session.
-    //
-    NodeId picked_by = 2;
-
     // When the shard processed within the session was last picked by the node.
     //
     // This field is unset if no nodes ever picked the session.
-    //
     google.protobuf.Timestamp when_last_picked = 3;
+
+    // An identifier of an application worker, which picked up the shard and processes it.
+    //
+    // Unset until a worker picks the shard.
+    WorkerId worker = 4;
+
+    reserved 2;
+    reserved "picked_by";
 }
 
 // A stage of the `Delivery` process running for some particular `ShardIndex`.
@@ -88,7 +88,6 @@ message DeliveryStage {
 //
 // Represented in each of the bounded contexts as an event reactor,
 // as it's impossible to have several process managers of the same state across bounded contexts.
-//
 message ShardMaintenance {
 
     ShardIndex id = 1;
@@ -105,4 +104,20 @@ message DeliveryRunInfo {
 
     // The catch-up jobs observed by the Delivery.
     repeated catchup.CatchUp catch_up_job = 1;
+}
+
+// An identifier of a worker which processes a shard.
+//
+// This value is unique across the application. It is used to indicate who is currently processing
+// which shard. A single node can contain several workers (typically represented by threads)
+// processing different shards.
+message WorkerId {
+
+    // A node to which this worker belongs.
+    NodeId nodeId = 1 [(required) = true];
+
+    // Worker's identifier.
+    //
+    // An example of such an identifier could be ID of the thread which processes a shard.
+    string value = 2 [(required) = true];
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,11 +25,11 @@
  */
 
 /** Versions of the Spine libraries that `core-java` depends on. */
-val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.78")
+val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.77")
 val spineBaseTypesVersion: String by extra("2.0.0-SNAPSHOT.75")
 val spineTimeVersion: String by extra("2.0.0-SNAPSHOT.76")
 val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.84")
 val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.83")
 
 /** The version of this library. */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.88")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.89")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,7 +25,7 @@
  */
 
 /** Versions of the Spine libraries that `core-java` depends on. */
-val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.77")
+val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.78")
 val spineBaseTypesVersion: String by extra("2.0.0-SNAPSHOT.75")
 val spineTimeVersion: String by extra("2.0.0-SNAPSHOT.76")
 val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.84")


### PR DESCRIPTION
This is a port of #1433 to the `master` branch.

Previously, `ShardSessionRecord` used `NodeId` to indicate who is currently processing which shard. 

On an application node, several workers (threads) can be used to deliver messages. Thus, their identifiers should be used in registry to clearly say who is processing the shard.

This PR updates `AbstractWorkRegistry` to request the current  node's `WorkerId` to use it in `ShardSessionRecord`. `WorkerId` stores information about the node it belongs and an a worker identifier itself (typically, a thread ID).

The library version is bumped to `2.0.0-SNAPSHOT.89`.