### PR TITLE
[1.x] Allow to configure the underlying gRPC server

### DIFF
--- a/server/src/main/java/io/spine/server/GrpcContainer.java
+++ b/server/src/main/java/io/spine/server/GrpcContainer.java
@@ -333,7 +333,7 @@ public final class GrpcContainer {
      *
      * <p>All calls to {@link #createGrpcServer(Executor)} will resolve to the given server
      * instance. The server instance is used as-is, no other
-     * {@linkplain Builder#apply(ConfigureServer) configuration methods} have any effect on it.
+     * {@linkplain Builder#withServer(ConfigureServer) configuration methods} have any effect on it.
      *
      * <p>A test-only method.
      */
@@ -444,7 +444,7 @@ public final class GrpcContainer {
 
         /**
          * Sets an additional configuration action for the gRPC {@link Server} instance,
-         * created for this {@code GrpcContainer} to run on top of. This action is applied
+         * created for this {@code GrpcContainer} to run on top of. This configuration is applied
          * right before the {@linkplain #start() server is started}.
          *
          * <p>Allows the direct access to gRPC {@link ServerBuilder}'s API.
@@ -456,7 +456,7 @@ public final class GrpcContainer {
          */
         @Experimental
         @CanIgnoreReturnValue
-        public Builder apply(ConfigureServer action) {
+        public Builder withServer(ConfigureServer action) {
             this.configureServer = checkNotNull(action);
             return this;
         }
@@ -497,7 +497,7 @@ public final class GrpcContainer {
      *
      * GrpcContainer container =
      *     GrpcContainer.atPort(1654)
-     * {@literal                 .apply((server) -> server.maxInboundMessageSize(16_000_000))  }
+     * {@literal                 .withServer((server) -> server.maxInboundMessageSize(16_000_000)) }
      *                  // ...
      *                  .build();
      *
@@ -505,7 +505,7 @@ public final class GrpcContainer {
      *
      * <p>Please note this interface is a part of experimental API.
      *
-     * @see Builder#apply(ConfigureServer)
+     * @see Builder#withServer(ConfigureServer)
      */
     @Experimental
     @FunctionalInterface

--- a/server/src/main/java/io/spine/server/GrpcContainer.java
+++ b/server/src/main/java/io/spine/server/GrpcContainer.java
@@ -36,6 +36,7 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.inprocess.InProcessServerBuilder;
+import io.spine.annotation.Experimental;
 import io.spine.client.ConnectionConstants;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -413,18 +414,45 @@ public final class GrpcContainer {
             return port().orElse(0);
         }
 
+        /**
+         * Adds a gRPC service to deploy within the container being built.
+         *
+         * @return this instance of {@code Builder}, for call chaining
+         */
         @CanIgnoreReturnValue
         public Builder addService(BindableService service) {
+            checkNotNull(service);
             services.add(service.bindService());
             return this;
         }
 
+        /**
+         * Removes the {@linkplain #addService(BindableService) previously added}
+         * gRPC service.
+         *
+         * <p>If the service under the given definition was not added previously,
+         * this method does nothing.
+         *
+         * @return this instance of {@code Builder}, for call chaining
+         */
         @CanIgnoreReturnValue
         public Builder removeService(ServerServiceDefinition service) {
             services.remove(service);
             return this;
         }
 
+        /**
+         * Sets an additional configuration action for the gRPC {@link Server} instance,
+         * created for this {@code GrpcContainer} to run on top of.
+         *
+         * <p>Allows the direct access to gRPC {@link ServerBuilder}'s API.
+         *
+         * <p>Please note this API is experimental.
+         *
+         * @return this instance of {@code Builder}, for call chaining
+         * @see ConfigureServer
+         */
+        @Experimental
         @CanIgnoreReturnValue
         public Builder apply(ConfigureServer action) {
             this.configureServer = checkNotNull(action);
@@ -456,7 +484,28 @@ public final class GrpcContainer {
     /**
      * Allows to configure the gRPC's {@link Server} instance,
      * on top of which this {@code GrpcContainer} will operate.
+     *
+     * <p>It is expected that the obtained builder of gRPC server is used to perform
+     * some fine-grained tuning of its features. The same instance of {@link ServerBuilder}
+     * should be returned.
+     *
+     * <p>Example.
+     *
+     * <pre>
+     *
+     * GrpcContainer container =
+     *     GrpcContainer.atPort(1654)
+     *                  .apply((server) -> server.maxInboundMessageSize(16_000_000))
+     *                  // ...
+     *                  .build();
+     *
+     * </pre>
+     *
+     * <p>Please note this interface is a part of experimental API.
+     *
+     * @see Builder#apply(ConfigureServer)
      */
+    @Experimental
     @FunctionalInterface
     public interface ConfigureServer extends Function<ServerBuilder<?>, ServerBuilder<?>> {
 

--- a/server/src/main/java/io/spine/server/GrpcContainer.java
+++ b/server/src/main/java/io/spine/server/GrpcContainer.java
@@ -443,7 +443,8 @@ public final class GrpcContainer {
 
         /**
          * Sets an additional configuration action for the gRPC {@link Server} instance,
-         * created for this {@code GrpcContainer} to run on top of.
+         * created for this {@code GrpcContainer} to run on top of. This action is applied
+         * right before the {@linkplain #start() server is started}.
          *
          * <p>Allows the direct access to gRPC {@link ServerBuilder}'s API.
          *

--- a/server/src/main/java/io/spine/server/GrpcContainer.java
+++ b/server/src/main/java/io/spine/server/GrpcContainer.java
@@ -332,7 +332,8 @@ public final class GrpcContainer {
      * Injects a server to this container.
      *
      * <p>All calls to {@link #createGrpcServer(Executor)} will resolve to the given server
-     * instance.
+     * instance. The server instance is used as-is, no other
+     * {@linkplain Builder#apply(ConfigureServer) configuration methods} have effect onto it.
      *
      * <p>A test-only method.
      */

--- a/server/src/main/java/io/spine/server/GrpcContainer.java
+++ b/server/src/main/java/io/spine/server/GrpcContainer.java
@@ -497,7 +497,7 @@ public final class GrpcContainer {
      *
      * GrpcContainer container =
      *     GrpcContainer.atPort(1654)
-     *                  .apply((server) -> server.maxInboundMessageSize(16_000_000))
+     * {@literal                 .apply((server) -> server.maxInboundMessageSize(16_000_000))  }
      *                  // ...
      *                  .build();
      *

--- a/server/src/main/java/io/spine/server/GrpcContainer.java
+++ b/server/src/main/java/io/spine/server/GrpcContainer.java
@@ -333,7 +333,7 @@ public final class GrpcContainer {
      *
      * <p>All calls to {@link #createGrpcServer(Executor)} will resolve to the given server
      * instance. The server instance is used as-is, no other
-     * {@linkplain Builder#apply(ConfigureServer) configuration methods} have effect onto it.
+     * {@linkplain Builder#apply(ConfigureServer) configuration methods} have any effect on it.
      *
      * <p>A test-only method.
      */

--- a/server/src/test/java/io/spine/server/GrpcContainerTest.java
+++ b/server/src/test/java/io/spine/server/GrpcContainerTest.java
@@ -118,7 +118,7 @@ class GrpcContainerTest {
                                                .build();
         GrpcContainer container =
                 GrpcContainer.atPort(port)
-                             .apply((server) -> server.addService(service))
+                             .withServer((server) -> server.addService(service))
                              .build();
         try {
             container.start();

--- a/server/src/test/java/io/spine/server/GrpcContainerTest.java
+++ b/server/src/test/java/io/spine/server/GrpcContainerTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -107,6 +108,38 @@ class GrpcContainerTest {
 
         assertThat(grpcContainer.grpcServer())
                 .isNotNull();
+    }
+
+    @Test
+    @DisplayName("configure underlying gRPC server")
+    void configureUnderlyingGrpcServer() {
+        int port = 1654;
+        CommandService service = CommandService.newBuilder()
+                                               .build();
+        GrpcContainer container =
+                GrpcContainer.atPort(port)
+                             .apply((server) -> server.addService(service))
+                             .build();
+        try {
+            container.start();
+            Server server = container.grpcServer();
+            assertThat(server)
+                    .isNotNull();
+
+            List<ServerServiceDefinition> deployedServices = server.getServices();
+            assertThat(deployedServices)
+                    .hasSize(1);
+
+            String actualName = deployedServices.get(0)
+                                                .getServiceDescriptor()
+                                                .getName();
+            assertThat(actualName).contains(service.getClass()
+                                                   .getSimpleName());
+        } catch (IOException e) {
+            fail(e);
+        } finally {
+            container.shutdown();
+        }
     }
 
     @Test

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,7 +34,7 @@
 /**
  * Version of this library.
  */
-val coreJava = "1.8.2-SNAPSHOT.1"
+val coreJava = "1.8.2"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.


### PR DESCRIPTION
Prior to this changeset, there was no convenient way to set some "native" properties of the gRPC server, which is running underneath Spine's `GrpcContainer`. 

In particular, it is often needed [to set](https://grpc.github.io/grpc-java/javadoc/io/grpc/ServerBuilder.html#maxInboundMessageSize-int-) the maximum size for the inbound messages. And it was nearly not possible to achieve, other than using a test-only `GrpcContainer.injectServer()` method. There is also a number of other configuration endpoints provided by the gRPC's `ServerBuilder`, which could not be accessed.

In this PR, the gRPC's `ServerBuilder` API becomes exposed like this:

```java

GrpcContainer.atPort(1654)
             // `server` is an instance of `io.grpc.ServerBuilder`.
             .apply((server) -> server.maxInboundMessageSize(16_000_000))  }
             // ...
             .build();
```

So, rather than copying the `ServerBuilder`'s API in `GrpcContainer`, the direct access to the builder is provided. That will allow to be always up-to-date with the configuration capabilities of the gRPC `Server`, rather than copying and chasing their API in the gRPC releases to come.

However, as of this PR, the `GrpcContainer.Builder.apply(...)` method is marked as `@Experimental`. The reason is that the "native" `ServerBuilder` API allows to perform some destructive actions. Therefore, the decision to expose it as-is is not yet final.

The library version is set to `1.8.2`. The release notes will follow.