### PR TITLE
Direct `Delivery`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.99`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.100`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -619,12 +619,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 20 20:06:06 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 25 18:59:42 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.99`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.100`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1203,12 +1203,12 @@ This report was generated on **Wed Jul 20 20:06:06 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 20 20:06:07 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 25 18:59:43 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.99`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.100`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1827,12 +1827,12 @@ This report was generated on **Wed Jul 20 20:06:07 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 20 20:06:08 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 25 18:59:44 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.99`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.100`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -2551,12 +2551,12 @@ This report was generated on **Wed Jul 20 20:06:08 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 20 20:06:09 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 25 18:59:45 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.99`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.100`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3183,12 +3183,12 @@ This report was generated on **Wed Jul 20 20:06:09 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 20 20:06:10 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 25 18:59:46 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.99`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.100`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3859,12 +3859,12 @@ This report was generated on **Wed Jul 20 20:06:10 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 20 20:06:11 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 25 18:59:46 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.99`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.100`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4535,12 +4535,12 @@ This report was generated on **Wed Jul 20 20:06:11 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 20 20:06:11 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 25 18:59:47 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.99`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.100`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5256,4 +5256,4 @@ This report was generated on **Wed Jul 20 20:06:11 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 20 20:06:12 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 25 18:59:48 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.99</version>
+<version>2.0.0-SNAPSHOT.100</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/delivery/Delivery.java
+++ b/server/src/main/java/io/spine/server/delivery/Delivery.java
@@ -406,8 +406,9 @@ public final class Delivery implements Logging {
      * are not sharded.
      *
      * <p>This mode only suits the applications which operate in a single-thread mode
-     * and in scope of a single JVM. Typically, that would be the CLI apps executing linear jobs,
-     * aiming for maximum performance under a strictly controlled circumstances.
+     * and in scope of a single JVM. Typically, that would be some tools executing
+     * linear-style jobs, which aim for the maximum performance under
+     * the strictly controlled circumstances.
      *
      * <p>Any concurrent dispatching of signals (command posting, receiving external events, etc)
      * will likely break the consistency of their target entities.

--- a/server/src/main/java/io/spine/server/delivery/Delivery.java
+++ b/server/src/main/java/io/spine/server/delivery/Delivery.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Duration;
 import com.google.protobuf.util.Durations;
+import io.spine.annotation.Experimental;
 import io.spine.annotation.Internal;
 import io.spine.core.BoundedContextName;
 import io.spine.core.BoundedContextNames;
@@ -394,6 +395,37 @@ public final class Delivery implements Logging {
                 .setStrategy(strategy)
                 .build();
         delivery.subscribe(new LocalDispatchingObserver());
+        return delivery;
+    }
+
+    /**
+     * Creates a new instance of {@code Delivery} which makes all signals to skip
+     * the {@code Inbox}es and be delivered straight to their respective targets.
+     *
+     * <p>In this mode, no signals are stored in the {@code InboxStorage}. Also, the signals
+     * are not sharded.
+     *
+     * <p>This mode only suits the applications which operate in a single-thread mode
+     * and in scope of a single JVM. Typically, that would be the CLI apps executing linear jobs,
+     * aiming for maximum performance under a strictly controlled circumstances.
+     *
+     * <p>Any concurrent dispatching of signals (command posting, receiving external events, etc)
+     * will likely break the consistency of their target entities.
+     *
+     * <p>This API is experimental. Use with caution.
+     *
+     * @return a new instance of {@code Delivery}
+     */
+    @Experimental
+    public static Delivery direct() {
+        var delivery = newBuilder()
+                .setStrategy(UniformAcrossAllShards.singleShard())
+                .setInboxStorage(NoOpInboxStorage.instance())
+                .build();
+        delivery.subscribe(update -> {
+            var action = delivery.deliveries.get(update);
+            action.deliver(ImmutableList.of(update));
+        });
         return delivery;
     }
 

--- a/server/src/main/java/io/spine/server/delivery/NoOpInboxStorage.java
+++ b/server/src/main/java/io/spine/server/delivery/NoOpInboxStorage.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.delivery;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Timestamp;
+import io.spine.server.storage.memory.InMemoryStorageFactory;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Optional;
+
+/**
+ * An {@code InboxStorage} which does nothing.
+ *
+ * <p>To be used strictly in a {@linkplain Delivery#direct() direct} delivery mode,
+ * which assumes that dispatched signals should skip their corresponding {@code Inbox}es.
+ */
+final class NoOpInboxStorage extends InboxStorage {
+
+    private static @MonotonicNonNull NoOpInboxStorage instance = null;
+
+    private NoOpInboxStorage() {
+        super(InMemoryStorageFactory.newInstance(), false);
+    }
+
+    static synchronized NoOpInboxStorage instance() {
+        if (instance == null) {
+            instance = new NoOpInboxStorage();
+        }
+        return instance;
+    }
+
+    /**
+     * Always returns {@code Optional.empty()}.
+     */
+    @Override
+    public Optional<InboxMessage> read(InboxMessageId id) {
+        return Optional.empty();
+    }
+
+    /**
+     * Always returns an empty page of messages.
+     */
+    @Override
+    public Page<InboxMessage> readAll(ShardIndex index, int pageSize) {
+        return EmptyPage.instance();
+    }
+
+    /**
+     * Always returns an empty list of messages.
+     */
+    @Override
+    public ImmutableList<InboxMessage> readAll(ShardIndex index, @Nullable Timestamp sinceWhen,
+                                               int pageSize) {
+        return ImmutableList.of();
+    }
+
+    /**
+     * Always returns {@code Optional.empty()}.
+     */
+    @Override
+    public Optional<InboxMessage> newestMessageToDeliver(ShardIndex index) {
+        return Optional.empty();
+    }
+
+    /**
+     * Does nothing.
+     */
+    @Override
+    public synchronized void write(InboxMessageId id, InboxMessage message) {
+        // Do nothing.
+    }
+
+    /**
+     * A page of {@code InboxMessage}s which is always empty.
+     */
+    private static class EmptyPage implements Page<InboxMessage> {
+
+        private static @MonotonicNonNull EmptyPage instance = null;
+
+        private static synchronized EmptyPage instance() {
+            if (instance == null) {
+                instance = new EmptyPage();
+            }
+            return instance;
+        }
+
+        @Override
+        public ImmutableList<InboxMessage> contents() {
+            return ImmutableList.of();
+        }
+
+        @Override
+        public int size() {
+            return 0;
+        }
+
+        @Override
+        public Optional<Page<InboxMessage>> next() {
+            return Optional.empty();
+        }
+    }
+}

--- a/server/src/main/java/io/spine/server/delivery/NoOpInboxStorage.java
+++ b/server/src/main/java/io/spine/server/delivery/NoOpInboxStorage.java
@@ -48,6 +48,9 @@ final class NoOpInboxStorage extends InboxStorage {
         super(InMemoryStorageFactory.newInstance(), false);
     }
 
+    /**
+     * Returns the singleton instance of {@code NoOpInboxStorage}.
+     */
     static synchronized NoOpInboxStorage instance() {
         if (instance == null) {
             instance = new NoOpInboxStorage();
@@ -75,8 +78,8 @@ final class NoOpInboxStorage extends InboxStorage {
      * Always returns an empty list of messages.
      */
     @Override
-    public ImmutableList<InboxMessage> readAll(ShardIndex index, @Nullable Timestamp sinceWhen,
-                                               int pageSize) {
+    public ImmutableList<InboxMessage>
+    readAll(ShardIndex index, @Nullable Timestamp sinceWhen, int pageSize) {
         return ImmutableList.of();
     }
 

--- a/server/src/main/java/io/spine/server/delivery/ShardedMessageDelivery.java
+++ b/server/src/main/java/io/spine/server/delivery/ShardedMessageDelivery.java
@@ -51,6 +51,20 @@ interface ShardedMessageDelivery<M extends ShardedRecord> {
     void deliver(List<M> incoming);
 
     /**
+     * Delivers a single message to its target.
+     *
+     * <p>The descendants typically will initialize the targets for the messages (such as entities)
+     * and handle the dispatching results.
+     *
+     * <p>Any runtime issues should be handled by the descendants by emitting the corresponding
+     * rejection events and potentially notifying the respective entity repositories.
+     *
+     * @param message
+     *         the incoming message to deliver
+     */
+    void deliver(M message);
+
+    /**
      * Serves to notify that the given message was originally sent to be {@linkplain #deliver(List)
      * delivered}, but turned out to be a duplicate.
      */

--- a/server/src/main/java/io/spine/server/delivery/TargetDelivery.java
+++ b/server/src/main/java/io/spine/server/delivery/TargetDelivery.java
@@ -77,6 +77,11 @@ final class TargetDelivery<I> implements ShardedMessageDelivery<InboxMessage> {
     }
 
     @Override
+    public void deliver(InboxMessage message) {
+        doDeliver(inboxOfCmds, inboxOfEvents, message);
+    }
+
+    @Override
     public void onDuplicate(InboxMessage message) {
         if(message.hasCommand()) {
             inboxOfCmds.notifyOfDuplicated(message);

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@ val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.83")
 val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.83")
 
 /** The version of this library. */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.99")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.100")


### PR DESCRIPTION
This changeset introduces a "direct" mode of `Delivery`.

Prior to these changes, in any mode of its operation, `Delivery` operated by processing the `InboxMessage`s which were stored and read from `InboxStorage`. It guaranteed that no concurrent changes could be made to the same entity state.

However, in some cases a Spine-based application may look for more performance in dispatching the signals. In this changeset, a direct `Delivery` mode is now available:

```java
        ServerEnvironment.when(...)
                         .use(Delivery.direct());
```

Using this mode has the following impact onto the application:

* `Inbox`es and `InboxStorage` are skipped altogether. They no longer participate in dispatching of any signals. No sharding is performed as well. It improves the application performance by eliminating the `Inbox`-related I/O operations.

* Any concurrent modifications made to the entities are now out of control. I.e. simultaneous handling of signals by the same entity instance (loaded either in different threads or in different JVMs) is now possible.

A typical scenario is a single-threaded processing of a huge number of signals (such as importing an event log via third-party events) in a single-threaded application. In Spine-based tools, this feature is designed for ProtoData CLI tool.

Please note, this is an **experimental** API. 