### PR TITLE
[1.x] Prohibit calling Aggregate's `state()` from `@Apply`-er methods

### DIFF
--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -115,10 +115,11 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  *
  * <p>End-users must not call {@code state()} method within an event applier.
  * It is so, because event appliers are invoked in scope of an active transaction,
- * which accumulates the model updates via aggregate's {@code builder()},
- * and not {@code state()}. Therefore, {@code state()} invocation from the applier's code
- * may return some inconsistent results, and in general is prone to errors. All such
- * attempts will result in a {@code RuntimeException}.
+ * which accumulates the model updates in aggregate's {@code builder()},
+ * and not in {@code state()}. Therefore, {@code state()} invocation from
+ * the applier's code may return some inconsistent result,
+ * and in general is prone to errors.
+ * All such attempts will result in a {@code RuntimeException}.
  *
  * <p>An {@code Aggregate} class must have applier methods for
  * <em>all</em> types of the events that it produces.
@@ -251,10 +252,13 @@ public abstract class Aggregate<I,
      * Until this transaction is completed, the {@code state()} of the corresponding aggregate
      * is not up-to-date. Therefore, relying upon it in code is prone to errors,
      * and is prohibited for good sake.
+     *
+     * @throws IllegalStateException
+     *         if this method is called from within an event applier
      */
     @Override
     protected void ensureAccessToState() {
-        if(applierWatcher.inProgress()) {
+        if (applierWatcher.inProgress()) {
             throw newIllegalStateException(
                     "Aggregate `state()` method must not be used from `@Apply`-marked method." +
                             " Use `builder()` instead. The issue detected in `%s` aggregate class.",

--- a/server/src/main/java/io/spine/server/aggregate/AggregateTransaction.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateTransaction.java
@@ -40,7 +40,7 @@ import io.spine.server.type.EventEnvelope;
  *
  * @param <I> the type of aggregate IDs
  * @param <S> the type of aggregate state
- * @param <B> the type of a {@code ValidatingBuilder} for the aggregate state
+ * @param <B> the type of {@code ValidatingBuilder} for the aggregate state
  */
 @Internal
 public class AggregateTransaction<I,

--- a/server/src/main/java/io/spine/server/entity/AbstractEntity.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractEntity.java
@@ -92,7 +92,7 @@ public abstract class AbstractEntity<I, S extends EntityState>
     /**
      * The ID of the entity.
      *
-     * <p>Assigned either through the {@linkplain #AbstractEntity(Object)} constructor which
+     * <p>Assigned either through the {@linkplain #AbstractEntity(Object) constructor which
      * accepts the ID}, or via {@link #setId(Object)}. Is never {@code null}.
      */
     private @MonotonicNonNull I id;
@@ -386,7 +386,7 @@ public abstract class AbstractEntity<I, S extends EntityState>
      * Ensures that the entity is not marked as {@code archived}.
      *
      * @throws CannotModifyArchivedEntity
-     *         if the entity in in the archived status
+     *         if the entity in the archived status
      * @see #lifecycleFlags()
      * @see io.spine.server.entity.LifecycleFlags#getArchived()
      */

--- a/server/src/main/java/io/spine/server/entity/AbstractEntity.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractEntity.java
@@ -190,6 +190,7 @@ public abstract class AbstractEntity<I, S extends EntityState>
      */
     @Override
     public final S state() {
+        ensureAccessToState();
         S result = state;
         if (result == null) {
             synchronized (this) {
@@ -201,6 +202,24 @@ public abstract class AbstractEntity<I, S extends EntityState>
             }
         }
         return result;
+    }
+
+    /**
+     * Ensures that the callee is allowed to access Entity's {@link #state() state()} method.
+     *
+     * <p>In case the access is prohibited, throws a {@code RuntimeException}.
+     *
+     * <p>In some scenarios, the state of Entity may be not up-to-date,
+     * so descendants of {@code AbstractEntity} are able to put the corresponding restrictions
+     * on this method invocation.
+     *
+     * <p>By default, this method performs no checks,
+     * thus allowing to access Entity's {@code state()} at any point of time.
+     */
+    @Internal
+    @SuppressWarnings("NoopMethodInAbstractClass" /* By design. */)
+    protected void ensureAccessToState() {
+        // Do nothing by default.
     }
 
     /**

--- a/server/src/main/java/io/spine/server/entity/EventPlayer.java
+++ b/server/src/main/java/io/spine/server/entity/EventPlayer.java
@@ -89,8 +89,8 @@ public interface EventPlayer {
         checkNotNull(entity);
         Transaction<?, ?, ?, ?> tx = entity.tx();
         checkArgument(tx instanceof EventPlayingTransaction,
-                      "EventPlayer can only be created for the entity whose transaction type is " +
-                              "EventPlayingTransaction");
+                      "`EventPlayer` can only be created for the entity " +
+                              "whose transaction type is `EventPlayingTransaction`.");
         EventPlayingTransaction<?, ?, ?, ?> cast = (EventPlayingTransaction<?, ?, ?, ?>) tx;
         return new TransactionalEventPlayer(cast);
     }

--- a/server/src/main/java/io/spine/server/entity/TransactionalEntity.java
+++ b/server/src/main/java/io/spine/server/entity/TransactionalEntity.java
@@ -35,13 +35,14 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A base for entities, perform transactions {@linkplain Event events}.
  *
  * <p>Defines a transaction-based mechanism for state, version, and lifecycle flags update.
  *
- * <p>Exposes {@linkplain #builder()} validating builder} for the state as the only way
+ * <p>Exposes {@linkplain #builder() validating builder} for the state as the only way
  * to modify the state from the descendants.
  */
 public abstract class TransactionalEntity<I,
@@ -137,7 +138,7 @@ public abstract class TransactionalEntity<I,
         if (!isTransactionInProgress()) {
             throw new IllegalStateException(missingTxMessage());
         }
-        return checkNotNull(transaction);
+        return requireNonNull(transaction);
     }
 
     /**

--- a/server/src/test/java/io/spine/server/aggregate/AggregateTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateTest.java
@@ -607,6 +607,29 @@ public class AggregateTest {
     }
 
     @Nested
+    @DisplayName("prohibit")
+    class Prohibit {
+        @Test
+        @DisplayName("to call `state()` from within applier")
+        void callStateFromApplier() {
+            ModelTests.dropAllModels();
+            FaultyAggregate faultyAggregate =
+                    new FaultyAggregate(ID, false, false);
+
+            Command command = Given.ACommand.addTask(ID);
+            DispatchOutcome outcome = dispatchCommand(faultyAggregate, env(command));
+
+            assertThat(outcome.hasError()).isTrue();
+            Error error = outcome.getError();
+            assertThat(error)
+                    .comparingExpectedFieldsOnly()
+                    .isEqualTo(Error.newBuilder()
+                                    .setType(IllegalStateException.class.getCanonicalName())
+                                    .buildPartial());
+        }
+    }
+
+    @Nested
     @DisplayName("catch RuntimeExceptions in")
     class CatchHandlerFailures {
 

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/FaultyAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/FaultyAggregate.java
@@ -33,10 +33,13 @@ import io.spine.server.command.Assign;
 import io.spine.test.aggregate.Project;
 import io.spine.test.aggregate.ProjectId;
 import io.spine.test.aggregate.Status;
+import io.spine.test.aggregate.command.AggAddTask;
 import io.spine.test.aggregate.command.AggCreateProject;
 import io.spine.test.aggregate.event.AggProjectCreated;
+import io.spine.test.aggregate.event.AggTaskAdded;
 
 import static io.spine.server.aggregate.given.Given.EventMessage.projectCreated;
+import static io.spine.server.aggregate.given.Given.EventMessage.taskAdded;
 
 /**
  * The test environment class for checking raising and catching exceptions.
@@ -70,5 +73,17 @@ public final class FaultyAggregate
             throw new IllegalStateException(BROKEN_APPLIER);
         }
         builder().setStatus(Status.CREATED);
+    }
+
+    @Assign
+    AggTaskAdded handle(AggAddTask cmd) {
+        return taskAdded(cmd.getProjectId());
+    }
+
+    @Apply
+    private void event(AggTaskAdded event) {
+        /* This call to `state()` is prohibited from `Apply`-marked method. */
+        ProjectId id = state().getId();
+        builder().setId(id);
     }
 }

--- a/server/src/test/java/io/spine/server/aggregate/given/importado/Dot.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/importado/Dot.java
@@ -50,14 +50,14 @@ final class Dot extends Aggregate<ObjectId, Point, Point.Builder> {
 
     @Apply(allowImport = true)
     private void event(Moved event) {
-        Point newPosition = move(state(), event.getDirection());
+        Point newPosition = move(builder(), event.getDirection());
 
         builder().setId(event.getObject())
                  .setX(newPosition.getX())
                  .setY(newPosition.getY());
     }
 
-    private static Point move(Point p, Direction direction) {
+    private static Point move(PointOrBuilder p, Direction direction) {
         Point.Builder result = Point
                 .newBuilder()
                 .setX(p.getX())

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/FailingAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/FailingAggregate.java
@@ -109,7 +109,7 @@ class FailingAggregate extends Aggregate<Long, StringAggregate, StringAggregate.
 
     @Apply
     private void apply(NumberPassed event) {
-        builder().setValue(state().getValue()
+        builder().setValue(builder().getValue()
                                    + System.lineSeparator()
                                    + Timestamps.toString(event.getWhen()));
     }

--- a/server/src/test/java/io/spine/server/model/handler/given/RoverBot.java
+++ b/server/src/test/java/io/spine/server/model/handler/given/RoverBot.java
@@ -85,11 +85,11 @@ public class RoverBot extends Aggregate<Integer, Position, Position.Builder> {
     }
 
     private int currentX() {
-        return state().getX();
+        return builder().getX();
     }
 
     private int currentY() {
-        return state().getY();
+        return builder().getY();
     }
 
     @Apply

--- a/server/src/test/java/io/spine/server/route/given/switchman/Log.java
+++ b/server/src/test/java/io/spine/server/route/given/switchman/Log.java
@@ -74,8 +74,8 @@ public final class Log extends Aggregate<Long, LogState, LogState.Builder> {
     @Apply
     private void event(SwitchWorkRecorded event) {
         String switchmanName = event.getSwitchmanName();
-        Integer currentCount = state().getCountersMap()
-                                      .get(switchmanName);
+        Integer currentCount = builder().getCountersMap()
+                                        .get(switchmanName);
         builder().putCounters(switchmanName,
                               currentCount == null ? 1 : currentCount + 1);
     }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,7 +34,7 @@
 /**
  * Version of this library.
  */
-val coreJava = "1.9.0-SNAPSHOT.6"
+val coreJava = "1.9.0-SNAPSHOT.7"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.


### PR DESCRIPTION
This changeset addresses #1499 by disallowing to call `state()` method from aggregate appliers.

Previously, end-users could rely on `Aggregate.state()` from `@Apply`-ers. However, in some cases (such as the one described in #1499) `state()` does not reflect the last state of an aggregate. This is so because appliers are invoked in scope of a single transaction — be it when loading an aggregate instance from storage, or when applying the just-emitted events during the command dispatching. Until such a transaction is completed, `state()` does not reflect the model updates corresponding to the respective domain events. Using the returned state value most likely leads to bugs.

The designed way has always been to use `builder()` instead of `state()`, because it is kept up-to-date throughout the active aggregate transaction.

Therefore, once this PR is merged, any calls to `state()` from `@Apply`-annotated method will lead to an `IllegalStateException`.

