### PR TITLE
Allow fine-tuning of gRPC server underneath of `GrpcContainer`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.141`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.142`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -814,12 +814,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 27 14:21:23 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed May 31 16:51:40 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.141`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.142`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1593,12 +1593,12 @@ This report was generated on **Fri Jan 27 14:21:23 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 27 14:21:23 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed May 31 16:51:41 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.141`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.142`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2420,12 +2420,12 @@ This report was generated on **Fri Jan 27 14:21:23 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 27 14:21:24 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed May 31 16:51:42 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.141`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.142`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3364,12 +3364,12 @@ This report was generated on **Fri Jan 27 14:21:24 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 27 14:21:24 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed May 31 16:51:42 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.141`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.142`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4308,12 +4308,12 @@ This report was generated on **Fri Jan 27 14:21:24 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 27 14:21:24 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed May 31 16:51:43 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.141`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.142`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5300,4 +5300,4 @@ This report was generated on **Fri Jan 27 14:21:24 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jan 27 14:21:25 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed May 31 16:51:44 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.141</version>
+<version>2.0.0-SNAPSHOT.142</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/test/java/io/spine/server/GrpcContainerTest.java
+++ b/server/src/test/java/io/spine/server/GrpcContainerTest.java
@@ -38,6 +38,7 @@ import java.util.Set;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
+import static io.spine.server.given.service.GivenCommandService.noOpCommandService;
 import static io.spine.testing.TestValues.randomString;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -69,7 +70,7 @@ class GrpcContainerTest {
 
         var count = 3;
         for (var i = 0; i < count; i++) {
-            var service = CommandService.newBuilder().build();
+            var service = noOpCommandService();
             builder.addService(service);
         }
 
@@ -107,9 +108,7 @@ class GrpcContainerTest {
     @DisplayName("configure underlying gRPC server")
     void configureUnderlyingGrpcServer() {
         var port = 1654;
-        var service = CommandService
-                .newBuilder()
-                .build();
+        var service = noOpCommandService();
         var container = GrpcContainer
                 .atPort(port)
                 .withServer((server) -> server.addService(service))

--- a/server/src/test/java/io/spine/server/given/service/GivenCommandService.java
+++ b/server/src/test/java/io/spine/server/given/service/GivenCommandService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.given.service;
+
+import io.spine.server.CommandService;
+
+/**
+ * Factory of {@code CommandService} instances to use in tests.
+ */
+public final class GivenCommandService {
+
+    /**
+     * Prevents direct instantiation.
+     */
+    private GivenCommandService() {
+    }
+
+    /**
+     * Returns a new instance of {@code CommandService} which does not serve
+     * any command type.
+     */
+    public static CommandService noOpCommandService() {
+        return CommandService.newBuilder()
+                .build();
+    }
+}

--- a/server/src/test/java/io/spine/server/given/service/package-info.java
+++ b/server/src/test/java/io/spine/server/given/service/package-info.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Provides test-grade types and interfaces of gRPC services.
+ */
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.server.given.service;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/test/kotlin/io/spine/server/CommandServiceUnpublishedLanguageSpec.kt
+++ b/server/src/test/kotlin/io/spine/server/CommandServiceUnpublishedLanguageSpec.kt
@@ -33,6 +33,7 @@ import io.spine.core.Status
 import io.spine.grpc.MemoizingObserver
 import io.spine.grpc.StreamObservers.memoizingObserver
 import io.spine.protobuf.isNotDefault
+import io.spine.server.given.service.GivenCommandService.noOpCommandService
 import io.spine.test.unpublished.command.Halt
 import io.spine.testing.client.TestActorRequestFactory
 import io.spine.testing.logging.mute.MuteLogging
@@ -50,7 +51,7 @@ internal class CommandServiceUnpublishedLanguageSpec {
 
     @BeforeEach
     fun initServiceAndObserver() {
-        service = CommandService.newBuilder().build()
+        service = noOpCommandService()
         observer = memoizingObserver()
     }
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.internal.dependency.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.141")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.142")


### PR DESCRIPTION
This changeset is a port of #1454 to `master`.

### Disclaimer

Also, this is just a first of such "porting" PRs. To keep things going, we are going to use the _current_ state of `core-java:master`, rather than wait until the whole machinery (ProtoData et al) unwinds in its full blossom. Therefore, `config`, dependencies and stuff will NOT be updated in scope of "porting".

### What's Changed

Prior to this changeset, there was no convenient way to set some "native" properties of the gRPC server, which is running underneath Spine's `GrpcContainer`. 

In particular, it is often needed [to set](https://grpc.github.io/grpc-java/javadoc/io/grpc/ServerBuilder.html#maxInboundMessageSize-int-) the maximum size for the inbound messages. And it was nearly not possible to achieve, other than using a test-only `GrpcContainer.injectServer()` method. There is also a number of other configuration endpoints provided by the gRPC's `ServerBuilder`, which could not be accessed.

In this PR, the gRPC's `ServerBuilder` API becomes exposed like this:

```java

GrpcContainer.atPort(1654)
             // `server` is an instance of `io.grpc.ServerBuilder`.
             .withServer((server) -> server.maxInboundMessageSize(16_000_000))
             // ...
             .build();
```

So, rather than copying the `ServerBuilder`'s API in `GrpcContainer`, the direct access to the builder is provided. That will allow to be always up-to-date with the configuration capabilities of the gRPC `Server`, rather than copying and chasing their API in the gRPC releases to come.

However, as of this PR, the `GrpcContainer.Builder.withServer(...)` method is marked as `@Experimental`. The reason is that the "native" `ServerBuilder` API allows to perform some destructive actions. Therefore, the decision to expose it as-is is not yet final.