### PR TITLE
Fix gRPC dependency version and CPU-dependent test

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@
  */
 
 import io.spine.internal.dependency.ErrorProne
+import io.spine.internal.dependency.Grpc
 import io.spine.internal.dependency.JUnit
 import io.spine.internal.gradle.publish.IncrementGuard
 import io.spine.internal.gradle.VersionWriter
@@ -194,6 +195,13 @@ subprojects {
         all {
             resolutionStrategy {
                 force(
+                    /* Force the version of gRPC used by the `:client` module over the one
+                       set by `mc-java` in the `:core` module when specifying compiler artifact
+                       for the gRPC plugin.
+                       See `io.spine.tools.mc.java.gradle.plugins.JavaProtocConfigurationPlugin
+                       .configureProtocPlugins() method which sets the version from resources. */
+                    "io.grpc:protoc-gen-grpc-java:${Grpc.version}",
+
                     "io.spine:spine-base:$spineBaseVersion",
                     "io.spine:spine-time:$spineTimeVersion",
                     "io.spine.tools:spine-testlib:$spineBaseVersion",
@@ -203,7 +211,7 @@ subprojects {
                     "com.google.errorprone:error_prone_annotation:2.10.0",
                     "com.google.errorprone:error_prone_check_api:2.10.0",
                     "com.google.errorprone:error_prone_test_helpers:2.10.0",
-                    "com.google.errorprone:error_prone_type_annotations:2.10.0"
+                    "com.google.errorprone:error_prone_type_annotations:2.10.0",
                 )
             }
         }

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.100`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.101`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -335,7 +335,7 @@
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.38.0.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.45.1.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -619,12 +619,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 25 18:59:42 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 23 22:43:20 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.100`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.101`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -919,7 +919,7 @@ This report was generated on **Mon Jul 25 18:59:42 EEST 2022** using [Gradle-Lic
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.38.0.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.45.1.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -1203,12 +1203,12 @@ This report was generated on **Mon Jul 25 18:59:42 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 25 18:59:43 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 23 22:43:20 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.100`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.101`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1543,7 +1543,7 @@ This report was generated on **Mon Jul 25 18:59:43 EEST 2022** using [Gradle-Lic
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.38.0.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.45.1.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -1827,12 +1827,12 @@ This report was generated on **Mon Jul 25 18:59:43 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 25 18:59:44 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 23 22:43:21 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.100`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.101`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -2259,7 +2259,7 @@ This report was generated on **Mon Jul 25 18:59:44 EEST 2022** using [Gradle-Lic
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.38.0.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.45.1.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -2551,12 +2551,12 @@ This report was generated on **Mon Jul 25 18:59:44 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 25 18:59:45 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 23 22:43:24 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.100`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.101`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2899,7 +2899,7 @@ This report was generated on **Mon Jul 25 18:59:45 EEST 2022** using [Gradle-Lic
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.38.0.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.45.1.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -3183,12 +3183,12 @@ This report was generated on **Mon Jul 25 18:59:45 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 25 18:59:46 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 23 22:43:26 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.100`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.101`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3575,7 +3575,7 @@ This report was generated on **Mon Jul 25 18:59:46 EEST 2022** using [Gradle-Lic
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.38.0.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.45.1.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -3859,12 +3859,12 @@ This report was generated on **Mon Jul 25 18:59:46 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 25 18:59:46 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 23 22:43:26 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.100`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.101`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4251,7 +4251,7 @@ This report was generated on **Mon Jul 25 18:59:46 EEST 2022** using [Gradle-Lic
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.38.0.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.45.1.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -4535,12 +4535,12 @@ This report was generated on **Mon Jul 25 18:59:46 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 25 18:59:47 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 23 22:43:26 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.100`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.101`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4931,7 +4931,7 @@ This report was generated on **Mon Jul 25 18:59:47 EEST 2022** using [Gradle-Lic
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
-1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.38.0.
+1.  **Group** : io.grpc. **Name** : protoc-gen-grpc-java. **Version** : 1.45.1.
      * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
      * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
 
@@ -5256,4 +5256,4 @@ This report was generated on **Mon Jul 25 18:59:47 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 25 18:59:48 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Aug 23 22:43:36 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/model/model-verifier/src/test/resources/model-verifier-test/build.gradle.kts
+++ b/model/model-verifier/src/test/resources/model-verifier-test/build.gradle.kts
@@ -104,6 +104,19 @@ dependencies {
     annotationProcessor("io.spine.tools:spine-model-assembler:$versionToPublish")
 }
 
+configurations.all {
+    resolutionStrategy {
+        force(
+            /* Force the version of gRPC used by the `:client` module over the one
+               set by `mc-java` in the `:core` module when specifying compiler artifact
+               for the gRPC plugin.
+               See `io.spine.tools.mc.java.gradle.plugins.JavaProtocConfigurationPlugin
+               .configureProtocPlugins() method which sets the version from resources. */
+            "io.grpc:protoc-gen-grpc-java:${io.spine.internal.dependency.Grpc.version}",
+        )
+    }
+}
+
 sourceSets {
     main {
         java.srcDirs("$projectDir/generated/main/java", "$projectDir/generated/main/spine")

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.100</version>
+<version>2.0.0-SNAPSHOT.101</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/test/java/io/spine/server/migration/mirror/MirrorMigrationTest.java
+++ b/server/src/test/java/io/spine/server/migration/mirror/MirrorMigrationTest.java
@@ -26,7 +26,7 @@
 
 package io.spine.server.migration.mirror;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.Iterators;
 import io.spine.server.ContextSpec;
 import io.spine.server.migration.mirror.given.DeliveryService;
 import io.spine.server.migration.mirror.given.MemoizingMonitor;
@@ -173,9 +173,10 @@ final class MirrorMigrationTest {
         migration.run(monitor);
 
         @SuppressWarnings("resource") // Closed elsewhere.
-        var entityRecordStorage = migration.destinationStorage();
-        var entityRecords = Lists.newArrayList(entityRecordStorage.readAll());
-        assertThat(entityRecords.size()).isLessThan(expectedNumber);
-        assertThat(entityRecords.size()).isAtLeast(batchSize);
+        var destinationStorage = migration.destinationStorage();
+        var migratedRecords =  Iterators.size(destinationStorage.index());
+
+        assertThat(migratedRecords).isLessThan(expectedNumber);
+        assertThat(migratedRecords).isAtLeast(batchSize);
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@ val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.83")
 val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.83")
 
 /** The version of this library. */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.100")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.101")


### PR DESCRIPTION
This PR addresses two issues discovered when attempting to build under macOS running under M1 Max.

### Forced gRPC version
The first issue is that `mc-java` applied in the `:core` module of the project sets the artifact `protoc-gen-grpc-java-1.38.0-osx-aarch_64.exe` (because that version of `mc-java` depends on gRPC v 1.38). Due to some reason there is no such exe file available on Maven Plugin portal, which resulted in the error:
```
Execution failed for task ':core:generateProto'.
> Could not resolve all files for configuration ':core:protobufToolsLocator_grpc'.
   > Could not find protoc-gen-grpc-java-1.38.0-osx-aarch_64.exe (io.grpc:protoc-gen-grpc-java:1.38.0).
     Searched in the following locations:
         https://plugins.gradle.org/m2/io/grpc/protoc-gen-grpc-java/1.38.0/protoc-gen-grpc-java-1.38.0-osx-aarch_64.exe
``` 
Another version of gRPC is used by the `:client` module. Forcing this version in the main code _and_ in the `:model-verifier` tests fixes the issue.

### `MirrorMigrationTest` was altered to not depend on CPU performance
Before this PR the test used a stub `MirrorMigrationMonitor` which failed when 5000 records were not converted during 3 seconds. To make this stub instance fail a small batch size of 10 records and corresponding timing were used.

Such an approach is suboptimal because of two reasons:
  1. It slows tests down. 3 seconds is not much if it comes to one test, but with thousands of tests, seconds here and there add up.
  2. The assumption that migration wouldn't every go through with such a small batch is wrong. CPUs become faster eventually. Tests can be time-based if there's time involved in the business logic.

The test was updated to just count number of migration steps.

