### PR TITLE
Release 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository contains the code of:
 The project is under active ongoing development. 
 You are welcome to experiment and [provide your feedback][email-developers].
 
-The latest stable version is [1.6.0][latest-release].  
+The latest stable version is [1.8.0][latest-release].  
 
 ## Quick start and examples
 

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.7.7-SNAPSHOT.8`
+# Dependencies of `io.spine:spine-client:1.8.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -399,12 +399,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Dec 14 17:10:42 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 19:22:05 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.7.7-SNAPSHOT.8`
+# Dependencies of `io.spine:spine-core:1.8.0`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -763,12 +763,12 @@ This report was generated on **Tue Dec 14 17:10:42 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Dec 14 17:10:43 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 19:22:05 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.7.7-SNAPSHOT.8`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.8.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1162,12 +1162,12 @@ This report was generated on **Tue Dec 14 17:10:43 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Dec 14 17:10:43 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 19:22:05 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.7.7-SNAPSHOT.8`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.8.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1627,12 +1627,12 @@ This report was generated on **Tue Dec 14 17:10:43 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Dec 14 17:10:43 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 19:22:06 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.7.7-SNAPSHOT.8`
+# Dependencies of `io.spine:spine-server:1.8.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2039,12 +2039,12 @@ This report was generated on **Tue Dec 14 17:10:43 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Dec 14 17:10:44 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 19:22:06 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.7.7-SNAPSHOT.8`
+# Dependencies of `io.spine:spine-testutil-client:1.8.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2493,12 +2493,12 @@ This report was generated on **Tue Dec 14 17:10:44 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Dec 14 17:10:45 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 19:22:08 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.7.7-SNAPSHOT.8`
+# Dependencies of `io.spine:spine-testutil-core:1.8.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2947,12 +2947,12 @@ This report was generated on **Tue Dec 14 17:10:45 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Dec 14 17:10:46 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 19:22:09 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.7.7-SNAPSHOT.8`
+# Dependencies of `io.spine:spine-testutil-server:1.8.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3445,4 +3445,4 @@ This report was generated on **Tue Dec 14 17:10:46 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Dec 14 17:10:48 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 15 19:22:11 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.7.7-SNAPSHOT.8</version>
+<version>1.8.0</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -52,25 +52,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.7.4</version>
+    <version>1.8.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-time</artifactId>
-    <version>1.7.1</version>
+    <version>1.8.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.7.4</version>
+    <version>1.8.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.7.4</version>
+    <version>1.8.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -124,25 +124,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.7.4</version>
+    <version>1.8.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-time</artifactId>
-    <version>1.7.1</version>
+    <version>1.8.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.7.4</version>
+    <version>1.8.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.7.4</version>
+    <version>1.8.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -192,12 +192,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>1.7.4</version>
+    <version>1.8.0</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.7.4</version>
+    <version>1.8.0</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,13 +34,13 @@
 /**
  * Version of this library.
  */
-val coreJava = "1.7.7-SNAPSHOT.8"
+val coreJava = "1.8.0"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.
  */
-val base = "1.7.4"
-val time = "1.7.1"
+val base = "1.8.0"
+val time = "1.8.0"
 
 project.extra.apply {
     this["versionToPublish"] = coreJava


### PR DESCRIPTION
This changeset sets the version to 1.8.0 and updates the corresponding license report files.

---

This release brings numerous fixes, updates to the API of `BlackBoxContext` and performance improvements.

## Breaking Changes

- Instead of `NodeId`, `ShardSessionRecord` now uses `WorkerId` to indicate who is currently processing which shard.

   Thus, all shard processing sessions should be completed before the migration.

   Please see #1433 for details.

## API Changes

- Made `BlackBoxContext` implement `Closeable` (as addition of #1402).

- `BlackBoxContext` API has been extended to provide an instance of `Client` linked to the context under the test. 

   It makes possible to use `Client` in tests, for example:

   ```java
   BlackBoxContext context = BlackBoxContext.from(...);
   ClientRequest clientRequest = context.client().asGuest();
   
   assertThat(clientRequest.select(ProjectView.class).run())
           .hasSize(0);
   clientRequest.command(createProject()).postAndForget();
   assertThat(clientRequest.select(ProjectView.class).run())
           .hasSize(1);
   ```
   
   Please note, that provided `Client` would inherit `TenantId` from `BlackBoxContext`, but would NOT inherit `UserId` and `ZoneId`.
   
   Check #1407 for details.

- Made API calls for the conditional settings of `ServerEnvironment` "lazy".

   Previously, ServerEnvironment provided two kinds of API calls for the conditional settings:

   ```java
    ServerEnvironment.when(Staging.class)
                     // This call is handy when `myStorageFactory` is already available.
                     .use(myStorageFactory)

    ServerEnvironment.when(PreProduction.class)
                     // And this one looks lazy, so that it is only executed when and _if_ requested.
                     .use((env) -> createMySqlStorage())
   ```

   However, in fact, there was no "lazy" behavior, which caused numerous workarounds to actually postpone the initialization of environment-specific settings until they start to make sense.

   This release addresses the issue by making the behavior truly "lazy" (see #1421).

## Fixes

- Enabled `IntegrationBroker` dispatch events regardless of registration order of subscribing and publishing Bounded Contexts (see #1402).

- Transformation of an entity's state during `Migration` has been changed so that the `newState` completely overwrites the old one within the migration transaction (see #1405).

- The internals of `IntegrationBroker` were made more thread-safe (see #1423).

- `SubscriptionService` now properly locates the Bounded Context when subscribing to events produced by standalone producers, such as descendants of `AbstractCommandHandler` or `AbstractEventReactor` (see #1423).

## Performance

- Improved Catch-up caching (see #1406 for details).