### PR TITLE
Allow services serving no types

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.105`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.106`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -619,12 +619,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 29 17:33:17 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 01 15:08:23 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.105`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.106`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1203,12 +1203,12 @@ This report was generated on **Mon Aug 29 17:33:17 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 29 17:33:17 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 01 15:08:23 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.105`
+# Dependencies of `io.spine.tools:spine-model-assembler:2.0.0-SNAPSHOT.106`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1827,12 +1827,12 @@ This report was generated on **Mon Aug 29 17:33:17 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 29 17:33:18 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 01 15:08:24 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.105`
+# Dependencies of `io.spine.tools:spine-model-verifier:2.0.0-SNAPSHOT.106`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -2551,12 +2551,12 @@ This report was generated on **Mon Aug 29 17:33:18 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 29 17:33:18 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 01 15:08:24 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.105`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.106`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3183,12 +3183,12 @@ This report was generated on **Mon Aug 29 17:33:18 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 29 17:33:19 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 01 15:08:25 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.105`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.106`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3859,12 +3859,12 @@ This report was generated on **Mon Aug 29 17:33:19 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 29 17:33:19 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 01 15:08:25 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.105`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.106`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4535,12 +4535,12 @@ This report was generated on **Mon Aug 29 17:33:19 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 29 17:33:20 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 01 15:08:25 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.105`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.106`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5256,4 +5256,4 @@ This report was generated on **Mon Aug 29 17:33:20 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 29 17:33:20 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 01 15:08:26 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.105</version>
+<version>2.0.0-SNAPSHOT.106</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/CommandService.java
+++ b/server/src/main/java/io/spine/server/CommandService.java
@@ -60,19 +60,6 @@ public final class CommandService
     private CommandService(TypeDictionary types) {
         super();
         this.types = types;
-        warnIfEmpty();
-    }
-
-    /**
-     * Logs a warning message if there are no types handled by this service.
-     *
-     * <p>We do not prohibit such a case of "empty" service for unusual cases,
-     * or for creating stub instances for testing.
-     */
-    void warnIfEmpty() {
-        if (types.isEmpty()) {
-            _warn().log("A `%s` with no bounded contexts has been created.", simpleClassName());
-        }
     }
 
     private String simpleClassName() {
@@ -155,6 +142,7 @@ public final class CommandService
             );
 
             var result = new CommandService(dictionary.build());
+            warnIfEmpty(result);
             return result;
         }
 

--- a/server/src/main/java/io/spine/server/QueryService.java
+++ b/server/src/main/java/io/spine/server/QueryService.java
@@ -121,13 +121,13 @@ public final class QueryService
          */
         @Override
         public QueryService build() throws IllegalStateException {
-            checkNotEmpty();
             var dictionary = TypeDictionary.newBuilder();
             contexts().forEach(
                     context -> dictionary.putAll(context, (c) -> c.stand().exposedTypes())
             );
 
             var service = new QueryService(dictionary.build());
+            warnIfEmpty(service);
             return service;
         }
 

--- a/server/src/main/java/io/spine/server/SubscriptionService.java
+++ b/server/src/main/java/io/spine/server/SubscriptionService.java
@@ -204,7 +204,6 @@ public final class SubscriptionService
          */
         @Override
         public SubscriptionService build() throws IllegalStateException {
-            checkNotEmpty();
             var dictionary = TypeDictionary.newBuilder();
             contexts().forEach(
                     context -> dictionary.putAll(context, (c) ->
@@ -212,6 +211,7 @@ public final class SubscriptionService
                     )
             );
             var result = new SubscriptionService(dictionary.build());
+            warnIfEmpty(result);
             return result;
         }
 

--- a/server/src/main/java/io/spine/server/TypeDictionary.java
+++ b/server/src/main/java/io/spine/server/TypeDictionary.java
@@ -72,8 +72,18 @@ final class TypeDictionary {
         return result;
     }
 
+    /**
+     * Obtains the bounded contexts listed in this dictionary.
+     */
     ImmutableCollection<BoundedContext> contexts() {
         return map.values();
+    }
+
+    /**
+     * Tells if this dictionary empty or not.
+     */
+    boolean isEmpty() {
+        return map.isEmpty();
     }
 
     /**

--- a/server/src/test/java/io/spine/server/QueryServiceTest.java
+++ b/server/src/test/java/io/spine/server/QueryServiceTest.java
@@ -45,11 +45,11 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.spine.grpc.StreamObservers.memoizingObserver;
 import static io.spine.server.Given.CUSTOMERS_CONTEXT_NAME;
 import static io.spine.server.Given.PROJECTS_CONTEXT_NAME;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("`QueryService` should")
@@ -92,20 +92,12 @@ class QueryServiceTest {
     }
 
     @Test
-    @DisplayName("fail to create with Bounded Context removed from builder")
-    void notCreateWithRemovedBc() {
-        var boundedContext = BoundedContextBuilder.assumingTests().build();
-        var builder = QueryService.newBuilder();
-        assertThrows(IllegalStateException.class, () -> builder.add(boundedContext)
-                                                               .remove(boundedContext)
-                                                               .build());
-    }
-
-    @Test
-    @DisplayName("fail to create with no Bounded Context")
+    @DisplayName("allow to create an instance serving no types")
     void notCreateWithNoBc() {
-        assertThrows(IllegalStateException.class, () -> QueryService.newBuilder()
-                                                                    .build());
+        assertDoesNotThrow(
+                () -> QueryService.newBuilder()
+                        .build()
+        );
     }
 
     @Test

--- a/server/src/test/java/io/spine/server/SubscriptionServiceTest.java
+++ b/server/src/test/java/io/spine/server/SubscriptionServiceTest.java
@@ -192,7 +192,7 @@ class SubscriptionServiceTest {
     }
 
     @Test
-    @DisplayName("allow instance service not types")
+    @DisplayName("allow a service instance serving no types")
     void notInitFromEmptyBuilder() {
         assertDoesNotThrow(
                 () -> SubscriptionService.newBuilder()

--- a/server/src/test/java/io/spine/server/SubscriptionServiceTest.java
+++ b/server/src/test/java/io/spine/server/SubscriptionServiceTest.java
@@ -69,8 +69,8 @@ import static io.spine.grpc.StreamObservers.noOpObserver;
 import static io.spine.protobuf.AnyPacker.unpack;
 import static io.spine.server.Given.CommandMessage.createProject;
 import static io.spine.server.Given.CommandMessage.sendReport;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("`SubscriptionService` should")
@@ -81,10 +81,13 @@ class SubscriptionServiceTest {
 
     private BoundedContext context;
     private SubscriptionService subscriptionService;
+
     /** The observer for creating a subscription. */
     private MemoizingObserver<Subscription> observer;
+
     /** The observer for activating a subscription. */
     private MemoizingObserver<SubscriptionUpdate> activationObserver;
+
     /** The observer for cancelling a subscription. */
     private MemoizingObserver<Response> cancellationObserver;
 
@@ -189,11 +192,12 @@ class SubscriptionServiceTest {
     }
 
     @Test
-    @DisplayName("fail to initialize from empty builder")
+    @DisplayName("allow instance service not types")
     void notInitFromEmptyBuilder() {
-        assertThrows(IllegalStateException.class,
-                     () -> SubscriptionService.newBuilder()
-                                              .build());
+        assertDoesNotThrow(
+                () -> SubscriptionService.newBuilder()
+                        .build()
+        );
     }
 
     /*

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@ val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.83")
 val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.83")
 
 /** The version of this library. */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.105")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.106")


### PR DESCRIPTION
This PR unifies the convention on creating "empty" services. Previously, we allowed `CommandService` serving no types, but disallowed it for `QueryService` and `SubscriptionService`.

Now it is possible to create a service with no served types (because no bounded contexts were added to its builder).
It would allow to handle unusual server-side implementations and creating service stubs for testing.

If an empty service is created, a warning would be logged.

Also `CommandService` implementation was migrated to `TypeDictionary`.