### PR TITLE
Improve the performance of `ColumnMapping` lookup

### DIFF
--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -7,16 +7,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: zulu
           cache: gradle
-
-      - name: Pull config
-        run: git submodule update --init --recursive
 
       - name: Build project and run tests
         shell: bash
@@ -30,7 +29,7 @@ jobs:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 
       - name: Upload code coverage report
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -7,16 +7,15 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: zulu
           cache: gradle
-
-      - name: Pull config
-        run: git submodule update --init --recursive
 
       - name: Build project and run tests
         shell: cmd

--- a/.github/workflows/ensure-reports.updated.yml
+++ b/.github/workflows/ensure-reports.updated.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Configure the checkout of all branches, so that it is possible to run the comparison.
           fetch-depth: 0

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/increment-guard.yml
+++ b/.github/workflows/increment-guard.yml
@@ -13,16 +13,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: zulu
           cache: gradle
-
-      - name: Pull config
-        run: git submodule update --init --recursive
 
       - name: Check version is not yet published
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,15 +8,15 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: zulu
           cache: gradle
-
-      - run: git submodule update --init --recursive
 
       - name: Decrypt CloudRepo credentials
         run: ./config/scripts/decrypt.sh "$CLOUDREPO_CREDENTIALS_KEY" ./.github/keys/cloudrepo.properties.gpg ./cloudrepo.properties

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.98`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.99`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -619,12 +619,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 20 15:25:36 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 20 20:06:06 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.98`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.99`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1203,12 +1203,12 @@ This report was generated on **Mon Jun 20 15:25:36 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 20 15:25:37 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 20 20:06:07 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.98`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.99`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1827,12 +1827,12 @@ This report was generated on **Mon Jun 20 15:25:37 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 20 15:25:38 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 20 20:06:08 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.98`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.99`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -2551,12 +2551,12 @@ This report was generated on **Mon Jun 20 15:25:38 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 20 15:25:39 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 20 20:06:09 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.98`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.99`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3183,12 +3183,12 @@ This report was generated on **Mon Jun 20 15:25:39 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 20 15:25:41 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 20 20:06:10 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.98`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.99`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3859,12 +3859,12 @@ This report was generated on **Mon Jun 20 15:25:41 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 20 15:25:41 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 20 20:06:11 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.98`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.99`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4535,12 +4535,12 @@ This report was generated on **Mon Jun 20 15:25:41 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 20 15:25:42 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 20 20:06:11 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.98`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.99`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5256,4 +5256,4 @@ This report was generated on **Mon Jun 20 15:25:42 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 20 15:25:53 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jul 20 20:06:12 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.98</version>
+<version>2.0.0-SNAPSHOT.99</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/storage/KnownMappings.java
+++ b/server/src/main/java/io/spine/server/storage/KnownMappings.java
@@ -38,9 +38,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Speeds up the discovery of the {@link ColumnMapping} by the type of column.
  *
- * <p>In real-life scenarios, the search for the corresponding column mapping is performed
- * many times for the same inputs. As long as the mappings are configured during
- * the application setup, it makes sense to cache the mapping values per type.
+ * <p>Searches for the column mappings among user-provided custom mappings.
+ * If nothing is found for the given column type, the standard mappings are searched.
+ *
+ * <p>In real-life scenarios, the search for the column mapping corresponding
+ * to the column type is performed many times for the same inputs. As long as the mappings
+ * are configured during the application setup, it makes sense to cache
+ * the mapping values per column type.
  *
  * @param <R>
  *         type of the column to persist the column value as
@@ -50,6 +54,14 @@ final class KnownMappings<R> {
     private final FindMapping<R> findStandardMapping;
     private final FindMapping<R> findCustomMapping;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param findStandardMapping
+     *         function searching for the mapping in standard column mappings
+     * @param findCustomMapping
+     *         function searching for the mapping among custom mappings
+     */
     KnownMappings(FindMapping<R> findStandardMapping, FindMapping<R> findCustomMapping) {
         this.findStandardMapping = checkNotNull(findStandardMapping);
         this.findCustomMapping = checkNotNull(findCustomMapping);

--- a/server/src/main/java/io/spine/server/storage/KnownMappings.java
+++ b/server/src/main/java/io/spine/server/storage/KnownMappings.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.storage;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Speeds up the discovery of the {@link ColumnMapping} by the type of column.
+ *
+ * <p>In real-life scenarios, the search for the corresponding column mapping is performed
+ * many times for the same inputs. As long as the mappings are configured during
+ * the application setup, it makes sense to cache the mapping values per type.
+ *
+ * @param <R>
+ *         type of the column to persist the column value as
+ */
+final class KnownMappings<R> {
+
+    private final FindMapping<R> findStandardMapping;
+    private final FindMapping<R> findCustomMapping;
+
+    KnownMappings(FindMapping<R> findStandardMapping, FindMapping<R> findCustomMapping) {
+        this.findStandardMapping = checkNotNull(findStandardMapping);
+        this.findCustomMapping = checkNotNull(findCustomMapping);
+    }
+
+    /**
+     * Cached column mappings per type.
+     *
+     * <p>Without caching, this operation may be executed for too many times
+     * for the same input.
+     */
+    private final LoadingCache<Class<?>, Optional<ColumnTypeMapping<?, ? extends R>>>
+            mappingsByType = CacheBuilder.newBuilder()
+            .maximumSize(300)
+            .build(new CacheLoader<>() {
+                @Override
+                public Optional<ColumnTypeMapping<?, ? extends R>> load(Class<?> type) {
+                    var result = findCustomMapping.apply(type);
+                    if (result.isEmpty()) {
+                        result = findStandardMapping.apply(type);
+                    }
+                    return result;
+                }
+            });
+
+    /**
+     * Obtains the type mapping for the given value and returns it as {@code Optional}.
+     *
+     * <p>Returns {@code Optional.empty()} if no mapping has been found.
+     *
+     * @param type
+     *         type to look the mapping for
+     * @apiNote The returning type is {@code Optional}, as soon as the callee would have
+     *         some logic on handling the {@code Optional.empty()} results
+     *         in a pseudo-functional way. Returning {@code null} instead would break
+     *         the functional nature of the calling code.
+     */
+    Optional<ColumnTypeMapping<?, ? extends R>> get(Class<?> type) {
+        return mappingsByType.getUnchecked(type);
+    }
+
+    /**
+     * Obtains the mapping for the given column type.
+     *
+     * @param <R>
+     *         type of the column to persist the column value as
+     */
+    @FunctionalInterface
+    interface FindMapping<R>
+            extends Function<Class<?>, Optional<ColumnTypeMapping<?, ? extends R>>> {
+
+    }
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@ val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.83")
 val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.83")
 
 /** The version of this library. */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.98")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.99")


### PR DESCRIPTION
In scope of this changeset, the peformance of `ColumnMapping` lookup is improved by caching the results per column type.

Recently, a new version of Spine `modelCompiler` has been developed. Its main feature is that the validation codegen is performed via ProtoData library with Spine's Validation extensions to it. However, at this point, the performance of the corresponding build tasks is low, dragging the build duration into dozens of minutes.

The primary effort on optimization is concentrated in Validation library (see [this PR](https://github.com/SpineEventEngine/validation/pull/29)). However, some bits may be improved in `spine-server` artifact as well — since Validation library itself is a Spine-based application.

Therefore, this changeset introduces the `ColumnMapping` performance improvements, so that they could be later used in Validation library. 

At the moment, Validation library uses an "old" (pre-ProtoData) version of `spine-server`. So, in this changeset, a minimal set of changes was made to keep the resulting `spine-server` artifact as close to the one used currently as possible — in terms of versions of transitive dependencies.