### PR TITLE
Extract common parts in service creation

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.104`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.105`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -619,12 +619,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 20:05:13 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 27 22:40:43 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.104`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.105`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1203,12 +1203,12 @@ This report was generated on **Fri Aug 26 20:05:13 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 20:05:14 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 27 22:40:44 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.104`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.105`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1827,12 +1827,12 @@ This report was generated on **Fri Aug 26 20:05:14 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 20:05:14 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 27 22:40:44 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.104`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.105`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -2551,12 +2551,12 @@ This report was generated on **Fri Aug 26 20:05:14 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 20:05:14 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 27 22:40:44 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.104`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.105`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3183,12 +3183,12 @@ This report was generated on **Fri Aug 26 20:05:14 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 20:05:15 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 27 22:40:45 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.104`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.105`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3859,12 +3859,12 @@ This report was generated on **Fri Aug 26 20:05:15 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 20:05:15 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 27 22:40:45 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.104`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.105`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4535,12 +4535,12 @@ This report was generated on **Fri Aug 26 20:05:15 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 20:05:16 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 27 22:40:45 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.104`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.105`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5256,4 +5256,4 @@ This report was generated on **Fri Aug 26 20:05:16 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 26 20:05:16 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 27 22:40:46 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -619,7 +619,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 27 22:40:43 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Aug 28 22:20:31 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1203,7 +1203,7 @@ This report was generated on **Sat Aug 27 22:40:43 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 27 22:40:44 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Aug 28 22:20:31 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1827,7 +1827,7 @@ This report was generated on **Sat Aug 27 22:40:44 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 27 22:40:44 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Aug 28 22:20:31 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2551,7 +2551,7 @@ This report was generated on **Sat Aug 27 22:40:44 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 27 22:40:44 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Aug 28 22:20:32 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3183,7 +3183,7 @@ This report was generated on **Sat Aug 27 22:40:44 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 27 22:40:45 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Aug 28 22:20:32 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3859,7 +3859,7 @@ This report was generated on **Sat Aug 27 22:40:45 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 27 22:40:45 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Aug 28 22:20:32 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4535,7 +4535,7 @@ This report was generated on **Sat Aug 27 22:40:45 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 27 22:40:45 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Aug 28 22:20:33 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5256,4 +5256,4 @@ This report was generated on **Sat Aug 27 22:40:45 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 27 22:40:46 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Aug 28 22:20:33 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.104</version>
+<version>2.0.0-SNAPSHOT.105</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/AbstractServiceBuilder.java
+++ b/server/src/main/java/io/spine/server/AbstractServiceBuilder.java
@@ -42,6 +42,9 @@ public abstract class AbstractServiceBuilder<T, B extends AbstractServiceBuilder
 
     private final Set<BoundedContext> contexts = Sets.newHashSet();
 
+    /**
+     * Returns this instance with the overloaded type.
+     */
     abstract B self();
 
     /**
@@ -59,7 +62,7 @@ public abstract class AbstractServiceBuilder<T, B extends AbstractServiceBuilder
     }
 
     /**
-     * Adds the passed bounded context to be served by the query service.
+     * Adds the passed bounded context to be served by the service.
      */
     @CanIgnoreReturnValue
     public B add(BoundedContext context) {
@@ -68,7 +71,7 @@ public abstract class AbstractServiceBuilder<T, B extends AbstractServiceBuilder
     }
 
     /**
-     * Excludes the passed bounded context from being served by the query service.
+     * Excludes the passed bounded context from being served by the service.
      */
     @CanIgnoreReturnValue
     public B remove(BoundedContext context) {

--- a/server/src/main/java/io/spine/server/AbstractServiceBuilder.java
+++ b/server/src/main/java/io/spine/server/AbstractServiceBuilder.java
@@ -36,7 +36,9 @@ import java.util.Set;
  * Abstract for builder of service classes.
  *
  * @param <T>
- *         the type of service to be produced.
+ *         the type of service to be produced
+ * @param <B>
+ *         the self-type of the builder for return type covariance
  */
 public abstract class AbstractServiceBuilder<T, B extends AbstractServiceBuilder<T, B>> {
 

--- a/server/src/main/java/io/spine/server/AbstractServiceBuilder.java
+++ b/server/src/main/java/io/spine/server/AbstractServiceBuilder.java
@@ -92,10 +92,8 @@ public abstract class AbstractServiceBuilder<T, B extends AbstractServiceBuilder
      * Obtains the class of the service this builder creates.
      */
     Class<T> serviceClass() {
-        GenericTypeIndex<AbstractServiceBuilder<T, B>> typeIndex = () -> 0;
         @SuppressWarnings("unchecked")
-        var cls = (Class<T>) typeIndex.argumentIn(
-                (Class<? extends AbstractServiceBuilder<T, B>>) getClass());
+        var cls = (Class<T>) GenericParameter.SERVICE_TYPE.argumentIn(getClass());
         return cls;
     }
 
@@ -119,4 +117,15 @@ public abstract class AbstractServiceBuilder<T, B extends AbstractServiceBuilder
      * Creates a new instance of the service.
      */
     abstract T build();
+
+    @SuppressWarnings("rawtypes")
+    private enum GenericParameter implements GenericTypeIndex<AbstractServiceBuilder> {
+
+        SERVICE_TYPE;
+
+        @Override
+        public int index() {
+            return 0;
+        }
+    }
 }

--- a/server/src/main/java/io/spine/server/AbstractServiceBuilder.java
+++ b/server/src/main/java/io/spine/server/AbstractServiceBuilder.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+
+import java.util.Set;
+
+/**
+ * Abstract for builder of service classes.
+ *
+ * @param <T>
+ *         the type of service to be produced.
+ */
+public abstract class AbstractServiceBuilder<T, B extends AbstractServiceBuilder<T, B>> {
+
+    private final Set<BoundedContext> contexts = Sets.newHashSet();
+
+    abstract B self();
+
+    /**
+     * Tells if this builder has no bounded context.
+     */
+    boolean isEmpty() {
+        return contexts.isEmpty();
+    }
+
+    /**
+     * Obtains immutable copy of already added contexts.
+     */
+    ImmutableSet<BoundedContext> contexts() {
+        return ImmutableSet.copyOf(contexts);
+    }
+
+    /**
+     * Adds the passed bounded context to be served by the query service.
+     */
+    @CanIgnoreReturnValue
+    public B add(BoundedContext context) {
+        contexts.add(context);
+        return self();
+    }
+
+    /**
+     * Excludes the passed bounded context from being served by the query service.
+     */
+    @CanIgnoreReturnValue
+    public B remove(BoundedContext context) {
+        contexts.remove(context);
+        return self();
+    }
+
+    /**
+     * Tells if the builder already contains the passed bounded context.
+     */
+    public boolean contains(BoundedContext context) {
+        return contexts.contains(context);
+    }
+
+    /**
+     * Creates a new instance of the service.
+     */
+    abstract T build();
+}

--- a/server/src/main/java/io/spine/server/AbstractServiceBuilder.java
+++ b/server/src/main/java/io/spine/server/AbstractServiceBuilder.java
@@ -27,9 +27,9 @@
 package io.spine.server;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -40,7 +40,7 @@ import java.util.Set;
  */
 public abstract class AbstractServiceBuilder<T, B extends AbstractServiceBuilder<T, B>> {
 
-    private final Set<BoundedContext> contexts = Sets.newHashSet();
+    private final Set<BoundedContext> contexts = new HashSet<>();
 
     /**
      * Returns this instance with the overloaded type.

--- a/server/src/main/java/io/spine/server/CommandService.java
+++ b/server/src/main/java/io/spine/server/CommandService.java
@@ -39,7 +39,6 @@ import io.spine.logging.Logging;
 import io.spine.server.commandbus.UnsupportedCommandException;
 import io.spine.server.type.CommandClass;
 import io.spine.type.UnpublishedLanguageException;
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Map;
 import java.util.Set;

--- a/server/src/main/java/io/spine/server/CommandService.java
+++ b/server/src/main/java/io/spine/server/CommandService.java
@@ -27,8 +27,6 @@
 package io.spine.server;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Sets;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.grpc.stub.StreamObserver;
 import io.spine.base.Error;
 import io.spine.base.Errors;
@@ -41,7 +39,6 @@ import io.spine.server.type.CommandClass;
 import io.spine.type.UnpublishedLanguageException;
 
 import java.util.Map;
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.server.bus.MessageIdExtensions.causedError;
@@ -134,43 +131,12 @@ public final class CommandService
     /**
      * The builder for a {@code CommandService}.
      */
-    public static class Builder {
-
-        private final Set<BoundedContext> contexts = Sets.newHashSet();
-
-        /**
-         * Adds the {@code BoundedContext} to the builder.
-         */
-        @CanIgnoreReturnValue
-        public Builder add(BoundedContext context) {
-            // Saves it to a temporary set so that it is easy to remove it if needed.
-            contexts.add(context);
-            return this;
-        }
-
-        /**
-         * Removes the {@code BoundedContext} from the builder.
-         */
-        @CanIgnoreReturnValue
-        public Builder remove(BoundedContext context) {
-            contexts.remove(context);
-            return this;
-        }
-
-        /**
-         * Verifies if the passed {@code BoundedContext} was previously added to the builder.
-         *
-         * @param context the instance to check
-         * @return {@code true} if the instance was added to the builder, {@code false} otherwise
-         */
-        public boolean contains(BoundedContext context) {
-            var contains = contexts.contains(context);
-            return contains;
-        }
+    public static class Builder extends AbstractServiceBuilder<CommandService, Builder> {
 
         /**
          * Builds a new {@link CommandService}.
          */
+        @Override
         public CommandService build() {
             var map = createMap();
             var result = new CommandService(map);
@@ -183,7 +149,7 @@ public final class CommandService
          */
         private ImmutableMap<CommandClass, BoundedContext> createMap() {
             ImmutableMap.Builder<CommandClass, BoundedContext> builder = ImmutableMap.builder();
-            for (var boundedContext : contexts) {
+            for (var boundedContext : contexts()) {
                 putIntoMap(boundedContext, builder);
             }
             return builder.build();
@@ -200,6 +166,11 @@ public final class CommandService
             for (var commandClass : cmdClasses) {
                 builder.put(commandClass, context);
             }
+        }
+
+        @Override
+        Builder self() {
+            return this;
         }
     }
 }

--- a/server/src/main/java/io/spine/server/QueryService.java
+++ b/server/src/main/java/io/spine/server/QueryService.java
@@ -121,10 +121,7 @@ public final class QueryService
          */
         @Override
         public QueryService build() throws IllegalStateException {
-            if (isEmpty()) {
-                var message = "Query service must have at least one `BoundedContext`.";
-                throw new IllegalStateException(message);
-            }
+            checkNotEmpty();
             var dictionary = TypeDictionary.newBuilder();
             contexts().forEach(
                     context -> dictionary.putAll(context, (c) -> c.stand().exposedTypes())

--- a/server/src/main/java/io/spine/server/QueryService.java
+++ b/server/src/main/java/io/spine/server/QueryService.java
@@ -26,8 +26,6 @@
 package io.spine.server;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Sets;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.grpc.stub.StreamObserver;
 import io.spine.client.Query;
 import io.spine.client.QueryResponse;
@@ -38,7 +36,6 @@ import io.spine.server.stand.InvalidRequestException;
 import io.spine.type.TypeUrl;
 
 import java.util.Map;
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.flogger.LazyArgs.lazy;
@@ -120,33 +117,11 @@ public final class QueryService
     /**
      * The builder for a {@code QueryService}.
      */
-    public static class Builder {
+    public static class Builder extends AbstractServiceBuilder<QueryService, Builder> {
 
-        private final Set<BoundedContext> contexts = Sets.newHashSet();
-
-        /**
-         * Adds the passed bounded context to be served by the query service.
-         */
-        @CanIgnoreReturnValue
-        public Builder add(BoundedContext context) {
-            contexts.add(context);
+        @Override
+        Builder self() {
             return this;
-        }
-
-        /**
-         * Excludes the passed bounded context from being served by the query service.
-         */
-        @CanIgnoreReturnValue
-        public Builder remove(BoundedContext context) {
-            contexts.remove(context);
-            return this;
-        }
-
-        /**
-         * Tells if the builder already contains the passed bounded context.
-         */
-        public boolean contains(BoundedContext context) {
-            return contexts.contains(context);
         }
 
         /**
@@ -154,8 +129,9 @@ public final class QueryService
          *
          * @throws IllegalStateException if no bounded contexts were added.
          */
+        @Override
         public QueryService build() throws IllegalStateException {
-            if (contexts.isEmpty()) {
+            if (isEmpty()) {
                 var message = "Query service must have at least one `BoundedContext`.";
                 throw new IllegalStateException(message);
             }
@@ -166,7 +142,7 @@ public final class QueryService
 
         private ImmutableMap<TypeUrl, BoundedContext> createMap() {
             ImmutableMap.Builder<TypeUrl, BoundedContext> map = ImmutableMap.builder();
-            for (var context : contexts) {
+            for (var context : contexts()) {
                 putExposedTypes(context, map);
             }
             return map.build();

--- a/server/src/main/java/io/spine/server/SubscriptionService.java
+++ b/server/src/main/java/io/spine/server/SubscriptionService.java
@@ -206,10 +206,7 @@ public final class SubscriptionService
          */
         @Override
         public SubscriptionService build() throws IllegalStateException {
-            if (isEmpty()) {
-                throw new IllegalStateException(
-                        "Subscription service must have at least one Bounded Context.");
-            }
+            checkNotEmpty();
             var dictionary = TypeDictionary.newBuilder();
             contexts().forEach(
                     context -> dictionary.putAll(context, (c) ->

--- a/server/src/main/java/io/spine/server/SubscriptionService.java
+++ b/server/src/main/java/io/spine/server/SubscriptionService.java
@@ -27,11 +27,8 @@ package io.spine.server;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.grpc.stub.StreamObserver;
 import io.spine.client.Subscription;
 import io.spine.client.SubscriptionUpdate;
@@ -194,42 +191,16 @@ public final class SubscriptionService
     /**
      * The builder for the {@link SubscriptionService}.
      */
-    public static class Builder {
-        private final Set<BoundedContext> contexts = Sets.newHashSet();
-
-        /**
-         * Adds the context to be handled by the subscription service.
-         */
-        @CanIgnoreReturnValue
-        public Builder add(BoundedContext context) {
-            // Save it to a temporary set so that it is easy to remove it if needed.
-            contexts.add(context);
-            return this;
-        }
-
-        /**
-         * Removes the context from being handled by the subscription service.
-         */
-        @CanIgnoreReturnValue
-        public Builder remove(BoundedContext context) {
-            contexts.remove(context);
-            return this;
-        }
-
-        /**
-         * Obtains the context added to the subscription service by the time of the call.
-         */
-        public ImmutableList<BoundedContext> contexts() {
-            return ImmutableList.copyOf(contexts);
-        }
+    public static class Builder extends AbstractServiceBuilder<SubscriptionService, Builder> {
 
         /**
          * Builds the {@link SubscriptionService}.
          *
          * @throws IllegalStateException if no Bounded Contexts were added.
          */
+        @Override
         public SubscriptionService build() throws IllegalStateException {
-            if (contexts.isEmpty()) {
+            if (isEmpty()) {
                 throw new IllegalStateException(
                         "Subscription service must have at least one Bounded Context.");
             }
@@ -240,7 +211,7 @@ public final class SubscriptionService
 
         private ImmutableMap<TypeUrl, BoundedContext> createMap() {
             ImmutableMap.Builder<TypeUrl, BoundedContext> builder = ImmutableMap.builder();
-            for (var context : contexts) {
+            for (var context : contexts()) {
                 putIntoMap(context, builder);
             }
             return builder.build();
@@ -254,6 +225,11 @@ public final class SubscriptionService
                  .forEach(putIntoMap);
             stand.exposedEventTypes()
                  .forEach(putIntoMap);
+        }
+
+        @Override
+        Builder self() {
+            return this;
         }
     }
 }

--- a/server/src/main/java/io/spine/server/TypeDictionary.java
+++ b/server/src/main/java/io/spine/server/TypeDictionary.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server;
+
+import com.google.common.collect.ImmutableMap;
+import io.spine.type.TypeUrl;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Allows to find to which Bounded Context a given type belongs.
+ */
+final class TypeDictionary {
+
+    private final ImmutableMap<TypeUrl, BoundedContext> map;
+
+    private TypeDictionary(Builder builder) {
+        this.map = ImmutableMap.copyOf(builder.map);
+    }
+
+    /**
+     * Creates a new builder for a type dictionary.
+     */
+    static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * Obtains a bounded context to which the given type belongs.
+     *
+     * @param type
+     *         the type to search
+     * @return the bounded context or empty {@code Optional}
+     */
+    Optional<BoundedContext> find(TypeUrl type) {
+        var result = Optional.ofNullable(map.get(type));
+        return result;
+    }
+
+    /**
+     * A builder for new type dictionary.
+     */
+    static final class Builder {
+
+        private final Map<TypeUrl, BoundedContext> map = new HashMap<>();
+
+        /**
+         * Obtains the types from the given context and associates them with it.
+         *
+         * @param context
+         *         the bounded context to query for the types
+         * @param typeSupplier
+         *         the function obtaining the types from the given instance of the context
+         * @return this builder instance
+         */
+        Builder putAll(BoundedContext context,
+                       Function<BoundedContext, Set<TypeUrl>> typeSupplier) {
+            checkNotNull(context);
+            checkNotNull(typeSupplier);
+            var types = typeSupplier.apply(context);
+            types.forEach(type -> map.put(type, context));
+            return this;
+        }
+
+        /**
+         * Creates new type dictionary.
+         */
+        TypeDictionary build() {
+            return new TypeDictionary(this);
+        }
+    }
+}

--- a/server/src/main/java/io/spine/server/TypeDictionary.java
+++ b/server/src/main/java/io/spine/server/TypeDictionary.java
@@ -26,6 +26,7 @@
 
 package io.spine.server;
 
+import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.spine.type.TypeUrl;
@@ -69,6 +70,10 @@ final class TypeDictionary {
     Optional<BoundedContext> find(TypeUrl type) {
         var result = Optional.ofNullable(map.get(type));
         return result;
+    }
+
+    ImmutableCollection<BoundedContext> contexts() {
+        return map.values();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/TypeDictionary.java
+++ b/server/src/main/java/io/spine/server/TypeDictionary.java
@@ -27,6 +27,7 @@
 package io.spine.server;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.spine.type.TypeUrl;
 
 import java.util.HashMap;
@@ -39,13 +40,16 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Allows to find to which Bounded Context a given type belongs.
+ *
+ * <p>Such a dictionary is used in services exposed to client communications
+ * to find out to which bounded context a message received by the service belongs.
  */
 final class TypeDictionary {
 
     private final ImmutableMap<TypeUrl, BoundedContext> map;
 
-    private TypeDictionary(Builder builder) {
-        this.map = ImmutableMap.copyOf(builder.map);
+    private TypeDictionary(Map<TypeUrl, BoundedContext> map) {
+        this.map = ImmutableMap.copyOf(map);
     }
 
     /**
@@ -83,6 +87,7 @@ final class TypeDictionary {
          *         the function obtaining the types from the given instance of the context
          * @return this builder instance
          */
+        @CanIgnoreReturnValue
         Builder putAll(BoundedContext context,
                        Function<BoundedContext, Set<TypeUrl>> typeSupplier) {
             checkNotNull(context);
@@ -96,7 +101,7 @@ final class TypeDictionary {
          * Creates new type dictionary.
          */
         TypeDictionary build() {
-            return new TypeDictionary(this);
+            return new TypeDictionary(map);
         }
     }
 }

--- a/server/src/main/java/io/spine/server/enrich/EnricherBuilder.java
+++ b/server/src/main/java/io/spine/server/enrich/EnricherBuilder.java
@@ -47,7 +47,7 @@ import static io.spine.type.MessageClass.interfacesOf;
  * @param <C>
  *         the type of the contexts of the enriched messages
  * @param <B>
- *         the type of an enricher builder implementation, a descendant of this type, for covariance
+ *         the type of enricher builder implementation, a descendant of this type, for covariance
  */
 public abstract class EnricherBuilder<M extends Message,
                                       C extends EnrichableMessageContext,

--- a/server/src/test/java/io/spine/server/SubscriptionServiceTest.java
+++ b/server/src/test/java/io/spine/server/SubscriptionServiceTest.java
@@ -60,7 +60,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 

--- a/server/src/test/java/io/spine/server/SubscriptionServiceTest.java
+++ b/server/src/test/java/io/spine/server/SubscriptionServiceTest.java
@@ -61,6 +61,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -144,7 +145,7 @@ class SubscriptionServiceTest {
             var subscriptionService = builder.build();
             assertNotNull(subscriptionService);
 
-            List<BoundedContext> contexts = builder.contexts();
+            Set<BoundedContext> contexts = builder.contexts();
             assertThat(contexts).hasSize(1);
             assertTrue(contexts.contains(oneContext));
         }
@@ -163,7 +164,7 @@ class SubscriptionServiceTest {
             var service = builder.build();
             assertNotNull(service);
 
-            List<BoundedContext> contexts = builder.contexts();
+            Set<BoundedContext> contexts = builder.contexts();
             assertThat(contexts).containsExactly(bc1, bc2, bc3);
         }
     }
@@ -184,7 +185,7 @@ class SubscriptionServiceTest {
         var subscriptionService = builder.build();
         assertNotNull(subscriptionService);
 
-        List<BoundedContext> contexts = builder.contexts();
+        Set<BoundedContext> contexts = builder.contexts();
         assertThat(contexts).containsExactly(bc3);
     }
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@ val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.83")
 val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.83")
 
 /** The version of this library. */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.104")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.105")


### PR DESCRIPTION
This PR extracts the common parts of the code that was used to create `QueryService` and `SubscriptionService`.

An abstract base for service builders was introduced. Also `TypeDictionary` utility class was created to simplify mapping a type to a bounded context to which this type belongs.
