### PR TITLE
Flexible Server

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,11 +138,7 @@ allprojects {
 
 subprojects {
 
-    with(repositories) {
-        applyGitHubPackages("base", rootProject)
-        applyGitHubPackages("time", rootProject)
-        applyStandard()
-    }
+    repositories.applyStandard()
 
     apply {
         plugin("java-library")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/license-report.md
+++ b/license-report.md
@@ -512,7 +512,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 14:53:55 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 28 16:46:31 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -989,7 +989,7 @@ This report was generated on **Thu Jan 20 14:53:55 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 14:53:55 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 28 16:46:32 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1506,7 +1506,7 @@ This report was generated on **Thu Jan 20 14:53:55 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 14:53:56 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 28 16:46:32 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2123,7 +2123,7 @@ This report was generated on **Thu Jan 20 14:53:56 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 14:53:56 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 28 16:46:40 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2648,7 +2648,7 @@ This report was generated on **Thu Jan 20 14:53:56 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 14:53:57 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 28 16:46:49 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3217,7 +3217,7 @@ This report was generated on **Thu Jan 20 14:53:57 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 14:53:57 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 28 16:46:50 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3786,7 +3786,7 @@ This report was generated on **Thu Jan 20 14:53:57 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 14:53:58 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 28 16:46:50 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4399,4 +4399,4 @@ This report was generated on **Thu Jan 20 14:53:58 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 20 14:53:58 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 28 16:47:20 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.92`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.93`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -512,12 +512,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 28 16:46:31 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 28 18:05:31 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.92`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.93`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -989,12 +989,12 @@ This report was generated on **Mon Mar 28 16:46:31 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 28 16:46:32 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 28 18:05:32 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.92`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.93`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1506,12 +1506,12 @@ This report was generated on **Mon Mar 28 16:46:32 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 28 16:46:32 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 28 18:05:32 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.92`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.93`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -2123,12 +2123,12 @@ This report was generated on **Mon Mar 28 16:46:32 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 28 16:46:40 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 28 18:05:33 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.92`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.93`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2648,12 +2648,12 @@ This report was generated on **Mon Mar 28 16:46:40 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 28 16:46:49 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 28 18:05:34 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.92`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.93`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3217,12 +3217,12 @@ This report was generated on **Mon Mar 28 16:46:49 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 28 16:46:50 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 28 18:05:34 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.92`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.93`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3786,12 +3786,12 @@ This report was generated on **Mon Mar 28 16:46:50 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 28 16:46:50 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 28 18:05:35 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.92`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.93`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4399,4 +4399,4 @@ This report was generated on **Mon Mar 28 16:46:50 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 28 16:47:20 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 28 18:05:35 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -512,7 +512,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 28 18:05:31 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 29 13:28:53 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -989,7 +989,7 @@ This report was generated on **Mon Mar 28 18:05:31 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 28 18:05:32 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 29 13:28:56 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1506,7 +1506,7 @@ This report was generated on **Mon Mar 28 18:05:32 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 28 18:05:32 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 29 13:28:59 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2123,7 +2123,7 @@ This report was generated on **Mon Mar 28 18:05:32 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 28 18:05:33 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 29 13:29:02 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2648,7 +2648,7 @@ This report was generated on **Mon Mar 28 18:05:33 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 28 18:05:34 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 29 13:29:05 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3217,7 +3217,7 @@ This report was generated on **Mon Mar 28 18:05:34 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 28 18:05:34 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 29 13:29:08 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3786,7 +3786,7 @@ This report was generated on **Mon Mar 28 18:05:34 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 28 18:05:35 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 29 13:29:11 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4399,4 +4399,4 @@ This report was generated on **Mon Mar 28 18:05:35 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 28 18:05:35 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 29 13:29:14 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/model/model-verifier/src/test/resources/model-verifier-test/build.gradle.kts
+++ b/model/model-verifier/src/test/resources/model-verifier-test/build.gradle.kts
@@ -43,7 +43,6 @@ buildscript {
     val enclosingRootDir: String by extra
     apply(from = "${enclosingRootDir}/version.gradle.kts")
 
-    io.spine.internal.gradle.doApplyGitHubPackages(repositories, "core-java", rootProject)
     io.spine.internal.gradle.doApplyStandard(repositories)
 
     val spineBaseVersion: String by extra
@@ -89,7 +88,6 @@ apply {
     from("$enclosingRootDir/version.gradle.kts")
 }
 
-repositories.applyGitHubPackages("core-java", rootProject)
 repositories.applyStandard()
 
 tasks.compileJava {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.92</version>
+<version>2.0.0-SNAPSHOT.93</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/Server.java
+++ b/server/src/main/java/io/spine/server/Server.java
@@ -233,7 +233,6 @@ public final class Server implements Logging {
             var commandService = CommandService.newBuilder();
             var queryService = QueryService.newBuilder();
             var subscriptionService = SubscriptionService.newBuilder();
-
             contexts().forEach(context -> {
                 commandService.add(context);
                 queryService.add(context);

--- a/server/src/main/java/io/spine/server/Server.java
+++ b/server/src/main/java/io/spine/server/Server.java
@@ -29,6 +29,7 @@ package io.spine.server;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.grpc.BindableService;
 import io.spine.logging.Logging;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -58,6 +59,9 @@ public final class Server implements Logging {
 
     /** The container for Command- and Query- services. */
     private final GrpcContainer grpcContainer;
+    private final QueryService queryService;
+    private final SubscriptionService subscriptionService;
+    private final CommandService commandService;
 
     /**
      * Initiates creating a server exposed at the passed port.
@@ -79,6 +83,9 @@ public final class Server implements Logging {
     private Server(Builder builder) {
         this.contexts = builder.contexts();
         this.grpcContainer = builder.createContainer();
+        this.queryService = checkNotNull(builder.queryService);
+        this.subscriptionService = checkNotNull(builder.subscriptionService);
+        this.commandService = checkNotNull(builder.commandService);
     }
 
     /**
@@ -139,12 +146,39 @@ public final class Server implements Logging {
     }
 
     /**
+     * Obtains the {@link QueryService} exposed by this server.
+     */
+    public QueryService queryService() {
+        return queryService;
+    }
+
+    /**
+     * Obtains the {@link SubscriptionService} exposed by this server.
+     */
+    public SubscriptionService subscriptionService() {
+        return subscriptionService;
+    }
+
+    /**
+     * Obtains the {@link CommandService} exposed by this server.
+     */
+    public CommandService commandService() {
+        return commandService;
+    }
+
+
+
+    /**
      * The builder for the server.
      */
     public static final class Builder extends ConnectionBuilder {
 
+        private final Set<BindableService> extraServices = new HashSet<>();
         private final Set<BoundedContextBuilder> contextBuilders = new HashSet<>();
         private @MonotonicNonNull ImmutableSet<BoundedContext> contexts;
+        private @MonotonicNonNull QueryService queryService;
+        private @MonotonicNonNull SubscriptionService subscriptionService;
+        private @MonotonicNonNull CommandService commandService;
 
         private Builder(@Nullable Integer port, @Nullable String serverName) {
             super(port, serverName);
@@ -157,6 +191,21 @@ public final class Server implements Logging {
         public Builder add(BoundedContextBuilder context) {
             checkNotNull(context);
             contextBuilders.add(context);
+            return this;
+        }
+
+        /**
+         * Adds a gRPC service to the built server.
+         *
+         * <p>By default, the {@linkplain CommandService Command}, {@linkplain QueryService Query},
+         * and {@linkplain SubscriptionService Subscription} services are present in the server.
+         * But the users may add any other gRPC services to work alongside the standard ones,
+         * e.g. for monitoring, warmup procedures, etc.
+         */
+        @CanIgnoreReturnValue
+        public Builder include(BindableService service) {
+            checkNotNull(service);
+            extraServices.add(service);
             return this;
         }
 
@@ -190,12 +239,15 @@ public final class Server implements Logging {
                 queryService.add(context);
                 subscriptionService.add(context);
             });
+            this.queryService = queryService.build();
+            this.subscriptionService = subscriptionService.build();
+            this.commandService = commandService.build();
             var builder = createContainerBuilder();
-            var result = builder.addService(commandService.build())
-                                .addService(queryService.build())
-                                .addService(subscriptionService.build())
-                                .build();
-            return result;
+            builder.addService(this.commandService)
+                   .addService(this.queryService)
+                   .addService(this.subscriptionService);
+            extraServices.forEach(builder::addService);
+            return builder.build();
         }
 
         private GrpcContainer.Builder createContainerBuilder() {

--- a/server/src/test/java/io/spine/server/ServerTest.java
+++ b/server/src/test/java/io/spine/server/ServerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server;
+
+import com.google.protobuf.Empty;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.spine.server.given.service.StatusCheckService;
+import io.spine.test.server.Status;
+import io.spine.test.server.StatusCheckGrpc;
+import io.spine.test.server.StatusCheckGrpc.StatusCheckBlockingStub;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
+import static io.spine.test.client.ClientTestContext.tasks;
+import static io.spine.test.client.ClientTestContext.users;
+
+@DisplayName("`Server` should")
+class ServerTest {
+
+    @SuppressWarnings("DuplicateStringLiteralInspection")
+    private static final String ADDRESS = "localhost";
+    private static final int PORT = 4242;
+
+    @Test
+    @DisplayName("allow registering custom gRPC services")
+    void customServices() throws IOException {
+        Server server = Server.atPort(PORT)
+                              .add(users())
+                              .add(tasks())
+                              .include(new StatusCheckService())
+                              .build();
+        server.start();
+        ManagedChannel ch = ManagedChannelBuilder.forAddress(ADDRESS, PORT)
+                                                 .usePlaintext()
+                                                 .build();
+        StatusCheckBlockingStub client = StatusCheckGrpc.newBlockingStub(ch);
+        Status response = client.check(Empty.getDefaultInstance());
+        assertThat(response)
+                .isNotEqualToDefaultInstance();
+        server.shutdown();
+        ch.shutdownNow();
+    }
+
+    @Test
+    @DisplayName("provide `CommandService`, `QueryService`, and `SubscriptionService`")
+    void cAndQ() {
+        Server server = Server.atPort(PORT)
+                              .add(users())
+                              .add(tasks())
+                              .build();
+        assertThat(server.subscriptionService()).isNotNull();
+        assertThat(server.queryService()).isNotNull();
+        assertThat(server.commandService()).isNotNull();
+    }
+}

--- a/server/src/test/java/io/spine/server/given/service/StatusCheckService.java
+++ b/server/src/test/java/io/spine/server/given/service/StatusCheckService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.given.service;
+
+import com.google.protobuf.Empty;
+import io.grpc.stub.StreamObserver;
+import io.spine.test.server.Status;
+import io.spine.test.server.StatusCheckGrpc;
+
+import static io.spine.base.Time.currentTime;
+import static io.spine.test.server.ServerStatus.OK;
+
+public final class StatusCheckService extends StatusCheckGrpc.StatusCheckImplBase {
+
+    @Override
+    public void check(Empty request, StreamObserver<Status> responseObserver) {
+        Status status = Status.newBuilder()
+                .setStatus(OK)
+                .setLastUpdated(currentTime())
+                .build();
+        responseObserver.onNext(status);
+        responseObserver.onCompleted();
+    }
+}

--- a/server/src/test/proto/spine/test/server/status_check.proto
+++ b/server/src/test/proto/spine/test/server/status_check.proto
@@ -1,0 +1,36 @@
+syntax = "proto3";
+
+package spine.test.server;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.test.server";
+option java_outer_classname = "StatusCheckProto";
+option java_multiple_files = true;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
+// A gRPC service for `io.spine.server.Server` tests.
+service StatusCheck {
+
+    rpc check(google.protobuf.Empty) returns (Status);
+}
+
+message Status {
+
+    ServerStatus status = 1;
+
+    google.protobuf.Timestamp last_updated = 2;
+}
+
+enum ServerStatus {
+
+    SERVER_STATUS_UNKNOWN = 0;
+
+    OK = 1;
+    STARTING = 2;
+    SHUTTING_DOWN = 3;
+    DOWN = 4;
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@ val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.84")
 val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.83")
 
 /** The version of this library. */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.92")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.93")


### PR DESCRIPTION
In this PR we expand the `io.spine.server.Server` API to allow to:
 - obtain the Query, Subscription, and Command services after the `Server` is built;
 - add extra gRPC services to the same server.

This PR closes #1415. 