### PR TITLE
[1.x] Fix delivering the signals to aggregate `Mirror`s in a multi-Bounded Context environment

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.9.0-SNAPSHOT.6`
+# Dependencies of `io.spine:spine-client:1.9.0-SNAPSHOT.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -399,12 +399,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 02 10:21:33 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 03 15:42:45 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.9.0-SNAPSHOT.6`
+# Dependencies of `io.spine:spine-core:1.9.0-SNAPSHOT.8`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -763,12 +763,12 @@ This report was generated on **Mon Jan 02 10:21:33 WET 2023** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 02 10:21:34 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 03 15:42:45 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.9.0-SNAPSHOT.6`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.9.0-SNAPSHOT.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1162,12 +1162,12 @@ This report was generated on **Mon Jan 02 10:21:34 WET 2023** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 02 10:21:35 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 03 15:42:46 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.9.0-SNAPSHOT.6`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.9.0-SNAPSHOT.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1627,12 +1627,12 @@ This report was generated on **Mon Jan 02 10:21:35 WET 2023** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 02 10:21:35 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 03 15:42:46 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.9.0-SNAPSHOT.6`
+# Dependencies of `io.spine:spine-server:1.9.0-SNAPSHOT.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2039,12 +2039,12 @@ This report was generated on **Mon Jan 02 10:21:35 WET 2023** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 02 10:21:36 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 03 15:42:47 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.9.0-SNAPSHOT.6`
+# Dependencies of `io.spine:spine-testutil-client:1.9.0-SNAPSHOT.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2493,12 +2493,12 @@ This report was generated on **Mon Jan 02 10:21:36 WET 2023** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 02 10:21:39 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 03 15:42:50 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.9.0-SNAPSHOT.6`
+# Dependencies of `io.spine:spine-testutil-core:1.9.0-SNAPSHOT.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2947,12 +2947,12 @@ This report was generated on **Mon Jan 02 10:21:39 WET 2023** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 02 10:21:40 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 03 15:42:52 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.9.0-SNAPSHOT.6`
+# Dependencies of `io.spine:spine-testutil-server:1.9.0-SNAPSHOT.8`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3445,4 +3445,4 @@ This report was generated on **Mon Jan 02 10:21:40 WET 2023** using [Gradle-Lice
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jan 02 10:21:44 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 03 15:42:56 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.9.0-SNAPSHOT.6</version>
+<version>1.9.0-SNAPSHOT.8</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/command/Assign.java
+++ b/server/src/main/java/io/spine/server/command/Assign.java
@@ -46,7 +46,7 @@ import java.lang.annotation.Target;
  * </ul>
  *
  * <p>Like other message-handling methods, command handlers are designed to be called by
- * the framework only. Therefore, it is recommended to declare a them as package-private.
+ * the framework only. Therefore, it is recommended to declare them as package-private.
  * It discourages a developer from calling these methods directly from anywhere.
  *
  * <p>Package-private access level still declares that a command handler method is a part

--- a/server/src/main/java/io/spine/server/delivery/Delivery.java
+++ b/server/src/main/java/io/spine/server/delivery/Delivery.java
@@ -626,6 +626,14 @@ public final class Delivery implements Logging {
     }
 
     /**
+     * Returns the registry of known message deliveries.
+     */
+    @VisibleForTesting
+    InboxDeliveries registeredDeliveries() {
+        return deliveries;
+    }
+
+    /**
      * Determines the shard index for the message, judging on the identifier of the entity,
      * to which this message is dispatched.
      *

--- a/server/src/main/java/io/spine/server/delivery/Inbox.java
+++ b/server/src/main/java/io/spine/server/delivery/Inbox.java
@@ -122,7 +122,7 @@ public final class Inbox<I> {
     /**
      * Unregisters this {@code Inbox} instance in the JVM-wide {@code Delivery}.
      *
-     * After this call the messages residing in the sharded storage will not be delivered to the
+     * <p>After this call the messages residing in the sharded storage will not be delivered to the
      * entities served by this {@code Inbox}.
      */
     public void unregister() {

--- a/server/src/main/java/io/spine/server/delivery/InboxDeliveries.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxDeliveries.java
@@ -26,6 +26,8 @@
 
 package io.spine.server.delivery;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import io.spine.type.TypeUrl;
 
 import java.util.Map;
@@ -82,5 +84,15 @@ final class InboxDeliveries {
     void unregister(Inbox<?> inbox) {
         TypeUrl entityType = inbox.entityStateType();
         contents.remove(entityType.value());
+    }
+
+    /**
+     * Returns the {@code String} values of type URLs
+     * under which the message delivered are registered
+     * in this instance of {@code InboxDeliveries}.
+     */
+    @VisibleForTesting
+    ImmutableSet<String> knownTypeUrls() {
+        return ImmutableSet.copyOf(contents.keySet());
     }
 }

--- a/server/src/main/java/io/spine/server/projection/ProjectionRepository.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionRepository.java
@@ -61,6 +61,7 @@ import io.spine.server.storage.StorageFactory;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
 import io.spine.time.TimestampTemporal;
+import io.spine.type.TypeUrl;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -195,7 +196,7 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S, ?>, S e
      */
     private void initInbox(Delivery delivery) {
         inbox = delivery
-                .<I>newInbox(entityStateType())
+                .<I>newInbox(inboxStateType())
                 .withBatchListener(new BatchDeliveryListener<I>() {
                     @Override
                     public void onStart(I id) {
@@ -212,6 +213,20 @@ public abstract class ProjectionRepository<I, P extends Projection<I, S, ?>, S e
                 .addEventEndpoint(InboxLabel.CATCH_UP,
                                   e -> CatchUpEndpoint.of(this, e))
                 .build();
+    }
+
+    /**
+     * Returns a {@code TypeUrl} under which the entities of this repository will register
+     * their {@code Inbox}es.
+     *
+     * <p>Descendants may choose to customize this value in special cases.
+     * One of these cases is avoiding the duplication of {@code Inbox}es
+     * in an application-wide {@code Delivery} for the same system projection
+     * registered in several Bounded Contexts.
+     */
+    @Internal
+    protected TypeUrl inboxStateType() {
+        return entityStateType();
     }
 
     private Inbox<I> inbox() {

--- a/server/src/test/java/io/spine/server/aggregate/AggregateTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateTest.java
@@ -132,6 +132,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @DisplayName("Aggregate should")
 @SuppressWarnings({
         "InnerClassMayBeStatic", "ClassCanBeStatic" /* JUnit nested classes cannot be static. */,
+        "ClassWithTooManyMethods", "OverlyCoupledClass" /* Testing a centerpiece. */
 })
 @MuteLogging    /* Explicitly triggering failures in tests. */
 public class AggregateTest {

--- a/server/src/test/java/io/spine/server/aggregate/AggregateTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateTest.java
@@ -129,10 +129,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisplayName("Aggregate should")
 @SuppressWarnings({
         "InnerClassMayBeStatic", "ClassCanBeStatic" /* JUnit nested classes cannot be static. */,
 })
-@DisplayName("Aggregate should")
+@MuteLogging    /* Explicitly triggering failures in tests. */
 public class AggregateTest {
 
     private static final ProjectId ID = ProjectId.newBuilder()

--- a/server/src/test/java/io/spine/server/delivery/InboxRegistrationTest.java
+++ b/server/src/test/java/io/spine/server/delivery/InboxRegistrationTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.delivery;
+
+import com.google.common.collect.ImmutableSet;
+import io.spine.server.BoundedContext;
+import io.spine.server.DefaultRepository;
+import io.spine.server.ServerEnvironment;
+import io.spine.server.aggregate.Aggregate;
+import io.spine.server.delivery.given.InboxRegistrationTestEnv.InboxProject;
+import io.spine.server.delivery.given.InboxRegistrationTestEnv.InboxTask;
+import io.spine.system.server.Mirror;
+import io.spine.type.TypeUrl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+@DisplayName("`Inbox`es registration in `Delivery`")
+@SuppressWarnings("resource" /* Ignoring the closeables for tests is OK. */)
+final class InboxRegistrationTest {
+
+    private static final String MIRROR_TYPE_URL = TypeUrl.of(Mirror.class)
+                                                         .toTypeName()
+                                                         .value();
+
+    @Test
+    @DisplayName("should have no overlaps for `Aggregate` mirrors from multiple Bounded Contexts")
+    void registerMultipleMirrors() {
+        String firstContextName = "Mirror Projects";
+        buildContext(firstContextName, InboxProject.class);
+
+        String secondContextName = "Mirror Tasks";
+        buildContext(secondContextName, InboxTask.class);
+
+        InboxDeliveries deliveries = registeredDeliveries();
+        ImmutableSet<String> rawInboxTypes = deliveries.knownTypeUrls();
+        assertRegistered(firstContextName, rawInboxTypes);
+        assertRegistered(secondContextName, rawInboxTypes);
+    }
+
+    @SuppressWarnings("IfStatementMissingBreakInLoop")
+    private static void assertRegistered(String firstContextName,
+                                         ImmutableSet<String> rawInboxTypes) {
+        boolean found = false;
+        for (String type : rawInboxTypes) {
+            if (type.contains(firstContextName) && type.contains(MIRROR_TYPE_URL)) {
+                found = true;
+            }
+        }
+        assertWithMessage("`Inbox` deliveries must have an entry " +
+                                  "registered for Context `%s` and `%s` projection type.",
+                          firstContextName, MIRROR_TYPE_URL)
+                .that(found)
+                .isTrue();
+    }
+
+    private static InboxDeliveries registeredDeliveries() {
+        return ServerEnvironment.instance()
+                                .delivery()
+                                .registeredDeliveries();
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored" /* Just triggering `Inbox` registration. */)
+    private static <A extends Aggregate<String, ?, ?>>
+    void buildContext(String name, Class<A> entityType) {
+        BoundedContext.singleTenant(name)
+                      .add(DefaultRepository.of(entityType))
+                      .build();
+    }
+}

--- a/server/src/test/java/io/spine/server/delivery/given/InboxRegistrationTestEnv.java
+++ b/server/src/test/java/io/spine/server/delivery/given/InboxRegistrationTestEnv.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.delivery.given;
+
+import io.spine.server.aggregate.Aggregate;
+import io.spine.server.aggregate.Apply;
+import io.spine.server.command.Assign;
+import io.spine.test.delivery.registration.MirroredProject;
+import io.spine.test.delivery.registration.MirroredTask;
+import io.spine.test.delivery.registration.command.CreateMirroredProject;
+import io.spine.test.delivery.registration.command.CreateMirroredTask;
+import io.spine.test.delivery.registration.event.MirroredProjectCreated;
+import io.spine.test.delivery.registration.event.MirroredTaskCreated;
+
+/**
+ * Test environment for {@link io.spine.server.delivery.InboxRegistrationTest}.
+ */
+public final class InboxRegistrationTestEnv {
+
+    private InboxRegistrationTestEnv() {
+    }
+
+    public final class InboxProject
+            extends Aggregate<String, MirroredProject, MirroredProject.Builder> {
+
+        @Assign
+        MirroredProjectCreated handle(CreateMirroredProject cmd) {
+            return MirroredProjectCreated
+                    .newBuilder()
+                    .setId(cmd.getId())
+                    .vBuild();
+        }
+
+        @Apply
+        private void on(MirroredProjectCreated event) {
+            builder().setId(event.getId());
+        }
+    }
+
+    public final class InboxTask
+            extends Aggregate<String, MirroredTask, MirroredTask.Builder> {
+
+        @Assign
+        MirroredTaskCreated handle(CreateMirroredTask cmd) {
+            return MirroredTaskCreated
+                    .newBuilder()
+                    .setId(cmd.getId())
+                    .vBuild();
+        }
+
+        @Apply
+        private void on(MirroredTaskCreated event) {
+            builder().setId(event.getId());
+        }
+    }
+}

--- a/server/src/test/proto/spine/test/delivery/registration/mirrored_agg_commands.proto
+++ b/server/src/test/proto/spine/test/delivery/registration/mirrored_agg_commands.proto
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+syntax = "proto3";
+
+package spine.test.delivery;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.test.delivery.registration.command";
+option java_outer_classname = "MirroredAggregatesCommandsProto";
+option java_multiple_files = true;
+
+// This file describes commands belonging to two different Bounded Contexts.
+//
+// Technically, they should be defined in different `.proto` packages.
+// However, for simplicity, they are defined in a single file.
+
+message CreateMirroredProject {
+    string id = 1;
+}
+
+message CreateMirroredTask {
+    string id = 1;
+}

--- a/server/src/test/proto/spine/test/delivery/registration/mirrored_agg_events.proto
+++ b/server/src/test/proto/spine/test/delivery/registration/mirrored_agg_events.proto
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+syntax = "proto3";
+
+package spine.test.delivery;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.test.delivery.registration.event";
+option java_outer_classname = "MirroredAggregatesEventsProto";
+option java_multiple_files = true;
+
+// This file describes events belonging to two different Bounded Contexts.
+//
+// Technically, they should be defined in different `.proto` packages.
+// However, for simplicity, they are defined in a single file.
+
+message MirroredProjectCreated {
+    string id = 1;
+}
+
+message MirroredTaskCreated {
+    string id = 1;
+}

--- a/server/src/test/proto/spine/test/delivery/registration/mirrored_aggregates.proto
+++ b/server/src/test/proto/spine/test/delivery/registration/mirrored_aggregates.proto
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+syntax = "proto3";
+
+package spine.test.delivery.registration;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.test.delivery.registration";
+option java_outer_classname = "MirroredAggregatesProto";
+option java_multiple_files = true;
+
+// This file describes two Aggregate states to be used in `InboxRegistrationTest`.
+//
+// These Aggregates belong to different Bounded Contexts,
+// and technically should be defined in different `.proto` packages.
+// However, for simplicity, both of them are defined in a single file.
+//
+// Another simplification is using `string`-typed identifiers.
+// In real life, each of Aggregates should have typed IDs
+// as per Ubiquitous Language corresponding to each Bounded Context.
+
+message MirroredProject {
+
+    option (entity).kind = AGGREGATE;
+    option (entity).visibility = FULL;
+
+    string id = 1;
+
+    string title = 2;
+}
+
+message MirroredTask {
+
+    option (entity).kind = AGGREGATE;
+    option (entity).visibility = FULL;
+
+    string id = 1;
+
+    string description = 2;
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,7 +34,7 @@
 /**
  * Version of this library.
  */
-val coreJava = "1.9.0-SNAPSHOT.7"
+val coreJava = "1.9.0-SNAPSHOT.8"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.


### PR DESCRIPTION
This changeset allows to properly access the read-side of Aggregates which are registered in different Bounded Contexts, and are exposed to read-side via the corresponding `entity` visibility.

In a Spine-based application, it is possible to expose an Aggregate state to the read-side. Under-the-hood it is done via system-internal `Mirror` projection, which accumulates all changes for all such Aggregates in scope of a single Bounded Context. At the same time, `Delivery` (which performs signal dispatching) relies onto the type URL of entities to which the dispatched signals are being delivered.

When several Bounded Contexts have their Aggregates "visible" (i.e. exposed via `Mirror`), `Delivery` is confused with multiple `Mirror` entity types which technically are distinct, but at the same time have exactly the same type URL. Such a use-cases leads to failures when Aggregate state on read-side is updated by the framework code.

This changeset alters the type URL, under which `Mirror` projections register themselves in `Delivery`. The new type URL value includes the name of the Bounded Context — which makes this type URL invalid in terms of type discovery, but addresses the issue.

An important thing to know is that such a workaround makes sense for 1.x codebase only, because Aggregate mirroring was already completely redesigned in scope of Spine 2.x.