### PR TITLE
Release 1.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Welcome to Spine Event Engine
-[![Build Status](https://travis-ci.com/SpineEventEngine/core-java.svg?branch=master)](https://travis-ci.com/SpineEventEngine/core-java) &nbsp;
 [![codecov.io](https://codecov.io/github/SpineEventEngine/core-java/coverage.svg?branch=master)](https://codecov.io/github/SpineEventEngine/core-java?branch=master) &nbsp;
 [![license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0)
-[![Gitter chat](https://badges.gitter.im/SpineEventEngine.png)](https://gitter.im/SpineEventEngine)
 
 [Spine Event Engine][spine-site] is a Java framework for building Event Sourcing and CQRS
 applications that are accessed by clients built with JavaScript, Java Nano (Android), Dart, and Java.
@@ -18,7 +16,7 @@ This repository contains the code of:
 The project is under active ongoing development. 
 You are welcome to experiment and [provide your feedback][email-developers].
 
-The latest stable version is [1.8.2][latest-release].  
+The latest stable version is [1.9.0][latest-release].  
 
 ## Quick start and examples
 
@@ -59,7 +57,7 @@ latest version of the configuration files.
 If you need to use API with one of these annotations, please [contact us][email-developers].
 
 [email-developers]: mailto:developers@spine.io
-[latest-release]: https://github.com/SpineEventEngine/core-java/releases/tag/v1.8.2
+[latest-release]: https://github.com/SpineEventEngine/core-java/releases/tag/v1.9.0
 [spine-site]: https://spine.io/
 [quick-start]: https://spine.io/docs/quick-start
 [spine-examples]: https://github.com/spine-examples

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/CheckVersionIncrement.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/IncrementGuard.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/RunBuild.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/RunBuild.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/internal/deps.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/ActorRequestFactory.java
+++ b/client/src/main/java/io/spine/client/ActorRequestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/Client.java
+++ b/client/src/main/java/io/spine/client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/CommandFactory.java
+++ b/client/src/main/java/io/spine/client/CommandFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/CommandRequest.java
+++ b/client/src/main/java/io/spine/client/CommandRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/CompositeEntityStateFilter.java
+++ b/client/src/main/java/io/spine/client/CompositeEntityStateFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/CompositeEventFilter.java
+++ b/client/src/main/java/io/spine/client/CompositeEventFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/CompositeFilterMixin.java
+++ b/client/src/main/java/io/spine/client/CompositeFilterMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/CompositeMessageFilter.java
+++ b/client/src/main/java/io/spine/client/CompositeMessageFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/CompositeQueryFilter.java
+++ b/client/src/main/java/io/spine/client/CompositeQueryFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/ConnectionConstants.java
+++ b/client/src/main/java/io/spine/client/ConnectionConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/ConsumerErrorHandler.java
+++ b/client/src/main/java/io/spine/client/ConsumerErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/Consumers.java
+++ b/client/src/main/java/io/spine/client/Consumers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/DelegatingConsumer.java
+++ b/client/src/main/java/io/spine/client/DelegatingConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/DeliveringMultiEventObserver.java
+++ b/client/src/main/java/io/spine/client/DeliveringMultiEventObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/EntityStateFilter.java
+++ b/client/src/main/java/io/spine/client/EntityStateFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/ErrorHandler.java
+++ b/client/src/main/java/io/spine/client/ErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/EventConsumer.java
+++ b/client/src/main/java/io/spine/client/EventConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/EventConsumers.java
+++ b/client/src/main/java/io/spine/client/EventConsumers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/EventFilter.java
+++ b/client/src/main/java/io/spine/client/EventFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/EventObserver.java
+++ b/client/src/main/java/io/spine/client/EventObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/EventSubscriptionRequest.java
+++ b/client/src/main/java/io/spine/client/EventSubscriptionRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/FilterMixin.java
+++ b/client/src/main/java/io/spine/client/FilterMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/FilteringField.java
+++ b/client/src/main/java/io/spine/client/FilteringField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/FilteringRequest.java
+++ b/client/src/main/java/io/spine/client/FilteringRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/Filters.java
+++ b/client/src/main/java/io/spine/client/Filters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/LoggingConsumerErrorHandler.java
+++ b/client/src/main/java/io/spine/client/LoggingConsumerErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/LoggingHandler.java
+++ b/client/src/main/java/io/spine/client/LoggingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/LoggingHandlerWithType.java
+++ b/client/src/main/java/io/spine/client/LoggingHandlerWithType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/LoggingServerErrorHandler.java
+++ b/client/src/main/java/io/spine/client/LoggingServerErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/LoggingTypeErrorHandler.java
+++ b/client/src/main/java/io/spine/client/LoggingTypeErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/MessageConsumer.java
+++ b/client/src/main/java/io/spine/client/MessageConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/MessageFilter.java
+++ b/client/src/main/java/io/spine/client/MessageFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/MultiEventConsumers.java
+++ b/client/src/main/java/io/spine/client/MultiEventConsumers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/OperatorEvaluator.java
+++ b/client/src/main/java/io/spine/client/OperatorEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/QueryBuilder.java
+++ b/client/src/main/java/io/spine/client/QueryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/QueryFactory.java
+++ b/client/src/main/java/io/spine/client/QueryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/QueryFilter.java
+++ b/client/src/main/java/io/spine/client/QueryFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/QueryMixin.java
+++ b/client/src/main/java/io/spine/client/QueryMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/QueryRequest.java
+++ b/client/src/main/java/io/spine/client/QueryRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/QueryResponseMixin.java
+++ b/client/src/main/java/io/spine/client/QueryResponseMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/ServerErrorHandler.java
+++ b/client/src/main/java/io/spine/client/ServerErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/StateConsumer.java
+++ b/client/src/main/java/io/spine/client/StateConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/StateConsumers.java
+++ b/client/src/main/java/io/spine/client/StateConsumers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/SubscribingRequest.java
+++ b/client/src/main/java/io/spine/client/SubscribingRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/SubscriptionMixin.java
+++ b/client/src/main/java/io/spine/client/SubscriptionMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/SubscriptionObserver.java
+++ b/client/src/main/java/io/spine/client/SubscriptionObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/SubscriptionUpdateMixin.java
+++ b/client/src/main/java/io/spine/client/SubscriptionUpdateMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/Subscriptions.java
+++ b/client/src/main/java/io/spine/client/Subscriptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/TargetBuilder.java
+++ b/client/src/main/java/io/spine/client/TargetBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/TargetMixin.java
+++ b/client/src/main/java/io/spine/client/TargetMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/Targets.java
+++ b/client/src/main/java/io/spine/client/Targets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/Timeout.java
+++ b/client/src/main/java/io/spine/client/Timeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/TopicBuilder.java
+++ b/client/src/main/java/io/spine/client/TopicBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/TopicFactory.java
+++ b/client/src/main/java/io/spine/client/TopicFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/TypedFilter.java
+++ b/client/src/main/java/io/spine/client/TypedFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/java/io/spine/client/package-info.java
+++ b/client/src/main/java/io/spine/client/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/proto/spine/client/command_service.proto
+++ b/client/src/main/proto/spine/client/command_service.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/proto/spine/client/entities.proto
+++ b/client/src/main/proto/spine/client/entities.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/proto/spine/client/filters.proto
+++ b/client/src/main/proto/spine/client/filters.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/proto/spine/client/query.proto
+++ b/client/src/main/proto/spine/client/query.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/proto/spine/client/query_service.proto
+++ b/client/src/main/proto/spine/client/query_service.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/proto/spine/client/subscription.proto
+++ b/client/src/main/proto/spine/client/subscription.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/main/proto/spine/client/subscription_service.proto
+++ b/client/src/main/proto/spine/client/subscription_service.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/spine/client/ActorRequestFactoryTest.java
+++ b/client/src/test/java/io/spine/client/ActorRequestFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/spine/client/CommandFactoryTest.java
+++ b/client/src/test/java/io/spine/client/CommandFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/spine/client/ConnectionConstantsTest.java
+++ b/client/src/test/java/io/spine/client/ConnectionConstantsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/spine/client/QueryBuilderTest.java
+++ b/client/src/test/java/io/spine/client/QueryBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/spine/client/given/ActorRequestFactoryTestEnv.java
+++ b/client/src/test/java/io/spine/client/given/ActorRequestFactoryTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/spine/core/CommandTest.java
+++ b/client/src/test/java/io/spine/core/CommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/java/io/spine/core/CommandsTest.java
+++ b/client/src/test/java/io/spine/core/CommandsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/proto/spine/test/commands/command_factory_test_commands.proto
+++ b/client/src/test/proto/spine/test/commands/command_factory_test_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/proto/spine/test/commands/commands.proto
+++ b/client/src/test/proto/spine/test/commands/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/proto/spine/test/events/events.proto
+++ b/client/src/test/proto/spine/test/events/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/proto/spine/test/queries/client_requests.proto
+++ b/client/src/test/proto/spine/test/queries/client_requests.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/src/test/proto/spine/test/queries/identifiers.proto
+++ b/client/src/test/proto/spine/test/queries/identifiers.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/spine/change/BooleanMismatch.java
+++ b/core/src/main/java/io/spine/change/BooleanMismatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/spine/change/ChangePreconditions.java
+++ b/core/src/main/java/io/spine/change/ChangePreconditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/spine/change/Changes.java
+++ b/core/src/main/java/io/spine/change/Changes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/spine/change/DoubleMismatch.java
+++ b/core/src/main/java/io/spine/change/DoubleMismatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/spine/change/FloatMismatch.java
+++ b/core/src/main/java/io/spine/change/FloatMismatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/spine/change/IntMismatch.java
+++ b/core/src/main/java/io/spine/change/IntMismatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/spine/change/LongMismatch.java
+++ b/core/src/main/java/io/spine/change/LongMismatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/spine/change/MessageMismatch.java
+++ b/core/src/main/java/io/spine/change/MessageMismatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/spine/change/StringMismatch.java
+++ b/core/src/main/java/io/spine/change/StringMismatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/spine/change/package-info.java
+++ b/core/src/main/java/io/spine/change/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/spine/core/ByField.java
+++ b/core/src/main/java/io/spine/core/ByField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/spine/core/Where.java
+++ b/core/src/main/java/io/spine/core/Where.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/proto/spine/change/change.proto
+++ b/core/src/main/proto/spine/change/change.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/proto/spine/change/value_mismatch.proto
+++ b/core/src/main/proto/spine/change/value_mismatch.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/proto/spine/core/ack.proto
+++ b/core/src/main/proto/spine/core/ack.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/proto/spine/core/actor_context.proto
+++ b/core/src/main/proto/spine/core/actor_context.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/proto/spine/core/bounded_context.proto
+++ b/core/src/main/proto/spine/core/bounded_context.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/proto/spine/core/command.proto
+++ b/core/src/main/proto/spine/core/command.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/proto/spine/core/diagnostics.proto
+++ b/core/src/main/proto/spine/core/diagnostics.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/proto/spine/core/empty_context.proto
+++ b/core/src/main/proto/spine/core/empty_context.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/proto/spine/core/enrichment.proto
+++ b/core/src/main/proto/spine/core/enrichment.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/proto/spine/core/event.proto
+++ b/core/src/main/proto/spine/core/event.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/proto/spine/core/response.proto
+++ b/core/src/main/proto/spine/core/response.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/proto/spine/core/tenant_id.proto
+++ b/core/src/main/proto/spine/core/tenant_id.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/proto/spine/core/user_id.proto
+++ b/core/src/main/proto/spine/core/user_id.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/proto/spine/core/version.proto
+++ b/core/src/main/proto/spine/core/version.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/io/spine/change/BooleanMismatchTest.java
+++ b/core/src/test/java/io/spine/change/BooleanMismatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/io/spine/change/ChangePreconditionsTest.java
+++ b/core/src/test/java/io/spine/change/ChangePreconditionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/io/spine/change/ChangesTest.java
+++ b/core/src/test/java/io/spine/change/ChangesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/io/spine/change/DoubleMismatchTest.java
+++ b/core/src/test/java/io/spine/change/DoubleMismatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/io/spine/change/FloatMismatchTest.java
+++ b/core/src/test/java/io/spine/change/FloatMismatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/io/spine/change/IntMismatchTest.java
+++ b/core/src/test/java/io/spine/change/IntMismatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/io/spine/change/LongMismatchTest.java
+++ b/core/src/test/java/io/spine/change/LongMismatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/io/spine/change/MessageMismatchTest.java
+++ b/core/src/test/java/io/spine/change/MessageMismatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/io/spine/change/StringMismatchTest.java
+++ b/core/src/test/java/io/spine/change/StringMismatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/io/spine/core/AcksTest.java
+++ b/core/src/test/java/io/spine/core/AcksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/io/spine/core/ResponsesTest.java
+++ b/core/src/test/java/io/spine/core/ResponsesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/io/spine/core/SignalTest.java
+++ b/core/src/test/java/io/spine/core/SignalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/io/spine/core/VersionsTest.java
+++ b/core/src/test/java/io/spine/core/VersionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/proto/spine/test/core/events.proto
+++ b/core/src/test/proto/spine/test/core/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/proto/spine/test/core/project.proto
+++ b/core/src/test/proto/spine/test/core/project.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/proto/spine/test/core/task.proto
+++ b/core/src/test/proto/spine/test/core/task.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-client:1.9.0-SNAPSHOT.12`
+# Dependencies of `io.spine:spine-client:1.9.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -399,12 +399,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 20 16:31:59 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 18 15:19:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-core:1.9.0-SNAPSHOT.12`
+# Dependencies of `io.spine:spine-core:1.9.0`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -763,12 +763,12 @@ This report was generated on **Thu Apr 20 16:31:59 WEST 2023** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 20 16:32:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 18 15:19:01 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-assembler:1.9.0-SNAPSHOT.12`
+# Dependencies of `io.spine.tools:spine-model-assembler:1.9.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1162,12 +1162,12 @@ This report was generated on **Thu Apr 20 16:32:00 WEST 2023** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 20 16:32:01 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 18 15:19:02 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-verifier:1.9.0-SNAPSHOT.12`
+# Dependencies of `io.spine.tools:spine-model-verifier:1.9.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1627,12 +1627,12 @@ This report was generated on **Thu Apr 20 16:32:01 WEST 2023** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 20 16:32:03 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 18 15:19:03 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-server:1.9.0-SNAPSHOT.12`
+# Dependencies of `io.spine:spine-server:1.9.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2039,12 +2039,12 @@ This report was generated on **Thu Apr 20 16:32:03 WEST 2023** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 20 16:32:04 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 18 15:19:03 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-client:1.9.0-SNAPSHOT.12`
+# Dependencies of `io.spine:spine-testutil-client:1.9.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2493,12 +2493,12 @@ This report was generated on **Thu Apr 20 16:32:04 WEST 2023** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 20 16:32:07 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 18 15:19:08 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-core:1.9.0-SNAPSHOT.12`
+# Dependencies of `io.spine:spine-testutil-core:1.9.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -2947,12 +2947,12 @@ This report was generated on **Thu Apr 20 16:32:07 WEST 2023** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 20 16:32:08 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 18 15:19:10 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testutil-server:1.9.0-SNAPSHOT.12`
+# Dependencies of `io.spine:spine-testutil-server:1.9.0`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -3445,4 +3445,4 @@ This report was generated on **Thu Apr 20 16:32:08 WEST 2023** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 20 16:32:13 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 18 15:19:14 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/model/model-assembler/build.gradle.kts
+++ b/model/model-assembler/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-assembler/src/main/java/io/spine/model/assemble/AssignLookup.java
+++ b/model/model-assembler/src/main/java/io/spine/model/assemble/AssignLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-assembler/src/main/java/io/spine/model/assemble/SpineAnnotationProcessor.java
+++ b/model/model-assembler/src/main/java/io/spine/model/assemble/SpineAnnotationProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-assembler/src/main/java/io/spine/model/assemble/package-info.java
+++ b/model/model-assembler/src/main/java/io/spine/model/assemble/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-assembler/src/main/java/io/spine/model/package-info.java
+++ b/model/model-assembler/src/main/java/io/spine/model/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-assembler/src/main/proto/spine/model/spine_model.proto
+++ b/model/model-assembler/src/main/proto/spine/model/spine_model.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-assembler/src/test/java/io/spine/model/assemble/AssignLookupTest.java
+++ b/model/model-assembler/src/test/java/io/spine/model/assemble/AssignLookupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-assembler/src/test/java/io/spine/model/assemble/SpineAnnotationProcessorTest.java
+++ b/model/model-assembler/src/test/java/io/spine/model/assemble/SpineAnnotationProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-assembler/src/test/java/io/spine/model/assemble/given/MemoizingMessager.java
+++ b/model/model-assembler/src/test/java/io/spine/model/assemble/given/MemoizingMessager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-assembler/src/test/java/io/spine/model/assemble/given/package-info.java
+++ b/model/model-assembler/src/test/java/io/spine/model/assemble/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/build.gradle.kts
+++ b/model/model-verifier/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/main/java/io/spine/model/verify/ClassSet.java
+++ b/model/model-verifier/src/main/java/io/spine/model/verify/ClassSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifier.java
+++ b/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifierPlugin.java
+++ b/model/model-verifier/src/main/java/io/spine/model/verify/ModelVerifierPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/main/java/io/spine/model/verify/package-info.java
+++ b/model/model-verifier/src/main/java/io/spine/model/verify/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/main/resources/META-INF/gradle-plugins/io.spine.tools.spine-model-verifier.properties
+++ b/model/model-verifier/src/main/resources/META-INF/gradle-plugins/io.spine.tools.spine-model-verifier.properties
@@ -1,6 +1,6 @@
 
 #
-# Copyright 2022, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierPluginTest.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierTest.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/ModelVerifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/java/io/spine/model/verify/given/DuplicateCommandHandler.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/given/DuplicateCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/java/io/spine/model/verify/given/EditAggregate.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/given/EditAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/java/io/spine/model/verify/given/InvalidCommander.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/given/InvalidCommander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/java/io/spine/model/verify/given/InvalidDeleteAggregate.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/given/InvalidDeleteAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/java/io/spine/model/verify/given/InvalidEnhanceAggregate.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/given/InvalidEnhanceAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/java/io/spine/model/verify/given/InvalidRestoreAggregate.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/given/InvalidRestoreAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/java/io/spine/model/verify/given/RenameProcMan.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/given/RenameProcMan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/java/io/spine/model/verify/given/UploadCommandHandler.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/given/UploadCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/java/io/spine/model/verify/given/package-info.java
+++ b/model/model-verifier/src/test/java/io/spine/model/verify/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/proto/spine/test/model/verify/commands.proto
+++ b/model/model-verifier/src/test/proto/spine/test/model/verify/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/proto/spine/test/model/verify/edit.proto
+++ b/model/model-verifier/src/test/proto/spine/test/model/verify/edit.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/proto/spine/test/model/verify/events.proto
+++ b/model/model-verifier/src/test/proto/spine/test/model/verify/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/resources/build.gradle.kts
+++ b/model/model-verifier/src/test/resources/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/resources/model-verifier-test/src/main/java/io/spine/model/verify/DuplicateAggregate.java
+++ b/model/model-verifier/src/test/resources/model-verifier-test/src/main/java/io/spine/model/verify/DuplicateAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/resources/model-verifier-test/src/main/java/io/spine/model/verify/DuplicateCommandHandler.java
+++ b/model/model-verifier/src/test/resources/model-verifier-test/src/main/java/io/spine/model/verify/DuplicateCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/resources/model-verifier-test/src/main/java/io/spine/model/verify/MalformedAggregate.java
+++ b/model/model-verifier/src/test/resources/model-verifier-test/src/main/java/io/spine/model/verify/MalformedAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/resources/model-verifier-test/src/main/java/io/spine/model/verify/ValidAggregate.java
+++ b/model/model-verifier/src/test/resources/model-verifier-test/src/main/java/io/spine/model/verify/ValidAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/resources/model-verifier-test/src/main/java/io/spine/model/verify/ValidCommandHandler.java
+++ b/model/model-verifier/src/test/resources/model-verifier-test/src/main/java/io/spine/model/verify/ValidCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/resources/model-verifier-test/src/main/java/io/spine/model/verify/ValidProcMan.java
+++ b/model/model-verifier/src/test/resources/model-verifier-test/src/main/java/io/spine/model/verify/ValidProcMan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/resources/model-verifier-test/src/main/proto/spine/model/verify/call_entity.proto
+++ b/model/model-verifier/src/test/resources/model-verifier-test/src/main/proto/spine/model/verify/call_entity.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/resources/model-verifier-test/src/main/proto/spine/model/verify/commands.proto
+++ b/model/model-verifier/src/test/resources/model-verifier-test/src/main/proto/spine/model/verify/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/model-verifier/src/test/resources/model-verifier-test/src/main/proto/spine/model/verify/events.proto
+++ b/model/model-verifier/src/test/resources/model-verifier-test/src/main/proto/spine/model/verify/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>1.9.0-SNAPSHOT.12</version>
+<version>1.9.0</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -52,25 +52,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>1.9.0-SNAPSHOT.5</version>
+    <version>1.9.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-time</artifactId>
-    <version>1.9.0-SNAPSHOT.5</version>
+    <version>1.9.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>1.9.0-SNAPSHOT.5</version>
+    <version>1.9.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>1.9.0-SNAPSHOT.5</version>
+    <version>1.9.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -124,25 +124,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testlib</artifactId>
-    <version>1.9.0-SNAPSHOT.5</version>
+    <version>1.9.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-testutil-time</artifactId>
-    <version>1.9.0-SNAPSHOT.5</version>
+    <version>1.9.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-mute-logging</artifactId>
-    <version>1.9.0-SNAPSHOT.5</version>
+    <version>1.9.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>1.9.0-SNAPSHOT.5</version>
+    <version>1.9.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -210,12 +210,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-javadoc-filter</artifactId>
-    <version>1.9.0-SNAPSHOT.5</version>
+    <version>1.9.0</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.9.0-SNAPSHOT.5</version>
+    <version>1.9.0</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/scripts/dependent-repositories/gae-update-core-version.sh
+++ b/scripts/dependent-repositories/gae-update-core-version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright 2022, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/dependent-repositories/jdbc-update-core-version.sh
+++ b/scripts/dependent-repositories/jdbc-update-core-version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright 2022, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/dependent-repositories/update-dependency-version.sh
+++ b/scripts/dependent-repositories/update-dependency-version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright 2022, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/dependent-repositories/update-dependent-repositories.sh
+++ b/scripts/dependent-repositories/update-dependent-repositories.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright 2022, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/report-coverage.sh
+++ b/scripts/report-coverage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright 2022, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/BoundedContext.java
+++ b/server/src/main/java/io/spine/server/BoundedContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/BoundedContextBuilder.java
+++ b/server/src/main/java/io/spine/server/BoundedContextBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/Closeable.java
+++ b/server/src/main/java/io/spine/server/Closeable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/CommandService.java
+++ b/server/src/main/java/io/spine/server/CommandService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/ConnectionBuilder.java
+++ b/server/src/main/java/io/spine/server/ConnectionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/ContextAware.java
+++ b/server/src/main/java/io/spine/server/ContextAware.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/ContextSpec.java
+++ b/server/src/main/java/io/spine/server/ContextSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/DefaultRepository.java
+++ b/server/src/main/java/io/spine/server/DefaultRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/DeploymentDetector.java
+++ b/server/src/main/java/io/spine/server/DeploymentDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/DomainContext.java
+++ b/server/src/main/java/io/spine/server/DomainContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/EnvSetting.java
+++ b/server/src/main/java/io/spine/server/EnvSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/EventProducer.java
+++ b/server/src/main/java/io/spine/server/EventProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/GrpcContainer.java
+++ b/server/src/main/java/io/spine/server/GrpcContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/Identity.java
+++ b/server/src/main/java/io/spine/server/Identity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/MessageError.java
+++ b/server/src/main/java/io/spine/server/MessageError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/MessageInvalid.java
+++ b/server/src/main/java/io/spine/server/MessageInvalid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/QueryService.java
+++ b/server/src/main/java/io/spine/server/QueryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/Server.java
+++ b/server/src/main/java/io/spine/server/Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/ServerEnvironment.java
+++ b/server/src/main/java/io/spine/server/ServerEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/SubscriptionService.java
+++ b/server/src/main/java/io/spine/server/SubscriptionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/VisibilityGuard.java
+++ b/server/src/main/java/io/spine/server/VisibilityGuard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateCommandEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateCommandEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateEventEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateEventEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateEventReactionEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateEventReactionEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateField.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/AggregatePart.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregatePart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/AggregatePartRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregatePartRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateReadRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRoot.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRootDirectory.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRootDirectory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateTransaction.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/Apply.java
+++ b/server/src/main/java/io/spine/server/aggregate/Apply.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/DefaultAggregatePartRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/DefaultAggregatePartRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/DefaultAggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/DefaultAggregateRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/EventImportDispatcher.java
+++ b/server/src/main/java/io/spine/server/aggregate/EventImportDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/EventImportEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/EventImportEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/IdempotencyGuard.java
+++ b/server/src/main/java/io/spine/server/aggregate/IdempotencyGuard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/ImportBus.java
+++ b/server/src/main/java/io/spine/server/aggregate/ImportBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/ImportValidator.java
+++ b/server/src/main/java/io/spine/server/aggregate/ImportValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/InMemoryRootDirectory.java
+++ b/server/src/main/java/io/spine/server/aggregate/InMemoryRootDirectory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/ReadOperation.java
+++ b/server/src/main/java/io/spine/server/aggregate/ReadOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/UncommittedEvents.java
+++ b/server/src/main/java/io/spine/server/aggregate/UncommittedEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/UnsupportedImportEventException.java
+++ b/server/src/main/java/io/spine/server/aggregate/UnsupportedImportEventException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/VersionSequence.java
+++ b/server/src/main/java/io/spine/server/aggregate/VersionSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/Write.java
+++ b/server/src/main/java/io/spine/server/aggregate/Write.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/model/AggregateClass.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/AggregateClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/model/AggregatePartClass.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/AggregatePartClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/model/AllowImportAttribute.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/AllowImportAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/model/Applier.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/Applier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/model/EventApplierSignature.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/EventApplierSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/model/PartFactory.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/PartFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/model/package-info.java
+++ b/server/src/main/java/io/spine/server/aggregate/model/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/aggregate/package-info.java
+++ b/server/src/main/java/io/spine/server/aggregate/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/Acks.java
+++ b/server/src/main/java/io/spine/server/bus/Acks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/Bus.java
+++ b/server/src/main/java/io/spine/server/bus/Bus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/BusBuilder.java
+++ b/server/src/main/java/io/spine/server/bus/BusBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/BusFilter.java
+++ b/server/src/main/java/io/spine/server/bus/BusFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/DeadMessageFilter.java
+++ b/server/src/main/java/io/spine/server/bus/DeadMessageFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/DeadMessageHandler.java
+++ b/server/src/main/java/io/spine/server/bus/DeadMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/DispatcherRegistry.java
+++ b/server/src/main/java/io/spine/server/bus/DispatcherRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/EnvelopeValidator.java
+++ b/server/src/main/java/io/spine/server/bus/EnvelopeValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/FilterChain.java
+++ b/server/src/main/java/io/spine/server/bus/FilterChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/Listener.java
+++ b/server/src/main/java/io/spine/server/bus/Listener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/Listeners.java
+++ b/server/src/main/java/io/spine/server/bus/Listeners.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/MessageDispatcher.java
+++ b/server/src/main/java/io/spine/server/bus/MessageDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/MessageUnhandled.java
+++ b/server/src/main/java/io/spine/server/bus/MessageUnhandled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/MulticastBus.java
+++ b/server/src/main/java/io/spine/server/bus/MulticastBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/MulticastDispatchListener.java
+++ b/server/src/main/java/io/spine/server/bus/MulticastDispatchListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/MulticastDispatcher.java
+++ b/server/src/main/java/io/spine/server/bus/MulticastDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/UnicastBus.java
+++ b/server/src/main/java/io/spine/server/bus/UnicastBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/UnicastDispatcher.java
+++ b/server/src/main/java/io/spine/server/bus/UnicastDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/ValidatingFilter.java
+++ b/server/src/main/java/io/spine/server/bus/ValidatingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/bus/package-info.java
+++ b/server/src/main/java/io/spine/server/bus/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/AbstractCommandDispatcher.java
+++ b/server/src/main/java/io/spine/server/command/AbstractCommandDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/AbstractCommandHandler.java
+++ b/server/src/main/java/io/spine/server/command/AbstractCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/AbstractCommander.java
+++ b/server/src/main/java/io/spine/server/command/AbstractCommander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/Assign.java
+++ b/server/src/main/java/io/spine/server/command/Assign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/Command.java
+++ b/server/src/main/java/io/spine/server/command/Command.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/CommandDispatchingException.java
+++ b/server/src/main/java/io/spine/server/command/CommandDispatchingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/CommandHandler.java
+++ b/server/src/main/java/io/spine/server/command/CommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/CommandHandlingEntity.java
+++ b/server/src/main/java/io/spine/server/command/CommandHandlingEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/CommandReceiver.java
+++ b/server/src/main/java/io/spine/server/command/CommandReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/Commander.java
+++ b/server/src/main/java/io/spine/server/command/Commander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/DispatchCommand.java
+++ b/server/src/main/java/io/spine/server/command/DispatchCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/Rejections.java
+++ b/server/src/main/java/io/spine/server/command/Rejections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/model/AbstractCommandHandlingClass.java
+++ b/server/src/main/java/io/spine/server/command/model/AbstractCommandHandlingClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/model/CommandAcceptingMethod.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandAcceptingMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/model/CommandAcceptingSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandAcceptingSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/model/CommandHandlerClass.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandHandlerClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/model/CommandHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandHandlerMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/model/CommandHandlerSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandHandlerSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/model/CommandHandlingClass.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandHandlingClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/model/CommandReactionMethod.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandReactionMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/model/CommandReactionSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandReactionSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/model/CommandSubstituteMethod.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandSubstituteMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/model/CommandSubstituteSignature.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandSubstituteSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/model/CommanderClass.java
+++ b/server/src/main/java/io/spine/server/command/model/CommanderClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/model/CommandingClass.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandingClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/model/CommandingMethod.java
+++ b/server/src/main/java/io/spine/server/command/model/CommandingMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/model/DuplicateHandlerCheck.java
+++ b/server/src/main/java/io/spine/server/command/model/DuplicateHandlerCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/model/package-info.java
+++ b/server/src/main/java/io/spine/server/command/model/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/command/package-info.java
+++ b/server/src/main/java/io/spine/server/command/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/AckRejectionPublisher.java
+++ b/server/src/main/java/io/spine/server/commandbus/AckRejectionPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/CommandAckMonitor.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandAckMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/CommandBus.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/CommandDispatcher.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/CommandDispatcherDelegate.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandDispatcherDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/CommandDispatcherRegistry.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandDispatcherRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/CommandException.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/CommandFlowWatcher.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandFlowWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/CommandPostingException.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandPostingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/CommandReceivedTap.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandReceivedTap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/CommandScheduler.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/CommandValidator.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/DeadCommandHandler.java
+++ b/server/src/main/java/io/spine/server/commandbus/DeadCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/DelegatingCommandDispatcher.java
+++ b/server/src/main/java/io/spine/server/commandbus/DelegatingCommandDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/ExecutorCommandScheduler.java
+++ b/server/src/main/java/io/spine/server/commandbus/ExecutorCommandScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/FlightRecorder.java
+++ b/server/src/main/java/io/spine/server/commandbus/FlightRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/InvalidCommandException.java
+++ b/server/src/main/java/io/spine/server/commandbus/InvalidCommandException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/UnsupportedCommandException.java
+++ b/server/src/main/java/io/spine/server/commandbus/UnsupportedCommandException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/commandbus/package-info.java
+++ b/server/src/main/java/io/spine/server/commandbus/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/AbstractMessageEndpoint.java
+++ b/server/src/main/java/io/spine/server/delivery/AbstractMessageEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/AbstractWorkRegistry.java
+++ b/server/src/main/java/io/spine/server/delivery/AbstractWorkRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/BatchDeliveryListener.java
+++ b/server/src/main/java/io/spine/server/delivery/BatchDeliveryListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/CatchUpAlreadyStartedException.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpAlreadyStartedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/CatchUpEventFactory.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpEventFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/CatchUpMessageComparator.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpMessageComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/CatchUpMessages.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/CatchUpMixin.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/CatchUpProcess.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/CatchUpProcessBuilder.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpProcessBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/CatchUpReadRequest.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpReadRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/CatchUpRepositories.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpRepositories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/CatchUpSignal.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpSignal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/CatchUpStarter.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpStarter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/CatchUpStation.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpStation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/CatchUpStorage.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/CleanupStation.java
+++ b/server/src/main/java/io/spine/server/delivery/CleanupStation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/CommandEndpoint.java
+++ b/server/src/main/java/io/spine/server/delivery/CommandEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/Conveyor.java
+++ b/server/src/main/java/io/spine/server/delivery/Conveyor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/DeliveredMessages.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveredMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/Delivery.java
+++ b/server/src/main/java/io/spine/server/delivery/Delivery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/DeliveryAction.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/DeliveryBuilder.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/DeliveryDispatchListener.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryDispatchListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/DeliveryErrors.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryErrors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/DeliveryMonitor.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/DeliveryStats.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/DeliveryStrategy.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/DispatchingId.java
+++ b/server/src/main/java/io/spine/server/delivery/DispatchingId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/Endpoints.java
+++ b/server/src/main/java/io/spine/server/delivery/Endpoints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/EventEndpoint.java
+++ b/server/src/main/java/io/spine/server/delivery/EventEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/FailedReception.java
+++ b/server/src/main/java/io/spine/server/delivery/FailedReception.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/GroupByTargetAndDeliver.java
+++ b/server/src/main/java/io/spine/server/delivery/GroupByTargetAndDeliver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/Inbox.java
+++ b/server/src/main/java/io/spine/server/delivery/Inbox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/InboxDeliveries.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxDeliveries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/InboxIds.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxIds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/InboxMessageComparator.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxMessageComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/InboxMessageMixin.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxMessageMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/InboxOfCommands.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxOfCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/InboxOfEvents.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxOfEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/InboxPart.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/InboxReadRequest.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxReadRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/InboxStorage.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/InboxWriter.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/LabelNotFoundException.java
+++ b/server/src/main/java/io/spine/server/delivery/LabelNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/LazyEndpoint.java
+++ b/server/src/main/java/io/spine/server/delivery/LazyEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/LiveDeliveryStation.java
+++ b/server/src/main/java/io/spine/server/delivery/LiveDeliveryStation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/LocalDispatchingObserver.java
+++ b/server/src/main/java/io/spine/server/delivery/LocalDispatchingObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/MessageEndpoint.java
+++ b/server/src/main/java/io/spine/server/delivery/MessageEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/NotifyingWriter.java
+++ b/server/src/main/java/io/spine/server/delivery/NotifyingWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/Page.java
+++ b/server/src/main/java/io/spine/server/delivery/Page.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/RepositoryLookup.java
+++ b/server/src/main/java/io/spine/server/delivery/RepositoryLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/RunResult.java
+++ b/server/src/main/java/io/spine/server/delivery/RunResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/ShardEvent.java
+++ b/server/src/main/java/io/spine/server/delivery/ShardEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/ShardMaintenanceProcess.java
+++ b/server/src/main/java/io/spine/server/delivery/ShardMaintenanceProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/ShardObserver.java
+++ b/server/src/main/java/io/spine/server/delivery/ShardObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/ShardedMessageDelivery.java
+++ b/server/src/main/java/io/spine/server/delivery/ShardedMessageDelivery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/ShardedRecord.java
+++ b/server/src/main/java/io/spine/server/delivery/ShardedRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/ShardedWorkRegistry.java
+++ b/server/src/main/java/io/spine/server/delivery/ShardedWorkRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/Station.java
+++ b/server/src/main/java/io/spine/server/delivery/Station.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/TargetDelivery.java
+++ b/server/src/main/java/io/spine/server/delivery/TargetDelivery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/Turbulence.java
+++ b/server/src/main/java/io/spine/server/delivery/Turbulence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/UniformAcrossAllShards.java
+++ b/server/src/main/java/io/spine/server/delivery/UniformAcrossAllShards.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/VersionCounter.java
+++ b/server/src/main/java/io/spine/server/delivery/VersionCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
+++ b/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/memory/package-info.java
+++ b/server/src/main/java/io/spine/server/delivery/memory/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/delivery/package-info.java
+++ b/server/src/main/java/io/spine/server/delivery/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/dispatch/BatchDispatchOutcomeMixin.java
+++ b/server/src/main/java/io/spine/server/dispatch/BatchDispatchOutcomeMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/dispatch/DispatchOutcomeHandler.java
+++ b/server/src/main/java/io/spine/server/dispatch/DispatchOutcomeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/dispatch/DispatchOutcomeMixin.java
+++ b/server/src/main/java/io/spine/server/dispatch/DispatchOutcomeMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/dispatch/DispatchOutcomes.java
+++ b/server/src/main/java/io/spine/server/dispatch/DispatchOutcomes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/dispatch/IgnoreMixin.java
+++ b/server/src/main/java/io/spine/server/dispatch/IgnoreMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/dispatch/InterruptionMixin.java
+++ b/server/src/main/java/io/spine/server/dispatch/InterruptionMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/dispatch/OutcomeHandler.java
+++ b/server/src/main/java/io/spine/server/dispatch/OutcomeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/dispatch/ProducedCommandsMixin.java
+++ b/server/src/main/java/io/spine/server/dispatch/ProducedCommandsMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/dispatch/ProducedEventsMixin.java
+++ b/server/src/main/java/io/spine/server/dispatch/ProducedEventsMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/dispatch/SuccessMixin.java
+++ b/server/src/main/java/io/spine/server/dispatch/SuccessMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/dispatch/package-info.java
+++ b/server/src/main/java/io/spine/server/dispatch/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/enrich/CompositeFn.java
+++ b/server/src/main/java/io/spine/server/enrich/CompositeFn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/enrich/Enricher.java
+++ b/server/src/main/java/io/spine/server/enrich/Enricher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/enrich/EnricherBuilder.java
+++ b/server/src/main/java/io/spine/server/enrich/EnricherBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/enrich/EnrichmentFn.java
+++ b/server/src/main/java/io/spine/server/enrich/EnrichmentFn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/enrich/EnrichmentService.java
+++ b/server/src/main/java/io/spine/server/enrich/EnrichmentService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/enrich/EventEnrichmentFn.java
+++ b/server/src/main/java/io/spine/server/enrich/EventEnrichmentFn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/enrich/Schema.java
+++ b/server/src/main/java/io/spine/server/enrich/Schema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/enrich/SchemaFn.java
+++ b/server/src/main/java/io/spine/server/enrich/SchemaFn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/enrich/SingularFn.java
+++ b/server/src/main/java/io/spine/server/enrich/SingularFn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/enrich/package-info.java
+++ b/server/src/main/java/io/spine/server/enrich/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/AbstractEntity.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/BatchDispatch.java
+++ b/server/src/main/java/io/spine/server/entity/BatchDispatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/CommandDispatchingPhase.java
+++ b/server/src/main/java/io/spine/server/entity/CommandDispatchingPhase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/CompositeEventFilter.java
+++ b/server/src/main/java/io/spine/server/entity/CompositeEventFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/DefaultConverter.java
+++ b/server/src/main/java/io/spine/server/entity/DefaultConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/DefaultEntityFactory.java
+++ b/server/src/main/java/io/spine/server/entity/DefaultEntityFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/DefaultRecordBasedRepository.java
+++ b/server/src/main/java/io/spine/server/entity/DefaultRecordBasedRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/Entity.java
+++ b/server/src/main/java/io/spine/server/entity/Entity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/EntityFactory.java
+++ b/server/src/main/java/io/spine/server/entity/EntityFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/EntityLifecycle.java
+++ b/server/src/main/java/io/spine/server/entity/EntityLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/EntityLifecycleMonitor.java
+++ b/server/src/main/java/io/spine/server/entity/EntityLifecycleMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/EntityMessageEndpoint.java
+++ b/server/src/main/java/io/spine/server/entity/EntityMessageEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/EntityStateChangedFilter.java
+++ b/server/src/main/java/io/spine/server/entity/EntityStateChangedFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/EntityVisibility.java
+++ b/server/src/main/java/io/spine/server/entity/EntityVisibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/EventBlackList.java
+++ b/server/src/main/java/io/spine/server/entity/EventBlackList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/EventDispatchingPhase.java
+++ b/server/src/main/java/io/spine/server/entity/EventDispatchingPhase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/EventDispatchingRepository.java
+++ b/server/src/main/java/io/spine/server/entity/EventDispatchingRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/EventFieldFilter.java
+++ b/server/src/main/java/io/spine/server/entity/EventFieldFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/EventFilter.java
+++ b/server/src/main/java/io/spine/server/entity/EventFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/EventPlayer.java
+++ b/server/src/main/java/io/spine/server/entity/EventPlayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/EventPlayingTransaction.java
+++ b/server/src/main/java/io/spine/server/entity/EventPlayingTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/EventProducingRepository.java
+++ b/server/src/main/java/io/spine/server/entity/EventProducingRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/EventWhiteList.java
+++ b/server/src/main/java/io/spine/server/entity/EventWhiteList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/FieldMasks.java
+++ b/server/src/main/java/io/spine/server/entity/FieldMasks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/HasLifecycleColumns.java
+++ b/server/src/main/java/io/spine/server/entity/HasLifecycleColumns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/HasVersionColumn.java
+++ b/server/src/main/java/io/spine/server/entity/HasVersionColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/IdField.java
+++ b/server/src/main/java/io/spine/server/entity/IdField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/InvalidEntityStateException.java
+++ b/server/src/main/java/io/spine/server/entity/InvalidEntityStateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/Migration.java
+++ b/server/src/main/java/io/spine/server/entity/Migration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/NoOpEventFilter.java
+++ b/server/src/main/java/io/spine/server/entity/NoOpEventFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/Phase.java
+++ b/server/src/main/java/io/spine/server/entity/Phase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/RecentHistory.java
+++ b/server/src/main/java/io/spine/server/entity/RecentHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
+++ b/server/src/main/java/io/spine/server/entity/RecordBasedRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/Repository.java
+++ b/server/src/main/java/io/spine/server/entity/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/RepositoryCache.java
+++ b/server/src/main/java/io/spine/server/entity/RepositoryCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/SilentWitness.java
+++ b/server/src/main/java/io/spine/server/entity/SilentWitness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/StorageConverter.java
+++ b/server/src/main/java/io/spine/server/entity/StorageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/Transaction.java
+++ b/server/src/main/java/io/spine/server/entity/Transaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/TransactionListener.java
+++ b/server/src/main/java/io/spine/server/entity/TransactionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/TransactionalEntity.java
+++ b/server/src/main/java/io/spine/server/entity/TransactionalEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/TransactionalEventPlayer.java
+++ b/server/src/main/java/io/spine/server/entity/TransactionalEventPlayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/VersionIncrement.java
+++ b/server/src/main/java/io/spine/server/entity/VersionIncrement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/WithLifecycle.java
+++ b/server/src/main/java/io/spine/server/entity/WithLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/model/AbstractEntityFactory.java
+++ b/server/src/main/java/io/spine/server/entity/model/AbstractEntityFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/model/CommandHandlingEntityClass.java
+++ b/server/src/main/java/io/spine/server/entity/model/CommandHandlingEntityClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/model/EntityClass.java
+++ b/server/src/main/java/io/spine/server/entity/model/EntityClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/model/StateClass.java
+++ b/server/src/main/java/io/spine/server/entity/model/StateClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/model/StateSubscribingClass.java
+++ b/server/src/main/java/io/spine/server/entity/model/StateSubscribingClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/model/package-info.java
+++ b/server/src/main/java/io/spine/server/entity/model/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/package-info.java
+++ b/server/src/main/java/io/spine/server/entity/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/rejection/StandardRejection.java
+++ b/server/src/main/java/io/spine/server/entity/rejection/StandardRejection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/rejection/package-info.java
+++ b/server/src/main/java/io/spine/server/entity/rejection/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/status/package-info.java
+++ b/server/src/main/java/io/spine/server/entity/status/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/AbstractColumn.java
+++ b/server/src/main/java/io/spine/server/entity/storage/AbstractColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/AbstractColumnMapping.java
+++ b/server/src/main/java/io/spine/server/entity/storage/AbstractColumnMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/Column.java
+++ b/server/src/main/java/io/spine/server/entity/storage/Column.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/ColumnDeclaredInProto.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ColumnDeclaredInProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/ColumnMapping.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ColumnMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/ColumnName.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ColumnName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/ColumnTypeMapping.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ColumnTypeMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/ColumnWithCustomGetter.java
+++ b/server/src/main/java/io/spine/server/entity/storage/ColumnWithCustomGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/Columns.java
+++ b/server/src/main/java/io/spine/server/entity/storage/Columns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/CompositeQueryParameter.java
+++ b/server/src/main/java/io/spine/server/entity/storage/CompositeQueryParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/DefaultColumnMapping.java
+++ b/server/src/main/java/io/spine/server/entity/storage/DefaultColumnMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/EntityQueries.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityQueries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/EntityQuery.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/EntityRecordWithColumns.java
+++ b/server/src/main/java/io/spine/server/entity/storage/EntityRecordWithColumns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/InterfaceBasedColumn.java
+++ b/server/src/main/java/io/spine/server/entity/storage/InterfaceBasedColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/QueryParameters.java
+++ b/server/src/main/java/io/spine/server/entity/storage/QueryParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/Scanner.java
+++ b/server/src/main/java/io/spine/server/entity/storage/Scanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/SimpleColumn.java
+++ b/server/src/main/java/io/spine/server/entity/storage/SimpleColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/SysColumn.java
+++ b/server/src/main/java/io/spine/server/entity/storage/SysColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/SystemColumn.java
+++ b/server/src/main/java/io/spine/server/entity/storage/SystemColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/entity/storage/package-info.java
+++ b/server/src/main/java/io/spine/server/entity/storage/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/AbstractEventReactor.java
+++ b/server/src/main/java/io/spine/server/event/AbstractEventReactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/AbstractEventSubscriber.java
+++ b/server/src/main/java/io/spine/server/event/AbstractEventSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/AbstractStatefulReactor.java
+++ b/server/src/main/java/io/spine/server/event/AbstractStatefulReactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/DeadEventTap.java
+++ b/server/src/main/java/io/spine/server/event/DeadEventTap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
+++ b/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/EventBus.java
+++ b/server/src/main/java/io/spine/server/event/EventBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/EventComparator.java
+++ b/server/src/main/java/io/spine/server/event/EventComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/EventDispatch.java
+++ b/server/src/main/java/io/spine/server/event/EventDispatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/EventDispatcher.java
+++ b/server/src/main/java/io/spine/server/event/EventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/EventDispatcherDelegate.java
+++ b/server/src/main/java/io/spine/server/event/EventDispatcherDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/EventDispatcherRegistry.java
+++ b/server/src/main/java/io/spine/server/event/EventDispatcherRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/EventEnricher.java
+++ b/server/src/main/java/io/spine/server/event/EventEnricher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/EventException.java
+++ b/server/src/main/java/io/spine/server/event/EventException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/EventFactory.java
+++ b/server/src/main/java/io/spine/server/event/EventFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/EventOrigin.java
+++ b/server/src/main/java/io/spine/server/event/EventOrigin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/EventReactor.java
+++ b/server/src/main/java/io/spine/server/event/EventReactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/EventReceiver.java
+++ b/server/src/main/java/io/spine/server/event/EventReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/EventStore.java
+++ b/server/src/main/java/io/spine/server/event/EventStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/EventStreamQueryMixin.java
+++ b/server/src/main/java/io/spine/server/event/EventStreamQueryMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/EventSubscriber.java
+++ b/server/src/main/java/io/spine/server/event/EventSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/EventValidator.java
+++ b/server/src/main/java/io/spine/server/event/EventValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/InvalidEventException.java
+++ b/server/src/main/java/io/spine/server/event/InvalidEventException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/React.java
+++ b/server/src/main/java/io/spine/server/event/React.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/RejectionEnvelope.java
+++ b/server/src/main/java/io/spine/server/event/RejectionEnvelope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/UnsupportedEventException.java
+++ b/server/src/main/java/io/spine/server/event/UnsupportedEventException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/EventAcceptingMethodParams.java
+++ b/server/src/main/java/io/spine/server/event/model/EventAcceptingMethodParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/EventAcceptingSignature.java
+++ b/server/src/main/java/io/spine/server/event/model/EventAcceptingSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/EventHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/EventHandlerMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/EventReactorClass.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReactorClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/EventReactorMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReactorMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/EventReactorSignature.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReactorSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/EventReceiverClass.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReceiverClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/EventReceivingClassDelegate.java
+++ b/server/src/main/java/io/spine/server/event/model/EventReceivingClassDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/EventSubscriberClass.java
+++ b/server/src/main/java/io/spine/server/event/model/EventSubscriberClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/EventSubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/EventSubscriberMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/InsufficientVisibilityError.java
+++ b/server/src/main/java/io/spine/server/event/model/InsufficientVisibilityError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/ReactingClass.java
+++ b/server/src/main/java/io/spine/server/event/model/ReactingClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/ReactorClassDelegate.java
+++ b/server/src/main/java/io/spine/server/event/model/ReactorClassDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/RejectionDispatchKeys.java
+++ b/server/src/main/java/io/spine/server/event/model/RejectionDispatchKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/RejectionHandler.java
+++ b/server/src/main/java/io/spine/server/event/model/RejectionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/StateSubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/StateSubscriberMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/StateSubscriberSpec.java
+++ b/server/src/main/java/io/spine/server/event/model/StateSubscriberSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/SubscriberMethod.java
+++ b/server/src/main/java/io/spine/server/event/model/SubscriberMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/SubscriberSignature.java
+++ b/server/src/main/java/io/spine/server/event/model/SubscriberSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/SubscribingClass.java
+++ b/server/src/main/java/io/spine/server/event/model/SubscribingClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/model/package-info.java
+++ b/server/src/main/java/io/spine/server/event/model/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/package-info.java
+++ b/server/src/main/java/io/spine/server/event/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/storage/EventContextField.java
+++ b/server/src/main/java/io/spine/server/event/storage/EventContextField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/storage/EventField.java
+++ b/server/src/main/java/io/spine/server/event/storage/EventField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/storage/package-info.java
+++ b/server/src/main/java/io/spine/server/event/storage/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/store/ColumnName.java
+++ b/server/src/main/java/io/spine/server/event/store/ColumnName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/store/DefaultEventStore.java
+++ b/server/src/main/java/io/spine/server/event/store/DefaultEventStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/store/EEntity.java
+++ b/server/src/main/java/io/spine/server/event/store/EEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/store/EmptyEventStore.java
+++ b/server/src/main/java/io/spine/server/event/store/EmptyEventStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/store/MatchFilter.java
+++ b/server/src/main/java/io/spine/server/event/store/MatchFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/store/MatchesStreamQuery.java
+++ b/server/src/main/java/io/spine/server/event/store/MatchesStreamQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/store/QueryToFilters.java
+++ b/server/src/main/java/io/spine/server/event/store/QueryToFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/event/store/package-info.java
+++ b/server/src/main/java/io/spine/server/event/store/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/integration/AbstractChannelObserver.java
+++ b/server/src/main/java/io/spine/server/integration/AbstractChannelObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/integration/BusAdapter.java
+++ b/server/src/main/java/io/spine/server/integration/BusAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/integration/DeadExternalMessageHandler.java
+++ b/server/src/main/java/io/spine/server/integration/DeadExternalMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/integration/DomesticEventPublisher.java
+++ b/server/src/main/java/io/spine/server/integration/DomesticEventPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/integration/ExternalMessageClass.java
+++ b/server/src/main/java/io/spine/server/integration/ExternalMessageClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/integration/ExternalMessageEnvelope.java
+++ b/server/src/main/java/io/spine/server/integration/ExternalMessageEnvelope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/integration/ExternalMessageObserver.java
+++ b/server/src/main/java/io/spine/server/integration/ExternalMessageObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/integration/ExternalMessageTypeMixin.java
+++ b/server/src/main/java/io/spine/server/integration/ExternalMessageTypeMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/integration/ExternalMessages.java
+++ b/server/src/main/java/io/spine/server/integration/ExternalMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/integration/ExternalNeedsObserver.java
+++ b/server/src/main/java/io/spine/server/integration/ExternalNeedsObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/integration/IntegrationBroker.java
+++ b/server/src/main/java/io/spine/server/integration/IntegrationBroker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/integration/InternalNeedsBroadcast.java
+++ b/server/src/main/java/io/spine/server/integration/InternalNeedsBroadcast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/integration/ThirdPartyContext.java
+++ b/server/src/main/java/io/spine/server/integration/ThirdPartyContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/integration/UnsupportedExternalMessageException.java
+++ b/server/src/main/java/io/spine/server/integration/UnsupportedExternalMessageException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/integration/grpc/package-info.java
+++ b/server/src/main/java/io/spine/server/integration/grpc/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/integration/package-info.java
+++ b/server/src/main/java/io/spine/server/integration/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/log/HandlerLifecycle.java
+++ b/server/src/main/java/io/spine/server/log/HandlerLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/log/HandlerLog.java
+++ b/server/src/main/java/io/spine/server/log/HandlerLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/log/HandlerMethodSite.java
+++ b/server/src/main/java/io/spine/server/log/HandlerMethodSite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/log/LoggingEntity.java
+++ b/server/src/main/java/io/spine/server/log/LoggingEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/log/package-info.java
+++ b/server/src/main/java/io/spine/server/log/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/AbstractHandlerMethod.java
+++ b/server/src/main/java/io/spine/server/model/AbstractHandlerMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/AccessModifier.java
+++ b/server/src/main/java/io/spine/server/model/AccessModifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/AllowedParams.java
+++ b/server/src/main/java/io/spine/server/model/AllowedParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/ArgumentFilter.java
+++ b/server/src/main/java/io/spine/server/model/ArgumentFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/Attribute.java
+++ b/server/src/main/java/io/spine/server/model/Attribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/ClassMap.java
+++ b/server/src/main/java/io/spine/server/model/ClassMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/CommandProducingMethod.java
+++ b/server/src/main/java/io/spine/server/model/CommandProducingMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/DispatchKey.java
+++ b/server/src/main/java/io/spine/server/model/DispatchKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/DuplicateCommandHandlerError.java
+++ b/server/src/main/java/io/spine/server/model/DuplicateCommandHandlerError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/DuplicateHandlerMethodError.java
+++ b/server/src/main/java/io/spine/server/model/DuplicateHandlerMethodError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/EventProducingMethod.java
+++ b/server/src/main/java/io/spine/server/model/EventProducingMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/ExternalAttribute.java
+++ b/server/src/main/java/io/spine/server/model/ExternalAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/ExternalCommandReceiverMethodError.java
+++ b/server/src/main/java/io/spine/server/model/ExternalCommandReceiverMethodError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/HandlerFieldFilterClashError.java
+++ b/server/src/main/java/io/spine/server/model/HandlerFieldFilterClashError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/HandlerMap.java
+++ b/server/src/main/java/io/spine/server/model/HandlerMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/HandlerMethod.java
+++ b/server/src/main/java/io/spine/server/model/HandlerMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/IllegalOutcomeException.java
+++ b/server/src/main/java/io/spine/server/model/IllegalOutcomeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/MatchCriterion.java
+++ b/server/src/main/java/io/spine/server/model/MatchCriterion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
+++ b/server/src/main/java/io/spine/server/model/MethodAccessChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/MethodExceptionCheck.java
+++ b/server/src/main/java/io/spine/server/model/MethodExceptionCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/MethodParams.java
+++ b/server/src/main/java/io/spine/server/model/MethodParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/MethodResult.java
+++ b/server/src/main/java/io/spine/server/model/MethodResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/MethodResults.java
+++ b/server/src/main/java/io/spine/server/model/MethodResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/MethodScan.java
+++ b/server/src/main/java/io/spine/server/model/MethodScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/MethodSignature.java
+++ b/server/src/main/java/io/spine/server/model/MethodSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/Model.java
+++ b/server/src/main/java/io/spine/server/model/Model.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/ModelClass.java
+++ b/server/src/main/java/io/spine/server/model/ModelClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/ModelError.java
+++ b/server/src/main/java/io/spine/server/model/ModelError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/ParameterSpec.java
+++ b/server/src/main/java/io/spine/server/model/ParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/ReturnTypes.java
+++ b/server/src/main/java/io/spine/server/model/ReturnTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/SelectiveHandler.java
+++ b/server/src/main/java/io/spine/server/model/SelectiveHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/SignalOriginMismatchError.java
+++ b/server/src/main/java/io/spine/server/model/SignalOriginMismatchError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/SignatureMismatch.java
+++ b/server/src/main/java/io/spine/server/model/SignatureMismatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/SignatureMismatchException.java
+++ b/server/src/main/java/io/spine/server/model/SignatureMismatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/TypeMatcher.java
+++ b/server/src/main/java/io/spine/server/model/TypeMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/UnknownEntityTypeException.java
+++ b/server/src/main/java/io/spine/server/model/UnknownEntityTypeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/VoidMethod.java
+++ b/server/src/main/java/io/spine/server/model/VoidMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/model/package-info.java
+++ b/server/src/main/java/io/spine/server/model/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/package-info.java
+++ b/server/src/main/java/io/spine/server/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/procman/DefaultProcessManagerRepository.java
+++ b/server/src/main/java/io/spine/server/procman/DefaultProcessManagerRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/procman/PmCommandEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmCommandEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/procman/PmEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/procman/PmEventEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmEventEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/procman/PmTransaction.java
+++ b/server/src/main/java/io/spine/server/procman/PmTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/procman/ProcessManager.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerMigration.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/procman/migration/MarkPmArchived.java
+++ b/server/src/main/java/io/spine/server/procman/migration/MarkPmArchived.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/procman/migration/MarkPmDeleted.java
+++ b/server/src/main/java/io/spine/server/procman/migration/MarkPmDeleted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/procman/migration/RemovePmFromStorage.java
+++ b/server/src/main/java/io/spine/server/procman/migration/RemovePmFromStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/procman/migration/UpdatePmColumns.java
+++ b/server/src/main/java/io/spine/server/procman/migration/UpdatePmColumns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/procman/migration/package-info.java
+++ b/server/src/main/java/io/spine/server/procman/migration/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/procman/model/ProcessManagerClass.java
+++ b/server/src/main/java/io/spine/server/procman/model/ProcessManagerClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/procman/model/package-info.java
+++ b/server/src/main/java/io/spine/server/procman/model/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/procman/package-info.java
+++ b/server/src/main/java/io/spine/server/procman/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/projection/CatchUpEndpoint.java
+++ b/server/src/main/java/io/spine/server/projection/CatchUpEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/projection/DefaultProjectionRepository.java
+++ b/server/src/main/java/io/spine/server/projection/DefaultProjectionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/projection/Projection.java
+++ b/server/src/main/java/io/spine/server/projection/Projection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/projection/ProjectionEndpoint.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/projection/ProjectionMigration.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/projection/ProjectionRepository.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/projection/ProjectionStorage.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/projection/ProjectionTransaction.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/projection/migration/MarkProjectionArchived.java
+++ b/server/src/main/java/io/spine/server/projection/migration/MarkProjectionArchived.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/projection/migration/MarkProjectionDeleted.java
+++ b/server/src/main/java/io/spine/server/projection/migration/MarkProjectionDeleted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/projection/migration/RemoveProjectionFromStorage.java
+++ b/server/src/main/java/io/spine/server/projection/migration/RemoveProjectionFromStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/projection/migration/UpdateProjectionColumns.java
+++ b/server/src/main/java/io/spine/server/projection/migration/UpdateProjectionColumns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/projection/migration/package-info.java
+++ b/server/src/main/java/io/spine/server/projection/migration/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/projection/model/ProjectionClass.java
+++ b/server/src/main/java/io/spine/server/projection/model/ProjectionClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/projection/model/package-info.java
+++ b/server/src/main/java/io/spine/server/projection/model/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/projection/package-info.java
+++ b/server/src/main/java/io/spine/server/projection/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/route/ByContext.java
+++ b/server/src/main/java/io/spine/server/route/ByContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/route/ByFirstMessageField.java
+++ b/server/src/main/java/io/spine/server/route/ByFirstMessageField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/route/CommandRoute.java
+++ b/server/src/main/java/io/spine/server/route/CommandRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/route/CommandRouting.java
+++ b/server/src/main/java/io/spine/server/route/CommandRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/route/DefaultCommandRoute.java
+++ b/server/src/main/java/io/spine/server/route/DefaultCommandRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/route/DefaultStateRoute.java
+++ b/server/src/main/java/io/spine/server/route/DefaultStateRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/route/EventFnRoute.java
+++ b/server/src/main/java/io/spine/server/route/EventFnRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/route/EventRoute.java
+++ b/server/src/main/java/io/spine/server/route/EventRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/route/EventRouting.java
+++ b/server/src/main/java/io/spine/server/route/EventRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/route/FirstField.java
+++ b/server/src/main/java/io/spine/server/route/FirstField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/route/MessageRouting.java
+++ b/server/src/main/java/io/spine/server/route/MessageRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/route/Multicast.java
+++ b/server/src/main/java/io/spine/server/route/Multicast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/route/Route.java
+++ b/server/src/main/java/io/spine/server/route/Route.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/route/StateUpdateRoute.java
+++ b/server/src/main/java/io/spine/server/route/StateUpdateRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/route/StateUpdateRouting.java
+++ b/server/src/main/java/io/spine/server/route/StateUpdateRouting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/route/Unicast.java
+++ b/server/src/main/java/io/spine/server/route/Unicast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/route/package-info.java
+++ b/server/src/main/java/io/spine/server/route/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/security/Security.java
+++ b/server/src/main/java/io/spine/server/security/Security.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/security/package-info.java
+++ b/server/src/main/java/io/spine/server/security/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/AbstractTargetValidator.java
+++ b/server/src/main/java/io/spine/server/stand/AbstractTargetValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/AggregateQueryProcessor.java
+++ b/server/src/main/java/io/spine/server/stand/AggregateQueryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/EntityChangeHandler.java
+++ b/server/src/main/java/io/spine/server/stand/EntityChangeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/EntityQueryProcessor.java
+++ b/server/src/main/java/io/spine/server/stand/EntityQueryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/EventRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/EventRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/EventTap.java
+++ b/server/src/main/java/io/spine/server/stand/EventTap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/EventUpdateHandler.java
+++ b/server/src/main/java/io/spine/server/stand/EventUpdateHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/InMemoryEventRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/InMemoryEventRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/InMemoryTypeRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/InMemoryTypeRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/InvalidQueryException.java
+++ b/server/src/main/java/io/spine/server/stand/InvalidQueryException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/InvalidRequestException.java
+++ b/server/src/main/java/io/spine/server/stand/InvalidRequestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/InvalidSubscriptionException.java
+++ b/server/src/main/java/io/spine/server/stand/InvalidSubscriptionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/InvalidTopicException.java
+++ b/server/src/main/java/io/spine/server/stand/InvalidTopicException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/MultitenantSubscriptionRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/MultitenantSubscriptionRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/NoOpQueryProcessor.java
+++ b/server/src/main/java/io/spine/server/stand/NoOpQueryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/QueryProcessor.java
+++ b/server/src/main/java/io/spine/server/stand/QueryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/QueryValidator.java
+++ b/server/src/main/java/io/spine/server/stand/QueryValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/RequestValidator.java
+++ b/server/src/main/java/io/spine/server/stand/RequestValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/Stand.java
+++ b/server/src/main/java/io/spine/server/stand/Stand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/SubscriptionCallback.java
+++ b/server/src/main/java/io/spine/server/stand/SubscriptionCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/SubscriptionRecord.java
+++ b/server/src/main/java/io/spine/server/stand/SubscriptionRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/SubscriptionRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/SubscriptionRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/SubscriptionValidator.java
+++ b/server/src/main/java/io/spine/server/stand/SubscriptionValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/TenantSubscriptionRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/TenantSubscriptionRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/TopicValidator.java
+++ b/server/src/main/java/io/spine/server/stand/TopicValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/TypeRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/TypeRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/UpdateHandler.java
+++ b/server/src/main/java/io/spine/server/stand/UpdateHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/stand/package-info.java
+++ b/server/src/main/java/io/spine/server/stand/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/AbstractStorage.java
+++ b/server/src/main/java/io/spine/server/storage/AbstractStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/BulkStorageOperationsMixin.java
+++ b/server/src/main/java/io/spine/server/storage/BulkStorageOperationsMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/LifecycleFlagField.java
+++ b/server/src/main/java/io/spine/server/storage/LifecycleFlagField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/ReadRequest.java
+++ b/server/src/main/java/io/spine/server/storage/ReadRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/RecordReadRequest.java
+++ b/server/src/main/java/io/spine/server/storage/RecordReadRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/RecordStorage.java
+++ b/server/src/main/java/io/spine/server/storage/RecordStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/StateField.java
+++ b/server/src/main/java/io/spine/server/storage/StateField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/Storage.java
+++ b/server/src/main/java/io/spine/server/storage/Storage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/StorageFactory.java
+++ b/server/src/main/java/io/spine/server/storage/StorageFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/StorageField.java
+++ b/server/src/main/java/io/spine/server/storage/StorageField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/StorageWithLifecycleFlags.java
+++ b/server/src/main/java/io/spine/server/storage/StorageWithLifecycleFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/VersionField.java
+++ b/server/src/main/java/io/spine/server/storage/VersionField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/memory/EntityQueryMatcher.java
+++ b/server/src/main/java/io/spine/server/storage/memory/EntityQueryMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/memory/EntityRecordComparator.java
+++ b/server/src/main/java/io/spine/server/storage/memory/EntityRecordComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/memory/EntityRecordUnpacker.java
+++ b/server/src/main/java/io/spine/server/storage/memory/EntityRecordUnpacker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/memory/InMemoryAggregateStorage.java
+++ b/server/src/main/java/io/spine/server/storage/memory/InMemoryAggregateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/memory/InMemoryCatchUpStorage.java
+++ b/server/src/main/java/io/spine/server/storage/memory/InMemoryCatchUpStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/memory/InMemoryInboxStorage.java
+++ b/server/src/main/java/io/spine/server/storage/memory/InMemoryInboxStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/memory/InMemoryProjectionStorage.java
+++ b/server/src/main/java/io/spine/server/storage/memory/InMemoryProjectionStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/memory/InMemoryRecordStorage.java
+++ b/server/src/main/java/io/spine/server/storage/memory/InMemoryRecordStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/memory/InMemoryStorageFactory.java
+++ b/server/src/main/java/io/spine/server/storage/memory/InMemoryStorageFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/memory/MultitenantStorage.java
+++ b/server/src/main/java/io/spine/server/storage/memory/MultitenantStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/memory/StorageSpec.java
+++ b/server/src/main/java/io/spine/server/storage/memory/StorageSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/memory/TenantAggregateRecords.java
+++ b/server/src/main/java/io/spine/server/storage/memory/TenantAggregateRecords.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/memory/TenantCatchUpRecords.java
+++ b/server/src/main/java/io/spine/server/storage/memory/TenantCatchUpRecords.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/memory/TenantInboxRecords.java
+++ b/server/src/main/java/io/spine/server/storage/memory/TenantInboxRecords.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/memory/TenantRecords.java
+++ b/server/src/main/java/io/spine/server/storage/memory/TenantRecords.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/memory/TenantStorage.java
+++ b/server/src/main/java/io/spine/server/storage/memory/TenantStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/memory/package-info.java
+++ b/server/src/main/java/io/spine/server/storage/memory/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/package-info.java
+++ b/server/src/main/java/io/spine/server/storage/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/system/SystemAwareStorageFactory.java
+++ b/server/src/main/java/io/spine/server/storage/system/SystemAwareStorageFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/storage/system/package-info.java
+++ b/server/src/main/java/io/spine/server/storage/system/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tenant/ActorRequestOperation.java
+++ b/server/src/main/java/io/spine/server/tenant/ActorRequestOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tenant/CurrentTenant.java
+++ b/server/src/main/java/io/spine/server/tenant/CurrentTenant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tenant/DefaultTenantRepository.java
+++ b/server/src/main/java/io/spine/server/tenant/DefaultTenantRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tenant/EventOperation.java
+++ b/server/src/main/java/io/spine/server/tenant/EventOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tenant/IdInTenant.java
+++ b/server/src/main/java/io/spine/server/tenant/IdInTenant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tenant/QueryOperation.java
+++ b/server/src/main/java/io/spine/server/tenant/QueryOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tenant/SingleTenantIndex.java
+++ b/server/src/main/java/io/spine/server/tenant/SingleTenantIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tenant/SubscriptionOperation.java
+++ b/server/src/main/java/io/spine/server/tenant/SubscriptionOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tenant/TenantAware.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantAware.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tenant/TenantAwareFunction.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantAwareFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tenant/TenantAwareFunction0.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantAwareFunction0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tenant/TenantAwareOperation.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantAwareOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tenant/TenantAwareRunner.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantAwareRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tenant/TenantAwareTestSupport.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantAwareTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tenant/TenantFunction.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tenant/TenantIndex.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tenant/TenantRepository.java
+++ b/server/src/main/java/io/spine/server/tenant/TenantRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tenant/package-info.java
+++ b/server/src/main/java/io/spine/server/tenant/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/trace/AbstractTracer.java
+++ b/server/src/main/java/io/spine/server/trace/AbstractTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/trace/Tracer.java
+++ b/server/src/main/java/io/spine/server/trace/Tracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/trace/TracerFactory.java
+++ b/server/src/main/java/io/spine/server/trace/TracerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/trace/package-info.java
+++ b/server/src/main/java/io/spine/server/trace/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/transport/AbstractChannel.java
+++ b/server/src/main/java/io/spine/server/transport/AbstractChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/transport/ChannelHub.java
+++ b/server/src/main/java/io/spine/server/transport/ChannelHub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/transport/MessageChannel.java
+++ b/server/src/main/java/io/spine/server/transport/MessageChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/transport/Publisher.java
+++ b/server/src/main/java/io/spine/server/transport/Publisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/transport/PublisherHub.java
+++ b/server/src/main/java/io/spine/server/transport/PublisherHub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/transport/Statuses.java
+++ b/server/src/main/java/io/spine/server/transport/Statuses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/transport/Subscriber.java
+++ b/server/src/main/java/io/spine/server/transport/Subscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/transport/SubscriberHub.java
+++ b/server/src/main/java/io/spine/server/transport/SubscriberHub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/transport/TransportFactory.java
+++ b/server/src/main/java/io/spine/server/transport/TransportFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/transport/memory/InMemoryPublisher.java
+++ b/server/src/main/java/io/spine/server/transport/memory/InMemoryPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/transport/memory/InMemorySubscriber.java
+++ b/server/src/main/java/io/spine/server/transport/memory/InMemorySubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/transport/memory/InMemoryTransportFactory.java
+++ b/server/src/main/java/io/spine/server/transport/memory/InMemoryTransportFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/transport/memory/SingleThreadInMemSubscriber.java
+++ b/server/src/main/java/io/spine/server/transport/memory/SingleThreadInMemSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/transport/memory/SingleThreadInMemTransportFactory.java
+++ b/server/src/main/java/io/spine/server/transport/memory/SingleThreadInMemTransportFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/transport/memory/package-info.java
+++ b/server/src/main/java/io/spine/server/transport/memory/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/transport/package-info.java
+++ b/server/src/main/java/io/spine/server/transport/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tuple/Either.java
+++ b/server/src/main/java/io/spine/server/tuple/Either.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tuple/EitherOf2.java
+++ b/server/src/main/java/io/spine/server/tuple/EitherOf2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tuple/EitherOf3.java
+++ b/server/src/main/java/io/spine/server/tuple/EitherOf3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tuple/EitherOf4.java
+++ b/server/src/main/java/io/spine/server/tuple/EitherOf4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tuple/EitherOf5.java
+++ b/server/src/main/java/io/spine/server/tuple/EitherOf5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tuple/Element.java
+++ b/server/src/main/java/io/spine/server/tuple/Element.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tuple/Pair.java
+++ b/server/src/main/java/io/spine/server/tuple/Pair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tuple/Quartet.java
+++ b/server/src/main/java/io/spine/server/tuple/Quartet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tuple/Quintet.java
+++ b/server/src/main/java/io/spine/server/tuple/Quintet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tuple/Triplet.java
+++ b/server/src/main/java/io/spine/server/tuple/Triplet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tuple/Tuple.java
+++ b/server/src/main/java/io/spine/server/tuple/Tuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/tuple/package-info.java
+++ b/server/src/main/java/io/spine/server/tuple/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/type/AbstractMessageEnvelope.java
+++ b/server/src/main/java/io/spine/server/type/AbstractMessageEnvelope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/type/CommandClass.java
+++ b/server/src/main/java/io/spine/server/type/CommandClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/type/CommandEnvelope.java
+++ b/server/src/main/java/io/spine/server/type/CommandEnvelope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/type/EmptyClass.java
+++ b/server/src/main/java/io/spine/server/type/EmptyClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/type/EnrichableMessageEnvelope.java
+++ b/server/src/main/java/io/spine/server/type/EnrichableMessageEnvelope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/type/EventClass.java
+++ b/server/src/main/java/io/spine/server/type/EventClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/type/EventEnvelope.java
+++ b/server/src/main/java/io/spine/server/type/EventEnvelope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/type/MessageEnvelope.java
+++ b/server/src/main/java/io/spine/server/type/MessageEnvelope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/type/SignalEnvelope.java
+++ b/server/src/main/java/io/spine/server/type/SignalEnvelope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/server/type/package-info.java
+++ b/server/src/main/java/io/spine/server/type/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/CannotDispatchDuplicate.java
+++ b/server/src/main/java/io/spine/system/server/CannotDispatchDuplicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/CommandLogProjection.java
+++ b/server/src/main/java/io/spine/system/server/CommandLogProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/CommandLogRepository.java
+++ b/server/src/main/java/io/spine/system/server/CommandLogRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/DefaultSystemClient.java
+++ b/server/src/main/java/io/spine/system/server/DefaultSystemClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/DefaultSystemReadSide.java
+++ b/server/src/main/java/io/spine/system/server/DefaultSystemReadSide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/DefaultSystemWriteSide.java
+++ b/server/src/main/java/io/spine/system/server/DefaultSystemWriteSide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/DiagnosticEvent.java
+++ b/server/src/main/java/io/spine/system/server/DiagnosticEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/MirrorProjection.java
+++ b/server/src/main/java/io/spine/system/server/MirrorProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/MirrorRepository.java
+++ b/server/src/main/java/io/spine/system/server/MirrorRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/NoOpSystemClient.java
+++ b/server/src/main/java/io/spine/system/server/NoOpSystemClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/NoOpSystemReadSide.java
+++ b/server/src/main/java/io/spine/system/server/NoOpSystemReadSide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/NoOpSystemWriteSide.java
+++ b/server/src/main/java/io/spine/system/server/NoOpSystemWriteSide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/ReadSideFunction.java
+++ b/server/src/main/java/io/spine/system/server/ReadSideFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/ScheduledCommand.java
+++ b/server/src/main/java/io/spine/system/server/ScheduledCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/ScheduledCommandRepository.java
+++ b/server/src/main/java/io/spine/system/server/ScheduledCommandRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/SystemClient.java
+++ b/server/src/main/java/io/spine/system/server/SystemClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/SystemConfig.java
+++ b/server/src/main/java/io/spine/system/server/SystemConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/SystemContext.java
+++ b/server/src/main/java/io/spine/system/server/SystemContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/SystemEnricher.java
+++ b/server/src/main/java/io/spine/system/server/SystemEnricher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/SystemEventFactory.java
+++ b/server/src/main/java/io/spine/system/server/SystemEventFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/SystemFeatures.java
+++ b/server/src/main/java/io/spine/system/server/SystemFeatures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/SystemReadSide.java
+++ b/server/src/main/java/io/spine/system/server/SystemReadSide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/SystemRequestFactory.java
+++ b/server/src/main/java/io/spine/system/server/SystemRequestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/SystemSettings.java
+++ b/server/src/main/java/io/spine/system/server/SystemSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/SystemWriteSide.java
+++ b/server/src/main/java/io/spine/system/server/SystemWriteSide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/TenantAwareSystemReadSide.java
+++ b/server/src/main/java/io/spine/system/server/TenantAwareSystemReadSide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/TenantAwareSystemWriteSide.java
+++ b/server/src/main/java/io/spine/system/server/TenantAwareSystemWriteSide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/TraceEventObserver.java
+++ b/server/src/main/java/io/spine/system/server/TraceEventObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/WriteSideFunction.java
+++ b/server/src/main/java/io/spine/system/server/WriteSideFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/event/CommandDispatchedMixin.java
+++ b/server/src/main/java/io/spine/system/server/event/CommandDispatchedMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/event/EntityLifecycleEvent.java
+++ b/server/src/main/java/io/spine/system/server/event/EntityLifecycleEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/event/EventDispatchedMixin.java
+++ b/server/src/main/java/io/spine/system/server/event/EventDispatchedMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/event/SignalDispatchedMixin.java
+++ b/server/src/main/java/io/spine/system/server/event/SignalDispatchedMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/event/package-info.java
+++ b/server/src/main/java/io/spine/system/server/event/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/java/io/spine/system/server/package-info.java
+++ b/server/src/main/java/io/spine/system/server/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/server/aggregate/aggregate.proto
+++ b/server/src/main/proto/spine/server/aggregate/aggregate.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/server/catchup/catch_up.proto
+++ b/server/src/main/proto/spine/server/catchup/catch_up.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/server/catchup/catch_up_events.proto
+++ b/server/src/main/proto/spine/server/catchup/catch_up_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/server/delivery/delivery.proto
+++ b/server/src/main/proto/spine/server/delivery/delivery.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/server/delivery/delivery_events.proto
+++ b/server/src/main/proto/spine/server/delivery/delivery_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/server/delivery/inbox.proto
+++ b/server/src/main/proto/spine/server/delivery/inbox.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/server/dispatch/dispatching.proto
+++ b/server/src/main/proto/spine/server/dispatch/dispatching.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/server/entity/entity.proto
+++ b/server/src/main/proto/spine/server/entity/entity.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/server/entity/standard_rejections.proto
+++ b/server/src/main/proto/spine/server/entity/standard_rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/server/event/event_filter.proto
+++ b/server/src/main/proto/spine/server/event/event_filter.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/server/event/event_stream_query.proto
+++ b/server/src/main/proto/spine/server/event/event_stream_query.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/server/integration/broker.proto
+++ b/server/src/main/proto/spine/server/integration/broker.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/server/model/standard_commands.proto
+++ b/server/src/main/proto/spine/server/model/standard_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/server/model/standard_events.proto
+++ b/server/src/main/proto/spine/server/model/standard_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/server/server_environment.proto
+++ b/server/src/main/proto/spine/server/server_environment.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/server/tenant/events.proto
+++ b/server/src/main/proto/spine/server/tenant/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/server/tenant/tenant.proto
+++ b/server/src/main/proto/spine/server/tenant/tenant.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/server/transport/transport.proto
+++ b/server/src/main/proto/spine/server/transport/transport.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/system/server/command_log.proto
+++ b/server/src/main/proto/spine/system/server/command_log.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/system/server/command_log_events.proto
+++ b/server/src/main/proto/spine/system/server/command_log_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/system/server/diagnostic_events.proto
+++ b/server/src/main/proto/spine/system/server/diagnostic_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/system/server/entity_log_events.proto
+++ b/server/src/main/proto/spine/system/server/entity_log_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/system/server/entity_type.proto
+++ b/server/src/main/proto/spine/system/server/entity_type.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/system/server/event_lifecycle_events.proto
+++ b/server/src/main/proto/spine/system/server/event_lifecycle_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/system/server/mirror.proto
+++ b/server/src/main/proto/spine/system/server/mirror.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/main/proto/spine/system/server/scheduled_command.proto
+++ b/server/src/main/proto/spine/system/server/scheduled_command.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/example/ForeignClass.java
+++ b/server/src/test/java/com/example/ForeignClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/example/ForeignContextConfig.java
+++ b/server/src/test/java/com/example/ForeignContextConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/com/example/package-info.java
+++ b/server/src/test/java/com/example/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/client/AbstractClientTest.java
+++ b/server/src/test/java/io/spine/client/AbstractClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/client/ClientBuilderTest.java
+++ b/server/src/test/java/io/spine/client/ClientBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/client/ClientEndToEndTest.java
+++ b/server/src/test/java/io/spine/client/ClientEndToEndTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/client/ClientErrorHandlersTest.java
+++ b/server/src/test/java/io/spine/client/ClientErrorHandlersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/client/ClientRequestTest.java
+++ b/server/src/test/java/io/spine/client/ClientRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/client/ClientTest.java
+++ b/server/src/test/java/io/spine/client/ClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/client/CommandRequestTest.java
+++ b/server/src/test/java/io/spine/client/CommandRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/client/ConsumerCallCounter.java
+++ b/server/src/test/java/io/spine/client/ConsumerCallCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/client/EventSubscriptionRequestTest.java
+++ b/server/src/test/java/io/spine/client/EventSubscriptionRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/client/package-info.java
+++ b/server/src/test/java/io/spine/client/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/core/CoreMixinsTest.java
+++ b/server/src/test/java/io/spine/core/CoreMixinsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/core/EnrichmentsTest.java
+++ b/server/src/test/java/io/spine/core/EnrichmentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/core/EventContextTest.java
+++ b/server/src/test/java/io/spine/core/EventContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/core/EventTest.java
+++ b/server/src/test/java/io/spine/core/EventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/core/EventsTest.java
+++ b/server/src/test/java/io/spine/core/EventsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/core/SignalTest.java
+++ b/server/src/test/java/io/spine/core/SignalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/core/given/CoreMixinsTestEnv.java
+++ b/server/src/test/java/io/spine/core/given/CoreMixinsTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/core/given/package-info.java
+++ b/server/src/test/java/io/spine/core/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/given/NonServerClass.java
+++ b/server/src/test/java/io/spine/given/NonServerClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/given/package-info.java
+++ b/server/src/test/java/io/spine/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/BoundedContextBuilderTest.java
+++ b/server/src/test/java/io/spine/server/BoundedContextBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/BoundedContextTest.java
+++ b/server/src/test/java/io/spine/server/BoundedContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/CommandServiceTest.java
+++ b/server/src/test/java/io/spine/server/CommandServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/EnvSettingTest.java
+++ b/server/src/test/java/io/spine/server/EnvSettingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/Given.java
+++ b/server/src/test/java/io/spine/server/Given.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/GrpcContainerTest.java
+++ b/server/src/test/java/io/spine/server/GrpcContainerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/IdentityTest.java
+++ b/server/src/test/java/io/spine/server/IdentityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/QueryServiceTest.java
+++ b/server/src/test/java/io/spine/server/QueryServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/ServerEnvironmentConfigTest.java
+++ b/server/src/test/java/io/spine/server/ServerEnvironmentConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/ServerEnvironmentTest.java
+++ b/server/src/test/java/io/spine/server/ServerEnvironmentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/ServerTest.java
+++ b/server/src/test/java/io/spine/server/ServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/StatusesTest.java
+++ b/server/src/test/java/io/spine/server/StatusesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/SubscriptionServiceTest.java
+++ b/server/src/test/java/io/spine/server/SubscriptionServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/VisibilityGuardTest.java
+++ b/server/src/test/java/io/spine/server/VisibilityGuardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/AggregateCommandEndpointTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateCommandEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/AggregateFieldTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/AggregatePartTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregatePartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/AggregateReadRequestTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateReadRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryViewsTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryViewsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRootTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRootTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageLifecycleFlagsHandlingTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageLifecycleFlagsHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageTruncationTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageTruncationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/AggregateTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/AggregateTestSupport.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/AggregateTransactionTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/ApplyAllowImportTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/ApplyAllowImportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/EventImportTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/EventImportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/IdempotencyGuardTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/IdempotencyGuardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/InMemoryRootDirectoryTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/InMemoryRootDirectoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/ReadOperationTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/ReadOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/TestAggregateStorage.java
+++ b/server/src/test/java/io/spine/server/aggregate/TestAggregateStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/WriteTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/WriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregateCommandEndpointTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregateCommandEndpointTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/AggregateRootTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/AggregateRootTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/Given.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/Given.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/IdempotencyGuardTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/IdempotencyGuardTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/ReadOperationTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/ReadOperationTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/StorageRecords.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/StorageRecords.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/AbstractAggregateTestRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/AbstractAggregateTestRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/AggregatePartTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/AggregatePartTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/AggregateTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/AggregateTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/AggregateWithMissingApplier.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/AggregateWithMissingApplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/AmishAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/AmishAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/FaultyAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/FaultyAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/IgTestAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/IgTestAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/IgTestAggregateRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/IgTestAggregateRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/IntAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/IntAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/TaskAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/TaskAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/TaskAggregateRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/TaskAggregateRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/TestAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/TestAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/TestAggregateRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/TestAggregateRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/package-info.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/dispatch/AggregateBuilder.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/dispatch/AggregateBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/dispatch/AggregateMessageDispatcher.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/dispatch/AggregateMessageDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/dispatch/AggregatePartBuilder.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/dispatch/AggregatePartBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/dispatch/package-info.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/dispatch/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/fibonacci/FibonacciAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/fibonacci/FibonacciAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/fibonacci/FibonacciRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/fibonacci/FibonacciRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/fibonacci/package-info.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/fibonacci/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/importado/Dot.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/importado/Dot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/importado/DotSpace.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/importado/DotSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/importado/MoveMessages.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/importado/MoveMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/importado/package-info.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/importado/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/klasse/EngineAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/klasse/EngineAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/klasse/EngineRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/klasse/EngineRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/klasse/package-info.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/klasse/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/package-info.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/part/AnAggregatePart.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/part/AnAggregatePart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/part/AnAggregateRoot.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/part/AnAggregateRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/part/TaskCommentsPart.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/part/TaskCommentsPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/part/TaskCommentsRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/part/TaskCommentsRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/part/TaskPart.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/part/TaskPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/part/TaskRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/part/TaskRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/part/TaskRoot.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/part/TaskRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/part/WrongAggregatePart.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/part/WrongAggregatePart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/part/package-info.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/part/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/AggregateRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/AggregateRepositoryTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/AggregateWithLifecycle.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/AggregateWithLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/AnemicAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/AnemicAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/AnemicAggregateRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/AnemicAggregateRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/EventDiscardingAggregateRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/EventDiscardingAggregateRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/FailingAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/FailingAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/FailingAggregateRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/FailingAggregateRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/GivenAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/GivenAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/ProjectAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/ProjectAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/ProjectAggregateRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/ProjectAggregateRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/ReactingAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/ReactingAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/ReactingRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/ReactingRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/RejectingAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/RejectingAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/RejectingRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/RejectingRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/RejectionReactingAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/RejectionReactingAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/RejectionReactingRepository.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/RejectionReactingRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/RepoOfAggregateWithLifecycle.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/RepoOfAggregateWithLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/package-info.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/thermometer/SafeThermometer.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/thermometer/SafeThermometer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/thermometer/SafeThermometerRepo.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/thermometer/SafeThermometerRepo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/given/thermometer/package-info.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/thermometer/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/model/AggregateClassTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/model/AggregateClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/model/AggregatePartClassTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/model/AggregatePartClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/aggregate/model/ApplierTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/model/ApplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bc/given/AnotherProjectAggregate.java
+++ b/server/src/test/java/io/spine/server/bc/given/AnotherProjectAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bc/given/FinishedProjectProjection.java
+++ b/server/src/test/java/io/spine/server/bc/given/FinishedProjectProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bc/given/Given.java
+++ b/server/src/test/java/io/spine/server/bc/given/Given.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bc/given/ProjectAggregate.java
+++ b/server/src/test/java/io/spine/server/bc/given/ProjectAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bc/given/ProjectAggregateRepository.java
+++ b/server/src/test/java/io/spine/server/bc/given/ProjectAggregateRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bc/given/ProjectCreationProcman.java
+++ b/server/src/test/java/io/spine/server/bc/given/ProjectCreationProcman.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bc/given/ProjectCreationRepository.java
+++ b/server/src/test/java/io/spine/server/bc/given/ProjectCreationRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bc/given/ProjectProcessManager.java
+++ b/server/src/test/java/io/spine/server/bc/given/ProjectProcessManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bc/given/ProjectProjection.java
+++ b/server/src/test/java/io/spine/server/bc/given/ProjectProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bc/given/ProjectRemovalProcman.java
+++ b/server/src/test/java/io/spine/server/bc/given/ProjectRemovalProcman.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bc/given/ProjectReport.java
+++ b/server/src/test/java/io/spine/server/bc/given/ProjectReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bc/given/SecretProjectAggregate.java
+++ b/server/src/test/java/io/spine/server/bc/given/SecretProjectAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bc/given/SecretProjectRepository.java
+++ b/server/src/test/java/io/spine/server/bc/given/SecretProjectRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bc/given/TestEventSubscriber.java
+++ b/server/src/test/java/io/spine/server/bc/given/TestEventSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bc/given/package-info.java
+++ b/server/src/test/java/io/spine/server/bc/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bc/package-info.java
+++ b/server/src/test/java/io/spine/server/bc/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bus/AcksTest.java
+++ b/server/src/test/java/io/spine/server/bus/AcksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bus/BusBuilderTest.java
+++ b/server/src/test/java/io/spine/server/bus/BusBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bus/BusFilterTest.java
+++ b/server/src/test/java/io/spine/server/bus/BusFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bus/DispatchingQueueSynchronisationTest.java
+++ b/server/src/test/java/io/spine/server/bus/DispatchingQueueSynchronisationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bus/FilterChainTest.java
+++ b/server/src/test/java/io/spine/server/bus/FilterChainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bus/given/BusFilters.java
+++ b/server/src/test/java/io/spine/server/bus/given/BusFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bus/given/package-info.java
+++ b/server/src/test/java/io/spine/server/bus/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bus/given/stock/JowDonsIndex.java
+++ b/server/src/test/java/io/spine/server/bus/given/stock/JowDonsIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bus/given/stock/ShareAggregate.java
+++ b/server/src/test/java/io/spine/server/bus/given/stock/ShareAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/bus/given/stock/package-info.java
+++ b/server/src/test/java/io/spine/server/bus/given/stock/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/AbstractCommanderTest.java
+++ b/server/src/test/java/io/spine/server/command/AbstractCommanderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/CommandHandlerSignatureTest.java
+++ b/server/src/test/java/io/spine/server/command/CommandHandlerSignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/CommandHandlingEntityTest.java
+++ b/server/src/test/java/io/spine/server/command/CommandHandlingEntityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/CommandHistory.java
+++ b/server/src/test/java/io/spine/server/command/CommandHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/CommandInterceptor.java
+++ b/server/src/test/java/io/spine/server/command/CommandInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/given/CommandHandlingEntityTestEnv.java
+++ b/server/src/test/java/io/spine/server/command/given/CommandHandlingEntityTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/given/package-info.java
+++ b/server/src/test/java/io/spine/server/command/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/CommandHandlerMethodTest.java
+++ b/server/src/test/java/io/spine/server/command/model/CommandHandlerMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/CommandReactionMethodTest.java
+++ b/server/src/test/java/io/spine/server/command/model/CommandReactionMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/CommandReactionSignatureTest.java
+++ b/server/src/test/java/io/spine/server/command/model/CommandReactionSignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/CommandSubstituteSignatureTest.java
+++ b/server/src/test/java/io/spine/server/command/model/CommandSubstituteSignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/CommanderClassTest.java
+++ b/server/src/test/java/io/spine/server/command/model/CommanderClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/commander/InvalidCommander.java
+++ b/server/src/test/java/io/spine/server/command/model/given/commander/InvalidCommander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/commander/SampleCommander.java
+++ b/server/src/test/java/io/spine/server/command/model/given/commander/SampleCommander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/commander/TestCommandMessage.java
+++ b/server/src/test/java/io/spine/server/command/model/given/commander/TestCommandMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/commander/ValidCommander.java
+++ b/server/src/test/java/io/spine/server/command/model/given/commander/ValidCommander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/commander/package-info.java
+++ b/server/src/test/java/io/spine/server/command/model/given/commander/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/handler/EventMessages.java
+++ b/server/src/test/java/io/spine/server/command/model/given/handler/EventMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/handler/HandlerReturnsEmptyList.java
+++ b/server/src/test/java/io/spine/server/command/model/given/handler/HandlerReturnsEmptyList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/handler/HandlerReturnsNothing.java
+++ b/server/src/test/java/io/spine/server/command/model/given/handler/HandlerReturnsNothing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/handler/InvalidHandler.java
+++ b/server/src/test/java/io/spine/server/command/model/given/handler/InvalidHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/handler/InvalidHandlerNoAnnotation.java
+++ b/server/src/test/java/io/spine/server/command/model/given/handler/InvalidHandlerNoAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/handler/ProcessManagerDoingNothing.java
+++ b/server/src/test/java/io/spine/server/command/model/given/handler/ProcessManagerDoingNothing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/handler/RejectingAggregate.java
+++ b/server/src/test/java/io/spine/server/command/model/given/handler/RejectingAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/handler/RejectingHandler.java
+++ b/server/src/test/java/io/spine/server/command/model/given/handler/RejectingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/handler/TestCommandHandler.java
+++ b/server/src/test/java/io/spine/server/command/model/given/handler/TestCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/handler/ValidHandler.java
+++ b/server/src/test/java/io/spine/server/command/model/given/handler/ValidHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/handler/ValidHandlerOneParam.java
+++ b/server/src/test/java/io/spine/server/command/model/given/handler/ValidHandlerOneParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/handler/ValidHandlerOneParamReturnsList.java
+++ b/server/src/test/java/io/spine/server/command/model/given/handler/ValidHandlerOneParamReturnsList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/handler/ValidHandlerTwoParams.java
+++ b/server/src/test/java/io/spine/server/command/model/given/handler/ValidHandlerTwoParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/handler/package-info.java
+++ b/server/src/test/java/io/spine/server/command/model/given/handler/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/reaction/EventMessages.java
+++ b/server/src/test/java/io/spine/server/command/model/given/reaction/EventMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/reaction/InvalidCommander.java
+++ b/server/src/test/java/io/spine/server/command/model/given/reaction/InvalidCommander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/reaction/ReEitherWithNothing.java
+++ b/server/src/test/java/io/spine/server/command/model/given/reaction/ReEitherWithNothing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/reaction/ReOneParam.java
+++ b/server/src/test/java/io/spine/server/command/model/given/reaction/ReOneParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/reaction/ReOptionalResult.java
+++ b/server/src/test/java/io/spine/server/command/model/given/reaction/ReOptionalResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/reaction/ReTwoParams.java
+++ b/server/src/test/java/io/spine/server/command/model/given/reaction/ReTwoParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/reaction/TestCommandReactor.java
+++ b/server/src/test/java/io/spine/server/command/model/given/reaction/TestCommandReactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/reaction/ValidCommander.java
+++ b/server/src/test/java/io/spine/server/command/model/given/reaction/ValidCommander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/command/model/given/reaction/package-info.java
+++ b/server/src/test/java/io/spine/server/command/model/given/reaction/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/AbstractCommandBusTestSuite.java
+++ b/server/src/test/java/io/spine/server/commandbus/AbstractCommandBusTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/AckRejectionPublisherTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/AckRejectionPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/CommandAckMonitorTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandAckMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/CommandBusBuilderTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandBusBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/CommandDispatcherRegistryTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandDispatcherRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/CommandHandlerTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/CommandReceivedTapTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandReceivedTapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/CommandSchedulingTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandSchedulingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/CommandValidatorViolationCheckTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/CommandValidatorViolationCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/ExecutorCommandSchedulerTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/ExecutorCommandSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/Given.java
+++ b/server/src/test/java/io/spine/server/commandbus/Given.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/MultiTenantCommandBusTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/MultiTenantCommandBusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/RejectionInFilterTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/RejectionInFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/SingleTenantCommandBusTest.java
+++ b/server/src/test/java/io/spine/server/commandbus/SingleTenantCommandBusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/given/CommandDispatcherRegistryTestEnv.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/CommandDispatcherRegistryTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/given/CommandHandlerTestEnv.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/CommandHandlerTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/given/DirectScheduledExecutor.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/DirectScheduledExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/given/MemoizingCommandFlowWatcher.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/MemoizingCommandFlowWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/given/MultitenantCommandBusTestEnv.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/MultitenantCommandBusTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/given/SingleTenantCommandBusTestEnv.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/SingleTenantCommandBusTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/given/ThrowingScheduledExecutor.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/ThrowingScheduledExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/given/caffetteria/BeachCustomerFilter.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/caffetteria/BeachCustomerFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/given/caffetteria/CaffetteriaStats.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/caffetteria/CaffetteriaStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/given/caffetteria/CaffetteriaStatsRepository.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/caffetteria/CaffetteriaStatsRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/given/caffetteria/OrderAggregate.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/caffetteria/OrderAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/given/caffetteria/package-info.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/caffetteria/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/commandbus/given/package-info.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/AbstractDeliveryTest.java
+++ b/server/src/test/java/io/spine/server/delivery/AbstractDeliveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/AbstractStationTest.java
+++ b/server/src/test/java/io/spine/server/delivery/AbstractStationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/CatchUpMessagesTest.java
+++ b/server/src/test/java/io/spine/server/delivery/CatchUpMessagesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/CatchUpStationTest.java
+++ b/server/src/test/java/io/spine/server/delivery/CatchUpStationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/CatchUpTest.java
+++ b/server/src/test/java/io/spine/server/delivery/CatchUpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/CleanupStationTest.java
+++ b/server/src/test/java/io/spine/server/delivery/CleanupStationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/DeliveryBuilderTest.java
+++ b/server/src/test/java/io/spine/server/delivery/DeliveryBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/DeliveryErrorsTest.java
+++ b/server/src/test/java/io/spine/server/delivery/DeliveryErrorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/DeliveryFactoryTest.java
+++ b/server/src/test/java/io/spine/server/delivery/DeliveryFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/DeliveryTest.java
+++ b/server/src/test/java/io/spine/server/delivery/DeliveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/DispatchingIdTest.java
+++ b/server/src/test/java/io/spine/server/delivery/DispatchingIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/EndpointsTest.java
+++ b/server/src/test/java/io/spine/server/delivery/EndpointsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/InMemoryInboxStorageTest.java
+++ b/server/src/test/java/io/spine/server/delivery/InMemoryInboxStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/InMemoryShardedWorkRegistryTest.java
+++ b/server/src/test/java/io/spine/server/delivery/InMemoryShardedWorkRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/InboxContents.java
+++ b/server/src/test/java/io/spine/server/delivery/InboxContents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/InboxIdsTest.java
+++ b/server/src/test/java/io/spine/server/delivery/InboxIdsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/InboxStorageTest.java
+++ b/server/src/test/java/io/spine/server/delivery/InboxStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/LiveDeliveryStationTest.java
+++ b/server/src/test/java/io/spine/server/delivery/LiveDeliveryStationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/MemoizingAction.java
+++ b/server/src/test/java/io/spine/server/delivery/MemoizingAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/NastyClient.java
+++ b/server/src/test/java/io/spine/server/delivery/NastyClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/ReceptionFailureTest.java
+++ b/server/src/test/java/io/spine/server/delivery/ReceptionFailureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/ShardedWorkRegistryTest.java
+++ b/server/src/test/java/io/spine/server/delivery/ShardedWorkRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/TestRoutines.java
+++ b/server/src/test/java/io/spine/server/delivery/TestRoutines.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/TurbulenceTest.java
+++ b/server/src/test/java/io/spine/server/delivery/TurbulenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/UniformStrategyTest.java
+++ b/server/src/test/java/io/spine/server/delivery/UniformStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/CalcAggregate.java
+++ b/server/src/test/java/io/spine/server/delivery/given/CalcAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/CalculatorSignal.java
+++ b/server/src/test/java/io/spine/server/delivery/given/CalculatorSignal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/ConsecutiveNumberProcess.java
+++ b/server/src/test/java/io/spine/server/delivery/given/ConsecutiveNumberProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/ConsecutiveProjection.java
+++ b/server/src/test/java/io/spine/server/delivery/given/ConsecutiveProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/CounterCatchUp.java
+++ b/server/src/test/java/io/spine/server/delivery/given/CounterCatchUp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/CounterView.java
+++ b/server/src/test/java/io/spine/server/delivery/given/CounterView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/DeliveryTestEnv.java
+++ b/server/src/test/java/io/spine/server/delivery/given/DeliveryTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/FixedShardStrategy.java
+++ b/server/src/test/java/io/spine/server/delivery/given/FixedShardStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/MemoizingDeliveryMonitor.java
+++ b/server/src/test/java/io/spine/server/delivery/given/MemoizingDeliveryMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/NoOpEndpoint.java
+++ b/server/src/test/java/io/spine/server/delivery/given/NoOpEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/ReceptionFailureTestEnv.java
+++ b/server/src/test/java/io/spine/server/delivery/given/ReceptionFailureTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/ReceptionistAggregate.java
+++ b/server/src/test/java/io/spine/server/delivery/given/ReceptionistAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/TaskAggregate.java
+++ b/server/src/test/java/io/spine/server/delivery/given/TaskAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/TaskAssignment.java
+++ b/server/src/test/java/io/spine/server/delivery/given/TaskAssignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/TaskView.java
+++ b/server/src/test/java/io/spine/server/delivery/given/TaskView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/TestCatchUpJobs.java
+++ b/server/src/test/java/io/spine/server/delivery/given/TestCatchUpJobs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/TestInboxMessages.java
+++ b/server/src/test/java/io/spine/server/delivery/given/TestInboxMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/WhatToCatchUp.java
+++ b/server/src/test/java/io/spine/server/delivery/given/WhatToCatchUp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/delivery/given/package-info.java
+++ b/server/src/test/java/io/spine/server/delivery/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/dispatch/DispatchMixinsTest.java
+++ b/server/src/test/java/io/spine/server/dispatch/DispatchMixinsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/dispatch/DispatchOutcomeHandlerTest.java
+++ b/server/src/test/java/io/spine/server/dispatch/DispatchOutcomeHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/dispatch/DispatchOutcomesTest.java
+++ b/server/src/test/java/io/spine/server/dispatch/DispatchOutcomesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/dispatch/given/Given.java
+++ b/server/src/test/java/io/spine/server/dispatch/given/Given.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/dispatch/given/package-info.java
+++ b/server/src/test/java/io/spine/server/dispatch/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/enrich/EnricherBuilderTest.java
+++ b/server/src/test/java/io/spine/server/enrich/EnricherBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/enrich/SingularFnTest.java
+++ b/server/src/test/java/io/spine/server/enrich/SingularFnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/enrich/given/EitEnricherSetup.java
+++ b/server/src/test/java/io/spine/server/enrich/given/EitEnricherSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/enrich/given/EitProjectAggregate.java
+++ b/server/src/test/java/io/spine/server/enrich/given/EitProjectAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/enrich/given/EitProjectRepository.java
+++ b/server/src/test/java/io/spine/server/enrich/given/EitProjectRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/enrich/given/EitTaskAggregate.java
+++ b/server/src/test/java/io/spine/server/enrich/given/EitTaskAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/enrich/given/EitTaskRepository.java
+++ b/server/src/test/java/io/spine/server/enrich/given/EitTaskRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/enrich/given/EitUserAggregate.java
+++ b/server/src/test/java/io/spine/server/enrich/given/EitUserAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/enrich/given/EitUserRepository.java
+++ b/server/src/test/java/io/spine/server/enrich/given/EitUserRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/enrich/given/event/EbtOrderEvent.java
+++ b/server/src/test/java/io/spine/server/enrich/given/event/EbtOrderEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/enrich/given/event/SfnTestEvent.java
+++ b/server/src/test/java/io/spine/server/enrich/given/event/SfnTestEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/enrich/given/event/package-info.java
+++ b/server/src/test/java/io/spine/server/enrich/given/event/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/enrich/given/package-info.java
+++ b/server/src/test/java/io/spine/server/enrich/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/AbstractEntityTest.java
+++ b/server/src/test/java/io/spine/server/entity/AbstractEntityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/AbstractEventSubscriberTest.java
+++ b/server/src/test/java/io/spine/server/entity/AbstractEventSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/CompositeEventFilterTest.java
+++ b/server/src/test/java/io/spine/server/entity/CompositeEventFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/DefaultCommandRouteTest.java
+++ b/server/src/test/java/io/spine/server/entity/DefaultCommandRouteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/DefaultConverterTest.java
+++ b/server/src/test/java/io/spine/server/entity/DefaultConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/DefaultEntityFactoryTest.java
+++ b/server/src/test/java/io/spine/server/entity/DefaultEntityFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/EntityBuilder.java
+++ b/server/src/test/java/io/spine/server/entity/EntityBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/EntityIdFunctionTest.java
+++ b/server/src/test/java/io/spine/server/entity/EntityIdFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/EntityLifecycleTest.java
+++ b/server/src/test/java/io/spine/server/entity/EntityLifecycleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/EntityTest.java
+++ b/server/src/test/java/io/spine/server/entity/EntityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/EntityVisibilityTest.java
+++ b/server/src/test/java/io/spine/server/entity/EntityVisibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/EventBlackListTest.java
+++ b/server/src/test/java/io/spine/server/entity/EventBlackListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/EventFieldFilterTest.java
+++ b/server/src/test/java/io/spine/server/entity/EventFieldFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/EventWhiteListTest.java
+++ b/server/src/test/java/io/spine/server/entity/EventWhiteListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/FieldMasksTest.java
+++ b/server/src/test/java/io/spine/server/entity/FieldMasksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/InvalidEntityStateExceptionTest.java
+++ b/server/src/test/java/io/spine/server/entity/InvalidEntityStateExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/NoOpEventFilterTest.java
+++ b/server/src/test/java/io/spine/server/entity/NoOpEventFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/RecordBasedRepositoryTest.java
+++ b/server/src/test/java/io/spine/server/entity/RecordBasedRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/RepositoryTest.java
+++ b/server/src/test/java/io/spine/server/entity/RepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/TestEntity.java
+++ b/server/src/test/java/io/spine/server/entity/TestEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/TestTransaction.java
+++ b/server/src/test/java/io/spine/server/entity/TestTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/TransactionTest.java
+++ b/server/src/test/java/io/spine/server/entity/TransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/TransactionalEntityTest.java
+++ b/server/src/test/java/io/spine/server/entity/TransactionalEntityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/TransactionalEventPlayerTest.java
+++ b/server/src/test/java/io/spine/server/entity/TransactionalEventPlayerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/DefaultEntityFactoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/entity/given/DefaultEntityFactoryTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/FieldMasksTestEnv.java
+++ b/server/src/test/java/io/spine/server/entity/given/FieldMasksTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/Given.java
+++ b/server/src/test/java/io/spine/server/entity/given/Given.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/MemoizingTransactionListener.java
+++ b/server/src/test/java/io/spine/server/entity/given/MemoizingTransactionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/RecordBasedRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/entity/given/RecordBasedRepositoryTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/TeEntity.java
+++ b/server/src/test/java/io/spine/server/entity/given/TeEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/VisibilityGuardTestEnv.java
+++ b/server/src/test/java/io/spine/server/entity/given/VisibilityGuardTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/entity/AnEntity.java
+++ b/server/src/test/java/io/spine/server/entity/given/entity/AnEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/entity/EntityWithMessageId.java
+++ b/server/src/test/java/io/spine/server/entity/given/entity/EntityWithMessageId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/entity/NaturalNumberEntity.java
+++ b/server/src/test/java/io/spine/server/entity/given/entity/NaturalNumberEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/entity/TestAggregate.java
+++ b/server/src/test/java/io/spine/server/entity/given/entity/TestAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/entity/TestEntityWithIdInteger.java
+++ b/server/src/test/java/io/spine/server/entity/given/entity/TestEntityWithIdInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/entity/TestEntityWithIdLong.java
+++ b/server/src/test/java/io/spine/server/entity/given/entity/TestEntityWithIdLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/entity/TestEntityWithIdMessage.java
+++ b/server/src/test/java/io/spine/server/entity/given/entity/TestEntityWithIdMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/entity/TestEntityWithIdString.java
+++ b/server/src/test/java/io/spine/server/entity/given/entity/TestEntityWithIdString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/entity/UserAggregate.java
+++ b/server/src/test/java/io/spine/server/entity/given/entity/UserAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/entity/package-info.java
+++ b/server/src/test/java/io/spine/server/entity/given/entity/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/package-info.java
+++ b/server/src/test/java/io/spine/server/entity/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/repository/EntityWithUnsupportedId.java
+++ b/server/src/test/java/io/spine/server/entity/given/repository/EntityWithUnsupportedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/repository/GivenLifecycleFlags.java
+++ b/server/src/test/java/io/spine/server/entity/given/repository/GivenLifecycleFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/repository/ProjectEntity.java
+++ b/server/src/test/java/io/spine/server/entity/given/repository/ProjectEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/repository/RepoForEntityWithUnsupportedId.java
+++ b/server/src/test/java/io/spine/server/entity/given/repository/RepoForEntityWithUnsupportedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/repository/TestRepo.java
+++ b/server/src/test/java/io/spine/server/entity/given/repository/TestRepo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/repository/package-info.java
+++ b/server/src/test/java/io/spine/server/entity/given/repository/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/tx/TxAggregate.java
+++ b/server/src/test/java/io/spine/server/entity/given/tx/TxAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/tx/TxProcessManager.java
+++ b/server/src/test/java/io/spine/server/entity/given/tx/TxProcessManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/tx/TxProjection.java
+++ b/server/src/test/java/io/spine/server/entity/given/tx/TxProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/given/tx/package-info.java
+++ b/server/src/test/java/io/spine/server/entity/given/tx/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/model/EntityClassTest.java
+++ b/server/src/test/java/io/spine/server/entity/model/EntityClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/AbstractColumnMappingTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/AbstractColumnMappingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/ColumnNameTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ColumnNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/ColumnTests.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ColumnTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/ColumnsTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ColumnsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/CompositeQueryParameterTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/CompositeQueryParameterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/EntityQueriesTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/EntityQueriesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/EntityQueryTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/EntityQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/EntityRecordWithColumnsTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/EntityRecordWithColumnsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/QueryParametersTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/QueryParametersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/ScannerTest.java
+++ b/server/src/test/java/io/spine/server/entity/storage/ScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/TestCompositeQueryParameterFactory.java
+++ b/server/src/test/java/io/spine/server/entity/storage/TestCompositeQueryParameterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/TestEntityQueryFactory.java
+++ b/server/src/test/java/io/spine/server/entity/storage/TestEntityQueryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/TestEntityRecordWithColumnsFactory.java
+++ b/server/src/test/java/io/spine/server/entity/storage/TestEntityRecordWithColumnsFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/given/AColumn.java
+++ b/server/src/test/java/io/spine/server/entity/storage/given/AColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/given/EntityWithoutCustomColumns.java
+++ b/server/src/test/java/io/spine/server/entity/storage/given/EntityWithoutCustomColumns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/given/IntIdentifier.java
+++ b/server/src/test/java/io/spine/server/entity/storage/given/IntIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/given/IntrospectorTestEnv.java
+++ b/server/src/test/java/io/spine/server/entity/storage/given/IntrospectorTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/given/TaskListViewProjection.java
+++ b/server/src/test/java/io/spine/server/entity/storage/given/TaskListViewProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/given/TaskViewProjection.java
+++ b/server/src/test/java/io/spine/server/entity/storage/given/TaskViewProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/given/TestColumnMapping.java
+++ b/server/src/test/java/io/spine/server/entity/storage/given/TestColumnMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/given/TestEntity.java
+++ b/server/src/test/java/io/spine/server/entity/storage/given/TestEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/given/TestProjection.java
+++ b/server/src/test/java/io/spine/server/entity/storage/given/TestProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/entity/storage/given/package-info.java
+++ b/server/src/test/java/io/spine/server/entity/storage/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/AbstractEventReactorTest.java
+++ b/server/src/test/java/io/spine/server/event/AbstractEventReactorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/DelegatingEventDispatcherTest.java
+++ b/server/src/test/java/io/spine/server/event/DelegatingEventDispatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/EventBusBuilderTest.java
+++ b/server/src/test/java/io/spine/server/event/EventBusBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/EventBusEnrichmentTest.java
+++ b/server/src/test/java/io/spine/server/event/EventBusEnrichmentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/EventBusTest.java
+++ b/server/src/test/java/io/spine/server/event/EventBusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/EventEnricherIntegrationTest.java
+++ b/server/src/test/java/io/spine/server/event/EventEnricherIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/EventFactoryTest.java
+++ b/server/src/test/java/io/spine/server/event/EventFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/EventRootMessageIdTest.java
+++ b/server/src/test/java/io/spine/server/event/EventRootMessageIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/EventSubscriberTest.java
+++ b/server/src/test/java/io/spine/server/event/EventSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/EventValidatorTest.java
+++ b/server/src/test/java/io/spine/server/event/EventValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/InvalidEventExceptionTest.java
+++ b/server/src/test/java/io/spine/server/event/InvalidEventExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/UnsupportedEventExceptionTest.java
+++ b/server/src/test/java/io/spine/server/event/UnsupportedEventExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/AbstractReactorTestEnv.java
+++ b/server/src/test/java/io/spine/server/event/given/AbstractReactorTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/DelegatingEventDispatcherTestEnv.java
+++ b/server/src/test/java/io/spine/server/event/given/DelegatingEventDispatcherTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/EventReactorSignatureTestEnv.java
+++ b/server/src/test/java/io/spine/server/event/given/EventReactorSignatureTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/EventRootCommandIdTestEnv.java
+++ b/server/src/test/java/io/spine/server/event/given/EventRootCommandIdTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/EventStoreTestEnv.java
+++ b/server/src/test/java/io/spine/server/event/given/EventStoreTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/EventSubscriberTestEnv.java
+++ b/server/src/test/java/io/spine/server/event/given/EventSubscriberTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/bus/BareDispatcher.java
+++ b/server/src/test/java/io/spine/server/event/given/bus/BareDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/bus/EBExternalTaskAddedSubscriber.java
+++ b/server/src/test/java/io/spine/server/event/given/bus/EBExternalTaskAddedSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/bus/EBProjectArchivedSubscriber.java
+++ b/server/src/test/java/io/spine/server/event/given/bus/EBProjectArchivedSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/bus/EBProjectCreatedNoOpSubscriber.java
+++ b/server/src/test/java/io/spine/server/event/given/bus/EBProjectCreatedNoOpSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/bus/EBTaskAddedNoOpSubscriber.java
+++ b/server/src/test/java/io/spine/server/event/given/bus/EBTaskAddedNoOpSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/bus/EventBusTestEnv.java
+++ b/server/src/test/java/io/spine/server/event/given/bus/EventBusTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/bus/GivenEvent.java
+++ b/server/src/test/java/io/spine/server/event/given/bus/GivenEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/bus/GivenEventMessage.java
+++ b/server/src/test/java/io/spine/server/event/given/bus/GivenEventMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/bus/ProjectAggregate.java
+++ b/server/src/test/java/io/spine/server/event/given/bus/ProjectAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/bus/RememberingSubscriber.java
+++ b/server/src/test/java/io/spine/server/event/given/bus/RememberingSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/bus/TaskCreatedFilter.java
+++ b/server/src/test/java/io/spine/server/event/given/bus/TaskCreatedFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/bus/package-info.java
+++ b/server/src/test/java/io/spine/server/event/given/bus/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/given/package-info.java
+++ b/server/src/test/java/io/spine/server/event/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/EventReactorClassTest.java
+++ b/server/src/test/java/io/spine/server/event/model/EventReactorClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/EventReactorMethodTest.java
+++ b/server/src/test/java/io/spine/server/event/model/EventReactorMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/EventReactorSignatureTest.java
+++ b/server/src/test/java/io/spine/server/event/model/EventReactorSignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/EventSubscriberClassTest.java
+++ b/server/src/test/java/io/spine/server/event/model/EventSubscriberClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/EventSubscriberMethodTest.java
+++ b/server/src/test/java/io/spine/server/event/model/EventSubscriberMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/EventSubscriberSignatureTest.java
+++ b/server/src/test/java/io/spine/server/event/model/EventSubscriberSignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/RejectionDispatchKeysTest.java
+++ b/server/src/test/java/io/spine/server/event/model/RejectionDispatchKeysTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/ValidTwoParams.java
+++ b/server/src/test/java/io/spine/server/event/model/ValidTwoParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/classes/ConferenceProgram.java
+++ b/server/src/test/java/io/spine/server/event/model/given/classes/ConferenceProgram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/classes/ConferenceSetup.java
+++ b/server/src/test/java/io/spine/server/event/model/given/classes/ConferenceSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/classes/package-info.java
+++ b/server/src/test/java/io/spine/server/event/model/given/classes/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/package-info.java
+++ b/server/src/test/java/io/spine/server/event/model/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/reactor/RcIterableReturn.java
+++ b/server/src/test/java/io/spine/server/event/model/given/reactor/RcIterableReturn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/reactor/RcOneParam.java
+++ b/server/src/test/java/io/spine/server/event/model/given/reactor/RcOneParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/reactor/RcReturnOptional.java
+++ b/server/src/test/java/io/spine/server/event/model/given/reactor/RcReturnOptional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/reactor/RcReturnPair.java
+++ b/server/src/test/java/io/spine/server/event/model/given/reactor/RcReturnPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/reactor/RcTwoParams.java
+++ b/server/src/test/java/io/spine/server/event/model/given/reactor/RcTwoParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/reactor/RcWrongAnnotation.java
+++ b/server/src/test/java/io/spine/server/event/model/given/reactor/RcWrongAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/reactor/RcWrongFirstParam.java
+++ b/server/src/test/java/io/spine/server/event/model/given/reactor/RcWrongFirstParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/reactor/RcWrongNoAnnotation.java
+++ b/server/src/test/java/io/spine/server/event/model/given/reactor/RcWrongNoAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/reactor/RcWrongNoParam.java
+++ b/server/src/test/java/io/spine/server/event/model/given/reactor/RcWrongNoParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/reactor/RcWrongSecondParam.java
+++ b/server/src/test/java/io/spine/server/event/model/given/reactor/RcWrongSecondParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/reactor/TestEventReactor.java
+++ b/server/src/test/java/io/spine/server/event/model/given/reactor/TestEventReactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/reactor/package-info.java
+++ b/server/src/test/java/io/spine/server/event/model/given/reactor/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/subscriber/ExternalSubscriber.java
+++ b/server/src/test/java/io/spine/server/event/model/given/subscriber/ExternalSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/subscriber/InvalidNoAnnotation.java
+++ b/server/src/test/java/io/spine/server/event/model/given/subscriber/InvalidNoAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/subscriber/InvalidSubscriber.java
+++ b/server/src/test/java/io/spine/server/event/model/given/subscriber/InvalidSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/subscriber/RejectionSubscriber.java
+++ b/server/src/test/java/io/spine/server/event/model/given/subscriber/RejectionSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/subscriber/TestEventSubscriber.java
+++ b/server/src/test/java/io/spine/server/event/model/given/subscriber/TestEventSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/subscriber/ValidOneParam.java
+++ b/server/src/test/java/io/spine/server/event/model/given/subscriber/ValidOneParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/subscriber/ValidSubscriber.java
+++ b/server/src/test/java/io/spine/server/event/model/given/subscriber/ValidSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/model/given/subscriber/package-info.java
+++ b/server/src/test/java/io/spine/server/event/model/given/subscriber/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/storage/EventContextFieldTest.java
+++ b/server/src/test/java/io/spine/server/event/storage/EventContextFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/storage/EventFieldTest.java
+++ b/server/src/test/java/io/spine/server/event/storage/EventFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/store/DefaultEventStoreTest.java
+++ b/server/src/test/java/io/spine/server/event/store/DefaultEventStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/store/EEntityTest.java
+++ b/server/src/test/java/io/spine/server/event/store/EEntityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/store/EmptyEventStoreTest.java
+++ b/server/src/test/java/io/spine/server/event/store/EmptyEventStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/store/MatchFilterTest.java
+++ b/server/src/test/java/io/spine/server/event/store/MatchFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/store/MatchesStreamQueryTest.java
+++ b/server/src/test/java/io/spine/server/event/store/MatchesStreamQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/event/store/QueryToFiltersTest.java
+++ b/server/src/test/java/io/spine/server/event/store/QueryToFiltersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/given/environment/Local.java
+++ b/server/src/test/java/io/spine/server/given/environment/Local.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/given/environment/package-info.java
+++ b/server/src/test/java/io/spine/server/given/environment/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/given/groups/FilteredStateSubscriber.java
+++ b/server/src/test/java/io/spine/server/given/groups/FilteredStateSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/given/groups/FilteredStateSubscriberWhere.java
+++ b/server/src/test/java/io/spine/server/given/groups/FilteredStateSubscriberWhere.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/given/groups/GroupNameProjection.java
+++ b/server/src/test/java/io/spine/server/given/groups/GroupNameProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/given/groups/GroupProjection.java
+++ b/server/src/test/java/io/spine/server/given/groups/GroupProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/given/groups/HiddenEntitySubscriber.java
+++ b/server/src/test/java/io/spine/server/given/groups/HiddenEntitySubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/given/groups/TestSubscriber.java
+++ b/server/src/test/java/io/spine/server/given/groups/TestSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/given/groups/WronglyDomesticSubscriber.java
+++ b/server/src/test/java/io/spine/server/given/groups/WronglyDomesticSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/given/groups/WronglyExternalSubscriber.java
+++ b/server/src/test/java/io/spine/server/given/groups/WronglyExternalSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/given/groups/package-info.java
+++ b/server/src/test/java/io/spine/server/given/groups/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/given/organizations/OrganizationProjection.java
+++ b/server/src/test/java/io/spine/server/given/organizations/OrganizationProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/given/organizations/package-info.java
+++ b/server/src/test/java/io/spine/server/given/organizations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/given/package-info.java
+++ b/server/src/test/java/io/spine/server/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/given/service/StatusCheckService.java
+++ b/server/src/test/java/io/spine/server/given/service/StatusCheckService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/given/service/package-info.java
+++ b/server/src/test/java/io/spine/server/given/service/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/given/transport/TestGrpcServer.java
+++ b/server/src/test/java/io/spine/server/given/transport/TestGrpcServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/given/transport/package-info.java
+++ b/server/src/test/java/io/spine/server/given/transport/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/integration/DomesticEventPublisherTest.java
+++ b/server/src/test/java/io/spine/server/integration/DomesticEventPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/integration/ExternalMessagesTest.java
+++ b/server/src/test/java/io/spine/server/integration/ExternalMessagesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/integration/IntegrationBrokerTest.java
+++ b/server/src/test/java/io/spine/server/integration/IntegrationBrokerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/integration/ThirdPartyContextTest.java
+++ b/server/src/test/java/io/spine/server/integration/ThirdPartyContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/integration/given/DocumentAggregate.java
+++ b/server/src/test/java/io/spine/server/integration/given/DocumentAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/integration/given/DocumentRepository.java
+++ b/server/src/test/java/io/spine/server/integration/given/DocumentRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/integration/given/EditHistoryProjection.java
+++ b/server/src/test/java/io/spine/server/integration/given/EditHistoryProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/integration/given/EditHistoryRepository.java
+++ b/server/src/test/java/io/spine/server/integration/given/EditHistoryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/integration/given/ExternalMismatchSubscriber.java
+++ b/server/src/test/java/io/spine/server/integration/given/ExternalMismatchSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/integration/given/broker/BillingAggregate.java
+++ b/server/src/test/java/io/spine/server/integration/given/broker/BillingAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/integration/given/broker/IntegrationBrokerTestEnv.java
+++ b/server/src/test/java/io/spine/server/integration/given/broker/IntegrationBrokerTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/integration/given/broker/PhotosAggregate.java
+++ b/server/src/test/java/io/spine/server/integration/given/broker/PhotosAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/integration/given/broker/SubscribedBillingAggregate.java
+++ b/server/src/test/java/io/spine/server/integration/given/broker/SubscribedBillingAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/integration/given/broker/SubscribedPhotosAggregate.java
+++ b/server/src/test/java/io/spine/server/integration/given/broker/SubscribedPhotosAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/integration/given/broker/SubscribedStatisticsAggregate.java
+++ b/server/src/test/java/io/spine/server/integration/given/broker/SubscribedStatisticsAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/integration/given/broker/SubscribedWarehouseAggregate.java
+++ b/server/src/test/java/io/spine/server/integration/given/broker/SubscribedWarehouseAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/integration/given/broker/package-info.java
+++ b/server/src/test/java/io/spine/server/integration/given/broker/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/integration/given/package-info.java
+++ b/server/src/test/java/io/spine/server/integration/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/log/LoggingEntityTest.java
+++ b/server/src/test/java/io/spine/server/log/LoggingEntityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/log/given/Books.java
+++ b/server/src/test/java/io/spine/server/log/given/Books.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/log/given/CardAggregate.java
+++ b/server/src/test/java/io/spine/server/log/given/CardAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/log/given/package-info.java
+++ b/server/src/test/java/io/spine/server/log/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/AbstractHandlerMethodTest.java
+++ b/server/src/test/java/io/spine/server/model/AbstractHandlerMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/AllowedParamsTest.java
+++ b/server/src/test/java/io/spine/server/model/AllowedParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/ArgumentFilterTest.java
+++ b/server/src/test/java/io/spine/server/model/ArgumentFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/CommandOnRejectionTest.java
+++ b/server/src/test/java/io/spine/server/model/CommandOnRejectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/ExternalAttributeTest.java
+++ b/server/src/test/java/io/spine/server/model/ExternalAttributeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/HandlerMapTest.java
+++ b/server/src/test/java/io/spine/server/model/HandlerMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/HandlerMethodTest.java
+++ b/server/src/test/java/io/spine/server/model/HandlerMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/MethodAccessCheckerTest.java
+++ b/server/src/test/java/io/spine/server/model/MethodAccessCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/MethodExceptionCheckTest.java
+++ b/server/src/test/java/io/spine/server/model/MethodExceptionCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/MethodParamsTest.java
+++ b/server/src/test/java/io/spine/server/model/MethodParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/MethodResultsTest.java
+++ b/server/src/test/java/io/spine/server/model/MethodResultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/MethodScanTest.java
+++ b/server/src/test/java/io/spine/server/model/MethodScanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/MethodSignatureTest.java
+++ b/server/src/test/java/io/spine/server/model/MethodSignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/ModelTest.java
+++ b/server/src/test/java/io/spine/server/model/ModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/TypeMatcherTest.java
+++ b/server/src/test/java/io/spine/server/model/TypeMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/contexts/TwoBoundedContextsTest.java
+++ b/server/src/test/java/io/spine/server/model/contexts/TwoBoundedContextsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/contexts/orders/OrderAggregate.java
+++ b/server/src/test/java/io/spine/server/model/contexts/orders/OrderAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/contexts/orders/OrdersContext.java
+++ b/server/src/test/java/io/spine/server/model/contexts/orders/OrdersContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/contexts/orders/package-info.java
+++ b/server/src/test/java/io/spine/server/model/contexts/orders/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/contexts/package-info.java
+++ b/server/src/test/java/io/spine/server/model/contexts/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/contexts/projects/package-info.java
+++ b/server/src/test/java/io/spine/server/model/contexts/projects/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/contexts/tasks/CreationRetry.java
+++ b/server/src/test/java/io/spine/server/model/contexts/tasks/CreationRetry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/contexts/tasks/TaskAggregate.java
+++ b/server/src/test/java/io/spine/server/model/contexts/tasks/TaskAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/contexts/tasks/TasksContext.java
+++ b/server/src/test/java/io/spine/server/model/contexts/tasks/TasksContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/contexts/tasks/package-info.java
+++ b/server/src/test/java/io/spine/server/model/contexts/tasks/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/Given.java
+++ b/server/src/test/java/io/spine/server/model/given/Given.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/HandlerReturnTypeTestEnv.java
+++ b/server/src/test/java/io/spine/server/model/given/HandlerReturnTypeTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/MethodAccessCheckerTestEnv.java
+++ b/server/src/test/java/io/spine/server/model/given/MethodAccessCheckerTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/MethodParamsTestEnv.java
+++ b/server/src/test/java/io/spine/server/model/given/MethodParamsTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/ModelTestEnv.java
+++ b/server/src/test/java/io/spine/server/model/given/ModelTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/SignatureTestCommand.java
+++ b/server/src/test/java/io/spine/server/model/given/SignatureTestCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/SignatureTestEvent.java
+++ b/server/src/test/java/io/spine/server/model/given/SignatureTestEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/StubMethodContainer.java
+++ b/server/src/test/java/io/spine/server/model/given/StubMethodContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/external/TestCommander.java
+++ b/server/src/test/java/io/spine/server/model/given/external/TestCommander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/external/TestReactor.java
+++ b/server/src/test/java/io/spine/server/model/given/external/TestReactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/external/TestSubscriber.java
+++ b/server/src/test/java/io/spine/server/model/given/external/TestSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/external/package-info.java
+++ b/server/src/test/java/io/spine/server/model/given/external/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/filter/Bucket.java
+++ b/server/src/test/java/io/spine/server/model/given/filter/Bucket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/filter/package-info.java
+++ b/server/src/test/java/io/spine/server/model/given/filter/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/map/ARejectionSubscriber.java
+++ b/server/src/test/java/io/spine/server/model/given/map/ARejectionSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/map/DupEventFilterValue.java
+++ b/server/src/test/java/io/spine/server/model/given/map/DupEventFilterValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/map/DupEventFilterValueWhere.java
+++ b/server/src/test/java/io/spine/server/model/given/map/DupEventFilterValueWhere.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/map/DuplicateCommandHandlers.java
+++ b/server/src/test/java/io/spine/server/model/given/map/DuplicateCommandHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/map/FilteredSubscription.java
+++ b/server/src/test/java/io/spine/server/model/given/map/FilteredSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/map/ProjectCreatedEventReactor.java
+++ b/server/src/test/java/io/spine/server/model/given/map/ProjectCreatedEventReactor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/map/RejectionsDispatchingTestEnv.java
+++ b/server/src/test/java/io/spine/server/model/given/map/RejectionsDispatchingTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/map/TwoFieldsInSubscription.java
+++ b/server/src/test/java/io/spine/server/model/given/map/TwoFieldsInSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/map/package-info.java
+++ b/server/src/test/java/io/spine/server/model/given/map/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/method/OneParamMethod.java
+++ b/server/src/test/java/io/spine/server/model/given/method/OneParamMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/method/OneParamSignature.java
+++ b/server/src/test/java/io/spine/server/model/given/method/OneParamSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/method/OneParamSpec.java
+++ b/server/src/test/java/io/spine/server/model/given/method/OneParamSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/method/StubHandler.java
+++ b/server/src/test/java/io/spine/server/model/given/method/StubHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/method/TwoParamMethod.java
+++ b/server/src/test/java/io/spine/server/model/given/method/TwoParamMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/method/TwoParamSpec.java
+++ b/server/src/test/java/io/spine/server/model/given/method/TwoParamSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/method/package-info.java
+++ b/server/src/test/java/io/spine/server/model/given/method/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/given/package-info.java
+++ b/server/src/test/java/io/spine/server/model/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/handler/MessageInterfaceResultTest.java
+++ b/server/src/test/java/io/spine/server/model/handler/MessageInterfaceResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/handler/given/RoverBot.java
+++ b/server/src/test/java/io/spine/server/model/handler/given/RoverBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/handler/given/event/MovingEvent.java
+++ b/server/src/test/java/io/spine/server/model/handler/given/event/MovingEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/handler/given/event/package-info.java
+++ b/server/src/test/java/io/spine/server/model/handler/given/event/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/handler/given/package-info.java
+++ b/server/src/test/java/io/spine/server/model/handler/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/model/handler/package-info.java
+++ b/server/src/test/java/io/spine/server/model/handler/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/package-info.java
+++ b/server/src/test/java/io/spine/server/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/PmTransactionTest.java
+++ b/server/src/test/java/io/spine/server/procman/PmTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/ProcessManagerRepositoryTest.java
+++ b/server/src/test/java/io/spine/server/procman/ProcessManagerRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/ProcessManagerTest.java
+++ b/server/src/test/java/io/spine/server/procman/ProcessManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/delivery/GivenMessage.java
+++ b/server/src/test/java/io/spine/server/procman/given/delivery/GivenMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/delivery/package-info.java
+++ b/server/src/test/java/io/spine/server/procman/given/delivery/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/dispatch/PmDispatcher.java
+++ b/server/src/test/java/io/spine/server/procman/given/dispatch/PmDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/dispatch/ProcessManagerBuilder.java
+++ b/server/src/test/java/io/spine/server/procman/given/dispatch/ProcessManagerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/dispatch/TestPmTransaction.java
+++ b/server/src/test/java/io/spine/server/procman/given/dispatch/TestPmTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/dispatch/package-info.java
+++ b/server/src/test/java/io/spine/server/procman/given/dispatch/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/package-info.java
+++ b/server/src/test/java/io/spine/server/procman/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/pm/DirectQuizProcman.java
+++ b/server/src/test/java/io/spine/server/procman/given/pm/DirectQuizProcman.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/pm/DirectQuizProcmanRepository.java
+++ b/server/src/test/java/io/spine/server/procman/given/pm/DirectQuizProcmanRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/pm/GivenMessages.java
+++ b/server/src/test/java/io/spine/server/procman/given/pm/GivenMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/pm/QuizGiven.java
+++ b/server/src/test/java/io/spine/server/procman/given/pm/QuizGiven.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/pm/QuizProcman.java
+++ b/server/src/test/java/io/spine/server/procman/given/pm/QuizProcman.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/pm/QuizProcmanRepository.java
+++ b/server/src/test/java/io/spine/server/procman/given/pm/QuizProcmanRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/pm/TestProcessManager.java
+++ b/server/src/test/java/io/spine/server/procman/given/pm/TestProcessManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/pm/TestProcessManagerRepo.java
+++ b/server/src/test/java/io/spine/server/procman/given/pm/TestProcessManagerRepo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/pm/package-info.java
+++ b/server/src/test/java/io/spine/server/procman/given/pm/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/repo/EventDiscardingProcManRepository.java
+++ b/server/src/test/java/io/spine/server/procman/given/repo/EventDiscardingProcManRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/repo/GivenCommandMessage.java
+++ b/server/src/test/java/io/spine/server/procman/given/repo/GivenCommandMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/repo/ProjectCompletion.java
+++ b/server/src/test/java/io/spine/server/procman/given/repo/ProjectCompletion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/repo/RandomFillProcess.java
+++ b/server/src/test/java/io/spine/server/procman/given/repo/RandomFillProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/repo/RememberingSubscriber.java
+++ b/server/src/test/java/io/spine/server/procman/given/repo/RememberingSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/repo/SensoryDeprivedPmRepository.java
+++ b/server/src/test/java/io/spine/server/procman/given/repo/SensoryDeprivedPmRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/repo/SensoryDeprivedProcessManager.java
+++ b/server/src/test/java/io/spine/server/procman/given/repo/SensoryDeprivedProcessManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/repo/SetTestProcessId.java
+++ b/server/src/test/java/io/spine/server/procman/given/repo/SetTestProcessId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/repo/SetTestProcessName.java
+++ b/server/src/test/java/io/spine/server/procman/given/repo/SetTestProcessName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/repo/TestProcessManager.java
+++ b/server/src/test/java/io/spine/server/procman/given/repo/TestProcessManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/repo/TestProcessManagerRepository.java
+++ b/server/src/test/java/io/spine/server/procman/given/repo/TestProcessManagerRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/given/repo/package-info.java
+++ b/server/src/test/java/io/spine/server/procman/given/repo/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/procman/model/ProcessManagerClassTest.java
+++ b/server/src/test/java/io/spine/server/procman/model/ProcessManagerClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/ProjectionColumnTest.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionColumnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/ProjectionRepositoryTest.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/ProjectionStorageTest.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/ProjectionTest.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/ProjectionTransactionTest.java
+++ b/server/src/test/java/io/spine/server/projection/ProjectionTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/StateRoutingTest.java
+++ b/server/src/test/java/io/spine/server/projection/StateRoutingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/e2e/ProjectionEndToEndTest.java
+++ b/server/src/test/java/io/spine/server/projection/e2e/ProjectionEndToEndTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/e2e/package-info.java
+++ b/server/src/test/java/io/spine/server/projection/e2e/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/given/EntitySubscriberProjection.java
+++ b/server/src/test/java/io/spine/server/projection/given/EntitySubscriberProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/given/NoDefaultOptionProjection.java
+++ b/server/src/test/java/io/spine/server/projection/given/NoDefaultOptionProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/given/ProjectionRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/server/projection/given/ProjectionRepositoryTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/given/ProjectionStorageTestEnv.java
+++ b/server/src/test/java/io/spine/server/projection/given/ProjectionStorageTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/given/RandomFillProjection.java
+++ b/server/src/test/java/io/spine/server/projection/given/RandomFillProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/given/SavingProjection.java
+++ b/server/src/test/java/io/spine/server/projection/given/SavingProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/given/SetTestProjectionId.java
+++ b/server/src/test/java/io/spine/server/projection/given/SetTestProjectionId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/given/SetTestProjectionName.java
+++ b/server/src/test/java/io/spine/server/projection/given/SetTestProjectionName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/given/TestProjection.java
+++ b/server/src/test/java/io/spine/server/projection/given/TestProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/given/cls/Calcumulator.java
+++ b/server/src/test/java/io/spine/server/projection/given/cls/Calcumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/given/cls/DifferentFieldSubscription.java
+++ b/server/src/test/java/io/spine/server/projection/given/cls/DifferentFieldSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/given/cls/DuplicateValueSubscription.java
+++ b/server/src/test/java/io/spine/server/projection/given/cls/DuplicateValueSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/given/cls/FilteringProjection.java
+++ b/server/src/test/java/io/spine/server/projection/given/cls/FilteringProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/given/cls/package-info.java
+++ b/server/src/test/java/io/spine/server/projection/given/cls/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/given/dispatch/ProjectionBuilder.java
+++ b/server/src/test/java/io/spine/server/projection/given/dispatch/ProjectionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/given/dispatch/ProjectionEventDispatcher.java
+++ b/server/src/test/java/io/spine/server/projection/given/dispatch/ProjectionEventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/given/dispatch/package-info.java
+++ b/server/src/test/java/io/spine/server/projection/given/dispatch/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/given/package-info.java
+++ b/server/src/test/java/io/spine/server/projection/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/projection/model/ProjectionClassTest.java
+++ b/server/src/test/java/io/spine/server/projection/model/ProjectionClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/CommandRoutingRejectionTest.java
+++ b/server/src/test/java/io/spine/server/route/CommandRoutingRejectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/CommandRoutingTest.java
+++ b/server/src/test/java/io/spine/server/route/CommandRoutingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/EventRoutingIntegrationTest.java
+++ b/server/src/test/java/io/spine/server/route/EventRoutingIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/EventRoutingTest.java
+++ b/server/src/test/java/io/spine/server/route/EventRoutingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/StateUpdateRoutingTest.java
+++ b/server/src/test/java/io/spine/server/route/StateUpdateRoutingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/given/package-info.java
+++ b/server/src/test/java/io/spine/server/route/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/given/sur/ArtistMoodProjection.java
+++ b/server/src/test/java/io/spine/server/route/given/sur/ArtistMoodProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/given/sur/ArtistMoodRepo.java
+++ b/server/src/test/java/io/spine/server/route/given/sur/ArtistMoodRepo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/given/sur/Gallery.java
+++ b/server/src/test/java/io/spine/server/route/given/sur/Gallery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/given/sur/MagazineAggregate.java
+++ b/server/src/test/java/io/spine/server/route/given/sur/MagazineAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/given/sur/PieceOfArtProjection.java
+++ b/server/src/test/java/io/spine/server/route/given/sur/PieceOfArtProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/given/sur/Surrealism.java
+++ b/server/src/test/java/io/spine/server/route/given/sur/Surrealism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/given/sur/WorksProjection.java
+++ b/server/src/test/java/io/spine/server/route/given/sur/WorksProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/given/sur/package-info.java
+++ b/server/src/test/java/io/spine/server/route/given/sur/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/given/switchman/Log.java
+++ b/server/src/test/java/io/spine/server/route/given/switchman/Log.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/given/switchman/Switchman.java
+++ b/server/src/test/java/io/spine/server/route/given/switchman/Switchman.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/given/switchman/SwitchmanBureau.java
+++ b/server/src/test/java/io/spine/server/route/given/switchman/SwitchmanBureau.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/given/switchman/package-info.java
+++ b/server/src/test/java/io/spine/server/route/given/switchman/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/given/user/SessionProjection.java
+++ b/server/src/test/java/io/spine/server/route/given/user/SessionProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/given/user/SessionRepository.java
+++ b/server/src/test/java/io/spine/server/route/given/user/SessionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/given/user/UserAggregate.java
+++ b/server/src/test/java/io/spine/server/route/given/user/UserAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/route/given/user/package-info.java
+++ b/server/src/test/java/io/spine/server/route/given/user/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/security/GivenRestrictedApi.java
+++ b/server/src/test/java/io/spine/server/security/GivenRestrictedApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/security/SecurityTest.java
+++ b/server/src/test/java/io/spine/server/security/SecurityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/stand/EntityQueryProcessorTest.java
+++ b/server/src/test/java/io/spine/server/stand/EntityQueryProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/stand/MultitenantStandTest.java
+++ b/server/src/test/java/io/spine/server/stand/MultitenantStandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/stand/QueryValidatorTest.java
+++ b/server/src/test/java/io/spine/server/stand/QueryValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/stand/StandBuilderTest.java
+++ b/server/src/test/java/io/spine/server/stand/StandBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/stand/StandTest.java
+++ b/server/src/test/java/io/spine/server/stand/StandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/stand/SubscriptionRecordTest.java
+++ b/server/src/test/java/io/spine/server/stand/SubscriptionRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/stand/given/AloneWaiter.java
+++ b/server/src/test/java/io/spine/server/stand/given/AloneWaiter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/stand/given/Given.java
+++ b/server/src/test/java/io/spine/server/stand/given/Given.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/stand/given/MenuProjection.java
+++ b/server/src/test/java/io/spine/server/stand/given/MenuProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/stand/given/MenuRepository.java
+++ b/server/src/test/java/io/spine/server/stand/given/MenuRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/stand/given/StandTestEnv.java
+++ b/server/src/test/java/io/spine/server/stand/given/StandTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/stand/given/SubscriptionRecordTestEnv.java
+++ b/server/src/test/java/io/spine/server/stand/given/SubscriptionRecordTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/stand/given/package-info.java
+++ b/server/src/test/java/io/spine/server/stand/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/AbstractRecordStorageTest.java
+++ b/server/src/test/java/io/spine/server/storage/AbstractRecordStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/AbstractStorageFieldTest.java
+++ b/server/src/test/java/io/spine/server/storage/AbstractStorageFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/AbstractStorageTest.java
+++ b/server/src/test/java/io/spine/server/storage/AbstractStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/LifecycleFlagFieldTest.java
+++ b/server/src/test/java/io/spine/server/storage/LifecycleFlagFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/RecordReadRequestTest.java
+++ b/server/src/test/java/io/spine/server/storage/RecordReadRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/RecordStorageTest.java
+++ b/server/src/test/java/io/spine/server/storage/RecordStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/StateFieldTest.java
+++ b/server/src/test/java/io/spine/server/storage/StateFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/StorageFieldTest.java
+++ b/server/src/test/java/io/spine/server/storage/StorageFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/VersionFieldTest.java
+++ b/server/src/test/java/io/spine/server/storage/VersionFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/given/AStorageField.java
+++ b/server/src/test/java/io/spine/server/storage/given/AStorageField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/given/Given.java
+++ b/server/src/test/java/io/spine/server/storage/given/Given.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/given/RecordStorageTestEnv.java
+++ b/server/src/test/java/io/spine/server/storage/given/RecordStorageTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/given/package-info.java
+++ b/server/src/test/java/io/spine/server/storage/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/memory/EntityQueryMatcherTest.java
+++ b/server/src/test/java/io/spine/server/storage/memory/EntityQueryMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/memory/InMemoryAggregateStorageStatusHandlingTest.java
+++ b/server/src/test/java/io/spine/server/storage/memory/InMemoryAggregateStorageStatusHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/memory/InMemoryAggregateStorageTest.java
+++ b/server/src/test/java/io/spine/server/storage/memory/InMemoryAggregateStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/memory/InMemoryAggregateStorageTruncationTest.java
+++ b/server/src/test/java/io/spine/server/storage/memory/InMemoryAggregateStorageTruncationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/memory/InMemoryProjectionStorageTest.java
+++ b/server/src/test/java/io/spine/server/storage/memory/InMemoryProjectionStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/memory/InMemoryRecordStorageTest.java
+++ b/server/src/test/java/io/spine/server/storage/memory/InMemoryRecordStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/memory/InMemoryStorageFactoryTest.java
+++ b/server/src/test/java/io/spine/server/storage/memory/InMemoryStorageFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/memory/MultitenantStorageTest.java
+++ b/server/src/test/java/io/spine/server/storage/memory/MultitenantStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/memory/StorageSpecTest.java
+++ b/server/src/test/java/io/spine/server/storage/memory/StorageSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/memory/given/EntityQueryMatcherTestEnv.java
+++ b/server/src/test/java/io/spine/server/storage/memory/given/EntityQueryMatcherTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/memory/given/package-info.java
+++ b/server/src/test/java/io/spine/server/storage/memory/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/system/SystemAwareStorageFactoryTest.java
+++ b/server/src/test/java/io/spine/server/storage/system/SystemAwareStorageFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/system/given/MemoizingStorageFactory.java
+++ b/server/src/test/java/io/spine/server/storage/system/given/MemoizingStorageFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/system/given/TestAggregate.java
+++ b/server/src/test/java/io/spine/server/storage/system/given/TestAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/system/given/TestProjection.java
+++ b/server/src/test/java/io/spine/server/storage/system/given/TestProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/storage/system/given/package-info.java
+++ b/server/src/test/java/io/spine/server/storage/system/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tenant/CurrentTenantTest.java
+++ b/server/src/test/java/io/spine/server/tenant/CurrentTenantTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tenant/QueryOperationTest.java
+++ b/server/src/test/java/io/spine/server/tenant/QueryOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tenant/SingleTenantIndexTest.java
+++ b/server/src/test/java/io/spine/server/tenant/SingleTenantIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tenant/TenantAwareFunction0Test.java
+++ b/server/src/test/java/io/spine/server/tenant/TenantAwareFunction0Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tenant/TenantAwareOperationTest.java
+++ b/server/src/test/java/io/spine/server/tenant/TenantAwareOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tenant/TenantIndexTest.java
+++ b/server/src/test/java/io/spine/server/tenant/TenantIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tenant/TenantRepositoryTest.java
+++ b/server/src/test/java/io/spine/server/tenant/TenantRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/trace/TracingTest.java
+++ b/server/src/test/java/io/spine/server/trace/TracingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/trace/given/MemoizingTracer.java
+++ b/server/src/test/java/io/spine/server/trace/given/MemoizingTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/trace/given/MemoizingTracerFactory.java
+++ b/server/src/test/java/io/spine/server/trace/given/MemoizingTracerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/trace/given/TracingTestEnv.java
+++ b/server/src/test/java/io/spine/server/trace/given/TracingTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/trace/given/airport/AirportContext.java
+++ b/server/src/test/java/io/spine/server/trace/given/airport/AirportContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/trace/given/airport/BoardingProcman.java
+++ b/server/src/test/java/io/spine/server/trace/given/airport/BoardingProcman.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/trace/given/airport/FlightAggregate.java
+++ b/server/src/test/java/io/spine/server/trace/given/airport/FlightAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/trace/given/airport/FlightRepository.java
+++ b/server/src/test/java/io/spine/server/trace/given/airport/FlightRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/trace/given/airport/TimetableProjection.java
+++ b/server/src/test/java/io/spine/server/trace/given/airport/TimetableProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/trace/given/airport/TimetableRepository.java
+++ b/server/src/test/java/io/spine/server/trace/given/airport/TimetableRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/trace/given/airport/package-info.java
+++ b/server/src/test/java/io/spine/server/trace/given/airport/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/trace/given/package-info.java
+++ b/server/src/test/java/io/spine/server/trace/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/transport/memory/InMemoryTransportFactoryTest.java
+++ b/server/src/test/java/io/spine/server/transport/memory/InMemoryTransportFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/transport/memory/SingleThreadInMemSubscriberTest.java
+++ b/server/src/test/java/io/spine/server/transport/memory/SingleThreadInMemSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/transport/memory/SingleThreadInMemTransportFactoryTest.java
+++ b/server/src/test/java/io/spine/server/transport/memory/SingleThreadInMemTransportFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/transport/memory/given/ThrowingObserver.java
+++ b/server/src/test/java/io/spine/server/transport/memory/given/ThrowingObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/transport/memory/given/package-info.java
+++ b/server/src/test/java/io/spine/server/transport/memory/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tuple/EitherOf2Test.java
+++ b/server/src/test/java/io/spine/server/tuple/EitherOf2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tuple/EitherOf3Test.java
+++ b/server/src/test/java/io/spine/server/tuple/EitherOf3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tuple/EitherOf4Test.java
+++ b/server/src/test/java/io/spine/server/tuple/EitherOf4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tuple/EitherOf5Test.java
+++ b/server/src/test/java/io/spine/server/tuple/EitherOf5Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tuple/ElementTest.java
+++ b/server/src/test/java/io/spine/server/tuple/ElementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tuple/PairTest.java
+++ b/server/src/test/java/io/spine/server/tuple/PairTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tuple/QuartetTest.java
+++ b/server/src/test/java/io/spine/server/tuple/QuartetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tuple/QuintetTest.java
+++ b/server/src/test/java/io/spine/server/tuple/QuintetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tuple/TripletTest.java
+++ b/server/src/test/java/io/spine/server/tuple/TripletTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tuple/TupleTest.java
+++ b/server/src/test/java/io/spine/server/tuple/TupleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tuple/given/QuintetTestEnv.java
+++ b/server/src/test/java/io/spine/server/tuple/given/QuintetTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/tuple/given/package-info.java
+++ b/server/src/test/java/io/spine/server/tuple/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/type/CommandEnvelopeTest.java
+++ b/server/src/test/java/io/spine/server/type/CommandEnvelopeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/type/EmptyClassTest.java
+++ b/server/src/test/java/io/spine/server/type/EmptyClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/type/EventClassTest.java
+++ b/server/src/test/java/io/spine/server/type/EventClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/type/EventEnvelopeTest.java
+++ b/server/src/test/java/io/spine/server/type/EventEnvelopeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/type/EventMessageTest.java
+++ b/server/src/test/java/io/spine/server/type/EventMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/type/MessageEnvelopeTest.java
+++ b/server/src/test/java/io/spine/server/type/MessageEnvelopeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/type/given/EventEnvelopeTestEnv.java
+++ b/server/src/test/java/io/spine/server/type/given/EventEnvelopeTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/type/given/EventsTestEnv.java
+++ b/server/src/test/java/io/spine/server/type/given/EventsTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/type/given/GivenEvent.java
+++ b/server/src/test/java/io/spine/server/type/given/GivenEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/server/type/given/package-info.java
+++ b/server/src/test/java/io/spine/server/type/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/CommandLogTest.java
+++ b/server/src/test/java/io/spine/system/server/CommandLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/ConstraintViolatedTest.java
+++ b/server/src/test/java/io/spine/system/server/ConstraintViolatedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/DefaultSystemReadSideTest.java
+++ b/server/src/test/java/io/spine/system/server/DefaultSystemReadSideTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/DefaultSystemWriteSideTest.java
+++ b/server/src/test/java/io/spine/system/server/DefaultSystemWriteSideTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/DiagnosticMonitor.java
+++ b/server/src/test/java/io/spine/system/server/DiagnosticMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/EntityEventsTest.java
+++ b/server/src/test/java/io/spine/system/server/EntityEventsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/MemoizedSystemMessage.java
+++ b/server/src/test/java/io/spine/system/server/MemoizedSystemMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/MemoizingReadSide.java
+++ b/server/src/test/java/io/spine/system/server/MemoizingReadSide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/MemoizingWriteSide.java
+++ b/server/src/test/java/io/spine/system/server/MemoizingWriteSide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/MirrorProjectionTest.java
+++ b/server/src/test/java/io/spine/system/server/MirrorProjectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/MirrorRepositoryTest.java
+++ b/server/src/test/java/io/spine/system/server/MirrorRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/ModelInfo.java
+++ b/server/src/test/java/io/spine/system/server/ModelInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/ScheduledCommandTest.java
+++ b/server/src/test/java/io/spine/system/server/ScheduledCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/SystemBoundedContexts.java
+++ b/server/src/test/java/io/spine/system/server/SystemBoundedContexts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/SystemContextSettingsTest.java
+++ b/server/src/test/java/io/spine/system/server/SystemContextSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/SystemSettingsTest.java
+++ b/server/src/test/java/io/spine/system/server/SystemSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/TenantAwareSystemReadSideTest.java
+++ b/server/src/test/java/io/spine/system/server/TenantAwareSystemReadSideTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/TenantAwareSystemWriteSideTest.java
+++ b/server/src/test/java/io/spine/system/server/TenantAwareSystemWriteSideTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/AbstractEventAccumulator.java
+++ b/server/src/test/java/io/spine/system/server/given/AbstractEventAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/SystemConfig.java
+++ b/server/src/test/java/io/spine/system/server/given/SystemConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/SystemContextSettingsTestEnv.java
+++ b/server/src/test/java/io/spine/system/server/given/SystemContextSettingsTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/client/MealOrderProjection.java
+++ b/server/src/test/java/io/spine/system/server/given/client/MealOrderProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/client/MealOrderRepository.java
+++ b/server/src/test/java/io/spine/system/server/given/client/MealOrderRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/client/ShoppingListAggregate.java
+++ b/server/src/test/java/io/spine/system/server/given/client/ShoppingListAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/client/SystemClientTestEnv.java
+++ b/server/src/test/java/io/spine/system/server/given/client/SystemClientTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/client/package-info.java
+++ b/server/src/test/java/io/spine/system/server/given/client/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/command/CommandLifecycleWatcher.java
+++ b/server/src/test/java/io/spine/system/server/given/command/CommandLifecycleWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/command/CompanyAggregate.java
+++ b/server/src/test/java/io/spine/system/server/given/command/CompanyAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/command/CompanyNameProcman.java
+++ b/server/src/test/java/io/spine/system/server/given/command/CompanyNameProcman.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/command/CompanyNameProcmanRepo.java
+++ b/server/src/test/java/io/spine/system/server/given/command/CompanyNameProcmanRepo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/command/package-info.java
+++ b/server/src/test/java/io/spine/system/server/given/command/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/diagnostics/ValidatedAggregate.java
+++ b/server/src/test/java/io/spine/system/server/given/diagnostics/ValidatedAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/diagnostics/VerificationProcman.java
+++ b/server/src/test/java/io/spine/system/server/given/diagnostics/VerificationProcman.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/diagnostics/ViolationsWatch.java
+++ b/server/src/test/java/io/spine/system/server/given/diagnostics/ViolationsWatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/diagnostics/package-info.java
+++ b/server/src/test/java/io/spine/system/server/given/diagnostics/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/entity/HistoryEventWatcher.java
+++ b/server/src/test/java/io/spine/system/server/given/entity/HistoryEventWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/entity/PersonAggregate.java
+++ b/server/src/test/java/io/spine/system/server/given/entity/PersonAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/entity/PersonNamePart.java
+++ b/server/src/test/java/io/spine/system/server/given/entity/PersonNamePart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/entity/PersonProcman.java
+++ b/server/src/test/java/io/spine/system/server/given/entity/PersonProcman.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/entity/PersonProcmanRepository.java
+++ b/server/src/test/java/io/spine/system/server/given/entity/PersonProcmanRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/entity/PersonProjection.java
+++ b/server/src/test/java/io/spine/system/server/given/entity/PersonProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/entity/PersonRoot.java
+++ b/server/src/test/java/io/spine/system/server/given/entity/PersonRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/entity/package-info.java
+++ b/server/src/test/java/io/spine/system/server/given/entity/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/mirror/MirrorProjectionTestEnv.java
+++ b/server/src/test/java/io/spine/system/server/given/mirror/MirrorProjectionTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/mirror/MirrorRepositoryTestEnv.java
+++ b/server/src/test/java/io/spine/system/server/given/mirror/MirrorRepositoryTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/mirror/package-info.java
+++ b/server/src/test/java/io/spine/system/server/given/mirror/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/package-info.java
+++ b/server/src/test/java/io/spine/system/server/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/schedule/TestCommandScheduler.java
+++ b/server/src/test/java/io/spine/system/server/given/schedule/TestCommandScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/system/server/given/schedule/package-info.java
+++ b/server/src/test/java/io/spine/system/server/given/schedule/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/test/client/ActiveUsersProjection.java
+++ b/server/src/test/java/io/spine/test/client/ActiveUsersProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/test/client/ClientTestContext.java
+++ b/server/src/test/java/io/spine/test/client/ClientTestContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/test/client/LoginProcess.java
+++ b/server/src/test/java/io/spine/test/client/LoginProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/test/client/package-info.java
+++ b/server/src/test/java/io/spine/test/client/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/test/route/LoginEvent.java
+++ b/server/src/test/java/io/spine/test/route/LoginEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/test/route/UserAccountEvent.java
+++ b/server/src/test/java/io/spine/test/route/UserAccountEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/test/route/UserEvent.java
+++ b/server/src/test/java/io/spine/test/route/UserEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/test/route/package-info.java
+++ b/server/src/test/java/io/spine/test/route/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/testdata/Sample.java
+++ b/server/src/test/java/io/spine/testdata/Sample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/testdata/TestEntityStorageRecordFactory.java
+++ b/server/src/test/java/io/spine/testdata/TestEntityStorageRecordFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/io/spine/testdata/package-info.java
+++ b/server/src/test/java/io/spine/testdata/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/tres/quattro/Counter.java
+++ b/server/src/test/java/tres/quattro/Counter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/tres/quattro/package-info.java
+++ b/server/src/test/java/tres/quattro/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/uno/dos/Encounter.java
+++ b/server/src/test/java/uno/dos/Encounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/java/uno/dos/package-info.java
+++ b/server/src/test/java/uno/dos/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/cli/commands.proto
+++ b/server/src/test/proto/spine/test/aggregate/cli/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/cli/events.proto
+++ b/server/src/test/proto/spine/test/aggregate/cli/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/commands.proto
+++ b/server/src/test/proto/spine/test/aggregate/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/events.proto
+++ b/server/src/test/proto/spine/test/aggregate/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/fibonacci/commands.proto
+++ b/server/src/test/proto/spine/test/aggregate/fibonacci/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/fibonacci/events.proto
+++ b/server/src/test/proto/spine/test/aggregate/fibonacci/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/fibonacci/fibonacci.proto
+++ b/server/src/test/proto/spine/test/aggregate/fibonacci/fibonacci.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/importado/commands.proto
+++ b/server/src/test/proto/spine/test/aggregate/importado/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/importado/events.proto
+++ b/server/src/test/proto/spine/test/aggregate/importado/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/importado/movement.proto
+++ b/server/src/test/proto/spine/test/aggregate/importado/movement.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/klasse/commands.proto
+++ b/server/src/test/proto/spine/test/aggregate/klasse/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/klasse/events.proto
+++ b/server/src/test/proto/spine/test/aggregate/klasse/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/klasse/motor.proto
+++ b/server/src/test/proto/spine/test/aggregate/klasse/motor.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/klasse/rejections.proto
+++ b/server/src/test/proto/spine/test/aggregate/klasse/rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/log.proto
+++ b/server/src/test/proto/spine/test/aggregate/log.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/number/commands.proto
+++ b/server/src/test/proto/spine/test/aggregate/number/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/number/events.proto
+++ b/server/src/test/proto/spine/test/aggregate/number/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/project.proto
+++ b/server/src/test/proto/spine/test/aggregate/project.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/rejections.proto
+++ b/server/src/test/proto/spine/test/aggregate/rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/task.proto
+++ b/server/src/test/proto/spine/test/aggregate/task.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/aggregate/thermometer/events.proto
+++ b/server/src/test/proto/spine/test/aggregate/thermometer/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/bc/commands.proto
+++ b/server/src/test/proto/spine/test/bc/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/bc/events.proto
+++ b/server/src/test/proto/spine/test/bc/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/bc/project.proto
+++ b/server/src/test/proto/spine/test/bc/project.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/bus/stock/commands.proto
+++ b/server/src/test/proto/spine/test/bus/stock/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/bus/stock/events.proto
+++ b/server/src/test/proto/spine/test/bus/stock/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/bus/stock/index.proto
+++ b/server/src/test/proto/spine/test/bus/stock/index.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/bus/stock/rejections.proto
+++ b/server/src/test/proto/spine/test/bus/stock/rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/bus/stock/share.proto
+++ b/server/src/test/proto/spine/test/bus/stock/share.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/client/billing/events.proto
+++ b/server/src/test/proto/spine/test/client/billing/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/client/tasks/commands.proto
+++ b/server/src/test/proto/spine/test/client/tasks/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/client/tasks/events.proto
+++ b/server/src/test/proto/spine/test/client/tasks/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/client/tasks/task.proto
+++ b/server/src/test/proto/spine/test/client/tasks/task.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/client/users/active_users.proto
+++ b/server/src/test/proto/spine/test/client/users/active_users.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/client/users/commands.proto
+++ b/server/src/test/proto/spine/test/client/users/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/client/users/events.proto
+++ b/server/src/test/proto/spine/test/client/users/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/client/users/login.proto
+++ b/server/src/test/proto/spine/test/client/users/login.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/client/users/rejections.proto
+++ b/server/src/test/proto/spine/test/client/users/rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/client/users/user_account.proto
+++ b/server/src/test/proto/spine/test/client/users/user_account.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/command/commands.proto
+++ b/server/src/test/proto/spine/test/command/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/command/events.proto
+++ b/server/src/test/proto/spine/test/command/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/command/project.proto
+++ b/server/src/test/proto/spine/test/command/project.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/commandbus/caffetteria.proto
+++ b/server/src/test/proto/spine/test/commandbus/caffetteria.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/commandbus/caffetteria_commands.proto
+++ b/server/src/test/proto/spine/test/commandbus/caffetteria_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/commandbus/caffetteria_events.proto
+++ b/server/src/test/proto/spine/test/commandbus/caffetteria_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/commandbus/caffetteria_rejections.proto
+++ b/server/src/test/proto/spine/test/commandbus/caffetteria_rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/commandbus/commands.proto
+++ b/server/src/test/proto/spine/test/commandbus/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/commandbus/events.proto
+++ b/server/src/test/proto/spine/test/commandbus/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/commandbus/project.proto
+++ b/server/src/test/proto/spine/test/commandbus/project.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/commandservice/commands.proto
+++ b/server/src/test/proto/spine/test/commandservice/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/commandservice/customer/commands.proto
+++ b/server/src/test/proto/spine/test/commandservice/customer/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/commandservice/customer/customer.proto
+++ b/server/src/test/proto/spine/test/commandservice/customer/customer.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/commandservice/customer/events.proto
+++ b/server/src/test/proto/spine/test/commandservice/customer/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/commandservice/events.proto
+++ b/server/src/test/proto/spine/test/commandservice/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/commandservice/project.proto
+++ b/server/src/test/proto/spine/test/commandservice/project.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/commandservice/unknown_commands.proto
+++ b/server/src/test/proto/spine/test/commandservice/unknown_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/core/given/enrichments_test_events.proto
+++ b/server/src/test/proto/spine/test/core/given/enrichments_test_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/delivery/calc.proto
+++ b/server/src/test/proto/spine/test/delivery/calc.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/delivery/consecutive_number.proto
+++ b/server/src/test/proto/spine/test/delivery/consecutive_number.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/delivery/counter.proto
+++ b/server/src/test/proto/spine/test/delivery/counter.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/delivery/delivery_commands.proto
+++ b/server/src/test/proto/spine/test/delivery/delivery_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/delivery/delivery_events.proto
+++ b/server/src/test/proto/spine/test/delivery/delivery_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/delivery/receptionist.proto
+++ b/server/src/test/proto/spine/test/delivery/receptionist.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/delivery/receptionist_commands.proto
+++ b/server/src/test/proto/spine/test/delivery/receptionist_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/delivery/receptionist_events.proto
+++ b/server/src/test/proto/spine/test/delivery/receptionist_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/delivery/task.proto
+++ b/server/src/test/proto/spine/test/delivery/task.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/diagnostics/commands.proto
+++ b/server/src/test/proto/spine/test/diagnostics/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/diagnostics/events.proto
+++ b/server/src/test/proto/spine/test/diagnostics/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/diagnostics/validated.proto
+++ b/server/src/test/proto/spine/test/diagnostics/validated.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/diagnostics/verification.proto
+++ b/server/src/test/proto/spine/test/diagnostics/verification.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/diagnostics/violations.proto
+++ b/server/src/test/proto/spine/test/diagnostics/violations.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/dispatch/dispatch_commands.proto
+++ b/server/src/test/proto/spine/test/dispatch/dispatch_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/dispatch/dispatch_entities.proto
+++ b/server/src/test/proto/spine/test/dispatch/dispatch_entities.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/dispatch/dispatch_events.proto
+++ b/server/src/test/proto/spine/test/dispatch/dispatch_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/dispatch/dispatch_rejections.proto
+++ b/server/src/test/proto/spine/test/dispatch/dispatch_rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/enrichment/enrichment_builder_test_events.proto
+++ b/server/src/test/proto/spine/test/enrichment/enrichment_builder_test_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/enrichment/enrichment_test_commands.proto
+++ b/server/src/test/proto/spine/test/enrichment/enrichment_test_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/enrichment/enrichment_test_entities.proto
+++ b/server/src/test/proto/spine/test/enrichment/enrichment_test_entities.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/enrichment/enrichment_test_events.proto
+++ b/server/src/test/proto/spine/test/enrichment/enrichment_test_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/enrichment/enrichment_test_identifiers.proto
+++ b/server/src/test/proto/spine/test/enrichment/enrichment_test_identifiers.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/enrichment/schema_fn_tests_events.proto
+++ b/server/src/test/proto/spine/test/enrichment/schema_fn_tests_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/entity/commands.proto
+++ b/server/src/test/proto/spine/test/entity/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/entity/events.proto
+++ b/server/src/test/proto/spine/test/entity/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/entity/groups/group.proto
+++ b/server/src/test/proto/spine/test/entity/groups/group.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/entity/groups/hidden_participant.proto
+++ b/server/src/test/proto/spine/test/entity/groups/hidden_participant.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/entity/natural_number.proto
+++ b/server/src/test/proto/spine/test/entity/natural_number.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/entity/organizations/events.proto
+++ b/server/src/test/proto/spine/test/entity/organizations/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/entity/organizations/organization.proto
+++ b/server/src/test/proto/spine/test/entity/organizations/organization.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/entity/project.proto
+++ b/server/src/test/proto/spine/test/entity/project.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/entity/task_view.proto
+++ b/server/src/test/proto/spine/test/entity/task_view.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/entity/user.proto
+++ b/server/src/test/proto/spine/test/entity/user.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/entity/user_commands.proto
+++ b/server/src/test/proto/spine/test/entity/user_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/entity/user_events.proto
+++ b/server/src/test/proto/spine/test/entity/user_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/entity/visibility_guard_test.proto
+++ b/server/src/test/proto/spine/test/entity/visibility_guard_test.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/entity/visibility_test.proto
+++ b/server/src/test/proto/spine/test/entity/visibility_test.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/event/charity_events.proto
+++ b/server/src/test/proto/spine/test/event/charity_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/event/commands.proto
+++ b/server/src/test/proto/spine/test/event/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/event/control_events.proto
+++ b/server/src/test/proto/spine/test/event/control_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/event/events.proto
+++ b/server/src/test/proto/spine/test/event/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/event/model/conference.proto
+++ b/server/src/test/proto/spine/test/event/model/conference.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/event/model/events.proto
+++ b/server/src/test/proto/spine/test/event/model/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/event/project.proto
+++ b/server/src/test/proto/spine/test/event/project.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/event/rejections.proto
+++ b/server/src/test/proto/spine/test/event/rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/event/restaurant.proto
+++ b/server/src/test/proto/spine/test/event/restaurant.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/event/restaurant_events.proto
+++ b/server/src/test/proto/spine/test/event/restaurant_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/event/team.proto
+++ b/server/src/test/proto/spine/test/event/team.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/integration/broker/commands.proto
+++ b/server/src/test/proto/spine/test/integration/broker/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/integration/broker/entities.proto
+++ b/server/src/test/proto/spine/test/integration/broker/entities.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/integration/broker/events.proto
+++ b/server/src/test/proto/spine/test/integration/broker/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/integration/commands.proto
+++ b/server/src/test/proto/spine/test/integration/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/integration/doc_commands.proto
+++ b/server/src/test/proto/spine/test/integration/doc_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/integration/doc_events.proto
+++ b/server/src/test/proto/spine/test/integration/doc_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/integration/docs.proto
+++ b/server/src/test/proto/spine/test/integration/docs.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/integration/events.proto
+++ b/server/src/test/proto/spine/test/integration/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/integration/identifiers.proto
+++ b/server/src/test/proto/spine/test/integration/identifiers.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/integration/integration_rejections.proto
+++ b/server/src/test/proto/spine/test/integration/integration_rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/integration/project.proto
+++ b/server/src/test/proto/spine/test/integration/project.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/library/card.proto
+++ b/server/src/test/proto/spine/test/library/card.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/library/commands.proto
+++ b/server/src/test/proto/spine/test/library/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/library/events.proto
+++ b/server/src/test/proto/spine/test/library/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/library/rejections.proto
+++ b/server/src/test/proto/spine/test/library/rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/mixin/mixin_commands.proto
+++ b/server/src/test/proto/spine/test/mixin/mixin_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/commands.proto
+++ b/server/src/test/proto/spine/test/model/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/contexts/orders/order.proto
+++ b/server/src/test/proto/spine/test/model/contexts/orders/order.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/contexts/orders/order_commands.proto
+++ b/server/src/test/proto/spine/test/model/contexts/orders/order_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/contexts/orders/order_events.proto
+++ b/server/src/test/proto/spine/test/model/contexts/orders/order_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/contexts/projects/commands.proto
+++ b/server/src/test/proto/spine/test/model/contexts/projects/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/contexts/projects/events.proto
+++ b/server/src/test/proto/spine/test/model/contexts/projects/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/contexts/projects/project.proto
+++ b/server/src/test/proto/spine/test/model/contexts/projects/project.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/contexts/projects/rejections.proto
+++ b/server/src/test/proto/spine/test/model/contexts/projects/rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/contexts/tasks/task.proto
+++ b/server/src/test/proto/spine/test/model/contexts/tasks/task.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/contexts/tasks/task_commands.proto
+++ b/server/src/test/proto/spine/test/model/contexts/tasks/task_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/contexts/tasks/task_events.proto
+++ b/server/src/test/proto/spine/test/model/contexts/tasks/task_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/contexts/tasks/task_rejections.proto
+++ b/server/src/test/proto/spine/test/model/contexts/tasks/task_rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/events.proto
+++ b/server/src/test/proto/spine/test/model/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/external/events.proto
+++ b/server/src/test/proto/spine/test/model/external/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/filter/argument_filter_test_events.proto
+++ b/server/src/test/proto/spine/test/model/filter/argument_filter_test_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/handler/commands.proto
+++ b/server/src/test/proto/spine/test/model/handler/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/handler/events.proto
+++ b/server/src/test/proto/spine/test/model/handler/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/handler/moving_bot.proto
+++ b/server/src/test/proto/spine/test/model/handler/moving_bot.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/model/rejections.proto
+++ b/server/src/test/proto/spine/test/model/rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/procman/cmd_routing_test.proto
+++ b/server/src/test/proto/spine/test/procman/cmd_routing_test.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/procman/commands.proto
+++ b/server/src/test/proto/spine/test/procman/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/procman/events.proto
+++ b/server/src/test/proto/spine/test/procman/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/procman/project.proto
+++ b/server/src/test/proto/spine/test/procman/project.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/procman/quiz/commands.proto
+++ b/server/src/test/proto/spine/test/procman/quiz/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/procman/quiz/events.proto
+++ b/server/src/test/proto/spine/test/procman/quiz/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/procman/quiz/quiz.proto
+++ b/server/src/test/proto/spine/test/procman/quiz/quiz.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/procman/rejections.proto
+++ b/server/src/test/proto/spine/test/procman/rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/procman/unknown_commands.proto
+++ b/server/src/test/proto/spine/test/procman/unknown_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/projection/commands.proto
+++ b/server/src/test/proto/spine/test/projection/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/projection/events.proto
+++ b/server/src/test/proto/spine/test/projection/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/projection/project.proto
+++ b/server/src/test/proto/spine/test/projection/project.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/projection/projection_test_env.proto
+++ b/server/src/test/proto/spine/test/projection/projection_test_env.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/reflect/commands.proto
+++ b/server/src/test/proto/spine/test/reflect/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/reflect/events.proto
+++ b/server/src/test/proto/spine/test/reflect/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/reflect/field_test.proto
+++ b/server/src/test/proto/spine/test/reflect/field_test.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/reflect/project.proto
+++ b/server/src/test/proto/spine/test/reflect/project.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/reflect/reflect_rejections.proto
+++ b/server/src/test/proto/spine/test/reflect/reflect_rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/rejection/test_rejections.proto
+++ b/server/src/test/proto/spine/test/rejection/test_rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/route/commands.proto
+++ b/server/src/test/proto/spine/test/route/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/route/events.proto
+++ b/server/src/test/proto/spine/test/route/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/route/state/commands.proto
+++ b/server/src/test/proto/spine/test/route/state/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/route/state/events.proto
+++ b/server/src/test/proto/spine/test/route/state/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/route/state/surrealism.proto
+++ b/server/src/test/proto/spine/test/route/state/surrealism.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/route/user/events.proto
+++ b/server/src/test/proto/spine/test/route/user/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/route/user/user.proto
+++ b/server/src/test/proto/spine/test/route/user/user.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/server/route/commands.proto
+++ b/server/src/test/proto/spine/test/server/route/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/server/route/events.proto
+++ b/server/src/test/proto/spine/test/server/route/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/server/route/rejections.proto
+++ b/server/src/test/proto/spine/test/server/route/rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/server/route/switchman.proto
+++ b/server/src/test/proto/spine/test/server/route/switchman.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/shared_types.proto
+++ b/server/src/test/proto/spine/test/shared_types.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/stand/cafeteria.proto
+++ b/server/src/test/proto/spine/test/stand/cafeteria.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/stand/cafeteria_events.proto
+++ b/server/src/test/proto/spine/test/stand/cafeteria_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/storage/commands.proto
+++ b/server/src/test/proto/spine/test/storage/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/storage/events.proto
+++ b/server/src/test/proto/spine/test/storage/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/storage/imports/events.proto
+++ b/server/src/test/proto/spine/test/storage/imports/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/storage/project.proto
+++ b/server/src/test/proto/spine/test/storage/project.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/subscriptionservice/report.proto
+++ b/server/src/test/proto/spine/test/subscriptionservice/report.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/subscriptionservice/report_commands.proto
+++ b/server/src/test/proto/spine/test/subscriptionservice/report_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/subscriptionservice/report_events.proto
+++ b/server/src/test/proto/spine/test/subscriptionservice/report_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/system/server/bus_test_events.proto
+++ b/server/src/test/proto/spine/test/system/server/bus_test_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/system/server/command_lifecycle_test.proto
+++ b/server/src/test/proto/spine/test/system/server/command_lifecycle_test.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/system/server/command_lifecycle_test_commands.proto
+++ b/server/src/test/proto/spine/test/system/server/command_lifecycle_test_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/system/server/command_lifecycle_test_events.proto
+++ b/server/src/test/proto/spine/test/system/server/command_lifecycle_test_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/system/server/command_lifecycle_test_rejections.proto
+++ b/server/src/test/proto/spine/test/system/server/command_lifecycle_test_rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/system/server/entity_history_test.proto
+++ b/server/src/test/proto/spine/test/system/server/entity_history_test.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/system/server/entity_history_test_commands.proto
+++ b/server/src/test/proto/spine/test/system/server/entity_history_test_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/system/server/entity_history_test_events.proto
+++ b/server/src/test/proto/spine/test/system/server/entity_history_test_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/system/server/meal_events.proto
+++ b/server/src/test/proto/spine/test/system/server/meal_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/system/server/meal_order.proto
+++ b/server/src/test/proto/spine/test/system/server/meal_order.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/system/server/mirror_test.proto
+++ b/server/src/test/proto/spine/test/system/server/mirror_test.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/system/server/mirror_test_commands.proto
+++ b/server/src/test/proto/spine/test/system/server/mirror_test_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/system/server/mirror_test_events.proto
+++ b/server/src/test/proto/spine/test/system/server/mirror_test_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/system/server/shoppling_list.proto
+++ b/server/src/test/proto/spine/test/system/server/shoppling_list.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/system/server/system_client_test_commands.proto
+++ b/server/src/test/proto/spine/test/system/server/system_client_test_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/system/server/system_client_test_events.proto
+++ b/server/src/test/proto/spine/test/system/server/system_client_test_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/system/server/system_features.proto
+++ b/server/src/test/proto/spine/test/system/server/system_features.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/trace/airport.proto
+++ b/server/src/test/proto/spine/test/trace/airport.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/trace/airport_commands.proto
+++ b/server/src/test/proto/spine/test/trace/airport_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/trace/airport_events.proto
+++ b/server/src/test/proto/spine/test/trace/airport_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/trace/boarding.proto
+++ b/server/src/test/proto/spine/test/trace/boarding.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/trace/timetable.proto
+++ b/server/src/test/proto/spine/test/trace/timetable.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/tuple/quartet.proto
+++ b/server/src/test/proto/spine/test/tuple/quartet.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/tuple/quintet.proto
+++ b/server/src/test/proto/spine/test/tuple/quintet.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/tx/tx_commands.proto
+++ b/server/src/test/proto/spine/test/tx/tx_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/tx/tx_entities.proto
+++ b/server/src/test/proto/spine/test/tx/tx_entities.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/test/proto/spine/test/tx/tx_events.proto
+++ b/server/src/test/proto/spine/test/tx/tx_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-client/src/main/java/io/spine/testing/client/TestActorRequestFactory.java
+++ b/testutil-client/src/main/java/io/spine/testing/client/TestActorRequestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-client/src/main/java/io/spine/testing/client/grpc/TestClient.java
+++ b/testutil-client/src/main/java/io/spine/testing/client/grpc/TestClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-client/src/main/java/io/spine/testing/client/grpc/package-info.java
+++ b/testutil-client/src/main/java/io/spine/testing/client/grpc/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-client/src/main/java/io/spine/testing/client/package-info.java
+++ b/testutil-client/src/main/java/io/spine/testing/client/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-client/src/main/proto/spine/testing/client/commands.proto
+++ b/testutil-client/src/main/proto/spine/testing/client/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-client/src/test/proto/spine/testing/client/blackbox/commands.proto
+++ b/testutil-client/src/test/proto/spine/testing/client/blackbox/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-client/src/test/proto/spine/testing/client/blackbox/events.proto
+++ b/testutil-client/src/test/proto/spine/testing/client/blackbox/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-client/src/test/proto/spine/testing/client/blackbox/project.proto
+++ b/testutil-client/src/test/proto/spine/testing/client/blackbox/project.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-client/src/test/proto/spine/testing/client/blackbox/rejections.proto
+++ b/testutil-client/src/test/proto/spine/testing/client/blackbox/rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-client/src/test/proto/spine/testing/client/blackbox/report.proto
+++ b/testutil-client/src/test/proto/spine/testing/client/blackbox/report.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-client/src/test/proto/spine/testing/client/ping/commands.proto
+++ b/testutil-client/src/test/proto/spine/testing/client/ping/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-client/src/test/proto/spine/testing/client/ping/events.proto
+++ b/testutil-client/src/test/proto/spine/testing/client/ping/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-client/src/test/proto/spine/testing/client/ping/table.proto
+++ b/testutil-client/src/test/proto/spine/testing/client/ping/table.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/Actor.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/Actor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxSetup.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/ClientSupplier.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/ClientSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/CommandCollector.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/CommandCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/ContextAwareTest.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/ContextAwareTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/DiagnosticLog.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/DiagnosticLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/DiagnosticLogging.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/DiagnosticLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/EventCollector.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/EventCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/FailedHandlerGuard.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/FailedHandlerGuard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/HandlerFailureTolerance.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/HandlerFailureTolerance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/MessageCollector.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/MessageCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/MessageTypeCounter.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/MessageTypeCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/MultiTenantContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/MultiTenantContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/SingleTenantContext.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/SingleTenantContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/SubscriptionFixture.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/SubscriptionFixture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/UnsupportedCommandGuard.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/UnsupportedCommandGuard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/package-info.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/entity/EntitySubject.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/entity/EntitySubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/entity/EntityVersionSubject.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/entity/EntityVersionSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/entity/IterableEntityVersionSubject.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/entity/IterableEntityVersionSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/entity/package-info.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/entity/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/query/QueryResultSubject.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/query/QueryResultSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/query/ResponseStatusSubject.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/query/ResponseStatusSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/query/package-info.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/query/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/tenant/TenantAwareTest.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/tenant/TenantAwareTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/java/io/spine/testing/server/tenant/package-info.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/tenant/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/main/proto/spine/testing/server/black_box.proto
+++ b/testutil-server/src/main/proto/spine/testing/server/black_box.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/client/grpc/TestClientTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/client/grpc/TestClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/client/grpc/given/GameProcess.java
+++ b/testutil-server/src/test/java/io/spine/testing/client/grpc/given/GameProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/client/grpc/given/GameRepository.java
+++ b/testutil-server/src/test/java/io/spine/testing/client/grpc/given/GameRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/client/grpc/given/package-info.java
+++ b/testutil-server/src/test/java/io/spine/testing/client/grpc/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/CommandSubjectTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/CommandSubjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/EmittedMessageSubjectTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/EmittedMessageSubjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/EventSubjectTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/EventSubjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/BlackBoxContextTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/BlackBoxContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/ContextAwareTestTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/ContextAwareTestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/DiagnosticLogTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/DiagnosticLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/DiagnosticLoggingTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/DiagnosticLoggingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/FailedHandlerGuardTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/FailedHandlerGuardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/MultiTenantContextTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/MultiTenantContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/SingleTenantContextTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/SingleTenantContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/UnsupportedCommandGuardTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/UnsupportedCommandGuardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbCommandDispatcher.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbCommandDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbEventDispatcher.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbEventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbInitProcess.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbInitProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbProjectAggregate.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbProjectAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbProjectFailerProcess.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbProjectFailerProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbProjectRepository.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbProjectRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbProjectViewProjection.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbProjectViewProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbReportAggregate.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbReportAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbReportRepository.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbReportRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbTaskViewProjection.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbTaskViewProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/EmittedEventsTestEnv.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/EmittedEventsTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/Given.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/Given.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/GivenCommandError.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/GivenCommandError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/RepositoryThrowingExceptionOnClose.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/RepositoryThrowingExceptionOnClose.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/package-info.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/entity/EntitySubjectTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/entity/EntitySubjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/entity/EntityVersionSubjectTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/entity/EntityVersionSubjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/entity/HasVersionColumnTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/entity/HasVersionColumnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/entity/IterableEntityVersionSubjectTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/entity/IterableEntityVersionSubjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/entity/given/GivenEntityVersion.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/entity/given/GivenEntityVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/entity/given/GivenTestEnv.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/entity/given/GivenTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/entity/given/TestEntity.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/entity/given/TestEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/entity/given/package-info.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/entity/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/given/GivenSubscriptionUpdate.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/given/GivenSubscriptionUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/given/package-info.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/model/ModelTestsTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/model/ModelTestsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/model/given/ModelTestsTestEnv.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/model/given/ModelTestsTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/model/given/package-info.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/model/given/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/query/GivenResponseStatus.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/query/GivenResponseStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/query/QueryResultSubjectTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/query/QueryResultSubjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/query/QueryResultSubjectTestEnv.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/query/QueryResultSubjectTestEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/java/io/spine/testing/server/query/ResponseStatusSubjectTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/query/ResponseStatusSubjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/proto/spine/testing/server/blackbox/commands.proto
+++ b/testutil-server/src/test/proto/spine/testing/server/blackbox/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/proto/spine/testing/server/blackbox/entities.proto
+++ b/testutil-server/src/test/proto/spine/testing/server/blackbox/entities.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/proto/spine/testing/server/blackbox/events.proto
+++ b/testutil-server/src/test/proto/spine/testing/server/blackbox/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/proto/spine/testing/server/blackbox/rejections.proto
+++ b/testutil-server/src/test/proto/spine/testing/server/blackbox/rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/proto/spine/testing/server/blackbox/report.proto
+++ b/testutil-server/src/test/proto/spine/testing/server/blackbox/report.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/proto/spine/testing/server/commands.proto
+++ b/testutil-server/src/test/proto/spine/testing/server/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/proto/spine/testing/server/entities.proto
+++ b/testutil-server/src/test/proto/spine/testing/server/entities.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/proto/spine/testing/server/events.proto
+++ b/testutil-server/src/test/proto/spine/testing/server/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/proto/spine/testing/server/log/commands.proto
+++ b/testutil-server/src/test/proto/spine/testing/server/log/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/proto/spine/testing/server/log/events.proto
+++ b/testutil-server/src/test/proto/spine/testing/server/log/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/proto/spine/testing/server/log/external_events.proto
+++ b/testutil-server/src/test/proto/spine/testing/server/log/external_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/proto/spine/testing/server/rejections.proto
+++ b/testutil-server/src/test/proto/spine/testing/server/rejections.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testutil-server/src/test/proto/spine/testing/server/user.proto
+++ b/testutil-server/src/test/proto/spine/testing/server/user.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,13 +34,13 @@
 /**
  * Version of this library.
  */
-val coreJava = "1.9.0-SNAPSHOT.13"
+val coreJava = "1.9.0"
 
 /**
  * Versions of the Spine libraries that `core-java` depends on.
  */
-val base = "1.9.0-SNAPSHOT.6"
-val time = "1.9.0-SNAPSHOT.6"
+val base = "1.9.0"
+val time = "1.9.0"
 
 project.extra.apply {
     this["versionToPublish"] = coreJava


### PR DESCRIPTION
This changeset releases `core-java` libraries in version 1.9.0.

Also, copyright headers were updated to be dated in 2023.