### PR TITLE
Improve creation of `BlackBox` context from `BoundedContextBuilder`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.142`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.143`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -814,12 +814,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 31 16:51:40 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 02 12:27:37 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.142`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.143`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1593,12 +1593,12 @@ This report was generated on **Wed May 31 16:51:40 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 31 16:51:41 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 02 12:27:38 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.142`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.143`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2420,12 +2420,12 @@ This report was generated on **Wed May 31 16:51:41 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 31 16:51:42 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 02 12:27:38 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.142`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.143`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3364,12 +3364,12 @@ This report was generated on **Wed May 31 16:51:42 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 31 16:51:42 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 02 12:27:38 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.142`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.143`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4308,12 +4308,12 @@ This report was generated on **Wed May 31 16:51:42 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 31 16:51:43 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 02 12:27:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.142`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.143`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5300,4 +5300,4 @@ This report was generated on **Wed May 31 16:51:43 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 31 16:51:44 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 02 12:27:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.142</version>
+<version>2.0.0-SNAPSHOT.143</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/BoundedContextBuilder.java
+++ b/server/src/main/java/io/spine/server/BoundedContextBuilder.java
@@ -669,8 +669,7 @@ public final class BoundedContextBuilder implements Logging {
     public BoundedContextBuilder testingCopy() {
         var copy = new BoundedContextBuilder(this.spec, this.systemSettings);
         var enricher = eventEnricher()
-                .orElseGet(() -> EventEnricher.newBuilder()
-                        .build());
+                .orElseGet(() -> EventEnricher.newBuilder().build());
         copy.enrichEventsUsing(enricher);
         tenantIndex().ifPresent(copy::setTenantIndex);
         repositories().forEach(copy::add);

--- a/server/src/main/java/io/spine/server/BoundedContextBuilder.java
+++ b/server/src/main/java/io/spine/server/BoundedContextBuilder.java
@@ -672,7 +672,7 @@ public final class BoundedContextBuilder implements Logging {
                 .orElseGet(() -> EventEnricher.newBuilder()
                         .build());
         copy.enrichEventsUsing(enricher);
-        tenantIndex().map(copy::setTenantIndex);
+        tenantIndex().ifPresent(copy::setTenantIndex);
         repositories().forEach(copy::add);
         commandDispatchers().forEach(copy::addCommandDispatcher);
         commandBus.filters().forEach(copy::addCommandFilter);

--- a/server/src/main/java/io/spine/server/BoundedContextBuilder.java
+++ b/server/src/main/java/io/spine/server/BoundedContextBuilder.java
@@ -667,19 +667,19 @@ public final class BoundedContextBuilder implements Logging {
     @Internal
     @VisibleForTesting
     public BoundedContextBuilder testingCopy() {
-        var name = name().getValue();
-        var enricher = eventEnricher().orElseGet(() ->
-                                                         EventEnricher.newBuilder().build());
-        var copy =
-                isMultitenant()
-                ? BoundedContext.multitenant(name)
-                : BoundedContext.singleTenant(name);
+        var copy = new BoundedContextBuilder(this.spec, this.systemSettings);
+        var enricher = eventEnricher()
+                .orElseGet(() -> EventEnricher.newBuilder()
+                        .build());
         copy.enrichEventsUsing(enricher);
+        tenantIndex().map(copy::setTenantIndex);
         repositories().forEach(copy::add);
         commandDispatchers().forEach(copy::addCommandDispatcher);
         commandBus.filters().forEach(copy::addCommandFilter);
+        commandBus.listeners().forEach(copy::addCommandListener);
         eventDispatchers().forEach(copy::addEventDispatcher);
         eventBus.filters().forEach(copy::addEventFilter);
+        eventBus.listeners().forEach(copy::addEventListener);
         return copy;
     }
 }

--- a/server/src/main/java/io/spine/system/server/DefaultSystemWriteSide.java
+++ b/server/src/main/java/io/spine/system/server/DefaultSystemWriteSide.java
@@ -84,4 +84,9 @@ final class DefaultSystemWriteSide implements SystemWriteSide {
         system.eventBus()
               .post(event, noOpObserver());
     }
+
+    @Override
+    public SystemFeatures features() {
+        return system.config();
+    }
 }

--- a/server/src/main/java/io/spine/system/server/SystemFeatures.java
+++ b/server/src/main/java/io/spine/system/server/SystemFeatures.java
@@ -29,7 +29,7 @@ package io.spine.system.server;
 /**
  * A configuration of a {@link SystemContext}.
  */
-interface SystemFeatures {
+public interface SystemFeatures {
 
     /**
      * Obtains the {@link io.spine.system.server.CommandLog CommandLog} setting.

--- a/server/src/main/java/io/spine/system/server/SystemWriteSide.java
+++ b/server/src/main/java/io/spine/system/server/SystemWriteSide.java
@@ -84,4 +84,9 @@ public interface SystemWriteSide {
         checkNotNull(system);
         return new DefaultSystemWriteSide(system);
     }
+
+    /**
+     * Returns the original set of features enabled for the parent {@code SystemContext}.
+     */
+    SystemFeatures features();
 }

--- a/server/src/main/java/io/spine/system/server/TenantAwareSystemWriteSide.java
+++ b/server/src/main/java/io/spine/system/server/TenantAwareSystemWriteSide.java
@@ -75,4 +75,9 @@ final class TenantAwareSystemWriteSide implements SystemWriteSide {
         var event = runner.evaluate(() -> delegate.postEvent(systemEvent, origin));
         return event;
     }
+
+    @Override
+    public SystemFeatures features() {
+        return delegate.features();
+    }
 }

--- a/server/src/test/java/io/spine/system/server/MemoizingWriteSide.java
+++ b/server/src/test/java/io/spine/system/server/MemoizingWriteSide.java
@@ -31,9 +31,11 @@ import io.spine.core.Event;
 import io.spine.core.Origin;
 import io.spine.core.TenantId;
 import io.spine.server.tenant.TenantFunction;
+import io.spine.util.Exceptions;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.util.Exceptions.newIllegalStateException;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -104,5 +106,12 @@ public final class MemoizingWriteSide implements SystemWriteSide {
     public MemoizedSystemMessage lastSeenEvent() {
         assertNotNull(lastSeenEvent);
         return lastSeenEvent;
+    }
+
+    @Override
+    public SystemFeatures features() {
+        throw newIllegalStateException(
+                "This implementation of `SystemWriteSide` does not provide `features()`."
+        );
     }
 }

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/StubTenantIndex.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/StubTenantIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,35 +24,38 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.system.server;
+package io.spine.testing.server.blackbox.given;
 
-import io.spine.base.EventMessage;
-import io.spine.core.Event;
-import io.spine.core.Origin;
+import com.google.common.collect.ImmutableSet;
+import io.spine.core.TenantId;
+import io.spine.server.tenant.TenantIndex;
 
-import static io.spine.util.Exceptions.newIllegalStateException;
+import java.util.Set;
 
 /**
- * An implementation of {@link SystemWriteSide} which never performs an operation.
- *
- * <p>All the methods inherited from {@link SystemWriteSide} exit without any action or exception.
- *
- * <p>This implementation is used by the system bounded context itself, since there is no system
- * bounded context for a system bounded context.
+ * A no-op implementation of {@code TenantIndex} for tests.
  */
-public enum NoOpSystemWriteSide implements SystemWriteSide {
+public final class StubTenantIndex implements TenantIndex {
 
-    INSTANCE;
-
+    /**
+     * Does nothing.
+     */
     @Override
-    public Event postEvent(EventMessage systemEvent, Origin origin) {
-        return Event.getDefaultInstance();
+    public void keep(TenantId id) {
     }
 
+    /**
+     * Returns an empty set.
+     */
     @Override
-    public SystemFeatures features() {
-        throw newIllegalStateException(
-                "No-op of `SystemWriteSide` does not provide `features()`."
-        );
+    public Set<TenantId> all() {
+        return ImmutableSet.of();
+    }
+
+    /**
+     * Does nothing.
+     */
+    @Override
+    public void close() {
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.internal.dependency.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.142")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.143")


### PR DESCRIPTION
Previously, not all settings of `BoundedContextBuilder` were taken into account, when a new instance of `BlackBox` was created:
```java
var builder = BoundedContextBuilder.assumingTests(..)
                 // more configuration here.
var box = BlackBox.from(builder);
```
In particular, it was not possible to configure the system side of a `BlackBox` instance (see #1485).

This issue was addressed in 1.x branch (see #1495). 

This PR addresses it for `master`. Now, the settings of "System" context are copied, as well as tenant index and bus listeners.