### PR TITLE
Bump `base` etc.

### DIFF
--- a/client/src/main/java/io/spine/client/CommandFactory.java
+++ b/client/src/main/java/io/spine/client/CommandFactory.java
@@ -38,6 +38,7 @@ import io.spine.validate.ValidationException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.base.Time.currentTime;
+import static io.spine.validate.Validate.check;
 import static io.spine.validate.Validate.checkValid;
 
 /**
@@ -47,7 +48,7 @@ import static io.spine.validate.Validate.checkValid;
  * such as the actor, the tenant, and others.
  *
  * <p>The command messages passed to the factory are
- * {@linkplain io.spine.validate.Validate#checkValid(com.google.protobuf.Message) validated}
+ * {@linkplain io.spine.validate.Validate#check(com.google.protobuf.Message) validated}
  * according to their Proto definitions. If a given message is invalid,
  * a {@link ValidationException} is thrown.
  *
@@ -73,7 +74,7 @@ public final class CommandFactory {
      */
     public Command create(CommandMessage message) throws ValidationException {
         checkNotNull(message);
-        checkValid(message);
+        check(message);
 
         var context = createContext();
         var result = createCommand(message, context);
@@ -98,7 +99,7 @@ public final class CommandFactory {
      */
     public Command create(CommandMessage message, int targetVersion) throws ValidationException {
         checkNotNull(message);
-        checkValid(message);
+        check(message);
 
         var context = createContext(targetVersion);
         var result = createCommand(message, context);
@@ -126,7 +127,7 @@ public final class CommandFactory {
             throws ValidationException {
         checkNotNull(message);
         checkNotNull(context);
-        checkValid(message);
+        check(message);
 
         var newContext = withCurrentTime(context);
         var result = createCommand(message, newContext);

--- a/client/src/main/proto/spine/client/query_service.proto
+++ b/client/src/main/proto/spine/client/query_service.proto
@@ -35,10 +35,18 @@ option java_multiple_files = true;
 option java_outer_classname = "QueryServiceProto";
 
 import "spine/client/query.proto";
+import "google/protobuf/type.proto";
 
 // A service for querying the read-side from clients.
 service QueryService {
 
     // Reads a certain data from the read-side by setting the criteria via Query.
     rpc Read(Query) returns (QueryResponse);
+}
+
+// This types makes the `google.protobuf.EnumValue` type known to the client- and
+// server side. The type is available via the descriptors in the `base` artifact.
+// But due to some unknown reason it is filtered out
+message TypeAttractor {
+    google.protobuf.EnumValue enum_value = 1;
 }

--- a/client/src/main/proto/spine/client/query_service.proto
+++ b/client/src/main/proto/spine/client/query_service.proto
@@ -46,7 +46,8 @@ service QueryService {
 
 // This types makes the `google.protobuf.EnumValue` type known to the client- and
 // server side. The type is available via the descriptors in the `base` artifact.
-// But due to some unknown reason it is filtered out
+// But due to some unknown reason it is filtered out.
+// See https://github.com/SpineEventEngine/core-java/issues/1475 for details.
 message TypeAttractor {
     google.protobuf.EnumValue enum_value = 1;
 }

--- a/client/src/test/java/io/spine/client/QueryTest.java
+++ b/client/src/test/java/io/spine/client/QueryTest.java
@@ -27,9 +27,11 @@
 package io.spine.client;
 
 import io.spine.test.client.TestEntity;
+import io.spine.type.KnownTypes;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -39,6 +41,22 @@ class QueryTest {
 
     private static final String TARGET_ENTITY_TYPE_URL =
             "type.spine.io/spine.test.queries.TestEntity";
+
+    private static final KnownTypes knownTypes = KnownTypes.instance();
+
+    @Test
+    void knowTypeProto() {
+        var files = knownTypes.fileNames();
+        assertThat(files)
+                .contains("google/protobuf/type.proto");
+    }
+
+    @Test
+    void knowEnumValueType() {
+        var types = knownTypes.typeNames();
+        assertThat(types)
+             .contains("google.protobuf.EnumValue");
+    }
 
     @Test
     @DisplayName("obtain entity type url for known query target type")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -30,7 +30,7 @@ val spineBaseTypesVersion: String by extra
 val spineTimeVersion: String by extra
 
 dependencies {
-    implementation("io.spine:spine-base-types:$spineBaseTypesVersion")
+    api("io.spine:spine-base-types:$spineBaseTypesVersion")
     testImplementation(project(":testutil-core"))
     testImplementation("io.spine.tools:spine-testutil-time:$spineTimeVersion")
 }

--- a/license-report.md
+++ b/license-report.md
@@ -626,7 +626,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Sep 22 18:54:36 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 28 13:24:58 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1217,7 +1217,7 @@ This report was generated on **Thu Sep 22 18:54:36 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Sep 22 18:54:37 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 28 13:24:59 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1848,7 +1848,7 @@ This report was generated on **Thu Sep 22 18:54:37 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Sep 22 18:54:37 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 28 13:24:59 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2592,7 +2592,7 @@ This report was generated on **Thu Sep 22 18:54:37 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Sep 22 18:54:38 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 28 13:25:00 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3231,7 +3231,7 @@ This report was generated on **Thu Sep 22 18:54:38 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Sep 22 18:54:38 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 28 13:25:00 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3914,7 +3914,7 @@ This report was generated on **Thu Sep 22 18:54:38 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Sep 22 18:54:38 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 28 13:25:00 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4597,7 +4597,7 @@ This report was generated on **Thu Sep 22 18:54:38 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Sep 22 18:54:39 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 28 13:25:01 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5325,4 +5325,4 @@ This report was generated on **Thu Sep 22 18:54:39 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Sep 22 18:54:39 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 28 13:25:01 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -626,7 +626,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 28 13:24:58 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 28 19:32:13 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1217,7 +1217,7 @@ This report was generated on **Wed Sep 28 13:24:58 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 28 13:24:59 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 28 19:32:13 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1848,7 +1848,7 @@ This report was generated on **Wed Sep 28 13:24:59 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 28 13:24:59 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 28 19:32:13 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2592,7 +2592,7 @@ This report was generated on **Wed Sep 28 13:24:59 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 28 13:25:00 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 28 19:32:14 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3231,7 +3231,7 @@ This report was generated on **Wed Sep 28 13:25:00 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 28 13:25:00 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 28 19:32:14 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3914,7 +3914,7 @@ This report was generated on **Wed Sep 28 13:25:00 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 28 13:25:00 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 28 19:32:15 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4597,7 +4597,7 @@ This report was generated on **Wed Sep 28 13:25:00 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 28 13:25:01 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 28 19:32:15 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5325,4 +5325,4 @@ This report was generated on **Wed Sep 28 13:25:01 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 28 13:25:01 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 28 19:32:15 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -626,7 +626,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Sep 01 19:16:00 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 22 18:54:36 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1217,7 +1217,7 @@ This report was generated on **Thu Sep 01 19:16:00 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Sep 01 19:16:01 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 22 18:54:37 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1848,7 +1848,7 @@ This report was generated on **Thu Sep 01 19:16:01 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Sep 01 19:16:02 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 22 18:54:37 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2592,7 +2592,7 @@ This report was generated on **Thu Sep 01 19:16:02 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Sep 01 19:16:03 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 22 18:54:38 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3231,7 +3231,7 @@ This report was generated on **Thu Sep 01 19:16:03 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Sep 01 19:16:04 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 22 18:54:38 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3914,7 +3914,7 @@ This report was generated on **Thu Sep 01 19:16:04 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Sep 01 19:16:05 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 22 18:54:38 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4597,7 +4597,7 @@ This report was generated on **Thu Sep 01 19:16:05 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Sep 01 19:16:06 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 22 18:54:39 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5325,4 +5325,4 @@ This report was generated on **Thu Sep 01 19:16:06 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Sep 01 19:16:07 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Sep 22 18:54:39 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/model/model-verifier/src/test/resources/model-verifier-test/build.gradle.kts
+++ b/model/model-verifier/src/test/resources/model-verifier-test/build.gradle.kts
@@ -63,6 +63,7 @@ buildscript {
             force(
                 "io.spine:spine-base:$spineBaseVersion",
                 "io.spine:spine-time:$spineTimeVersion",
+                "io.spine.tools:spine-tool-base:$toolBaseVersion",
                 "io.spine.tools:spine-plugin-base:$toolBaseVersion"
             )
         }

--- a/pom.xml
+++ b/pom.xml
@@ -62,19 +62,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.95</version>
+    <version>2.0.0-SNAPSHOT.100</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base-types</artifactId>
-    <version>2.0.0-SNAPSHOT.95</version>
+    <version>2.0.0-SNAPSHOT.96</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-time</artifactId>
-    <version>2.0.0-SNAPSHOT.95</version>
+    <version>2.0.0-SNAPSHOT.96</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -92,7 +92,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.93</version>
+    <version>2.0.0-SNAPSHOT.95</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -152,19 +152,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.93</version>
+    <version>2.0.0-SNAPSHOT.95</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.95</version>
+    <version>2.0.0-SNAPSHOT.100</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testutil-time</artifactId>
-    <version>2.0.0-SNAPSHOT.95</version>
+    <version>2.0.0-SNAPSHOT.96</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.100</version>
+    <version>2.0.0-SNAPSHOT.102</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -158,7 +158,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.100</version>
+    <version>2.0.0-SNAPSHOT.102</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -87,7 +87,7 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  *         the type of the state of aggregates managed by this repository
  * @see Aggregate
  */
-@SuppressWarnings({"ClassWithTooManyMethods", "OverlyCoupledClass"})
+@SuppressWarnings("ClassWithTooManyMethods")
 public abstract class AggregateRepository<I, A extends Aggregate<I, S, ?>, S extends EntityState<I>>
         extends Repository<I, A>
         implements CommandDispatcher, EventProducingRepository,
@@ -182,7 +182,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, S, ?>, S ext
                                         .delivery();
         inbox = delivery
                 .<I>newInbox(entityStateType())
-                .withBatchListener(new BatchDeliveryListener<I>() {
+                .withBatchListener(new BatchDeliveryListener<>() {
                     @Override
                     public void onStart(I id) {
                         cache.startCaching(id);
@@ -256,7 +256,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, S, ?>, S ext
      * producer ID} of the event as the ID of the target aggregate.
      *
      * <p>This default routing requires that {@link Event Event} instances
-     * {@linkplain ImportBus#post(io.spine.core.Signal, io.grpc.stub.StreamObserver)}  posted}
+     * {@linkplain ImportBus#post(io.spine.core.Signal, io.grpc.stub.StreamObserver)} posted
      * for import must {@link io.spine.core.EventContext#getProducerId() contain} the ID of the
      * target aggregate. Not providing a valid aggregate ID would result in
      * {@code RuntimeException}.
@@ -494,7 +494,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, S, ?>, S ext
      *
      * <p><b>NOTE</b>: repository read operations are optimized around the current snapshot
      * trigger. Setting the snapshot trigger to a new value may cause read operations to perform
-     * sub-optimally, until a new snapshot is created. This doesn't apply to newly created
+     * suboptimally, until a new snapshot is created. This doesn't apply to newly created
      * repositories.
      *
      * @param snapshotTrigger
@@ -591,7 +591,7 @@ public abstract class AggregateRepository<I, A extends Aggregate<I, S, ?>, S ext
      * <p>The method loads only the recent history of the aggregate.
      *
      * <p>The current {@link #snapshotTrigger} is used as a batch size of the read operation,
-     * so the method can perform sub-optimally for some time
+     * so the method can perform suboptimally for some time
      * after the {@link #snapshotTrigger} change.
      *
      * @param id

--- a/server/src/main/java/io/spine/server/entity/AbstractEntity.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractEntity.java
@@ -60,7 +60,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static io.spine.logging.Logging.loggerFor;
 import static io.spine.util.Exceptions.newIllegalArgumentException;
-import static io.spine.validate.Validate.checkValid;
+import static io.spine.validate.Validate.check;
 import static io.spine.validate.Validate.validateChange;
 import static io.spine.validate.Validate.violationsOf;
 
@@ -461,7 +461,7 @@ public abstract class AbstractEntity<I, S extends EntityState<I>>
 
     final void updateVersion(Version newVersion) {
         checkNotNull(newVersion);
-        checkValid(newVersion);
+        check(newVersion);
         if (version.equals(newVersion)) {
             return;
         }

--- a/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
+++ b/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
@@ -47,6 +47,7 @@ import io.spine.server.entity.storage.ToEntityRecordQuery;
 import io.spine.server.storage.QueryConverter;
 import io.spine.server.storage.RecordWithColumns;
 import io.spine.type.TypeUrl;
+import io.spine.validate.Validate;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Collection;
@@ -65,6 +66,7 @@ import static com.google.common.collect.Lists.newLinkedList;
 import static io.spine.protobuf.AnyPacker.unpack;
 import static io.spine.util.Exceptions.newIllegalArgumentException;
 import static io.spine.util.Exceptions.newIllegalStateException;
+import static io.spine.validate.Validate.check;
 import static io.spine.validate.Validate.checkValid;
 import static java.util.Objects.requireNonNull;
 
@@ -397,7 +399,7 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
      */
     public Iterator<E> find(TargetFilters filters, ResponseFormat format) {
         checkNotNull(filters);
-        checkValid(filters);
+        check(filters);
         checkNotNull(format);
 
         var records = findRecords(filters, format);
@@ -435,7 +437,7 @@ public abstract class RecordBasedRepository<I, E extends Entity<I, S>, S extends
     @Internal
     public Iterator<EntityRecord> findRecords(TargetFilters filters, ResponseFormat format) {
         checkNotNull(filters);
-        checkValid(filters);
+        check(filters);
         checkNotNull(format);
 
         var storage = recordStorage();

--- a/server/src/main/java/io/spine/server/event/EventFactory.java
+++ b/server/src/main/java/io/spine/server/event/EventFactory.java
@@ -32,12 +32,11 @@ import io.spine.core.ActorContext;
 import io.spine.core.Event;
 import io.spine.core.Version;
 import io.spine.server.type.MessageEnvelope;
-import io.spine.validate.Validate;
 import io.spine.validate.ValidationException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.server.event.EventOrigin.fromAnotherMessage;
-import static io.spine.validate.Validate.checkValid;
+import static io.spine.validate.Validate.check;
 
 /**
  * Produces events.
@@ -76,7 +75,7 @@ public class EventFactory extends EventFactoryBase {
     public static EventFactory forImport(ActorContext actorContext, Any producerId) {
         checkNotNull(actorContext);
         checkNotNull(producerId);
-        Validate.check(actorContext);
+        check(actorContext);
 
         var origin = EventOrigin.forImport(actorContext);
         return new EventFactory(origin, producerId);

--- a/server/src/main/java/io/spine/server/event/EventFactory.java
+++ b/server/src/main/java/io/spine/server/event/EventFactory.java
@@ -32,6 +32,7 @@ import io.spine.core.ActorContext;
 import io.spine.core.Event;
 import io.spine.core.Version;
 import io.spine.server.type.MessageEnvelope;
+import io.spine.validate.Validate;
 import io.spine.validate.ValidationException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -75,7 +76,7 @@ public class EventFactory extends EventFactoryBase {
     public static EventFactory forImport(ActorContext actorContext, Any producerId) {
         checkNotNull(actorContext);
         checkNotNull(producerId);
-        checkValid(actorContext);
+        Validate.check(actorContext);
 
         var origin = EventOrigin.forImport(actorContext);
         return new EventFactory(origin, producerId);

--- a/server/src/main/java/io/spine/server/stand/RequestValidator.java
+++ b/server/src/main/java/io/spine/server/stand/RequestValidator.java
@@ -28,6 +28,7 @@ package io.spine.server.stand;
 import com.google.protobuf.Message;
 import com.google.protobuf.ProtocolMessageEnum;
 import io.spine.base.Error;
+import io.spine.protobuf.AnyPacker;
 import io.spine.type.TypeName;
 import io.spine.validate.Validate;
 import io.spine.validate.ValidationError;
@@ -163,10 +164,10 @@ abstract class RequestValidator<M extends Message> {
         var error = Error.newBuilder()
                 .setType(typeName)
                 .setCode(errorCode.getNumber())
-                .setValidationError(validationError)
+                .setDetails(AnyPacker.pack(validationError))
                 .setMessage(errorText)
                 .build();
-        var exceptionMsg = formatExceptionMessage(request, error);
+        var exceptionMsg = formatExceptionMessage(request, validationError);
         var exception = invalidMessageException(exceptionMsg, request, error);
         return exception;
     }
@@ -191,9 +192,8 @@ abstract class RequestValidator<M extends Message> {
         return null;
     }
 
-    private String formatExceptionMessage(M request, Error error) {
-        return format("%s. Validation error: %s.",
-                      errorConstraintsViolated(request), error.getValidationError());
+    private String formatExceptionMessage(M request, ValidationError error) {
+        return format("%s. Validation error: `%s`.", errorConstraintsViolated(request), error);
     }
 
     private String errorConstraintsViolated(M request) {

--- a/server/src/main/kotlin/io/spine/server/event/EventFactoryBase.kt
+++ b/server/src/main/kotlin/io/spine/server/event/EventFactoryBase.kt
@@ -34,6 +34,7 @@ import io.spine.core.Events
 import io.spine.core.Version
 import io.spine.protobuf.AnyPacker.pack
 import io.spine.validate.Validate.checkValid
+import io.spine.validate.checkValid
 
 /**
  * Abstract base for event factories.
@@ -67,7 +68,7 @@ internal abstract class EventFactoryBase(
      * Creates a new `Event` instance.
      */
     protected fun assemble(message: EventMessage, context: EventContext): Event {
-        checkValid(message)
+        message.checkValid()
         val eventId = Events.generateId()
         val packed = pack(message)
         return with(Event.newBuilder()) {

--- a/server/src/test/java/io/spine/server/aggregate/AggregateQueryingTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateQueryingTest.java
@@ -27,6 +27,7 @@
 package io.spine.server.aggregate;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.truth.Truth8;
 import io.spine.base.CommandMessage;
 import io.spine.base.EntityState;
 import io.spine.client.ArchivedColumn;
@@ -43,6 +44,8 @@ import io.spine.test.aggregate.query.MRPhoto;
 import io.spine.test.aggregate.query.MRPhotoId;
 import io.spine.test.aggregate.query.MRSoundRecord;
 import io.spine.testing.client.TestActorRequestFactory;
+import io.spine.type.KnownTypes;
+import io.spine.type.MessageType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -69,7 +72,7 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@DisplayName("`AggregateRepository` should ")
+@DisplayName("`AggregateRepository` running queries should ")
 class AggregateQueryingTest {
 
     private QueryFactory queries;
@@ -89,6 +92,30 @@ class AggregateQueryingTest {
         commands = requestFactory.command();
         givenPhotos = givenPhotos();
         prepareAggregates(givenPhotos);
+    }
+
+    @Test
+    void hasGoogleTypes() {
+        var types = KnownTypes.instance()
+                              .asTypeSet()
+                              .messageTypes();
+        var found = types.stream()
+                .filter(MessageType::isGoogle)
+                .count();
+        assertThat(found)
+              .isGreaterThan(0);
+    }
+
+    @Test
+    void knowsEnumValueClass() {
+        var types = KnownTypes.instance()
+                              .asTypeSet()
+                              .messageTypes();
+        var found = types.stream()
+                .filter( t -> t.name().value().equals("google.protobuf.EnumValue"))
+                .findFirst();
+        Truth8.assertThat(found)
+              .isPresent();
     }
 
     @Nested

--- a/server/src/test/java/io/spine/server/aggregate/AggregateQueryingTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateQueryingTest.java
@@ -27,7 +27,6 @@
 package io.spine.server.aggregate;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.truth.Truth8;
 import io.spine.base.CommandMessage;
 import io.spine.base.EntityState;
 import io.spine.client.ArchivedColumn;
@@ -44,8 +43,6 @@ import io.spine.test.aggregate.query.MRPhoto;
 import io.spine.test.aggregate.query.MRPhotoId;
 import io.spine.test.aggregate.query.MRSoundRecord;
 import io.spine.testing.client.TestActorRequestFactory;
-import io.spine.type.KnownTypes;
-import io.spine.type.MessageType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -92,30 +89,6 @@ class AggregateQueryingTest {
         commands = requestFactory.command();
         givenPhotos = givenPhotos();
         prepareAggregates(givenPhotos);
-    }
-
-    @Test
-    void hasGoogleTypes() {
-        var types = KnownTypes.instance()
-                              .asTypeSet()
-                              .messageTypes();
-        var found = types.stream()
-                .filter(MessageType::isGoogle)
-                .count();
-        assertThat(found)
-              .isGreaterThan(0);
-    }
-
-    @Test
-    void knowsEnumValueClass() {
-        var types = KnownTypes.instance()
-                              .asTypeSet()
-                              .messageTypes();
-        var found = types.stream()
-                .filter( t -> t.name().value().equals("google.protobuf.EnumValue"))
-                .findFirst();
-        Truth8.assertThat(found)
-              .isPresent();
     }
 
     @Nested

--- a/server/src/test/java/io/spine/server/entity/AbstractEntityTest.java
+++ b/server/src/test/java/io/spine/server/entity/AbstractEntityTest.java
@@ -29,12 +29,14 @@ package io.spine.server.entity;
 import com.google.common.reflect.Invokable;
 import com.google.common.testing.EqualsTester;
 import io.spine.base.EntityState;
+import io.spine.protobuf.AnyPacker;
 import io.spine.server.entity.given.entity.AnEntity;
 import io.spine.server.entity.given.entity.NaturalNumberEntity;
 import io.spine.server.test.shared.LongIdAggregate;
 import io.spine.test.entity.Project;
 import io.spine.test.entity.ProjectId;
 import io.spine.test.server.number.NaturalNumber;
+import io.spine.validate.ValidationError;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -69,7 +71,7 @@ class AbstractEntityTest {
         }
 
         /**
-         * Ensures that {@link AbstractEntity#validate(EntityState)} is final so that
+         * Ensures that the {@code AbstractEntity.validate(EntityState)} method is final so that
          * it's not possible to override the default behaviour.
          */
         @Test
@@ -96,9 +98,10 @@ class AbstractEntityTest {
 
             fail("Exception expected.");
         } catch (InvalidEntityStateException e) {
-            assertThat(e.error()
-                        .getValidationError()
-                        .getConstraintViolationList()).hasSize(1);
+            var details = AnyPacker.unpack(e.error().getDetails());
+            assertThat(details).isInstanceOf(ValidationError.class);
+            assertThat(((ValidationError)details).getConstraintViolationList())
+                    .hasSize(1);
         }
     }
 

--- a/server/src/test/java/io/spine/server/stand/StandTest.java
+++ b/server/src/test/java/io/spine/server/stand/StandTest.java
@@ -115,7 +115,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
-@DisplayName("Stand should")  // It's OK for this test.
+@DisplayName("`Stand` should")  // It's OK for this test.
 class StandTest extends TenantAwareTest {
 
     private static final int TOTAL_PROJECTS_FOR_BATCH_READING = 10;

--- a/server/src/test/java/io/spine/server/tuple/given/QuintetTestEnv.java
+++ b/server/src/test/java/io/spine/server/tuple/given/QuintetTestEnv.java
@@ -31,11 +31,11 @@ import io.spine.test.tuple.quintet.InstrumentNumber;
 import io.spine.test.tuple.quintet.Viola;
 import io.spine.test.tuple.quintet.Violin;
 import io.spine.test.tuple.quintet.ViolinCello;
-import io.spine.validate.Validate;
 
 import static io.spine.server.tuple.given.QuintetTestEnv.InstrumentFactory.newViola;
 import static io.spine.server.tuple.given.QuintetTestEnv.InstrumentFactory.newViolin;
 import static io.spine.server.tuple.given.QuintetTestEnv.InstrumentFactory.newViolinCello;
+import static io.spine.validate.Validate.check;
 
 public class QuintetTestEnv {
 
@@ -92,7 +92,7 @@ public class QuintetTestEnv {
             var result = Violin.newBuilder()
                     .setNumber(number)
                     .build();
-            Validate.checkValid(result);
+            check(result);
             return result;
         }
 
@@ -100,7 +100,7 @@ public class QuintetTestEnv {
             var result = Viola.newBuilder()
                     .setSingle(true)
                     .build();
-            Validate.checkValid(result);
+            check(result);
             return result;
         }
 
@@ -108,7 +108,7 @@ public class QuintetTestEnv {
             var result = Viola.newBuilder()
                     .setNumber(number)
                     .build();
-            Validate.checkValid(result);
+            check(result);
             return result;
         }
 
@@ -116,7 +116,7 @@ public class QuintetTestEnv {
             var result = ViolinCello.newBuilder()
                     .setNumber(number)
                     .build();
-            Validate.checkValid(result);
+            check(result);
             return result;
         }
 
@@ -124,7 +124,7 @@ public class QuintetTestEnv {
             var result = ViolinCello.newBuilder()
                     .setSingle(true)
                     .build();
-            Validate.checkValid(result);
+            check(result);
             return result;
         }
     }

--- a/server/src/test/java/io/spine/server/type/EventMessageTest.java
+++ b/server/src/test/java/io/spine/server/type/EventMessageTest.java
@@ -39,7 +39,7 @@ import io.spine.validate.ValidationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.validate.Validate.checkValid;
+import static io.spine.validate.Validate.check;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("Event message should")
@@ -54,7 +54,7 @@ class EventMessageTest {
                 .setUserName("John Doe")
                 .build();
         var event = event(msg);
-        checkValid(event);
+        check(event);
     }
 
     @Test
@@ -65,7 +65,7 @@ class EventMessageTest {
                 .setProjectId(newProjectId())
                 .buildPartial();
         var event = partiallyBuiltEvent(msg);
-        assertThrows(ValidationException.class, () -> checkValid(event));
+        assertThrows(ValidationException.class, () -> check(event));
     }
 
     private static TaskId newTaskId() {

--- a/server/src/test/java/io/spine/system/server/CommandLogTest.java
+++ b/server/src/test/java/io/spine/system/server/CommandLogTest.java
@@ -55,6 +55,7 @@ import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.testing.core.given.GivenUserId;
 import io.spine.testing.logging.mute.MuteLogging;
 import io.spine.type.TypeUrl;
+import io.spine.validate.ValidationError;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -137,7 +138,10 @@ class CommandLogTest {
             assertEquals(expectedId, actualId);
 
             var error = checkErrored(actualId);
-            assertTrue(isNotDefault(error.getValidationError()));
+            assertTrue(error.hasDetails());
+            var details = AnyPacker.unpack(error.getDetails());
+            assertThat(details).isInstanceOf(ValidationError.class);
+            assertTrue(isNotDefault(details));
         }
 
         @Test

--- a/testutil-core/src/test/java/io/spine/testing/core/given/GivenCommandContextTest.java
+++ b/testutil-core/src/test/java/io/spine/testing/core/given/GivenCommandContextTest.java
@@ -39,7 +39,7 @@ import static io.spine.base.Time.currentTime;
 import static io.spine.protobuf.Durations2.hours;
 import static io.spine.protobuf.Durations2.minutes;
 import static io.spine.testing.core.given.GivenUserId.newUuid;
-import static io.spine.validate.Validate.checkValid;
+import static io.spine.validate.Validate.check;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -63,8 +63,8 @@ class GivenCommandContextTest extends UtilityClassTest<GivenCommandContext> {
         var first = GivenCommandContext.withRandomActor();
         var second = GivenCommandContext.withRandomActor();
 
-        checkValid(first);
-        checkValid(second);
+        check(first);
+        check(second);
 
         var firstActorContext = first.actorContext();
         var secondActorContext = second.actorContext();
@@ -78,7 +78,7 @@ class GivenCommandContextTest extends UtilityClassTest<GivenCommandContext> {
         var when = add(currentTime(), minutes(100));
 
         var context = GivenCommandContext.withActorAndTime(actorId, when);
-        checkValid(context);
+        check(context);
 
         var actualActorContext = context.getActorContext();
 
@@ -95,7 +95,7 @@ class GivenCommandContextTest extends UtilityClassTest<GivenCommandContext> {
                 .build();
 
         var context = GivenCommandContext.withScheduledDelayOf(delay);
-        checkValid(context);
+        check(context);
 
         var actualSchedule = context.getSchedule();
         assertEquals(expectedSchedule, actualSchedule);

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/Actor.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/Actor.java
@@ -36,7 +36,7 @@ import io.spine.time.ZoneIds;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.validate.Validate.checkValid;
+import static io.spine.validate.Validate.check;
 
 /**
  * A factory of test actor request factories.
@@ -85,12 +85,12 @@ final class Actor {
 
     private static void checkUser(UserId userId) {
         checkNotNull(userId);
-        checkValid(userId);
+        check(userId);
     }
 
     private static void checkZone(ZoneId zone) {
         checkNotNull(zone);
-        checkValid(zone);
+        check(zone);
     }
 
     /** Creates a new factory for requests of the single tenant. */
@@ -101,7 +101,7 @@ final class Actor {
     /** Creates a new factory for requests of the given tenant. */
     TestActorRequestFactory requestsFor(TenantId tenant) {
         checkNotNull(tenant);
-        checkValid(tenant);
+        check(tenant);
         return new TestActorRequestFactory(tenant, id, zoneId);
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,7 +25,7 @@
  */
 
 /** Versions of the Spine libraries that `core-java` depends on. */
-val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.100")
+val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.102")
 val spineBaseTypesVersion: String by extra("2.0.0-SNAPSHOT.96")
 val spineTimeVersion: String by extra("2.0.0-SNAPSHOT.96")
 val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.95")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@ val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.95")
 val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.97")
 
 /** The version of this library. */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.107")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.108")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,10 +25,10 @@
  */
 
 /** Versions of the Spine libraries that `core-java` depends on. */
-val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.95")
-val spineBaseTypesVersion: String by extra("2.0.0-SNAPSHOT.95")
-val spineTimeVersion: String by extra("2.0.0-SNAPSHOT.95")
-val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.93")
+val spineBaseVersion: String by extra("2.0.0-SNAPSHOT.100")
+val spineBaseTypesVersion: String by extra("2.0.0-SNAPSHOT.96")
+val spineTimeVersion: String by extra("2.0.0-SNAPSHOT.96")
+val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.95")
 val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.97")
 
 /** The version of this library. */


### PR DESCRIPTION
This PR updates dependency on `base` and other subprojects that are involved into separation of `io.spine.validate` into a separate artifact.

It depends on [this PR from `base`](https://github.com/SpineEventEngine/base/pull/730).
