### PR TITLE
Set `MaxMetaspaceSize` in `publish` workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Publish artifacts to Maven
         # Since we're in the `master` branch already, this means that tests of a PR passed.
         # So, no need to run the tests again when publishing.
-        run: ./gradlew publish -x test --stacktrace
+        run: ./gradlew publish -x test --stacktrace "-Dorg.gradle.jvmargs=-XX:MaxMetaspaceSize=512m"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORMAL_GIT_HUB_PAGES_AUTHOR: developers@spine.io


### PR DESCRIPTION
In [this PR](https://github.com/SpineEventEngine/core-java/pull/1450), Dokka documentation was added as a publish artifact. This project is large enough to run into `OutOfSpaceError` when generating documentation by Dokka. To overcome this issue, `MaxMetaspaceSize` was set in `build-on-ubuntu` and `build-on-windows` workflows. However, I forgot to set the metaspace setting in the `publish` workflow, which goes through the build stage. That mistake led to the failed `publish` workflow. This PR fixes this issue.