### PR TITLE
Fix publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -314,7 +314,7 @@ subprojects {
     project.afterEvaluate {
         tasks.findByName("launchProtoDataMain")?.apply {
             val launchProtoDataMain = this
-            arrayOf("compileKotlin", "sourcesJar", "dokkaHtml").forEach {
+            arrayOf("compileKotlin").forEach {
                 tasks.findByName(it)?.dependsOn(launchProtoDataMain)
             }
         }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@ val toolBaseVersion: String by extra("2.0.0-SNAPSHOT.109")
 val mcJavaVersion: String by extra("2.0.0-SNAPSHOT.101")
 
 /** The version of this library. */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.110")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.111")


### PR DESCRIPTION
This PR temporarily removes explicit dependencies of `dokkaHtml` and `sourcesJar` onto `launchProtoDataMain`, since they break publishing. 

It happens because `launchProtoDataMain` (and a bunch of other tasks) is re-launched once again right before sources and-or documentation are being assembled. In turn, it leads to non-compilable sources processed, and ultimately to the compilation failure. Yes, compilation failure, on a stage of assembling the documentation and sources.