### PR TITLE
Flexible server

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -1,9 +1,6 @@
 name: Tests on Windows
 
-on:
-  pull_request:
-    branches:
-    - master
+on: pull_request
 
 jobs:
   build:

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -50,5 +50,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
 </project>

--- a/license-report.md
+++ b/license-report.md
@@ -399,7 +399,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Mar 22 12:53:34 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 13:37:04 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -763,7 +763,7 @@ This report was generated on **Tue Mar 22 12:53:34 EET 2022** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Mar 22 12:53:35 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 13:37:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1162,7 +1162,7 @@ This report was generated on **Tue Mar 22 12:53:35 EET 2022** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Mar 22 12:53:35 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 13:37:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1627,7 +1627,7 @@ This report was generated on **Tue Mar 22 12:53:35 EET 2022** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Mar 22 12:53:36 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 13:37:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2039,7 +2039,7 @@ This report was generated on **Tue Mar 22 12:53:36 EET 2022** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Mar 22 12:53:37 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 13:37:06 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2493,7 +2493,7 @@ This report was generated on **Tue Mar 22 12:53:37 EET 2022** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Mar 22 12:53:38 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 13:37:07 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2947,7 +2947,7 @@ This report was generated on **Tue Mar 22 12:53:38 EET 2022** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Mar 22 12:53:39 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 13:37:08 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3445,4 +3445,4 @@ This report was generated on **Tue Mar 22 12:53:39 EET 2022** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Mar 22 12:53:41 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 13:37:11 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -399,7 +399,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Mar 22 13:37:04 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 16:20:09 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -763,7 +763,7 @@ This report was generated on **Tue Mar 22 13:37:04 EET 2022** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Mar 22 13:37:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 16:20:09 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1162,7 +1162,7 @@ This report was generated on **Tue Mar 22 13:37:05 EET 2022** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Mar 22 13:37:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 16:20:10 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1627,7 +1627,7 @@ This report was generated on **Tue Mar 22 13:37:05 EET 2022** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Mar 22 13:37:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 16:20:10 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2039,7 +2039,7 @@ This report was generated on **Tue Mar 22 13:37:05 EET 2022** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Mar 22 13:37:06 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 16:20:11 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2493,7 +2493,7 @@ This report was generated on **Tue Mar 22 13:37:06 EET 2022** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Mar 22 13:37:07 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 16:20:12 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2947,7 +2947,7 @@ This report was generated on **Tue Mar 22 13:37:07 EET 2022** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Mar 22 13:37:08 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 16:20:13 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3445,4 +3445,4 @@ This report was generated on **Tue Mar 22 13:37:08 EET 2022** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Tue Mar 22 13:37:11 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 16:20:15 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.8.0`
+# Dependencies of `io.spine:spine-client:1.8.1`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -399,12 +399,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Dec 15 19:22:05 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 12:53:34 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.8.0`
+# Dependencies of `io.spine:spine-core:1.8.1`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -763,12 +763,12 @@ This report was generated on **Wed Dec 15 19:22:05 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Dec 15 19:22:05 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 12:53:35 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.8.0`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.8.1`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1162,12 +1162,12 @@ This report was generated on **Wed Dec 15 19:22:05 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Dec 15 19:22:05 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 12:53:35 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.8.0`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.8.1`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1627,12 +1627,12 @@ This report was generated on **Wed Dec 15 19:22:05 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Dec 15 19:22:06 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 12:53:36 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.8.0`
+# Dependencies of `io.spine:spine-server:1.8.1`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2039,12 +2039,12 @@ This report was generated on **Wed Dec 15 19:22:06 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Dec 15 19:22:06 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 12:53:37 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.8.0`
+# Dependencies of `io.spine:spine-testutil-client:1.8.1`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2493,12 +2493,12 @@ This report was generated on **Wed Dec 15 19:22:06 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Dec 15 19:22:08 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 12:53:38 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.8.0`
+# Dependencies of `io.spine:spine-testutil-core:1.8.1`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2947,12 +2947,12 @@ This report was generated on **Wed Dec 15 19:22:08 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Dec 15 19:22:09 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 12:53:39 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.8.0`
+# Dependencies of `io.spine:spine-testutil-server:1.8.1`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3445,4 +3445,4 @@ This report was generated on **Wed Dec 15 19:22:09 EET 2021** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Dec 15 19:22:11 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 22 12:53:41 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.8.0</version>
+<version>1.8.1</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/Server.java
+++ b/server/src/main/java/io/spine/server/Server.java
@@ -152,14 +152,23 @@ public final class Server implements Logging {
         grpcContainer.shutdownNowAndWait();
     }
 
+    /**
+     * Obtains the {@link QueryService} exposed by this server.
+     */
     public QueryService queryService() {
         return queryService;
     }
 
+    /**
+     * Obtains the {@link SubscriptionService} exposed by this server.
+     */
     public SubscriptionService subscriptionService() {
         return subscriptionService;
     }
 
+    /**
+     * Obtains the {@link CommandService} exposed by this server.
+     */
     public CommandService commandService() {
         return commandService;
     }
@@ -200,6 +209,14 @@ public final class Server implements Logging {
             return this;
         }
 
+        /**
+         * Adds a gRPC service to the built server.
+         *
+         * <p>By default, the {@linkplain CommandService Command}, {@linkplain QueryService Query},
+         * and {@linkplain SubscriptionService Subscription} services are present in the server.
+         * But the users may add any other gRPC services to work alongside the standard ones,
+         * e.g. for monitoring, warmup procedures, etc.
+         */
         @CanIgnoreReturnValue
         public Builder include(BindableService service) {
             checkNotNull(service);

--- a/server/src/main/java/io/spine/server/Server.java
+++ b/server/src/main/java/io/spine/server/Server.java
@@ -30,6 +30,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.FluentLogger;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.grpc.BindableService;
 import io.spine.logging.Logging;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -54,6 +55,10 @@ public final class Server implements Logging {
 
     /** The container for Command- and Query- services. */
     private final GrpcContainer grpcContainer;
+
+    private final QueryService queryService;
+    private final SubscriptionService subscriptionService;
+    private final CommandService commandService;
 
     /**
      * Creates a new builder for the server.
@@ -85,6 +90,9 @@ public final class Server implements Logging {
     private Server(Builder builder) {
         this.contexts = builder.contexts();
         this.grpcContainer = builder.createContainer();
+        this.queryService = checkNotNull(builder.queryService);
+        this.subscriptionService = checkNotNull(builder.subscriptionService);
+        this.commandService = checkNotNull(builder.commandService);
     }
 
     /**
@@ -144,6 +152,18 @@ public final class Server implements Logging {
         grpcContainer.shutdownNowAndWait();
     }
 
+    public QueryService queryService() {
+        return queryService;
+    }
+
+    public SubscriptionService subscriptionService() {
+        return subscriptionService;
+    }
+
+    public CommandService commandService() {
+        return commandService;
+    }
+
     /**
      * Always returns zero.
      *
@@ -159,8 +179,12 @@ public final class Server implements Logging {
      */
     public static final class Builder extends ConnectionBuilder {
 
+        private final Set<BindableService> extraServices = new HashSet<>();
         private final Set<BoundedContextBuilder> contextBuilders = new HashSet<>();
         private @MonotonicNonNull ImmutableSet<BoundedContext> contexts;
+        private @MonotonicNonNull QueryService queryService;
+        private @MonotonicNonNull SubscriptionService subscriptionService;
+        private @MonotonicNonNull CommandService commandService;
 
         private Builder(@Nullable Integer port, @Nullable String serverName) {
             super(port, serverName);
@@ -173,6 +197,13 @@ public final class Server implements Logging {
         public Builder add(BoundedContextBuilder context) {
             checkNotNull(context);
             contextBuilders.add(context);
+            return this;
+        }
+
+        @CanIgnoreReturnValue
+        public Builder include(BindableService service) {
+            checkNotNull(service);
+            extraServices.add(service);
             return this;
         }
 
@@ -217,13 +248,15 @@ public final class Server implements Logging {
                 queryService.add(context);
                 subscriptionService.add(context);
             });
+            this.queryService = queryService.build();
+            this.subscriptionService = subscriptionService.build();
+            this.commandService = commandService.build();
             GrpcContainer.Builder builder = createContainerBuilder();
-            GrpcContainer result = builder
-                    .addService(commandService.build())
-                    .addService(queryService.build())
-                    .addService(subscriptionService.build())
-                    .build();
-            return result;
+            builder.addService(this.commandService)
+                   .addService(this.queryService)
+                   .addService(this.subscriptionService);
+            extraServices.forEach(builder::addService);
+            return builder.build();
         }
 
         private GrpcContainer.Builder createContainerBuilder() {

--- a/server/src/test/java/io/spine/server/ServerTest.java
+++ b/server/src/test/java/io/spine/server/ServerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server;
+
+import com.google.protobuf.Empty;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.spine.server.given.service.StatusCheckService;
+import io.spine.test.server.Status;
+import io.spine.test.server.StatusCheckGrpc;
+import io.spine.test.server.StatusCheckGrpc.StatusCheckBlockingStub;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
+import static io.spine.test.client.ClientTestContext.tasks;
+import static io.spine.test.client.ClientTestContext.users;
+
+@DisplayName("`Server` should")
+class ServerTest {
+
+    @SuppressWarnings("DuplicateStringLiteralInspection")
+    private static final String ADDRESS = "localhost";
+    private static final int PORT = 4242;
+
+    @Test
+    @DisplayName("allow registering custom gRPC services")
+    void customServices() throws IOException {
+        Server server = Server.atPort(PORT)
+                              .add(users())
+                              .add(tasks())
+                              .include(new StatusCheckService())
+                              .build();
+        server.start();
+        ManagedChannel ch = ManagedChannelBuilder.forAddress(ADDRESS, PORT)
+                                                 .usePlaintext()
+                                                 .build();
+        StatusCheckBlockingStub client = StatusCheckGrpc.newBlockingStub(ch);
+        Status response = client.check(Empty.getDefaultInstance());
+        assertThat(response)
+                .isNotEqualToDefaultInstance();
+        server.shutdown();
+        ch.shutdownNow();
+    }
+}

--- a/server/src/test/java/io/spine/server/ServerTest.java
+++ b/server/src/test/java/io/spine/server/ServerTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
 import static io.spine.test.client.ClientTestContext.tasks;
 import static io.spine.test.client.ClientTestContext.users;
@@ -67,5 +68,17 @@ class ServerTest {
                 .isNotEqualToDefaultInstance();
         server.shutdown();
         ch.shutdownNow();
+    }
+
+    @Test
+    @DisplayName("provide `CommandService`, `QueryService`, and `SubscriptionService`")
+    void cAndQ() {
+        Server server = Server.atPort(PORT)
+                              .add(users())
+                              .add(tasks())
+                              .build();
+        assertThat(server.subscriptionService()).isNotNull();
+        assertThat(server.queryService()).isNotNull();
+        assertThat(server.commandService()).isNotNull();
     }
 }

--- a/server/src/test/java/io/spine/server/given/service/StatusCheckService.java
+++ b/server/src/test/java/io/spine/server/given/service/StatusCheckService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.given.service;
+
+import com.google.protobuf.Empty;
+import io.grpc.stub.StreamObserver;
+import io.spine.test.server.Status;
+import io.spine.test.server.StatusCheckGrpc;
+
+import static io.spine.base.Time.currentTime;
+import static io.spine.test.server.ServerStatus.OK;
+
+public final class StatusCheckService extends StatusCheckGrpc.StatusCheckImplBase {
+
+    @Override
+    public void check(Empty request, StreamObserver<Status> responseObserver) {
+        Status status = Status.newBuilder()
+                              .setStatus(OK)
+                              .setLastUpdated(currentTime())
+                              .build();
+        responseObserver.onNext(status);
+        responseObserver.onCompleted();
+    }
+}

--- a/server/src/test/java/io/spine/server/given/service/package-info.java
+++ b/server/src/test/java/io/spine/server/given/service/package-info.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.server.given.service;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/test/proto/spine/test/status_check.proto
+++ b/server/src/test/proto/spine/test/status_check.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package spine.test.server;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.test.server";
+option java_outer_classname = "StatusCheckProto";
+option java_multiple_files = true;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
+// A gRPC service for `io.spine.server.Server` tests.
+service StatusCheck {
+
+    rpc check(google.protobuf.Empty) returns (Status);
+}
+
+message Status {
+
+    ServerStatus status = 1;
+
+    google.protobuf.Timestamp last_updated = 2;
+}
+
+enum ServerStatus {
+
+    SERVER_STATUS_UNKNOWN = 0;
+
+    OK = 1;
+    STARTING = 2;
+    SHUTTING_DOWN = 3;
+    DOWN = 4;
+}
+
+

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,7 +34,7 @@
 /**
  * Version of this library.
  */
-val coreJava = "1.8.0"
+val coreJava = "1.8.1"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.


### PR DESCRIPTION
This is a PR to the v1.8 branch.

In this PR we expand the `io.spine.server.Server` API to allow to:
 - obtain the Query, Subscription, and Command services after the `Server` is built;
 - add extra gRPC services to the same server.

This PR is related to #1415. That issue will be closed after the same change is done to the v2.0 branch.