### PR TITLE
Filter internal commands posted to `CommandService`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -619,7 +619,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 15:35:45 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 26 20:05:13 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1203,7 +1203,7 @@ This report was generated on **Fri Aug 26 15:35:45 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 15:35:46 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 26 20:05:14 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1827,7 +1827,7 @@ This report was generated on **Fri Aug 26 15:35:46 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 15:35:46 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 26 20:05:14 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2551,7 +2551,7 @@ This report was generated on **Fri Aug 26 15:35:46 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 15:35:47 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 26 20:05:14 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3183,7 +3183,7 @@ This report was generated on **Fri Aug 26 15:35:47 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 15:35:47 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 26 20:05:15 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3859,7 +3859,7 @@ This report was generated on **Fri Aug 26 15:35:47 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 15:35:47 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 26 20:05:15 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4535,7 +4535,7 @@ This report was generated on **Fri Aug 26 15:35:47 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 15:35:48 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 26 20:05:16 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5256,4 +5256,4 @@ This report was generated on **Fri Aug 26 15:35:48 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 15:35:48 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 26 20:05:16 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.103`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.104`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -619,12 +619,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 14:49:42 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 26 15:35:45 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.103`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.104`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1203,12 +1203,12 @@ This report was generated on **Fri Aug 26 14:49:42 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 14:49:42 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 26 15:35:46 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.103`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.104`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1827,12 +1827,12 @@ This report was generated on **Fri Aug 26 14:49:42 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 14:49:43 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 26 15:35:46 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.103`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.104`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -2551,12 +2551,12 @@ This report was generated on **Fri Aug 26 14:49:43 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 14:49:43 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 26 15:35:47 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.103`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.104`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3183,12 +3183,12 @@ This report was generated on **Fri Aug 26 14:49:43 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 14:49:43 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 26 15:35:47 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.103`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.104`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3859,12 +3859,12 @@ This report was generated on **Fri Aug 26 14:49:43 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 14:49:44 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 26 15:35:47 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.103`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.104`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4535,12 +4535,12 @@ This report was generated on **Fri Aug 26 14:49:44 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 14:49:44 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 26 15:35:48 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.103`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.104`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5256,4 +5256,4 @@ This report was generated on **Fri Aug 26 14:49:44 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 14:49:44 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 26 15:35:48 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.103</version>
+<version>2.0.0-SNAPSHOT.104</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/CommandService.java
+++ b/server/src/main/java/io/spine/server/CommandService.java
@@ -67,8 +67,8 @@ public final class CommandService
         if (map.isEmpty()) {
             /* We do not prohibit such a case of "empty" service for unusual cases of serving
                no commands (e.g. because of handling only events) or for creating stub instances. */
-            _warn().log("A `%s` with no bounded contexts has been created: `%s`.",
-                        getClass().getSimpleName(), this);
+            _warn().log("A `%s` with no bounded contexts has been created.",
+                        getClass().getSimpleName());
         }
     }
 

--- a/server/src/main/java/io/spine/server/CommandService.java
+++ b/server/src/main/java/io/spine/server/CommandService.java
@@ -72,7 +72,6 @@ public final class CommandService
         }
     }
 
-    @NonNull
     private String simpleClassName() {
         return getClass().getSimpleName();
     }

--- a/server/src/main/java/io/spine/server/CommandService.java
+++ b/server/src/main/java/io/spine/server/CommandService.java
@@ -30,18 +30,22 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.grpc.stub.StreamObserver;
+import io.spine.base.Error;
+import io.spine.base.Errors;
 import io.spine.client.grpc.CommandServiceGrpc;
 import io.spine.core.Ack;
 import io.spine.core.Command;
 import io.spine.logging.Logging;
-import io.spine.server.bus.MessageIdExtensions;
 import io.spine.server.commandbus.UnsupportedCommandException;
 import io.spine.server.type.CommandClass;
+import io.spine.type.UnpublishedLanguageException;
 
 import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.server.bus.MessageIdExtensions.causedError;
+import static io.spine.type.MessageExtensions.isInternal;
 
 /**
  * The {@code CommandService} allows client applications to post commands and
@@ -60,6 +64,12 @@ public final class CommandService
     private CommandService(Map<CommandClass, BoundedContext> map) {
         super();
         this.commandToContext = ImmutableMap.copyOf(map);
+        if (map.isEmpty()) {
+            /* We do not prohibit such a case of "empty" service for unusual cases of serving
+               no commands (e.g. because of handling only events) or for creating stub instances. */
+            _warn().log("A `%s` with no bounded contexts has been created: `%s`.",
+                        getClass().getSimpleName(), this);
+        }
     }
 
     /**
@@ -81,13 +91,25 @@ public final class CommandService
     @Override
     public void post(Command request, StreamObserver<Ack> responseObserver) {
         var commandClass = CommandClass.of(request);
-        var context = commandToContext.get(commandClass);
-        if (context == null) {
+        if (isInternal(commandClass.value())) {
+            handleInternal(request, responseObserver);
+            return;
+        }
+        var boundedContext = commandToContext.get(commandClass);
+        if (boundedContext == null) {
             handleUnsupported(request, responseObserver);
         } else {
-            var commandBus = context.commandBus();
+            var commandBus = boundedContext.commandBus();
             commandBus.post(request, responseObserver);
         }
+    }
+
+    private void handleInternal(Command command, StreamObserver<Ack> responseObserver) {
+        var unpublishedLanguage = new UnpublishedLanguageException(command.enclosedMessage());
+        _error().withCause(unpublishedLanguage)
+                .log("Unpublished command posted to `CommandService`.");
+        var error = Errors.fromThrowable(unpublishedLanguage);
+        respondWithError(command, error, responseObserver);
     }
 
     private void handleUnsupported(Command command, StreamObserver<Ack> responseObserver) {
@@ -95,8 +117,13 @@ public final class CommandService
         _error().withCause(unsupported)
                 .log("Unsupported command posted to `CommandService`.");
         var error = unsupported.asError();
+        respondWithError(command, error, responseObserver);
+    }
+
+    private static
+    void respondWithError(Command command, Error error, StreamObserver<Ack> responseObserver) {
         var id = command.getId();
-        var response = MessageIdExtensions.causedError(id, error);
+        var response = causedError(id, error);
         responseObserver.onNext(response);
         responseObserver.onCompleted();
     }

--- a/server/src/main/java/io/spine/server/CommandService.java
+++ b/server/src/main/java/io/spine/server/CommandService.java
@@ -39,6 +39,7 @@ import io.spine.logging.Logging;
 import io.spine.server.commandbus.UnsupportedCommandException;
 import io.spine.server.type.CommandClass;
 import io.spine.type.UnpublishedLanguageException;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Map;
 import java.util.Set;
@@ -67,9 +68,13 @@ public final class CommandService
         if (map.isEmpty()) {
             /* We do not prohibit such a case of "empty" service for unusual cases of serving
                no commands (e.g. because of handling only events) or for creating stub instances. */
-            _warn().log("A `%s` with no bounded contexts has been created.",
-                        getClass().getSimpleName());
+            _warn().log("A `%s` with no bounded contexts has been created.", simpleClassName());
         }
+    }
+
+    @NonNull
+    private String simpleClassName() {
+        return getClass().getSimpleName();
     }
 
     /**
@@ -107,7 +112,7 @@ public final class CommandService
     private void handleInternal(Command command, StreamObserver<Ack> responseObserver) {
         var unpublishedLanguage = new UnpublishedLanguageException(command.enclosedMessage());
         _error().withCause(unpublishedLanguage)
-                .log("Unpublished command posted to `CommandService`.");
+                .log("Unpublished command posted to `%s`.", simpleClassName());
         var error = Errors.fromThrowable(unpublishedLanguage);
         respondWithError(command, error, responseObserver);
     }
@@ -115,7 +120,7 @@ public final class CommandService
     private void handleUnsupported(Command command, StreamObserver<Ack> responseObserver) {
         var unsupported = new UnsupportedCommandException(command);
         _error().withCause(unsupported)
-                .log("Unsupported command posted to `CommandService`.");
+                .log("Unsupported command posted to `%s`.", simpleClassName());
         var error = unsupported.asError();
         respondWithError(command, error, responseObserver);
     }

--- a/server/src/test/java/io/spine/server/delivery/CatchUpTest.java
+++ b/server/src/test/java/io/spine/server/delivery/CatchUpTest.java
@@ -43,6 +43,7 @@ import io.spine.test.delivery.EmitNextNumber;
 import io.spine.testing.SlowTest;
 import io.spine.testing.server.blackbox.BlackBox;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -103,35 +104,45 @@ public class CatchUpTest extends AbstractDeliveryTest {
                          .clear();
     }
 
-    @Test
-    @DisplayName("given the time is provided with nanosecond resolution, catch up " +
-            "only particular instances by their IDs")
-    public void withNanosByIds() throws InterruptedException {
-        testCatchUpByIds();
+    @Nested
+    @DisplayName("given the time is provided with nanosecond resolution")
+    class NanosecondsResolution {
+
+        @Test
+        @DisplayName("catch up only particular instances by their IDs")
+        public void withNanosByIds() throws InterruptedException {
+            testCatchUpByIds();
+        }
+
+        @Test
+        @DisplayName("catch up all of projection instances " +
+                "and respect the order of the delivered events")
+        public void withNanosAllInOrder() throws InterruptedException {
+            testCatchUpAll();
+        }
     }
 
-    @Test
-    @DisplayName("given the time is provided with nanosecond resolution, " +
-            "catch up all of projection instances " +
-            "and respect the order of the delivered events")
-    public void withNanosAllInOrder() throws InterruptedException {
-        testCatchUpAll();
-    }
+    @Nested
+    @DisplayName("given the time is provided with millisecond resolution")
+    class MillisecondResolution {
 
-    @Test
-    @DisplayName("given the time is provided with millisecond resolution, " +
-            "catch up only particular instances by their IDs")
-    public void withMillisByIds() throws InterruptedException {
-        setupMillis();
-        testCatchUpByIds();
-    }
+        @BeforeEach
+        void useMillis() {
+            setupMillis();
+        }
 
-    @Test
-    @DisplayName("given the time is provided with millisecond resolution, catch up all " +
-            "of projection instances and respect the order of the delivered events")
-    public void withMillisAllInOrder() throws InterruptedException {
-        setupMillis();
-        testCatchUpAll();
+        @Test
+        @DisplayName("catch up only particular instances by their IDs")
+        public void withMillisByIds() throws InterruptedException {
+            testCatchUpByIds();
+        }
+
+        @Test
+        @DisplayName("catch up all of projection instances and " +
+                "respect the order of the delivered events")
+        public void withMillisAllInOrder() throws InterruptedException {
+            testCatchUpAll();
+        }
     }
 
     @Test
@@ -271,7 +282,6 @@ public class CatchUpTest extends AbstractDeliveryTest {
         assertThat(totalsAfterCatchUp).isEqualTo(expectedTotals);
     }
 
-    @SuppressWarnings("OverlyLongMethod")   // Complex environment setup.
     private static void testCatchUpAll() throws InterruptedException {
         ConsecutiveProjection.usePositives();
 

--- a/server/src/test/kotlin/io/spine/server/CommandServiceUnpublishedLanguageTest.kt
+++ b/server/src/test/kotlin/io/spine/server/CommandServiceUnpublishedLanguageTest.kt
@@ -35,10 +35,12 @@ import io.spine.grpc.StreamObservers.memoizingObserver
 import io.spine.protobuf.Messages.isNotDefault
 import io.spine.test.unpublished.command.Halt
 import io.spine.testing.client.TestActorRequestFactory
+import io.spine.testing.logging.mute.MuteLogging
 import io.spine.type.UnpublishedLanguageException
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+@MuteLogging
 internal class `'CommandService' should prohibit using 'internal_type' commands` {
 
     private lateinit var service: CommandService

--- a/server/src/test/kotlin/io/spine/server/CommandServiceUnpublishedLanguageTest.kt
+++ b/server/src/test/kotlin/io/spine/server/CommandServiceUnpublishedLanguageTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server
+
+import com.google.common.truth.Truth.assertThat
+import io.spine.core.Ack
+import io.spine.core.Command
+import io.spine.core.Status
+import io.spine.grpc.MemoizingObserver
+import io.spine.grpc.StreamObservers.memoizingObserver
+import io.spine.protobuf.Messages.isNotDefault
+import io.spine.test.unpublished.command.Halt
+import io.spine.testing.client.TestActorRequestFactory
+import io.spine.type.UnpublishedLanguageException
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class `'CommandService' should prohibit using 'internal_type' commands` {
+
+    private lateinit var service: CommandService
+    private lateinit var observer: MemoizingObserver<Ack>
+
+    @BeforeEach
+    fun initServiceAndObserver() {
+        service = CommandService.newBuilder().build()
+        observer = memoizingObserver()
+    }
+
+    @Test
+    fun `returning 'Error' when such a command posted`() {
+        val command = createCommand()
+
+        service.post(command, observer)
+
+        assertThat(observer.error).isNull()
+        assertThat(observer.isCompleted).isTrue()
+
+        val response = observer.firstResponse()
+        assertThat(isNotDefault(response)).isTrue()
+
+        val status = response.status
+        assertThat(status.statusCase).isEqualTo(Status.StatusCase.ERROR)
+
+        val error = status.error
+        assertThat(error.type)
+            .isEqualTo(UnpublishedLanguageException::class.java.canonicalName)
+    }
+
+    private fun createCommand(): Command {
+        val factory = TestActorRequestFactory(javaClass)
+        val commandMessage = Halt.newBuilder().setValue(true).build()
+        val command = factory.createCommand(commandMessage)
+        return command
+    }
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@ val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.83")
 val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.83")
 
 /** The version of this library. */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.103")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.104")


### PR DESCRIPTION
This PR extends the `CommandService` with an ability to reject commands with messages marked as `internal_type`.

Also creating `CommandService` without any bounded context associated cases now warning in logging. The ability to create such ”empty” command services may be useful for stubbing (which was employed in the test added by this PR), and for special cases when, for example, a server-side listens only to events.
