### PR TITLE
Allow to handle `RuntimeException`s when delivering `InboxMessage`s

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.143`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.144`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -814,12 +814,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 02 12:27:37 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 03 15:50:43 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.143`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.144`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1593,12 +1593,12 @@ This report was generated on **Fri Jun 02 12:27:37 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 02 12:27:38 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 03 15:50:43 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.143`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.144`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2420,12 +2420,12 @@ This report was generated on **Fri Jun 02 12:27:38 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 02 12:27:38 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 03 15:50:44 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.143`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.144`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3364,12 +3364,12 @@ This report was generated on **Fri Jun 02 12:27:38 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 02 12:27:38 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 03 15:50:44 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.143`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.144`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4308,12 +4308,12 @@ This report was generated on **Fri Jun 02 12:27:38 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 02 12:27:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 03 15:50:45 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.143`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.144`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5300,4 +5300,4 @@ This report was generated on **Fri Jun 02 12:27:39 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 02 12:27:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 03 15:50:45 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.143</version>
+<version>2.0.0-SNAPSHOT.144</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateEndpoint.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateEndpoint.java
@@ -68,7 +68,7 @@ abstract class AggregateEndpoint<I,
     }
 
     @Override
-    public final void dispatchTo(I aggregateId) {
+    protected final DispatchOutcome performDispatch(I aggregateId) {
         var aggregate = loadOrCreate(aggregateId);
         var flagsBefore = aggregate.lifecycleFlags();
         var outcome = handleAndApplyEvents(aggregate);
@@ -79,6 +79,7 @@ abstract class AggregateEndpoint<I,
             repository().lifecycleOf(aggregateId)
                         .onDispatchingFailed(envelope(), error);
         }
+        return outcome;
     }
 
     private void storeAndPost(A aggregate, DispatchOutcome outcome, LifecycleFlags flagsBefore) {

--- a/server/src/main/java/io/spine/server/aggregate/EventImportDispatcher.java
+++ b/server/src/main/java/io/spine/server/aggregate/EventImportDispatcher.java
@@ -29,6 +29,7 @@ package io.spine.server.aggregate;
 import com.google.common.collect.ImmutableSet;
 import io.spine.annotation.Internal;
 import io.spine.logging.Logging;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.event.EventDispatcher;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
@@ -82,7 +83,7 @@ public final class EventImportDispatcher<I> implements EventDispatcher, Logging 
     }
 
     @Override
-    public void dispatch(EventEnvelope event) {
-        repository.importEvent(event);
+    public DispatchOutcome dispatch(EventEnvelope event) {
+        return repository.importEvent(event);
     }
 }

--- a/server/src/main/java/io/spine/server/aggregate/ImportBus.java
+++ b/server/src/main/java/io/spine/server/aggregate/ImportBus.java
@@ -115,6 +115,8 @@ public final class ImportBus
     }
 
     @Override
+    @SuppressWarnings("ResultOfMethodCallIgnored"
+            /* Dispatching outcome is reported via system events, if needed. */)
     protected void dispatch(EventEnvelope event) {
         EventDispatcher dispatcher = dispatcherOf(event);
         dispatcher.dispatch(event);

--- a/server/src/main/java/io/spine/server/bus/MessageDispatcher.java
+++ b/server/src/main/java/io/spine/server/bus/MessageDispatcher.java
@@ -27,6 +27,7 @@
 package io.spine.server.bus;
 
 import com.google.common.collect.ImmutableSet;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.type.MessageEnvelope;
 import io.spine.type.MessageClass;
 
@@ -48,11 +49,14 @@ public interface MessageDispatcher<C extends MessageClass<?>, E extends MessageE
     ImmutableSet<C> messageClasses();
 
     /**
-     * Dispatches the message contained in the given envelope.
+     * Dispatches the message contained in passed envelope
+     * and returns the outcome.
      *
-     * @param envelope the envelope with the message
+     * @param envelope
+     *         the envelope with the message
+     * @return the outcome of dispatching
      */
-    void dispatch(E envelope);
+    DispatchOutcome dispatch(E envelope);
 
     /**
      * Checks if this dispatcher can dispatch the given message.

--- a/server/src/main/java/io/spine/server/bus/MulticastBus.java
+++ b/server/src/main/java/io/spine/server/bus/MulticastBus.java
@@ -60,9 +60,12 @@ public abstract class MulticastBus<M extends Signal<?, ?, ?>,
     /**
      * Call the dispatchers for the {@code messageEnvelope}.
      *
-     * @param messageEnvelope the message envelope to pass to the dispatchers
+     * @param messageEnvelope
+     *         the message envelope to pass to the dispatchers
      * @return the number of the dispatchers called or {@code 0} if there weren't any
      */
+    @SuppressWarnings("ResultOfMethodCallIgnored"
+            /* Dispatching outcomes are reported via system events, if needed. */)
     protected int callDispatchers(E messageEnvelope) {
         Collection<D> dispatchers = registry().dispatchersOf(messageEnvelope);
         for (var dispatcher : dispatchers) {

--- a/server/src/main/java/io/spine/server/command/AbstractAssignee.java
+++ b/server/src/main/java/io/spine/server/command/AbstractAssignee.java
@@ -31,6 +31,7 @@ import io.spine.core.Version;
 import io.spine.server.BoundedContext;
 import io.spine.server.command.model.AssigneeClass;
 import io.spine.server.commandbus.CommandDispatcher;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.dispatch.DispatchOutcomeHandler;
 import io.spine.server.event.EventBus;
 import io.spine.server.type.CommandClass;
@@ -79,14 +80,16 @@ public abstract class AbstractAssignee
      *         if an exception occurred during command dispatching with this exception as the cause
      */
     @Override
-    public void dispatch(CommandEnvelope envelope) {
+    public DispatchOutcome dispatch(CommandEnvelope envelope) {
         var method = thisClass.receptorOf(envelope);
+        var outcome = method.invoke(this, envelope);
         DispatchOutcomeHandler
-                .from(method.invoke(this, envelope))
+                .from(outcome)
                 .onEvents(this::postEvents)
                 .onError(error -> onError(envelope, error))
                 .onRejection(rejection -> onRejection(envelope, rejection))
                 .handle();
+        return outcome;
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/command/AbstractCommander.java
+++ b/server/src/main/java/io/spine/server/command/AbstractCommander.java
@@ -108,6 +108,7 @@ public abstract class AbstractCommander
     }
 
     @Override
+    @SuppressWarnings("FloggerLogString" /* Re-using the logged message. */)
     public DispatchOutcome dispatchEvent(EventEnvelope event) {
         var method = thisClass.commanderOn(event);
         if (method.isPresent()) {

--- a/server/src/main/java/io/spine/server/command/Command.java
+++ b/server/src/main/java/io/spine/server/command/Command.java
@@ -151,7 +151,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <p>Throwing {@linkplain Throwable other types} of {@code Throwable}s is not allowed in
  * the command-transforming methods.
  *
- *
  * <h1>Command Reaction</h1>
  *
  * <p>A commanding method may serve to emit commands in response to an incoming event. In this case

--- a/server/src/main/java/io/spine/server/commandbus/CommandBus.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandBus.java
@@ -214,6 +214,8 @@ public final class CommandBus
     }
 
     @Override
+    @SuppressWarnings("ResultOfMethodCallIgnored"
+            /* Dispatching outcome is reported via system events, if needed. */)
     protected void dispatch(CommandEnvelope command) {
         var dispatcher = dispatcherOf(command);
         watcher.onDispatchCommand(command);

--- a/server/src/main/java/io/spine/server/commandbus/CommandDispatcherDelegate.java
+++ b/server/src/main/java/io/spine/server/commandbus/CommandDispatcherDelegate.java
@@ -27,6 +27,7 @@ package io.spine.server.commandbus;
 
 import com.google.common.collect.ImmutableSet;
 import io.spine.annotation.Internal;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.type.CommandClass;
 import io.spine.server.type.CommandEnvelope;
 
@@ -68,9 +69,9 @@ public interface CommandDispatcherDelegate {
     ImmutableSet<CommandClass> commandClasses();
 
     /**
-     * Dispatches the command.
+     * Dispatches the command  and returns the outcome of the dispatching.
      */
-    void dispatchCommand(CommandEnvelope envelope);
+    DispatchOutcome dispatchCommand(CommandEnvelope envelope);
 
     /**
      * Tells if this instance dispatches at least one command.

--- a/server/src/main/java/io/spine/server/commandbus/DelegatingCommandDispatcher.java
+++ b/server/src/main/java/io/spine/server/commandbus/DelegatingCommandDispatcher.java
@@ -28,6 +28,7 @@ package io.spine.server.commandbus;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 import io.spine.annotation.Internal;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.type.CommandClass;
 import io.spine.server.type.CommandEnvelope;
 
@@ -65,8 +66,8 @@ public class DelegatingCommandDispatcher implements CommandDispatcher {
     }
 
     @Override
-    public final void dispatch(CommandEnvelope envelope) {
-        delegate.dispatchCommand(envelope);
+    public final DispatchOutcome dispatch(CommandEnvelope envelope) {
+        return delegate.dispatchCommand(envelope);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/delivery/AbstractMessageEndpoint.java
+++ b/server/src/main/java/io/spine/server/delivery/AbstractMessageEndpoint.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.delivery;
+
+import io.spine.annotation.Internal;
+import io.spine.base.Error;
+import io.spine.base.Errors;
+import io.spine.base.Identifier;
+import io.spine.server.dispatch.DispatchOutcome;
+import io.spine.server.type.SignalEnvelope;
+import io.spine.string.Stringifiers;
+
+import static java.lang.String.format;
+
+/**
+ * An abstract base for messages endpoints.
+ *
+ * <p>Upon a run-time dispatching, catches all {@code Exception}s throw,
+ * and transforms them into a {@link DispatchOutcome}.
+ *
+ * @param <I>
+ *         the type of target identifier
+ * @param <M>
+ *         the type of message envelope being delivered
+ */
+@Internal
+public abstract class AbstractMessageEndpoint<I, M extends SignalEnvelope<?, ?, ?>>
+        implements MessageEndpoint<I, M> {
+
+    /** The message which needs to dispatched. */
+    private final M envelope;
+
+    protected AbstractMessageEndpoint(M envelope) {
+        this.envelope = envelope;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>All {@code Exception}s which may occur during
+     * the {@linkplain #performDispatch(Object) dispatching} are caught
+     * and transformed into an erroneous {@code DispatchOutcome}.
+     */
+    @Override
+    @SuppressWarnings("OverlyBroadCatchBlock")  /* Handling all exceptions, by design. */
+    public final DispatchOutcome dispatchTo(I targetId) {
+        try {
+            var outcome = performDispatch(targetId);
+            return outcome;
+        } catch (Exception e) {
+            return onFailedDispatch(e, targetId);
+        }
+    }
+
+    /**
+     * Performs actual dispatching of the signal to the respective target by the passed ID.
+     *
+     * @param targetId
+     *         the ID of the target to which the signal should be dispatched
+     * @return an outcome of the dispatch operation
+     */
+    protected abstract DispatchOutcome performDispatch(I targetId);
+
+    private DispatchOutcome onFailedDispatch(Exception failure, I targetId) {
+        var error = failureToError(failure, targetId);
+        var outcome = DispatchOutcome.newBuilder()
+                .setPropagatedSignal(envelope.messageId())
+                .setError(error)
+                .build();
+        return outcome;
+    }
+
+    private Error failureToError(Exception failure, I targetId) {
+        var error = Errors.fromThrowable(failure);
+        var message = format("Runtime error when dispatching signal `%s` " +
+                                     "to the entity with ID `%s` of repository `%s`. %s",
+                             Stringifiers.toString(envelope.message()),
+                             Identifier.toString(targetId),
+                             repository().getClass()
+                                         .getSimpleName(),
+                             error.getMessage());
+        var result = error.toBuilder()
+                .setMessage(message)
+                .build();
+        return result;
+    }
+
+    /**
+     * Obtains the envelope of the message processed by this endpoint.
+     */
+    protected final M envelope() {
+        return envelope;
+    }
+}

--- a/server/src/main/java/io/spine/server/delivery/AbstractMessageEndpoint.java
+++ b/server/src/main/java/io/spine/server/delivery/AbstractMessageEndpoint.java
@@ -37,9 +37,9 @@ import io.spine.string.Stringifiers;
 import static java.lang.String.format;
 
 /**
- * An abstract base for messages endpoints.
+ * An abstract base for message endpoints.
  *
- * <p>Upon a run-time dispatching, catches all {@code Exception}s throw,
+ * <p>Upon a run-time dispatching, catches all {@code Exception}s thrown,
  * and transforms them into a {@link DispatchOutcome}.
  *
  * @param <I>
@@ -96,13 +96,14 @@ public abstract class AbstractMessageEndpoint<I, M extends SignalEnvelope<?, ?, 
 
     private Error failureToError(Exception failure, I targetId) {
         var error = Errors.fromThrowable(failure);
-        var message = format("Runtime error when dispatching signal `%s` " +
-                                     "to the entity with ID `%s` of repository `%s`. %s",
-                             Stringifiers.toString(envelope.message()),
-                             Identifier.toString(targetId),
-                             repository().getClass()
-                                         .getSimpleName(),
-                             error.getMessage());
+        var repoName = repository().getClass().getSimpleName();
+        var message =
+                format("Runtime error when dispatching signal `%s` " +
+                               "to the entity with ID `%s` of repository `%s`. %s",
+                       Stringifiers.toString(envelope.message()),
+                       Identifier.toString(targetId),
+                       repoName,
+                       error.getMessage());
         var result = error.toBuilder()
                 .setMessage(message)
                 .build();

--- a/server/src/main/java/io/spine/server/delivery/CleanupStation.java
+++ b/server/src/main/java/io/spine/server/delivery/CleanupStation.java
@@ -48,7 +48,7 @@ final class CleanupStation extends Station {
      * observed.
      */
     @Override
-    public final Result process(Conveyor conveyor) {
+    public Result process(Conveyor conveyor) {
         for (var message : conveyor) {
             if (message.getStatus() == InboxMessageStatus.DELIVERED) {
                 var keepUntil = message.getKeepUntil();

--- a/server/src/main/java/io/spine/server/delivery/Conveyor.java
+++ b/server/src/main/java/io/spine/server/delivery/Conveyor.java
@@ -89,7 +89,13 @@ final class Conveyor implements Iterable<InboxMessage> {
         return new ArrayList<>(messages.values()).iterator();
     }
 
-    private void markDelivered(InboxMessage message) {
+    /**
+     * Marks the passed message as {@link InboxMessageStatus#DELIVERED DELIVERED}.
+     *
+     * <p>The change made will be reflected in the storage upon the next
+     * {@link #flushTo(InboxStorage) flushTo(InboxStorage)} invocation.
+     */
+    void markDelivered(InboxMessage message) {
         changeStatus(message, DELIVERED);
         deliveredMessages.recordDelivered(message);
     }
@@ -97,7 +103,7 @@ final class Conveyor implements Iterable<InboxMessage> {
     /**
      * Marks all the passed messages as {@link InboxMessageStatus#DELIVERED DELIVERED}.
      *
-     * <p>Produced the bulk change to the storage, pending until the next
+     * <p>Produces the bulk change to the storage, pending until the next
      * {@link #flushTo(InboxStorage) flushTo(InboxStorage)} invocation.
      */
     void markDelivered(Collection<InboxMessage> messages) {

--- a/server/src/main/java/io/spine/server/delivery/Delivery.java
+++ b/server/src/main/java/io/spine/server/delivery/Delivery.java
@@ -410,7 +410,7 @@ public final class Delivery implements Logging {
      * linear-style jobs, which aim for the maximum performance under
      * the strictly controlled circumstances.
      *
-     * <p>Any concurrent dispatching of signals (command posting, receiving external events, etc)
+     * <p>Any concurrent dispatching of signals (command posting, receiving external events, etc.)
      * will likely break the consistency of their target entities.
      *
      * <p>This API is experimental. Use with caution.
@@ -425,7 +425,7 @@ public final class Delivery implements Logging {
                 .build();
         delivery.subscribe(update -> {
             var action = delivery.deliveries.get(update);
-            action.deliver(ImmutableList.of(update));
+            action.deliverDirectly(update);
         });
         return delivery;
     }
@@ -534,8 +534,8 @@ public final class Delivery implements Logging {
     private DeliveryStage deliverMessages(ImmutableList<InboxMessage> messages,
                                           ShardIndex index,
                                           Iterable<CatchUp> catchUpJobs) {
-        DeliveryAction action = new GroupByTargetAndDeliver(deliveries);
         var conveyor = new Conveyor(messages, deliveredMessages);
+        DeliveryAction action = new GroupByTargetAndDeliver(deliveries, monitor, conveyor);
         List<Station> stations = conveyorStationsFor(catchUpJobs, action);
         var stage = launch(conveyor, stations, index);
         return stage;

--- a/server/src/main/java/io/spine/server/delivery/DeliveryMonitor.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryMonitor.java
@@ -84,9 +84,9 @@ public class DeliveryMonitor {
      * @param stats
      *         the statistics of the performed delivery
      */
-    @SuppressWarnings("unused")  /* This SPI method is designed for descendants. */
+    @SuppressWarnings("unused" /* This SPI method is designed for descendants. */)
     public void onDeliveryCompleted(DeliveryStats stats) {
-        // do nothing.
+        // Do nothing.
     }
 
     /**
@@ -96,14 +96,14 @@ public class DeliveryMonitor {
      * @param index
      *         the index of the shard, the delivery from which has been started
      */
-    @SuppressWarnings({"unused", "WeakerAccess"}) /* This SPI method is designed for descendants. */
+    @SuppressWarnings({"unused", "WeakerAccess" /* This SPI method is designed for descendants. */})
     public void onDeliveryStarted(ShardIndex index) {
-        // do nothing.
+        // Do nothing.
     }
 
     /**
      * A callback invoked if the signal transmitted via given message
-     * was handled by the respective receptor with failure.
+     * is handled by the respective receptor with failure.
      *
      * <p>Returns an action to take in relation to the failure.
      *
@@ -115,7 +115,7 @@ public class DeliveryMonitor {
      * @param reception
      *         the details on failed reception
      */
-    @SuppressWarnings("WeakerAccess")   /* Part of public API. */
+    @SuppressWarnings("WeakerAccess" /* Part of public API. */)
     public FailedReception.Action onReceptionFailure(FailedReception reception) {
         return reception.markDelivered();
     }

--- a/server/src/main/java/io/spine/server/delivery/DeliveryMonitor.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryMonitor.java
@@ -102,6 +102,26 @@ public class DeliveryMonitor {
     }
 
     /**
+     * A callback invoked if the signal transmitted via given message
+     * was handled by the respective receptor with failure.
+     *
+     * <p>Returns an action to take in relation to the failure.
+     *
+     * <p>By default, this callback returns an action which
+     * marks the message as {@linkplain InboxMessageStatus#DELIVERED delivered}.
+     *
+     * <p>See {@link FailedReception} for more pre-defined actions.
+     *
+     * @param reception
+     *         the details on failed reception
+     */
+    @SuppressWarnings("WeakerAccess")   /* Part of public API. */
+    public FailedReception.Action onReceptionFailure(FailedReception reception) {
+        return reception.markDelivered();
+    }
+
+
+    /**
      * Returns an instance of {@code DeliveryMonitor} which always says to continue.
      */
     static DeliveryMonitor alwaysContinue() {

--- a/server/src/main/java/io/spine/server/delivery/FailedReception.java
+++ b/server/src/main/java/io/spine/server/delivery/FailedReception.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.delivery;
+
+import io.spine.annotation.SPI;
+import io.spine.base.Error;
+
+/**
+ * The evidence of an {@link InboxMessage} which has failed to be handled
+ * by its receptor, such as an event or a command handler method.
+ *
+ * <p>End-users may choose to do one of the following:
+ *
+ * <ul>
+ *     <li>{@linkplain #markDelivered() mark} the message as delivered;
+ *     <li>{@linkplain #repeatDispatching() repeat dispatching} of the message immediately.
+ * </ul>
+ *
+ * <p>Alternatively, end-users may choose to define their own way of reacting
+ * to reception failures by implementing a custom {@code FailedReception.Action},
+ * and returning it via the corresponding
+ * {@linkplain DeliveryMonitor#onReceptionFailure(FailedReception) API} of {@code DeliveryMonitor}.
+ */
+public final class FailedReception {
+
+    private final InboxMessage message;
+    private final Error error;
+    private final Conveyor conveyor;
+    private final RepeatDispatching repeat;
+
+    /**
+     * Creates an instance of the failed reception.
+     *
+     * @param message
+     *         the message which failed to handle
+     * @param error
+     *         the details of the failure
+     * @param conveyor
+     *         the conveyor holding the {@code InboxMessage}s currently being delivered;
+     *         used to manipulate the message upon end-user's choice
+     * @param repeat
+     *         a callback invoked to repeat the dispatching
+     *         of the {@code InboxMessage} immediately
+     */
+    FailedReception(InboxMessage message,
+                    Error error,
+                    Conveyor conveyor,
+                    RepeatDispatching repeat) {
+        this.message = message;
+        this.error = error;
+        this.conveyor = conveyor;
+        this.repeat = repeat;
+    }
+
+    /**
+     * Returns the original {@code InboxMessage}.
+     */
+    public InboxMessage message() {
+        return message;
+    }
+
+    /**
+     * Returns the failure.
+     */
+    public Error error() {
+        return error;
+    }
+
+    /**
+     * Returns an action which marks the message
+     * as {@linkplain InboxMessageStatus#DELIVERED delivered}.
+     *
+     * <p>The message will be automatically removed from its inbox
+     * at the end of the delivery stage.
+     */
+    @SuppressWarnings("WeakerAccess")   /* Part of the public API. */
+    public Action markDelivered() {
+        return () -> conveyor.markDelivered(message);
+    }
+
+    /**
+     * Returns an action immediately repeats the dispatching of the message.
+     */
+    @SuppressWarnings("WeakerAccess")   /* Part of the public API. */
+    public Action repeatDispatching() {
+        return repeat::dispatchAgain;
+    }
+
+    /**
+     * An action to take in relation to the failed reception.
+     */
+    @SPI
+    @FunctionalInterface
+    public interface Action {
+
+        /**
+         * Executes an action.
+         */
+        void execute();
+    }
+}

--- a/server/src/main/java/io/spine/server/delivery/FailedReception.java
+++ b/server/src/main/java/io/spine/server/delivery/FailedReception.java
@@ -56,7 +56,7 @@ public final class FailedReception {
      * Creates an instance of the failed reception.
      *
      * @param message
-     *         the message which failed to handle
+     *         the message which caused the failure
      * @param error
      *         the details of the failure
      * @param conveyor
@@ -97,7 +97,7 @@ public final class FailedReception {
      * <p>The message will be automatically removed from its inbox
      * at the end of the delivery stage.
      */
-    @SuppressWarnings("WeakerAccess")   /* Part of the public API. */
+    @SuppressWarnings("WeakerAccess" /* Part of the public API. */)
     public Action markDelivered() {
         return () -> conveyor.markDelivered(message);
     }
@@ -105,7 +105,7 @@ public final class FailedReception {
     /**
      * Returns an action immediately repeats the dispatching of the message.
      */
-    @SuppressWarnings("WeakerAccess")   /* Part of the public API. */
+    @SuppressWarnings("WeakerAccess" /* Part of the public API. */)
     public Action repeatDispatching() {
         return repeat::dispatchAgain;
     }

--- a/server/src/main/java/io/spine/server/delivery/GroupByTargetAndDeliver.java
+++ b/server/src/main/java/io/spine/server/delivery/GroupByTargetAndDeliver.java
@@ -37,9 +37,15 @@ import java.util.List;
 final class GroupByTargetAndDeliver implements DeliveryAction {
 
     private final InboxDeliveries inboxDeliveries;
+    private final DeliveryMonitor monitor;
+    private final Conveyor conveyor;
 
-    GroupByTargetAndDeliver(InboxDeliveries deliveries) {
+    GroupByTargetAndDeliver(InboxDeliveries deliveries,
+                            DeliveryMonitor monitor,
+                            Conveyor conveyor) {
         inboxDeliveries = deliveries;
+        this.monitor = monitor;
+        this.conveyor = conveyor;
     }
 
     /**
@@ -66,7 +72,7 @@ final class GroupByTargetAndDeliver implements DeliveryAction {
             var delivery = inboxDeliveries.get(segment.typeUrl());
             List<InboxMessage> deliveryPackage = segment.messages();
             try {
-                delivery.deliver(deliveryPackage);
+                delivery.deliver(deliveryPackage, monitor, conveyor);
             } catch (RuntimeException exception) {
                 errors.addException(exception);
             } catch (@SuppressWarnings("ErrorNotRethrown") /* False-positive */ ModelError error) {

--- a/server/src/main/java/io/spine/server/delivery/LiveDeliveryStation.java
+++ b/server/src/main/java/io/spine/server/delivery/LiveDeliveryStation.java
@@ -95,7 +95,7 @@ final class LiveDeliveryStation extends Station {
      *         the dispatching
      */
     @Override
-    public final Result process(Conveyor conveyor) {
+    public Result process(Conveyor conveyor) {
         var filter = new FilterToDeliver(conveyor);
         var filtered = filter.messagesToDispatch();
         if (filtered.isEmpty()) {
@@ -135,7 +135,7 @@ final class LiveDeliveryStation extends Station {
          * Processes the passed message matching it to the filter requirements.
          *
          * <p>The messages in {@link InboxMessageStatus#TO_DELIVER TO_DELIVER} are accepted for
-         * futher dispatching.
+         * further dispatching.
          *
          * <p>If this message has already been passed to this filter, it is removed as a duplicate.
          *

--- a/server/src/main/java/io/spine/server/delivery/RepeatDispatching.java
+++ b/server/src/main/java/io/spine/server/delivery/RepeatDispatching.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,41 +27,19 @@
 package io.spine.server.delivery;
 
 import io.spine.annotation.Internal;
-import io.spine.server.dispatch.DispatchOutcome;
-import io.spine.server.entity.Repository;
-import io.spine.server.type.SignalEnvelope;
+import io.spine.base.Error;
 
 /**
- * An endpoint for messages delivered to an abstract target.
+ * Specifies the way to repeat the dispatching of {@code InboxMessage}s.
  *
- * @param <I>
- *         the type of target identifier
- * @param <M>
- *         the type of message envelope being delivered
+ * @see FailedReception#FailedReception(InboxMessage, Error, Conveyor, RepeatDispatching)
  */
 @Internal
-public interface MessageEndpoint<I, M extends SignalEnvelope<?, ?, ?>> {
+@FunctionalInterface
+public interface RepeatDispatching {
 
     /**
-     * Dispatches the message to the target with the passed ID.
-     *
-     * @param targetId
-     *         the identifier of a target
+     * Dispatches the message one more time.
      */
-    DispatchOutcome dispatchTo(I targetId);
-
-    /**
-     * The callback invoked if the handled signal is a duplicate.
-     *
-     * @param target
-     *         the target entity
-     * @param envelope
-     *         the handled signal
-     */
-    void onDuplicate(I target, M envelope);
-
-    /**
-     * Obtains the repository which manages the target entities.
-     */
-    Repository<I, ?> repository();
+    void dispatchAgain();
 }

--- a/server/src/main/java/io/spine/server/delivery/ShardMaintenanceProcess.java
+++ b/server/src/main/java/io/spine/server/delivery/ShardMaintenanceProcess.java
@@ -30,6 +30,7 @@ import io.spine.annotation.Internal;
 import io.spine.base.Time;
 import io.spine.server.delivery.event.ShardProcessed;
 import io.spine.server.delivery.event.ShardProcessingRequested;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.entity.Repository;
 import io.spine.server.event.AbstractEventReactor;
 import io.spine.server.event.React;
@@ -37,6 +38,7 @@ import io.spine.server.stand.Stand;
 import io.spine.server.type.EventEnvelope;
 import io.spine.type.TypeUrl;
 
+import static io.spine.server.dispatch.DispatchOutcomes.sentToInbox;
 import static io.spine.util.Exceptions.newIllegalStateException;
 
 /**
@@ -80,10 +82,11 @@ final class ShardMaintenanceProcess extends AbstractEventReactor {
     }
 
     @Override
-    public void dispatch(EventEnvelope event) {
+    public DispatchOutcome dispatch(EventEnvelope event) {
         var message = (ShardEvent) event.message();
         inbox.send(event)
              .toReactor(message.getIndex());
+        return sentToInbox(event, message.getIndex());
     }
 
     /**
@@ -108,8 +111,8 @@ final class ShardMaintenanceProcess extends AbstractEventReactor {
         }
 
         @Override
-        public void dispatchTo(ShardIndex targetId) {
-            ShardMaintenanceProcess.super.dispatch(envelope);
+        public DispatchOutcome dispatchTo(ShardIndex targetId) {
+            return ShardMaintenanceProcess.super.dispatch(envelope);
         }
 
         @Override

--- a/server/src/main/java/io/spine/server/delivery/ShardedMessageDelivery.java
+++ b/server/src/main/java/io/spine/server/delivery/ShardedMessageDelivery.java
@@ -26,6 +26,8 @@
 
 package io.spine.server.delivery;
 
+import io.spine.annotation.Experimental;
+
 import java.util.List;
 
 /**
@@ -47,26 +49,29 @@ interface ShardedMessageDelivery<M extends ShardedRecord> {
      *
      * @param incoming
      *         the incoming messages to deliver
+     * @param monitor
+     *         the delivery monitor to be notified of the reception failures
+     * @param conveyor
+     *         the conveyor holding the current state of the inbox messages being delivered
      */
-    void deliver(List<M> incoming);
+    void deliver(List<M> incoming, DeliveryMonitor monitor, Conveyor conveyor);
 
     /**
-     * Delivers a single message to its target.
+     * Delivers a single message to its target directly, omitting any delivery monitoring etc.
      *
-     * <p>The descendants typically will initialize the targets for the messages (such as entities)
-     * and handle the dispatching results.
-     *
-     * <p>Any runtime issues should be handled by the descendants by emitting the corresponding
-     * rejection events and potentially notifying the respective entity repositories.
+     * <p>This method is experimental,
+     * and is a part of {@linkplain Delivery#direct() direct delivery} feature.
      *
      * @param message
      *         the incoming message to deliver
      */
-    void deliver(M message);
+    @Experimental
+    void deliverDirectly(M message);
 
     /**
-     * Serves to notify that the given message was originally sent to be {@linkplain #deliver(List)
-     * delivered}, but turned out to be a duplicate.
+     * Serves to notify that the given message was originally sent to be
+     * {@linkplain #deliver(List, DeliveryMonitor, Conveyor) delivered},
+     * but turned out to be a duplicate.
      */
     void onDuplicate(M message);
 }

--- a/server/src/main/java/io/spine/server/delivery/TargetDelivery.java
+++ b/server/src/main/java/io/spine/server/delivery/TargetDelivery.java
@@ -26,6 +26,7 @@
 
 package io.spine.server.delivery;
 
+import io.spine.annotation.Experimental;
 import io.spine.base.Identifier;
 import io.spine.core.TenantId;
 import io.spine.server.dispatch.DispatchOutcome;
@@ -78,12 +79,24 @@ final class TargetDelivery<I> implements ShardedMessageDelivery<InboxMessage> {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The dispatch outcomes are ignored in this mode of delivery,
+     * as there is no externally submitted {@code DeliveryMonitor}
+     * to notify of them.
+     *
+     * @param message
+     *         the incoming message to deliver
+     */
     @Override
+    @Experimental
+    @SuppressWarnings("ResultOfMethodCallIgnored" /* See the documentation. */)
     public void deliverDirectly(InboxMessage message) {
-        if(message.hasCommand()) {
-            inboxOfCmds.notifyOfDuplicated(message);
+        if (message.hasCommand()) {
+            inboxOfCmds.deliver(message);
         } else {
-            inboxOfEvents.notifyOfDuplicated(message);
+            inboxOfEvents.deliver(message);
         }
     }
 

--- a/server/src/main/java/io/spine/server/delivery/TargetDelivery.java
+++ b/server/src/main/java/io/spine/server/delivery/TargetDelivery.java
@@ -28,6 +28,7 @@ package io.spine.server.delivery;
 
 import io.spine.base.Identifier;
 import io.spine.core.TenantId;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.tenant.IdInTenant;
 import io.spine.server.tenant.TenantAwareRunner;
 import io.spine.server.type.SignalEnvelope;
@@ -65,20 +66,25 @@ final class TargetDelivery<I> implements ShardedMessageDelivery<InboxMessage> {
     }
 
     @Override
-    public void deliver(List<InboxMessage> incoming) {
+    public void deliver(List<InboxMessage> incoming, DeliveryMonitor monitor, Conveyor conveyor) {
+        var dispatcher = new MonitoringDispatcher<>(monitor, conveyor, inboxOfCmds, inboxOfEvents);
 
         if (batchListener == null) {
             for (var incomingMessage : incoming) {
-                doDeliver(inboxOfCmds, inboxOfEvents, incomingMessage);
+                dispatcher.dispatch(incomingMessage);
             }
         } else {
-            deliverInBatch(incoming, batchListener);
+            deliverInBatch(incoming, dispatcher, batchListener);
         }
     }
 
     @Override
-    public void deliver(InboxMessage message) {
-        doDeliver(inboxOfCmds, inboxOfEvents, message);
+    public void deliverDirectly(InboxMessage message) {
+        if(message.hasCommand()) {
+            inboxOfCmds.notifyOfDuplicated(message);
+        } else {
+            inboxOfEvents.notifyOfDuplicated(message);
+        }
     }
 
     @Override
@@ -90,24 +96,15 @@ final class TargetDelivery<I> implements ShardedMessageDelivery<InboxMessage> {
         }
     }
 
-    private static <I> void doDeliver(InboxOfCommands<I>  cmdDispatcher,
-                                      InboxOfEvents<I> eventDispatcher,
-                                      InboxMessage incomingMessage) {
-        if (incomingMessage.hasCommand()) {
-            cmdDispatcher.deliver(incomingMessage);
-        } else {
-            eventDispatcher.deliver(incomingMessage);
-        }
-    }
-
     private void deliverInBatch(List<InboxMessage> incoming,
+                                MonitoringDispatcher<I> dispatcher,
                                 BatchDeliveryListener<I> batchDispatcher) {
-        List<Batch<I>> batches = Batch.byInboxId(incoming, this::asEnvelope);
+        var batches = Batch.byInboxId(incoming, dispatcher, this::asEnvelope);
 
         for (var batch : batches) {
             var tenant = batch.inboxId.tenant();
             TenantAwareRunner.with(tenant).run(
-                    () -> batch.deliverVia(batchDispatcher, inboxOfCmds, inboxOfEvents)
+                    () -> batch.deliverWith(batchDispatcher)
             );
         }
     }
@@ -121,6 +118,50 @@ final class TargetDelivery<I> implements ShardedMessageDelivery<InboxMessage> {
     }
 
     /**
+     * Dispatches the signal to the respective target, monitors
+     * the erroneous {@code DispatchOutcome}s and notifies the {@code DeliveryMonitor} of such.
+     *
+     * @param <I>
+     *         type of identifiers of the delivery targets
+     */
+    private static class MonitoringDispatcher<I> {
+
+        private final DeliveryMonitor monitor;
+        private final Conveyor conveyor;
+        private final InboxOfCommands<I> inboxOfCommands;
+        private final InboxOfEvents<I> inboxOfEvents;
+
+
+        private MonitoringDispatcher(DeliveryMonitor monitor,
+                                     Conveyor conveyor,
+                                     InboxOfCommands<I> inboxOfCommands,
+                                     InboxOfEvents<I> inboxOfEvents) {
+            this.monitor = monitor;
+            this.conveyor = conveyor;
+            this.inboxOfCommands = inboxOfCommands;
+            this.inboxOfEvents = inboxOfEvents;
+        }
+
+        private void dispatch(InboxMessage message) {
+            var outcome = doDispatch(message);
+            if(outcome.hasError()) {
+                var error = outcome.getError();
+                var reception =
+                        new FailedReception(message, error, conveyor, () -> dispatch(message));
+                var action = monitor.onReceptionFailure(reception);
+                action.execute();
+            }
+        }
+
+        private DispatchOutcome doDispatch(InboxMessage message) {
+            return message.hasCommand()
+                   ? inboxOfCommands.deliver(message)
+                   : inboxOfEvents.deliver(message);
+        }
+    }
+
+
+    /**
      * The batch of messages headed to the same target.
      *
      * @param <I>
@@ -130,9 +171,11 @@ final class TargetDelivery<I> implements ShardedMessageDelivery<InboxMessage> {
 
         private final IdInTenant<InboxId> inboxId;
         private final List<InboxMessage> messages = new ArrayList<>();
+        private final MonitoringDispatcher<I> dispatcher;
 
-        private Batch(InboxId inboxId, TenantId tenantId) {
+        private Batch(InboxId inboxId, TenantId tenantId, MonitoringDispatcher<I> dispatcher) {
             this.inboxId = IdInTenant.of(inboxId, tenantId);
+            this.dispatcher = dispatcher;
         }
 
         /**
@@ -141,20 +184,22 @@ final class TargetDelivery<I> implements ShardedMessageDelivery<InboxMessage> {
          * <p>The resulting order of messages through all batches is preserved.
          */
         private static <I> List<Batch<I>>
-        byInboxId(List<InboxMessage> messages, Function<InboxMessage, SignalEnvelope<?, ?, ?>> fn) {
+        byInboxId(List<InboxMessage> messages,
+                  MonitoringDispatcher<I> dispatcher,
+                  Function<InboxMessage, SignalEnvelope<?, ?, ?>> toEnvelope) {
             List<Batch<I>> batches = new ArrayList<>();
             Batch<I> currentBatch = null;
             for (var message : messages) {
 
                 var msgInboxId = message.getInboxId();
-                var envelope = fn.apply(message);
+                var envelope = toEnvelope.apply(message);
                 var tenantId = envelope.tenantId();
                 if (currentBatch == null) {
-                    currentBatch = new Batch<>(msgInboxId, tenantId);
+                    currentBatch = new Batch<>(msgInboxId, tenantId, dispatcher);
                 } else {
                     if (!matchesBatch(currentBatch, msgInboxId, tenantId)) {
                         batches.add(currentBatch);
-                        currentBatch = new Batch<>(msgInboxId, tenantId);
+                        currentBatch = new Batch<>(msgInboxId, tenantId, dispatcher);
                     }
                 }
                 currentBatch.addMessage(message);
@@ -178,25 +223,23 @@ final class TargetDelivery<I> implements ShardedMessageDelivery<InboxMessage> {
             messages.add(message);
         }
 
-        private void deliverVia(BatchDeliveryListener<I> dispatcher,
-                                InboxOfCommands<I> cmdDispatcher,
-                                InboxOfEvents<I> eventDispatcher) {
+        private void deliverWith(BatchDeliveryListener<I> listener) {
             if (messages.size() > 1) {
                 var packedId = inboxId.value()
                                       .getEntityId()
                                       .getId();
                 @SuppressWarnings("unchecked")      // Only IDs of type `I` are stored.
                 var id = (I) Identifier.unpack(packedId);
-                dispatcher.onStart(id);
+                listener.onStart(id);
                 try {
                     for (var message : messages) {
-                        doDeliver(cmdDispatcher, eventDispatcher, message);
+                        dispatcher.dispatch(message);
                     }
                 } finally {
-                    dispatcher.onEnd(id);
+                    listener.onEnd(id);
                 }
             } else {
-                doDeliver(cmdDispatcher, eventDispatcher, messages.get(0));
+                dispatcher.dispatch(messages.get(0));
             }
         }
     }

--- a/server/src/main/java/io/spine/server/dispatch/DispatchOutcomes.java
+++ b/server/src/main/java/io/spine/server/dispatch/DispatchOutcomes.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.dispatch;
+
+import com.google.protobuf.Any;
+import io.spine.base.Identifier;
+import io.spine.core.MessageId;
+import io.spine.server.type.CommandEnvelope;
+import io.spine.server.type.EventEnvelope;
+import io.spine.server.type.SignalEnvelope;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.util.Preconditions2.checkNotEmptyOrBlank;
+
+/**
+ * A utility for working with {@link DispatchOutcome} instances.
+ */
+public final class DispatchOutcomes {
+
+    /**
+     * Prevents this utility from instantiation.
+     */
+    private DispatchOutcomes() {
+    }
+
+    /**
+     * Returns an outcome, which tells about a successful dispatching of the message
+     * with the passed ID.
+     *
+     * @param messageId
+     *         identifier of the message
+     */
+    public static DispatchOutcome successfulOutcome(MessageId messageId) {
+        checkNotNull(messageId);
+        return withMessageId(messageId)
+                .setSuccess(Success.getDefaultInstance())
+                .build();
+    }
+
+    private static DispatchOutcome.Builder withMessageId(MessageId messageId) {
+        return DispatchOutcome
+                .newBuilder()
+                .setPropagatedSignal(messageId);
+    }
+
+    /**
+     * Returns an outcome, which tells about a successful dispatching
+     * of the passed event envelope.
+     *
+     * @param event
+     *         envelope of the event which was successfully dispatched
+     */
+    public static DispatchOutcome successfulOutcome(EventEnvelope event) {
+        checkNotNull(event);
+        return successfulOutcome(event.messageId());
+    }
+
+    /**
+     * Returns an outcome, which tells about a successful dispatching
+     * of the passed command envelope.
+     *
+     * @param command
+     *         envelope of the command which was successfully dispatched
+     */
+    public static DispatchOutcome successfulOutcome(CommandEnvelope command) {
+        checkNotNull(command);
+        return successfulOutcome(command.messageId());
+    }
+
+    /**
+     * Returns an outcome, which tells that the passed signal
+     * was sent to the inbox of the entity with the passed ID.
+     *
+     * @param signal
+     *         the signal which has been sent to the inbox
+     * @param entityId
+     *         identifier of the entity, to which inbox the signal
+     *         has been sent
+     */
+    public static <I> DispatchOutcome sentToInbox(SignalEnvelope<?, ?, ?> signal, I entityId) {
+        checkNotNull(signal);
+        checkNotNull(entityId);
+
+        InboxAddresses addresses = inboxAddressOf(entityId);
+        DispatchOutcome outcome = withMessageId(signal.messageId())
+                .setSentToInbox(addresses)
+                .build();
+        return outcome;
+    }
+
+    /**
+     * Returns an outcome, which tells that the passed signal
+     * was intended to be sent to the inbox of the entity with the passed ID.
+     *
+     * <p>If the passed {@code Optional} of entity ID is not present,
+     * returns an outcome telling there were
+     * {@linkplain #noTargetsToRoute(SignalEnvelope) no targets} to route the signal to.
+     *
+     * @param signal
+     *         the signal which has been sent to the inbox
+     * @param entityId
+     *         an optional identifier of the entity, to which inbox the signal
+     *         should have been sent
+     */
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType") /* Handling `Optional` uniformly. */
+    public static <I>
+    DispatchOutcome maybeSentToInbox(SignalEnvelope<?, ?, ?> signal, Optional<I> entityId) {
+        checkNotNull(signal);
+        checkNotNull(entityId);
+
+        return entityId.map(id -> sentToInbox(signal, id))
+                       .orElseGet(() -> noTargetsToRoute(signal));
+    }
+
+    /**
+     * Returns an outcome, which tells that the passed event
+     * was sent to several inboxes of entities with the passed identifiers.
+     *
+     * <p>In case an empty set of entity IDs was passed, returns an outcome
+     * telling there were {@linkplain #noTargetsToRoute(SignalEnvelope) no targets}
+     * to route the signal to.
+     *
+     * @param event
+     *         the event which has been sent to inboxes
+     * @param entityIds
+     *         identifiers of entities, to which inboxes the event
+     *         has been sent
+     */
+    public static <I> DispatchOutcome sentToInbox(EventEnvelope event, Set<I> entityIds) {
+        checkNotNull(event);
+        checkNotNull(entityIds);
+
+        if (entityIds.isEmpty()) {
+            return noTargetsToRoute(event);
+        }
+
+        InboxAddresses addresses = inboxAddressesOf(entityIds);
+        DispatchOutcome outcome = withMessageId(event.messageId())
+                .setSentToInbox(addresses)
+                .build();
+        return outcome;
+    }
+
+    private static <I> InboxAddresses inboxAddressOf(I entityId) {
+        InboxAddresses address = InboxAddresses
+                .newBuilder()
+                .addId(Identifier.pack(entityId))
+                .build();
+        return address;
+    }
+
+    private static <I> InboxAddresses inboxAddressesOf(Set<I> entityIds) {
+        InboxAddresses.Builder builder = InboxAddresses.newBuilder();
+        for (I id : entityIds) {
+            Any packed = Identifier.pack(id);
+            builder.addId(packed);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Returns an outcome signifying that the given event has been published
+     * to a remote channel, most likely, to another Bounded Context.
+     *
+     * @param event
+     *         the event which has been published
+     */
+    public static DispatchOutcome publishedToRemote(EventEnvelope event) {
+        checkNotNull(event);
+        DispatchOutcome outcome = withMessageId(event.messageId())
+                .setPublishedToRemote(true)
+                .build();
+        return outcome;
+    }
+
+    /**
+     * Returns an outcome telling that during the dispatching there were no target entities
+     * to route the signal to.
+     *
+     * @param signal
+     *         the dispatched signal
+     */
+    private static DispatchOutcome noTargetsToRoute(SignalEnvelope<?, ?, ?> signal) {
+        checkNotNull(signal);
+        DispatchOutcome outcome = withMessageId(signal.messageId())
+                .setNoTargetsToRoute(true)
+                .build();
+        return outcome;
+    }
+
+    /**
+     * Returns an outcome telling that the event was ignored by the target.
+     *
+     * <p>Such a scenario is typical for cases, in which target has a filter set
+     * for incoming events, which the event does not pass.
+     *
+     * @param reason
+     *         why the event was ignored
+     */
+    public static DispatchOutcome ignored(EventEnvelope event, String reason) {
+        checkNotNull(event);
+        checkNotEmptyOrBlank(reason);
+        var ignore = Ignore.newBuilder()
+                .setReason(reason)
+                .build();
+        var outcome = withMessageId(event.messageId())
+                .setIgnored(ignore)
+                .build();
+        return outcome;
+    }
+}

--- a/server/src/main/java/io/spine/server/dispatch/DispatchOutcomes.java
+++ b/server/src/main/java/io/spine/server/dispatch/DispatchOutcomes.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.dispatch;
 
-import com.google.protobuf.Any;
 import io.spine.base.Identifier;
 import io.spine.core.MessageId;
 import io.spine.server.type.CommandEnvelope;
@@ -108,8 +107,8 @@ public final class DispatchOutcomes {
         checkNotNull(signal);
         checkNotNull(entityId);
 
-        InboxAddresses addresses = inboxAddressOf(entityId);
-        DispatchOutcome outcome = withMessageId(signal.messageId())
+        var addresses = inboxAddressOf(entityId);
+        var outcome = withMessageId(signal.messageId())
                 .setSentToInbox(addresses)
                 .build();
         return outcome;
@@ -129,7 +128,7 @@ public final class DispatchOutcomes {
      *         an optional identifier of the entity, to which inbox the signal
      *         should have been sent
      */
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType") /* Handling `Optional` uniformly. */
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType" /* Handling `Optional` uniformly. */)
     public static <I>
     DispatchOutcome maybeSentToInbox(SignalEnvelope<?, ?, ?> signal, Optional<I> entityId) {
         checkNotNull(signal);
@@ -161,15 +160,15 @@ public final class DispatchOutcomes {
             return noTargetsToRoute(event);
         }
 
-        InboxAddresses addresses = inboxAddressesOf(entityIds);
-        DispatchOutcome outcome = withMessageId(event.messageId())
+        var addresses = inboxAddressesOf(entityIds);
+        var outcome = withMessageId(event.messageId())
                 .setSentToInbox(addresses)
                 .build();
         return outcome;
     }
 
     private static <I> InboxAddresses inboxAddressOf(I entityId) {
-        InboxAddresses address = InboxAddresses
+        var address = InboxAddresses
                 .newBuilder()
                 .addId(Identifier.pack(entityId))
                 .build();
@@ -177,9 +176,9 @@ public final class DispatchOutcomes {
     }
 
     private static <I> InboxAddresses inboxAddressesOf(Set<I> entityIds) {
-        InboxAddresses.Builder builder = InboxAddresses.newBuilder();
-        for (I id : entityIds) {
-            Any packed = Identifier.pack(id);
+        var builder = InboxAddresses.newBuilder();
+        for (var id : entityIds) {
+            var packed = Identifier.pack(id);
             builder.addId(packed);
         }
         return builder.build();
@@ -194,7 +193,7 @@ public final class DispatchOutcomes {
      */
     public static DispatchOutcome publishedToRemote(EventEnvelope event) {
         checkNotNull(event);
-        DispatchOutcome outcome = withMessageId(event.messageId())
+        var outcome = withMessageId(event.messageId())
                 .setPublishedToRemote(true)
                 .build();
         return outcome;
@@ -209,7 +208,7 @@ public final class DispatchOutcomes {
      */
     private static DispatchOutcome noTargetsToRoute(SignalEnvelope<?, ?, ?> signal) {
         checkNotNull(signal);
-        DispatchOutcome outcome = withMessageId(signal.messageId())
+        var outcome = withMessageId(signal.messageId())
                 .setNoTargetsToRoute(true)
                 .build();
         return outcome;

--- a/server/src/main/java/io/spine/server/entity/EntityMessageEndpoint.java
+++ b/server/src/main/java/io/spine/server/entity/EntityMessageEndpoint.java
@@ -27,7 +27,7 @@
 package io.spine.server.entity;
 
 import io.spine.annotation.Internal;
-import io.spine.server.delivery.MessageEndpoint;
+import io.spine.server.delivery.AbstractMessageEndpoint;
 import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.type.SignalEnvelope;
 
@@ -46,17 +46,14 @@ import io.spine.server.type.SignalEnvelope;
 public abstract class EntityMessageEndpoint<I,
                                             E extends Entity<I, ?>,
                                             M extends SignalEnvelope<?, ?, ?>>
-        implements MessageEndpoint<I, M> {
+        extends AbstractMessageEndpoint<I, M> {
 
     /** The repository which created this endpoint. */
     private final Repository<I, E> repository;
 
-    /** The message which needs to dispatched. */
-    private final M envelope;
-
     protected EntityMessageEndpoint(Repository<I, E> repository, M envelope) {
+        super(envelope);
         this.repository = repository;
-        this.envelope = envelope;
     }
 
     /**
@@ -98,13 +95,6 @@ public abstract class EntityMessageEndpoint<I,
      * the entity in response to the message.
      */
     protected abstract void onEmptyResult(E entity);
-
-    /**
-     * Obtains the envelope of the message processed by this endpoint.
-     */
-    protected final M envelope() {
-        return envelope;
-    }
 
     /**
      * Obtains the parent repository of this endpoint.

--- a/server/src/main/java/io/spine/server/entity/EventDispatchingRepository.java
+++ b/server/src/main/java/io/spine/server/entity/EventDispatchingRepository.java
@@ -31,6 +31,7 @@ import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import io.spine.base.EntityState;
 import io.spine.core.Event;
 import io.spine.server.BoundedContext;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.event.EventDispatcher;
 import io.spine.server.route.EventRouting;
 import io.spine.server.type.EventEnvelope;
@@ -110,26 +111,22 @@ public abstract class EventDispatchingRepository<I,
      * @param event the event to dispatch
      */
     @Override
-    public final void dispatch(EventEnvelope event) {
+    public final DispatchOutcome dispatch(EventEnvelope event) {
         checkNotNull(event);
-        doDispatch(event);
-    }
-
-    private void doDispatch(EventEnvelope event) {
         var targets = route(event);
-        var outerObject = event.outerObject();
-        targets.forEach(id -> dispatchTo(id, outerObject));
+        return dispatchTo(targets, event);
     }
 
     /**
-     * Dispatches the given event to an entity with the given ID.
+     * Dispatches the given event to entities with the given identifiers,
+     * and returns the dispatch outcome.
      *
-     * @param id
-     *         the target entity ID
+     * @param ids
+     *         the identifiers of the target entities
      * @param event
      *         the event to dispatch
      */
-    protected abstract void dispatchTo(I id, Event event);
+    protected abstract DispatchOutcome dispatchTo(Set<I> ids, EventEnvelope event);
 
     /**
      * Determines the targets of the given event.

--- a/server/src/main/java/io/spine/server/event/AbstractEventReactor.java
+++ b/server/src/main/java/io/spine/server/event/AbstractEventReactor.java
@@ -121,6 +121,7 @@ public abstract class AbstractEventReactor
                                 .evaluate(() -> reactAndPost(event));
     }
 
+    @SuppressWarnings("FloggerLogString" /* Re-using the logged message. */)
     private DispatchOutcome reactAndPost(EventEnvelope event) {
         var method = thisClass.reactorOf(event);
         if (method.isPresent()) {

--- a/server/src/main/java/io/spine/server/event/AbstractEventReactor.java
+++ b/server/src/main/java/io/spine/server/event/AbstractEventReactor.java
@@ -39,6 +39,7 @@ import io.spine.protobuf.TypeConverter;
 import io.spine.server.BoundedContext;
 import io.spine.server.ContextAware;
 import io.spine.server.Identity;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.dispatch.DispatchOutcomeHandler;
 import io.spine.server.event.model.EventReactorClass;
 import io.spine.server.stand.Stand;
@@ -53,6 +54,8 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Suppliers.memoize;
+import static io.spine.server.dispatch.DispatchOutcomes.ignored;
+import static java.lang.String.format;
 
 /**
  * An abstract base for all classes that may produce events in response to other events.
@@ -113,22 +116,27 @@ public abstract class AbstractEventReactor
     }
 
     @Override
-    public void dispatch(EventEnvelope event) {
-        TenantAwareRunner.with(event.tenantId())
-                         .run(() -> reactAndPost(event));
+    public DispatchOutcome dispatch(EventEnvelope event) {
+        return TenantAwareRunner.with(event.tenantId())
+                                .evaluate(() -> reactAndPost(event));
     }
 
-    private void reactAndPost(EventEnvelope event) {
+    private DispatchOutcome reactAndPost(EventEnvelope event) {
         var method = thisClass.reactorOf(event);
         if (method.isPresent()) {
+            var outcome = method.get().invoke(this, event);
             DispatchOutcomeHandler
-                    .from(method.get().invoke(this, event))
+                    .from(outcome)
                     .onEvents(eventBus::post)
                     .onError(error -> postFailure(error, event))
                     .handle();
+            return outcome;
         } else {
-            _debug().log("Reactor `%s` filtered out and ignored event %s[ID: %s].",
-                         thisClass, event.messageClass(), event.id().value());
+            var eventId = event.id();
+            var msg = format("Reactor `%s` filtered out and ignored event %s[ID: %s].",
+                             thisClass, event.messageClass(), eventId.value());
+            _debug().log(msg);
+            return ignored(event, msg);
         }
     }
 

--- a/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
+++ b/server/src/main/java/io/spine/server/event/DelegatingEventDispatcher.java
@@ -29,6 +29,7 @@ package io.spine.server.event;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 import io.spine.annotation.Internal;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
 
@@ -80,8 +81,8 @@ public final class DelegatingEventDispatcher implements EventDispatcher {
     }
 
     @Override
-    public void dispatch(EventEnvelope event) {
-        delegate.dispatchEvent(event);
+    public DispatchOutcome dispatch(EventEnvelope event) {
+        return delegate.dispatchEvent(event);
     }
 
     @Override
@@ -92,7 +93,7 @@ public final class DelegatingEventDispatcher implements EventDispatcher {
     /**
      * Returns the string representation of this dispatcher.
      *
-     * <p>Includes an FQN of the {@code delegate} in order to allow distinguish
+     * <p>Includes an FQN of the {@code delegate} in order to allow distinguishing
      * {@code DelegatingEventDispatcher} instances with different delegates.
      */
     @Override

--- a/server/src/main/java/io/spine/server/event/EventDispatcherDelegate.java
+++ b/server/src/main/java/io/spine/server/event/EventDispatcherDelegate.java
@@ -28,6 +28,7 @@ package io.spine.server.event;
 
 import com.google.common.collect.ImmutableSet;
 import io.spine.annotation.Internal;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
 
@@ -61,9 +62,9 @@ public interface EventDispatcherDelegate {
     ImmutableSet<EventClass> externalEvents();
 
     /**
-     * Dispatches the event.
+     * Dispatches the event and returns the outcome of dispatching.
      */
-    void dispatchEvent(EventEnvelope event);
+    DispatchOutcome dispatchEvent(EventEnvelope event);
 
     /**
      * Returns immutable set with one element with the identity of the multicast dispatcher

--- a/server/src/main/java/io/spine/server/integration/DomesticEventPublisher.java
+++ b/server/src/main/java/io/spine/server/integration/DomesticEventPublisher.java
@@ -28,11 +28,13 @@ package io.spine.server.integration;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import io.spine.logging.Logging;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.event.EventDispatcher;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.server.dispatch.DispatchOutcomes.publishedToRemote;
 
 /**
  * A subscriber to local {@code EventBus}, which publishes each matching domestic event to
@@ -58,8 +60,9 @@ final class DomesticEventPublisher implements EventDispatcher, Logging {
     }
 
     @Override
-    public void dispatch(EventEnvelope event) {
+    public DispatchOutcome dispatch(EventEnvelope event) {
         broker.publish(event);
+        return publishedToRemote(event);
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/procman/PmEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmEndpoint.java
@@ -73,10 +73,11 @@ abstract class PmEndpoint<I,
      */
     @SuppressWarnings("UnnecessaryInheritDoc") // IDEA bug.
     @Override
-    public void dispatchTo(I id) {
+    protected final DispatchOutcome performDispatch(I id) {
         var manager = repository().findOrCreate(id);
+        var outcome = runTransactionFor(manager);
         DispatchOutcomeHandler
-                .from(runTransactionFor(manager))
+                .from(outcome)
                 .onSuccess(success -> store(manager))
                 .onCommands(repository()::postCommands)
                 .onEvents(repository()::postEvents)
@@ -84,6 +85,7 @@ abstract class PmEndpoint<I,
                 .afterSuccess(success -> afterDispatched(id))
                 .onError(error -> dispatchingFailed(id, error))
                 .handle();
+        return outcome;
     }
 
     private void dispatchingFailed(I id, Error error) {

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
@@ -32,7 +32,6 @@ import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import io.spine.annotation.Internal;
 import io.spine.base.EntityState;
 import io.spine.core.Command;
-import io.spine.core.Event;
 import io.spine.server.BoundedContext;
 import io.spine.server.ServerEnvironment;
 import io.spine.server.commandbus.CommandBus;
@@ -41,6 +40,7 @@ import io.spine.server.commandbus.DelegatingCommandDispatcher;
 import io.spine.server.delivery.BatchDeliveryListener;
 import io.spine.server.delivery.Inbox;
 import io.spine.server.delivery.InboxLabel;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.entity.EntityLifecycleMonitor;
 import io.spine.server.entity.EntityRecord;
 import io.spine.server.entity.EventDispatchingRepository;
@@ -61,12 +61,15 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Suppliers.memoize;
 import static io.spine.grpc.StreamObservers.noOpObserver;
 import static io.spine.option.EntityOption.Kind.PROCESS_MANAGER;
+import static io.spine.server.dispatch.DispatchOutcomes.maybeSentToInbox;
+import static io.spine.server.dispatch.DispatchOutcomes.sentToInbox;
 import static io.spine.server.procman.model.ProcessManagerClass.asProcessManagerClass;
 import static io.spine.server.tenant.TenantAwareRunner.with;
 import static io.spine.util.Exceptions.newIllegalStateException;
@@ -300,11 +303,12 @@ public abstract class ProcessManagerRepository<I,
      *         a request to dispatch
      */
     @Override
-    public final void dispatchCommand(CommandEnvelope command) {
+    public final DispatchOutcome dispatchCommand(CommandEnvelope command) {
         checkNotNull(command);
         var target = route(command);
         target.ifPresent(id -> inbox().send(command)
                                       .toHandler(id));
+        return maybeSentToInbox(command, target);
     }
 
     private Optional<I> route(CommandEnvelope cmd) {
@@ -336,12 +340,13 @@ public abstract class ProcessManagerRepository<I,
     /**
      * {@inheritDoc}
      *
-     * <p>Sends the given event to the {@code Inbox} of this repository.
+     * <p>Sends the given event to the {@code Inbox}es of respective entities.
      */
     @Override
-    protected final void dispatchTo(I id, Event event) {
-        inbox().send(EventEnvelope.of(event))
-               .toReactor(id);
+    protected final DispatchOutcome dispatchTo(Set<I> ids, EventEnvelope event) {
+        ids.forEach(id -> inbox().send(event)
+                                 .toReactor(id));
+        return sentToInbox(event, ids);
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})   // to avoid massive generic-related issues.
@@ -349,7 +354,8 @@ public abstract class ProcessManagerRepository<I,
     protected PmTransaction<?, ?, ?> beginTransactionFor(P manager) {
         @SuppressWarnings("RedundantExplicitVariableType")  /* Because of the wildcard generic. */
         PmTransaction<I, S, ?> tx = new PmTransaction<>((ProcessManager<I, S, ?>) manager);
-        TransactionListener listener = EntityLifecycleMonitor.newInstance(this, manager.id());
+        TransactionListener listener =
+                EntityLifecycleMonitor.newInstance(this, manager.id());
         tx.setListener(listener);
         return tx;
     }

--- a/server/src/main/java/io/spine/server/projection/CatchUpEndpoint.java
+++ b/server/src/main/java/io/spine/server/projection/CatchUpEndpoint.java
@@ -28,9 +28,12 @@ package io.spine.server.projection;
 
 import io.spine.base.EntityState;
 import io.spine.server.delivery.event.CatchUpStarted;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.entity.Repository;
 import io.spine.server.type.EventEnvelope;
 import io.spine.type.TypeName;
+
+import static io.spine.server.dispatch.DispatchOutcomes.successfulOutcome;
 
 /**
  * Dispatches an event to projections during the catch-up.
@@ -69,12 +72,13 @@ final class CatchUpEndpoint<I, P extends Projection<I, S, ?>, S extends EntitySt
     }
 
     @Override
-    public void dispatchTo(I entityId) {
+    protected DispatchOutcome performDispatch(I entityId) {
         var actualTypeName = envelope().messageTypeName();
-        if (actualTypeName.equals(CATCH_UP_STARTED)) {
+        if (CATCH_UP_STARTED.equals(actualTypeName)) {
             onCatchUpStarted(entityId);
+            return successfulOutcome(envelope().messageId());
         } else {
-            super.dispatchTo(entityId);
+            return super.performDispatch(entityId);
         }
     }
 

--- a/server/src/main/java/io/spine/server/projection/ProjectionEndpoint.java
+++ b/server/src/main/java/io/spine/server/projection/ProjectionEndpoint.java
@@ -69,11 +69,12 @@ public class ProjectionEndpoint<I, P extends Projection<I, S, ?>, S extends Enti
     }
 
     @Override
-    public void dispatchTo(I entityId) {
+    protected DispatchOutcome performDispatch(I entityId) {
         var repository = repository();
         var projection = repository.findOrCreate(entityId);
-        runTransactionFor(projection);
+        var outcome = runTransactionFor(projection);
         store(projection);
+        return outcome;
     }
 
     @Override
@@ -82,7 +83,7 @@ public class ProjectionEndpoint<I, P extends Projection<I, S, ?>, S extends Enti
                     .onDispatchEventToSubscriber(envelope().outerObject());
     }
 
-    protected void runTransactionFor(P projection) {
+    protected DispatchOutcome runTransactionFor(P projection) {
         var tx = start((Projection<I, S, ?>) projection);
         TransactionListener<I> listener =
                 EntityLifecycleMonitor.newInstance(repository(), projection.id());
@@ -96,6 +97,7 @@ public class ProjectionEndpoint<I, P extends Projection<I, S, ?>, S extends Enti
             repository().lifecycleOf(projection.id())
                         .onDispatchingFailed(envelope(), error);
         }
+        return outcome;
     }
 
     @CanIgnoreReturnValue

--- a/server/src/main/java/io/spine/server/route/MessageRouting.java
+++ b/server/src/main/java/io/spine/server/route/MessageRouting.java
@@ -36,6 +36,7 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.util.Exceptions.newIllegalStateException;
+import static java.util.Collections.synchronizedMap;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -55,7 +56,18 @@ public abstract class MessageRouting<M extends Message, C extends MessageContext
 
     private static final long serialVersionUID = 0L;
 
-    private final Map<Class<? extends M>, RouteFn<M, C, R>> routes = new LinkedHashMap<>();
+    /**
+     * Map of currently known routes.
+     *
+     * @implNote This collection is made {@code synchronized}, since in some cases it is
+     *         being simultaneously read and modified in different threads.
+     *         In particular, the modification at run-time is performed when storing
+     *         the routes discovered on per-interface basis. Therefore, if this collection
+     *         is not {@code synchronized}, a {@code ConcurrentModificationException}
+     *         is sometimes thrown.
+     */
+    private final Map<Class<? extends M>, RouteFn<M, C, R>> routes =
+            synchronizedMap(new LinkedHashMap<>());
 
     /** The default route to be used if there is no matching entry set in {@link #routes}. */
     private RouteFn<M, C, R> defaultRoute;

--- a/server/src/main/proto/spine/server/dispatch/dispatching.proto
+++ b/server/src/main/proto/spine/server/dispatch/dispatching.proto
@@ -35,6 +35,8 @@ option java_package = "io.spine.server.dispatch";
 option java_multiple_files = true;
 option java_outer_classname = "DispatchProto";
 
+import "google/protobuf/any.proto";
+
 import "spine/base/error.proto";
 import "spine/core/command.proto";
 import "spine/core/diagnostics.proto";
@@ -90,6 +92,22 @@ message DispatchOutcome {
         // If field filters of a receptor do not match a given signal, the signal is ignored.
         //
         Ignore ignored = 5 [(validate) = true];
+
+        // The signal has been sent to the inboxes of the corresponding targets.
+        //
+        // It will be handled as soon as it is delivered.
+        //
+        InboxAddresses sent_to_inbox = 6;
+
+        // The signal has been published to the remote channel.
+        //
+        // Typically, it means that the signals of this type were requested
+        // by other Bounded Contexts as their `external` subscriptions.
+        //
+        bool published_to_remote = 7;
+
+        // There were no targets to which the signal could have been dispatched.
+        bool no_targets_to_route = 8;
     }
 }
 
@@ -160,4 +178,15 @@ message Ignore {
     // Used for debugging.
     //
     string reason = 1 [(required) = true];
+}
+
+// The addresses of the entity inboxes,
+// to which the message has been sent during dispatching.
+//
+message InboxAddresses {
+
+    // The identifiers of entity targets,
+    // to which inboxes the message has been sent.
+    //
+    repeated google.protobuf.Any id = 1 [(required) = true, (validate) = true];
 }

--- a/server/src/test/java/com/example/ForeignContextConfig.java
+++ b/server/src/test/java/com/example/ForeignContextConfig.java
@@ -33,11 +33,14 @@ import io.spine.server.BoundedContextBuilder;
 import io.spine.server.DefaultRepository;
 import io.spine.server.bc.given.ProjectAggregate;
 import io.spine.server.commandbus.CommandDispatcher;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.event.EventDispatcher;
 import io.spine.server.type.CommandClass;
 import io.spine.server.type.CommandEnvelope;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
+
+import static io.spine.server.dispatch.DispatchOutcomes.successfulOutcome;
 
 /**
  * Test environment class for testing {@code BoundedContext} configuration from
@@ -80,8 +83,8 @@ public final class ForeignContextConfig {
 
             @CanIgnoreReturnValue
             @Override
-            public void dispatch(CommandEnvelope envelope) {
-                // Do nothing.
+            public DispatchOutcome dispatch(CommandEnvelope envelope) {
+                return successfulOutcome(envelope);
             }
         };
     }
@@ -109,8 +112,8 @@ public final class ForeignContextConfig {
 
         @Override
         @CanIgnoreReturnValue
-        public void dispatch(EventEnvelope envelope) {
-            // Do nothing.
+        public DispatchOutcome dispatch(EventEnvelope envelope) {
+            return successfulOutcome(envelope);
         }
     }
 }

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/RejectingAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/RejectingAggregate.java
@@ -26,7 +26,6 @@
 
 package io.spine.server.aggregate.given.repo;
 
-import com.google.errorprone.annotations.DoNotCall;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.Apply;
 import io.spine.server.command.Assign;
@@ -39,8 +38,7 @@ import io.spine.test.aggregate.event.AggProjectStarted;
 import io.spine.test.aggregate.rejection.AggCannotStartArchivedProject;
 
 /**
- * The aggregate with the state of {@linkplain io.spine.test.aggregate.event.AggProjectCreated
- * creation event} wrapped into {@code Any}. The event keeps the list of child project IDs,
+ * The aggregate keeping the list of child project IDs,
  * which we use in rejecting subsequent commands.
  */
 final class RejectingAggregate

--- a/server/src/test/java/io/spine/server/bc/given/Given.java
+++ b/server/src/test/java/io/spine/server/bc/given/Given.java
@@ -29,6 +29,7 @@ package io.spine.server.bc.given;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.spine.server.commandbus.CommandDispatcher;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.event.EventDispatcher;
 import io.spine.server.type.CommandClass;
 import io.spine.server.type.CommandEnvelope;
@@ -41,6 +42,7 @@ import io.spine.test.bc.event.BcProjectStarted;
 import io.spine.test.bc.event.BcTaskAdded;
 
 import static com.google.common.collect.Sets.union;
+import static io.spine.server.dispatch.DispatchOutcomes.successfulOutcome;
 
 public class Given {
 
@@ -82,8 +84,8 @@ public class Given {
 
         @Override
         @CanIgnoreReturnValue
-        public void dispatch(CommandEnvelope envelope) {
-            // Do nothing.
+        public DispatchOutcome dispatch(CommandEnvelope envelope) {
+            return successfulOutcome(envelope);
         }
     }
 
@@ -108,8 +110,8 @@ public class Given {
 
         @Override
         @CanIgnoreReturnValue
-        public void dispatch(EventEnvelope envelope) {
-            // Do nothing.
+        public DispatchOutcome dispatch(EventEnvelope envelope) {
+            return successfulOutcome(envelope);
         }
     }
 }

--- a/server/src/test/java/io/spine/server/command/CommandInterceptor.java
+++ b/server/src/test/java/io/spine/server/command/CommandInterceptor.java
@@ -29,9 +29,11 @@ package io.spine.server.command;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Message;
 import io.spine.base.CommandMessage;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.type.CommandClass;
 import io.spine.server.type.CommandEnvelope;
 
+import static io.spine.server.dispatch.DispatchOutcomes.successfulOutcome;
 import static io.spine.server.type.CommandClass.setOf;
 
 /**
@@ -49,8 +51,9 @@ public final class CommandInterceptor extends AbstractAssignee {
     }
 
     @Override
-    public void dispatch(CommandEnvelope envelope) {
+    public DispatchOutcome dispatch(CommandEnvelope envelope) {
         history.add(envelope);
+        return successfulOutcome(envelope);
     }
 
     @Override

--- a/server/src/test/java/io/spine/server/commandbus/given/CommandDispatcherRegistryTestEnv.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/CommandDispatcherRegistryTestEnv.java
@@ -35,6 +35,7 @@ import io.spine.core.Subscribe;
 import io.spine.server.command.AbstractAssignee;
 import io.spine.server.command.Assign;
 import io.spine.server.commandbus.CommandDispatcher;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.procman.ProcessManager;
 import io.spine.server.procman.ProcessManagerRepository;
 import io.spine.server.type.CommandClass;
@@ -48,6 +49,8 @@ import io.spine.test.commandbus.command.CmdBusStartProject;
 import io.spine.test.commandbus.event.CmdBusProjectCreated;
 import io.spine.test.commandbus.event.CmdBusProjectStarted;
 import io.spine.test.commandbus.event.CmdBusTaskAdded;
+
+import static io.spine.server.dispatch.DispatchOutcomes.successfulOutcome;
 
 public class CommandDispatcherRegistryTestEnv {
 
@@ -126,8 +129,8 @@ public class CommandDispatcherRegistryTestEnv {
         }
 
         @Override
-        public void dispatch(CommandEnvelope envelope) {
-            // Do nothing.
+        public DispatchOutcome dispatch(CommandEnvelope envelope) {
+            return successfulOutcome(envelope);
         }
     }
 
@@ -146,8 +149,8 @@ public class CommandDispatcherRegistryTestEnv {
         }
 
         @Override
-        public void dispatch(CommandEnvelope envelope) {
-            // Do nothing.
+        public DispatchOutcome dispatch(CommandEnvelope envelope) {
+            return successfulOutcome(envelope);
         }
     }
 
@@ -159,8 +162,8 @@ public class CommandDispatcherRegistryTestEnv {
         }
 
         @Override
-        public void dispatch(CommandEnvelope envelope) {
-            // Do nothing.
+        public DispatchOutcome dispatch(CommandEnvelope envelope) {
+            return successfulOutcome(envelope);
         }
     }
 
@@ -172,8 +175,8 @@ public class CommandDispatcherRegistryTestEnv {
         }
 
         @Override
-        public void dispatch(CommandEnvelope envelope) {
-            // Do nothing.
+        public DispatchOutcome dispatch(CommandEnvelope envelope) {
+            return successfulOutcome(envelope);
         }
     }
 

--- a/server/src/test/java/io/spine/server/commandbus/given/CommandHandlerTestEnv.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/CommandHandlerTestEnv.java
@@ -35,6 +35,7 @@ import io.spine.logging.Logging;
 import io.spine.server.command.AbstractAssignee;
 import io.spine.server.command.Assign;
 import io.spine.server.command.CommandHistory;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.event.EventDispatcher;
 import io.spine.server.tuple.Pair;
 import io.spine.server.type.CommandEnvelope;
@@ -55,6 +56,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.collect.Lists.newLinkedList;
+import static io.spine.server.dispatch.DispatchOutcomes.successfulOutcome;
 
 public class CommandHandlerTestEnv {
 
@@ -86,8 +88,9 @@ public class CommandHandlerTestEnv {
         }
 
         @Override
-        public void dispatch(EventEnvelope event) {
+        public DispatchOutcome dispatch(EventEnvelope event) {
             dispatched.add(event);
+            return successfulOutcome(event);
         }
 
         public List<EventEnvelope> dispatched() {

--- a/server/src/test/java/io/spine/server/commandbus/given/MultitenantCommandBusTestEnv.java
+++ b/server/src/test/java/io/spine/server/commandbus/given/MultitenantCommandBusTestEnv.java
@@ -28,10 +28,13 @@ package io.spine.server.commandbus.given;
 
 import com.google.common.collect.ImmutableSet;
 import io.spine.server.commandbus.CommandDispatcher;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.type.CommandClass;
 import io.spine.server.type.CommandEnvelope;
 import io.spine.server.type.MessageEnvelope;
 import io.spine.test.commandbus.command.CmdBusAddTask;
+
+import static io.spine.server.dispatch.DispatchOutcomes.successfulOutcome;
 
 public class MultitenantCommandBusTestEnv {
 
@@ -54,8 +57,9 @@ public class MultitenantCommandBusTestEnv {
         }
 
         @Override
-        public void dispatch(CommandEnvelope envelope) {
+        public DispatchOutcome dispatch(CommandEnvelope envelope) {
             dispatcherInvoked = true;
+            return successfulOutcome(envelope);
         }
 
         public boolean wasDispatcherInvoked() {

--- a/server/src/test/java/io/spine/server/delivery/DeliveryTest.java
+++ b/server/src/test/java/io/spine/server/delivery/DeliveryTest.java
@@ -27,7 +27,6 @@
 package io.spine.server.delivery;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.protobuf.util.Durations;
 import io.spine.base.Identifier;
 import io.spine.environment.Tests;
@@ -42,7 +41,6 @@ import io.spine.server.delivery.given.TaskAggregate;
 import io.spine.server.delivery.given.TaskAssignment;
 import io.spine.server.delivery.given.TaskView;
 import io.spine.server.delivery.memory.InMemoryShardedWorkRegistry;
-import io.spine.server.storage.memory.InMemoryStorageFactory;
 import io.spine.server.tenant.TenantAwareRunner;
 import io.spine.test.delivery.DCreateTask;
 import io.spine.testing.SlowTest;
@@ -56,7 +54,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
@@ -394,7 +391,7 @@ public class DeliveryTest extends AbstractDeliveryTest {
      * Test environment.
      *
      * <p>Accesses the {@linkplain Delivery Delivery API} which has been made
-     * package-private and marked as visible for testing. Therefore the test environment routines
+     * package-private and marked as visible for testing. Therefore, the test environment routines
      * aren't moved to a separate {@code ...TestEnv} class. Otherwise the test-only API
      * of {@code Delivery} must have been made {@code public}, which wouldn't be
      * a good API design move.

--- a/server/src/test/java/io/spine/server/delivery/DispatchOutcomesTest.java
+++ b/server/src/test/java/io/spine/server/delivery/DispatchOutcomesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,42 +26,29 @@
 
 package io.spine.server.delivery;
 
-import io.spine.annotation.Internal;
-import io.spine.server.dispatch.DispatchOutcome;
-import io.spine.server.entity.Repository;
-import io.spine.server.type.SignalEnvelope;
+import com.google.common.testing.NullPointerTester;
+import io.spine.core.MessageId;
+import io.spine.server.dispatch.DispatchOutcomes;
+import io.spine.server.type.CommandEnvelope;
+import io.spine.server.type.EventEnvelope;
+import io.spine.testing.UtilityClassTest;
+import org.junit.jupiter.api.DisplayName;
 
-/**
- * An endpoint for messages delivered to an abstract target.
- *
- * @param <I>
- *         the type of target identifier
- * @param <M>
- *         the type of message envelope being delivered
- */
-@Internal
-public interface MessageEndpoint<I, M extends SignalEnvelope<?, ?, ?>> {
+import static io.spine.server.dispatch.given.Given.commandEnvelope;
+import static io.spine.server.dispatch.given.Given.eventEnvelope;
 
-    /**
-     * Dispatches the message to the target with the passed ID.
-     *
-     * @param targetId
-     *         the identifier of a target
-     */
-    DispatchOutcome dispatchTo(I targetId);
+@DisplayName("`DispatchOutcomes` should")
+class DispatchOutcomesTest extends UtilityClassTest<DispatchOutcomes> {
 
-    /**
-     * The callback invoked if the handled signal is a duplicate.
-     *
-     * @param target
-     *         the target entity
-     * @param envelope
-     *         the handled signal
-     */
-    void onDuplicate(I target, M envelope);
+    DispatchOutcomesTest() {
+        super(DispatchOutcomes.class);
+    }
 
-    /**
-     * Obtains the repository which manages the target entities.
-     */
-    Repository<I, ?> repository();
+    @Override
+    protected void configure(NullPointerTester tester) {
+        super.configure(tester);
+        tester.setDefault(MessageId.class, MessageId.getDefaultInstance())
+              .setDefault(EventEnvelope.class, eventEnvelope())
+              .setDefault(CommandEnvelope.class, commandEnvelope());
+    }
 }

--- a/server/src/test/java/io/spine/server/delivery/InboxContents.java
+++ b/server/src/test/java/io/spine/server/delivery/InboxContents.java
@@ -34,10 +34,10 @@ import io.spine.server.ServerEnvironment;
 import static io.spine.server.tenant.TenantAwareRunner.with;
 
 /**
- * Utility providing an access to the raw contents of the {@link Inbox}es in the current
+ * Utility providing access to the raw contents of the {@link Inbox}es in the current
  * {@linkplain io.spine.server.ServerEnvironment server environment}.
  */
-final class InboxContents {
+public final class InboxContents {
 
     private InboxContents() {
     }
@@ -45,7 +45,7 @@ final class InboxContents {
     /**
      * Fetches the contents of the {@code Inbox}es for each of the {@code ShardIndex}es.
      */
-    static ImmutableMap<ShardIndex, ImmutableList<InboxMessage>> get() {
+    public static ImmutableMap<ShardIndex, ImmutableList<InboxMessage>> get() {
         var delivery = ServerEnvironment.instance()
                                         .delivery();
         var storage = delivery.inboxStorage();
@@ -58,7 +58,6 @@ final class InboxContents {
                     .evaluate(() -> storage.readAll(index, Integer.MAX_VALUE));
             builder.put(index, page.contents());
         }
-
         return builder.build();
     }
 }

--- a/server/src/test/java/io/spine/server/delivery/ReceptionFailureTest.java
+++ b/server/src/test/java/io/spine/server/delivery/ReceptionFailureTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.delivery;
+
+import io.spine.server.delivery.given.ReceptionFailureTestEnv.MarkFailureDeliveredMonitor;
+import io.spine.server.delivery.given.ReceptionFailureTestEnv.ObservingMonitor;
+import io.spine.testing.SlowTest;
+import io.spine.testing.logging.mute.MuteLogging;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+import static io.spine.base.Identifier.newUuid;
+import static io.spine.server.delivery.given.ReceptionFailureTestEnv.blackBox;
+import static io.spine.server.delivery.given.ReceptionFailureTestEnv.configureDelivery;
+import static io.spine.server.delivery.given.ReceptionFailureTestEnv.inboxMessages;
+import static io.spine.server.delivery.given.ReceptionFailureTestEnv.receptionist;
+import static io.spine.server.delivery.given.ReceptionFailureTestEnv.sleep;
+import static io.spine.server.delivery.given.ReceptionFailureTestEnv.tellToTurnConditioner;
+import static io.spine.server.delivery.given.ReceptionistAggregate.FAILURE_MESSAGE;
+import static io.spine.server.delivery.given.ReceptionistAggregate.makeApplierFail;
+import static io.spine.server.delivery.given.ReceptionistAggregate.makeApplierPass;
+
+@SlowTest
+@DisplayName("`Delivery` should allow to monitor the failed reception of signals ")
+@SuppressWarnings("resource")   /* We don't care about closing black boxes in this test. */
+final class ReceptionFailureTest extends AbstractDeliveryTest {
+
+    @Test
+    @DisplayName("and repeat dispatching of the corresponding `InboxMessage`")
+    @MuteLogging
+    void allowFailureRethrow() {
+        var monitor = new ObservingMonitor();
+        configureDelivery(monitor);
+        var context = blackBox().tolerateFailures();
+
+        var receptionistId = newUuid();
+        var command = tellToTurnConditioner(receptionistId);
+        makeApplierPass();
+        context.receivesCommand(command);
+        sleep();
+        assertThat(monitor.lastFailure()).isEmpty();
+        context.assertState(receptionistId, receptionist(receptionistId, 1));
+
+        var failureObserved = new AtomicBoolean(false);
+        monitor.setResolver((failure) -> {
+            failureObserved.set(true);
+            var error = failure.error();
+            assertThat(error.getStacktrace()).contains(FAILURE_MESSAGE);
+
+            makeApplierPass();
+            return failure.repeatDispatching();
+        });
+
+        makeApplierFail();
+        context.receivesCommand(command);
+        sleep();
+
+        assertThat(failureObserved.get())
+                .isTrue();
+        assertInboxEmpty();
+    }
+
+    @Test
+    @DisplayName("and mark the corresponding `InboxMessage` as delivered")
+    @MuteLogging
+    void allowMarkingFailedMessageAsDelivered() {
+        var monitor = new MarkFailureDeliveredMonitor();
+        configureDelivery(monitor);
+        var context = blackBox().tolerateFailures();
+
+        var receptionistId = newUuid();
+        var command = tellToTurnConditioner(receptionistId);
+        makeApplierFail();
+        context.receivesCommand(command);
+        sleep();
+
+        assertThat(monitor.failureReceived()).isTrue();
+        assertInboxEmpty();
+    }
+
+    private static void assertInboxEmpty() {
+        var messages = inboxMessages();
+        assertThat(messages.size()).isEqualTo(0);
+    }
+}

--- a/server/src/test/java/io/spine/server/delivery/ReceptionFailureTest.java
+++ b/server/src/test/java/io/spine/server/delivery/ReceptionFailureTest.java
@@ -50,7 +50,7 @@ import static io.spine.server.delivery.given.ReceptionistAggregate.makeApplierPa
 
 @SlowTest
 @DisplayName("`Delivery` should allow to monitor the failed reception of signals ")
-@SuppressWarnings("resource")   /* We don't care about closing black boxes in this test. */
+@SuppressWarnings("resource" /* We don't care about closing black boxes in this test. */)
 final class ReceptionFailureTest extends AbstractDeliveryTest {
 
     @Test

--- a/server/src/test/java/io/spine/server/delivery/given/NoOpEndpoint.java
+++ b/server/src/test/java/io/spine/server/delivery/given/NoOpEndpoint.java
@@ -26,17 +26,24 @@
 
 package io.spine.server.delivery.given;
 
+import io.spine.base.Identifier;
+import io.spine.core.MessageId;
 import io.spine.server.delivery.MessageEndpoint;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.entity.Repository;
 import io.spine.server.type.CommandEnvelope;
 
+import static io.spine.server.dispatch.DispatchOutcomes.successfulOutcome;
 import static io.spine.testing.TestValues.nullRef;
 
 public class NoOpEndpoint implements MessageEndpoint<String, CommandEnvelope> {
 
     @Override
-    public void dispatchTo(String targetId) {
-        // do nothing.
+    public DispatchOutcome dispatchTo(String targetId) {
+        var id = MessageId.newBuilder()
+                .setId(Identifier.pack(targetId))
+                .build();
+        return successfulOutcome(id);
     }
 
     @Override

--- a/server/src/test/java/io/spine/server/delivery/given/ReceptionFailureTestEnv.java
+++ b/server/src/test/java/io/spine/server/delivery/given/ReceptionFailureTestEnv.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.delivery.given;
+
+import com.google.common.collect.ImmutableList;
+import io.spine.environment.Tests;
+import io.spine.server.BoundedContextBuilder;
+import io.spine.server.DefaultRepository;
+import io.spine.server.ServerEnvironment;
+import io.spine.server.delivery.Delivery;
+import io.spine.server.delivery.DeliveryMonitor;
+import io.spine.server.delivery.FailedReception;
+import io.spine.server.delivery.InboxContents;
+import io.spine.server.delivery.InboxMessage;
+import io.spine.server.delivery.ShardObserver;
+import io.spine.server.tenant.TenantAwareRunner;
+import io.spine.test.delivery.Receptionist;
+import io.spine.test.delivery.command.TurnConditionerOn;
+import io.spine.testing.server.blackbox.BlackBox;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+
+/**
+ * Test environment for {@link io.spine.server.delivery.ReceptionFailureTest}.
+ */
+public final class ReceptionFailureTestEnv {
+
+    private ReceptionFailureTestEnv() {
+    }
+
+    public static BlackBox blackBox() {
+        var repository = DefaultRepository.of(ReceptionistAggregate.class);
+        var context = BlackBox.from(
+                BoundedContextBuilder.assumingTests()
+                                     .add(repository)
+        );
+        return context;
+    }
+
+    public static void configureDelivery(DeliveryMonitor monitor) {
+        var delivery = Delivery.newBuilder()
+                .setMonitor(monitor)
+                .build();
+        delivery.subscribe(new IgnoringObserver());
+        ServerEnvironment.when(Tests.class)
+                         .use(delivery);
+    }
+
+    public static void sleep() {
+        sleepUninterruptibly(Duration.ofMillis(900));
+    }
+
+    public static Receptionist receptionist(String receptionistId, int cmdsHandled) {
+        return Receptionist.newBuilder()
+                .setId(receptionistId)
+                .setHowManyCmdsHandled(cmdsHandled)
+                .build();
+    }
+
+    public static TurnConditionerOn tellToTurnConditioner(String receptionistId) {
+        var command = TurnConditionerOn
+                .newBuilder()
+                .setReceptionistId(receptionistId)
+                .build();
+        return command;
+    }
+
+    /**
+     * Fetches the contents of a single shard.
+     *
+     * <p>In case there are many shards configured, this method
+     * throws an {@code IllegalStateException}.
+     */
+    public static ImmutableList<InboxMessage> inboxMessages() {
+        var contents = InboxContents.get();
+        checkState(contents.size() == 1);
+        var messages = contents.values()
+                               .iterator()
+                               .next();
+        return messages;
+    }
+
+    /**
+     * A shard observer which deliberately ignores any exceptions thrown when dispatching
+     * inbox messages.
+     */
+    private static final class IgnoringObserver implements ShardObserver {
+
+        @Override
+        public void onMessage(InboxMessage message) {
+            new Thread(() -> runDelivery(message)).start();
+        }
+
+        @SuppressWarnings("resource")
+        private static void runDelivery(InboxMessage message) {
+            var tenant = message.tenant();
+            var index = message.shardIndex();
+            var delivery = ServerEnvironment.instance()
+                                            .delivery();
+            try {
+                TenantAwareRunner.with(tenant)
+                                 .run(() -> delivery.deliverMessagesFrom(index));
+            } catch (Exception ignored) {
+                // Do nothing.
+            }
+        }
+    }
+
+    /**
+     * A delivery monitor which remembers the last observed reception failure.
+     *
+     * <p>Allows to specify a {@link FailureResolver} and act upon the observed failure.
+     */
+    public static final class ObservingMonitor extends DeliveryMonitor {
+
+        private @Nullable FailedReception lastFailure = null;
+        private @Nullable FailureResolver resolver = null;
+
+        @Override
+        public FailedReception.Action onReceptionFailure(FailedReception reception) {
+            lastFailure = reception;
+            if (resolver != null) {
+                return resolver.onFailure(reception);
+            }
+            return super.onReceptionFailure(reception);
+        }
+
+        public Optional<FailedReception> lastFailure() {
+            return Optional.ofNullable(lastFailure);
+        }
+
+        /**
+         * Specifies the resolver for this monitor.
+         */
+        public void setResolver(FailureResolver resolver) {
+            this.resolver = checkNotNull(resolver);
+        }
+    }
+
+    /**
+     * Allows to act upon an observed {@link FailedReception}.
+     */
+    @FunctionalInterface
+    public interface FailureResolver {
+
+        /**
+         * Returns an action in response to a failed reception.
+         */
+        FailedReception.Action onFailure(FailedReception reception);
+    }
+
+    /**
+     * A delivery monitor which marks the message causing a reception failure
+     * as {@linkplain io.spine.server.delivery.InboxMessageStatus#DELIVERED delivered}.
+     */
+    public static final class MarkFailureDeliveredMonitor extends DeliveryMonitor {
+
+        private boolean failureReceived = false;
+
+        /**
+         * In case the reception of the {@code InboxMessage} failed,
+         * mark it as delivered anyway.
+         */
+        @Override
+        public FailedReception.Action onReceptionFailure(FailedReception reception) {
+            this.failureReceived = true;
+            return reception.markDelivered();
+        }
+
+        public boolean failureReceived() {
+            return failureReceived;
+        }
+    }
+}

--- a/server/src/test/java/io/spine/server/delivery/given/ReceptionistAggregate.java
+++ b/server/src/test/java/io/spine/server/delivery/given/ReceptionistAggregate.java
@@ -52,7 +52,7 @@ public final class ReceptionistAggregate
     }
 
     @Apply
-    @SuppressWarnings("ResultOfMethodCallIgnored")  /* Using Proto builder. */
+    @SuppressWarnings("ResultOfMethodCallIgnored" /* Using Proto builder. */)
     private void apply(ConditionerTurnedOn event) {
         maybeFail();
         int newValue = builder().getHowManyCmdsHandled() + 1;
@@ -69,7 +69,7 @@ public final class ReceptionistAggregate
     }
 
     @Apply
-    @SuppressWarnings("ResultOfMethodCallIgnored")  /* Using Proto builder. */
+    @SuppressWarnings("ResultOfMethodCallIgnored" /* Using Proto builder. */)
     private void apply(ConditionerTurnedOff event) {
         maybeFail();
         var newValue = builder().getHowManyCmdsHandled() + 1;

--- a/server/src/test/java/io/spine/server/delivery/given/ReceptionistAggregate.java
+++ b/server/src/test/java/io/spine/server/delivery/given/ReceptionistAggregate.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.delivery.given;
+
+import io.spine.server.aggregate.Aggregate;
+import io.spine.server.aggregate.Apply;
+import io.spine.server.command.Assign;
+import io.spine.test.delivery.Receptionist;
+import io.spine.test.delivery.command.TurnConditionerOff;
+import io.spine.test.delivery.command.TurnConditionerOn;
+import io.spine.test.delivery.event.ConditionerTurnedOff;
+import io.spine.test.delivery.event.ConditionerTurnedOn;
+
+import static io.spine.util.Exceptions.newIllegalStateException;
+
+public final class ReceptionistAggregate
+        extends Aggregate<String, Receptionist, Receptionist.Builder> {
+
+    public static final String FAILURE_MESSAGE = "Receptionist failed to apply an event.";
+
+    private static boolean failInAppliers = false;
+
+    @Assign
+    ConditionerTurnedOn handler(TurnConditionerOn cmd) {
+        return ConditionerTurnedOn.newBuilder()
+                .setReceptionist(id())
+                .build();
+    }
+
+    @Apply
+    @SuppressWarnings("ResultOfMethodCallIgnored")  /* Using Proto builder. */
+    private void apply(ConditionerTurnedOn event) {
+        maybeFail();
+        int newValue = builder().getHowManyCmdsHandled() + 1;
+        builder().setId(event.getReceptionist())
+                 .setHowManyCmdsHandled(newValue);
+    }
+
+    @Assign
+    ConditionerTurnedOff handler(TurnConditionerOff cmd) {
+        return ConditionerTurnedOff
+                .newBuilder()
+                .setReceptionist(id())
+                .build();
+    }
+
+    @Apply
+    @SuppressWarnings("ResultOfMethodCallIgnored")  /* Using Proto builder. */
+    private void apply(ConditionerTurnedOff event) {
+        maybeFail();
+        var newValue = builder().getHowManyCmdsHandled() + 1;
+        builder().setId(event.getReceptionist())
+                 .setHowManyCmdsHandled(newValue);
+    }
+
+    private static void maybeFail() throws IllegalStateException {
+        if (failInAppliers) {
+            throw newIllegalStateException(FAILURE_MESSAGE);
+        }
+    }
+
+    public static void makeApplierFail() {
+        failInAppliers = true;
+    }
+
+    public static void makeApplierPass() {
+        failInAppliers = false;
+    }
+}

--- a/server/src/test/java/io/spine/server/delivery/given/ReceptionistAggregate.java
+++ b/server/src/test/java/io/spine/server/delivery/given/ReceptionistAggregate.java
@@ -55,7 +55,7 @@ public final class ReceptionistAggregate
     @SuppressWarnings("ResultOfMethodCallIgnored" /* Using Proto builder. */)
     private void apply(ConditionerTurnedOn event) {
         maybeFail();
-        int newValue = builder().getHowManyCmdsHandled() + 1;
+        var newValue = builder().getHowManyCmdsHandled() + 1;
         builder().setId(event.getReceptionist())
                  .setHowManyCmdsHandled(newValue);
     }

--- a/server/src/test/java/io/spine/server/delivery/given/ReceptionistAggregate.java
+++ b/server/src/test/java/io/spine/server/delivery/given/ReceptionistAggregate.java
@@ -62,8 +62,7 @@ public final class ReceptionistAggregate
 
     @Assign
     ConditionerTurnedOff handler(TurnConditionerOff cmd) {
-        return ConditionerTurnedOff
-                .newBuilder()
+        return ConditionerTurnedOff.newBuilder()
                 .setReceptionist(id())
                 .build();
     }

--- a/server/src/test/java/io/spine/server/dispatch/given/Given.java
+++ b/server/src/test/java/io/spine/server/dispatch/given/Given.java
@@ -37,6 +37,8 @@ import io.spine.server.dispatch.DispatchOutcomeHandlerTest;
 import io.spine.server.dispatch.given.command.CreateDispatch;
 import io.spine.server.dispatch.given.event.DispatchCreated;
 import io.spine.server.dispatch.given.rejection.DispatchRejections;
+import io.spine.server.type.CommandEnvelope;
+import io.spine.server.type.EventEnvelope;
 import io.spine.testing.TestValues;
 import io.spine.testing.client.TestActorRequestFactory;
 import io.spine.testing.server.TestEventFactory;
@@ -72,8 +74,16 @@ public final class Given {
         return eventFactory.createEvent(dispatchCreated());
     }
 
+    public static EventEnvelope eventEnvelope() {
+        return EventEnvelope.of(event());
+    }
+
     public static Command command() {
         return commandFactory.create(createDispatch());
+    }
+
+    public static CommandEnvelope commandEnvelope() {
+        return CommandEnvelope.of(command());
     }
 
     private static CommandMessage createDispatch() {

--- a/server/src/test/java/io/spine/server/event/given/DelegatingEventDispatcherTestEnv.java
+++ b/server/src/test/java/io/spine/server/event/given/DelegatingEventDispatcherTestEnv.java
@@ -27,12 +27,14 @@
 package io.spine.server.event.given;
 
 import com.google.common.collect.ImmutableSet;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.event.EventDispatcherDelegate;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
 import io.spine.test.event.EvTeamCreated;
 
 import static com.google.common.collect.Sets.union;
+import static io.spine.server.dispatch.DispatchOutcomes.successfulOutcome;
 
 public class DelegatingEventDispatcherTestEnv {
 
@@ -60,8 +62,8 @@ public class DelegatingEventDispatcherTestEnv {
         }
 
         @Override
-        public void dispatchEvent(EventEnvelope event) {
-            // Do nothing.
+        public DispatchOutcome dispatchEvent(EventEnvelope event) {
+            return successfulOutcome(event);
         }
     }
 
@@ -84,8 +86,8 @@ public class DelegatingEventDispatcherTestEnv {
         }
 
         @Override
-        public void dispatchEvent(EventEnvelope event) {
-            // Do nothing.
+        public DispatchOutcome dispatchEvent(EventEnvelope event) {
+            return successfulOutcome(event);
         }
     }
 }

--- a/server/src/test/java/io/spine/server/event/given/bus/BareDispatcher.java
+++ b/server/src/test/java/io/spine/server/event/given/bus/BareDispatcher.java
@@ -27,10 +27,13 @@
 package io.spine.server.event.given.bus;
 
 import com.google.common.collect.ImmutableSet;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.event.EventDispatcher;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
 import io.spine.test.event.ProjectCreated;
+
+import static io.spine.server.dispatch.DispatchOutcomes.successfulOutcome;
 
 /**
  * A simple dispatcher class, which only dispatch and does not have own event
@@ -56,8 +59,9 @@ public class BareDispatcher implements EventDispatcher {
     }
 
     @Override
-    public void dispatch(EventEnvelope event) {
+    public DispatchOutcome dispatch(EventEnvelope event) {
         dispatchCalled = true;
+        return successfulOutcome(event);
     }
 
     public boolean isDispatchCalled() {

--- a/server/src/test/java/io/spine/system/server/given/AbstractEventAccumulator.java
+++ b/server/src/test/java/io/spine/system/server/given/AbstractEventAccumulator.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Message;
 import io.spine.base.EventMessage;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.event.EventDispatcher;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
@@ -37,6 +38,7 @@ import io.spine.server.type.EventEnvelope;
 import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static io.spine.server.dispatch.DispatchOutcomes.successfulOutcome;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -61,9 +63,10 @@ public abstract class AbstractEventAccumulator implements EventDispatcher {
      */
     @CanIgnoreReturnValue
     @Override
-    public final void dispatch(EventEnvelope event) {
+    public final DispatchOutcome dispatch(EventEnvelope event) {
         var msg = event.message();
         remember(msg);
+        return successfulOutcome(event);
     }
 
     @Override

--- a/server/src/test/proto/spine/test/delivery/receptionist.proto
+++ b/server/src/test/proto/spine/test/delivery/receptionist.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,45 +23,22 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+syntax = "proto3";
 
-package io.spine.server.delivery;
+package spine.test.delivery;
 
-import io.spine.annotation.Internal;
-import io.spine.server.dispatch.DispatchOutcome;
-import io.spine.server.entity.Repository;
-import io.spine.server.type.SignalEnvelope;
+import "spine/options.proto";
 
-/**
- * An endpoint for messages delivered to an abstract target.
- *
- * @param <I>
- *         the type of target identifier
- * @param <M>
- *         the type of message envelope being delivered
- */
-@Internal
-public interface MessageEndpoint<I, M extends SignalEnvelope<?, ?, ?>> {
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.test.delivery";
+option java_outer_classname = "ReceptionistProto";
+option java_multiple_files = true;
 
-    /**
-     * Dispatches the message to the target with the passed ID.
-     *
-     * @param targetId
-     *         the identifier of a target
-     */
-    DispatchOutcome dispatchTo(I targetId);
+message Receptionist {
 
-    /**
-     * The callback invoked if the handled signal is a duplicate.
-     *
-     * @param target
-     *         the target entity
-     * @param envelope
-     *         the handled signal
-     */
-    void onDuplicate(I target, M envelope);
+    option (entity).kind = AGGREGATE;
 
-    /**
-     * Obtains the repository which manages the target entities.
-     */
-    Repository<I, ?> repository();
+    string id = 1;
+
+    int32 how_many_cmds_handled = 2[(min).value = "0"];
 }

--- a/server/src/test/proto/spine/test/delivery/receptionist_commands.proto
+++ b/server/src/test/proto/spine/test/delivery/receptionist_commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,45 +23,21 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+syntax = "proto3";
 
-package io.spine.server.delivery;
+package spine.test.delivery;
 
-import io.spine.annotation.Internal;
-import io.spine.server.dispatch.DispatchOutcome;
-import io.spine.server.entity.Repository;
-import io.spine.server.type.SignalEnvelope;
+import "spine/options.proto";
 
-/**
- * An endpoint for messages delivered to an abstract target.
- *
- * @param <I>
- *         the type of target identifier
- * @param <M>
- *         the type of message envelope being delivered
- */
-@Internal
-public interface MessageEndpoint<I, M extends SignalEnvelope<?, ?, ?>> {
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.test.delivery.command";
+option java_outer_classname = "ReceptionistCommandsProto";
+option java_multiple_files = true;
 
-    /**
-     * Dispatches the message to the target with the passed ID.
-     *
-     * @param targetId
-     *         the identifier of a target
-     */
-    DispatchOutcome dispatchTo(I targetId);
+message TurnConditionerOn {
+    string receptionist_id = 1;
+}
 
-    /**
-     * The callback invoked if the handled signal is a duplicate.
-     *
-     * @param target
-     *         the target entity
-     * @param envelope
-     *         the handled signal
-     */
-    void onDuplicate(I target, M envelope);
-
-    /**
-     * Obtains the repository which manages the target entities.
-     */
-    Repository<I, ?> repository();
+message TurnConditionerOff {
+    string receptionist_id = 1;
 }

--- a/server/src/test/proto/spine/test/delivery/receptionist_events.proto
+++ b/server/src/test/proto/spine/test/delivery/receptionist_events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,45 +23,21 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+syntax = "proto3";
 
-package io.spine.server.delivery;
+package spine.test.delivery;
 
-import io.spine.annotation.Internal;
-import io.spine.server.dispatch.DispatchOutcome;
-import io.spine.server.entity.Repository;
-import io.spine.server.type.SignalEnvelope;
+import "spine/options.proto";
 
-/**
- * An endpoint for messages delivered to an abstract target.
- *
- * @param <I>
- *         the type of target identifier
- * @param <M>
- *         the type of message envelope being delivered
- */
-@Internal
-public interface MessageEndpoint<I, M extends SignalEnvelope<?, ?, ?>> {
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.test.delivery.event";
+option java_outer_classname = "ReceptionistEventsProto";
+option java_multiple_files = true;
 
-    /**
-     * Dispatches the message to the target with the passed ID.
-     *
-     * @param targetId
-     *         the identifier of a target
-     */
-    DispatchOutcome dispatchTo(I targetId);
+message ConditionerTurnedOn {
+    string receptionist = 1;
+}
 
-    /**
-     * The callback invoked if the handled signal is a duplicate.
-     *
-     * @param target
-     *         the target entity
-     * @param envelope
-     *         the handled signal
-     */
-    void onDuplicate(I target, M envelope);
-
-    /**
-     * Obtains the repository which manages the target entities.
-     */
-    Repository<I, ?> repository();
+message ConditionerTurnedOff {
+    string receptionist = 1;
 }

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/FailedHandlerGuard.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/FailedHandlerGuard.java
@@ -28,19 +28,21 @@ package io.spine.testing.server.blackbox;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.event.AbstractEventSubscriber;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
 import io.spine.system.server.HandlerFailedUnexpectedly;
 
 import static io.spine.json.Json.toJson;
+import static io.spine.server.dispatch.DispatchOutcomes.successfulOutcome;
 import static java.lang.String.format;
 import static java.lang.System.lineSeparator;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * Performs logging of failed signals handlers or fails the test depending the current
- * context exception tolerance.
+ * Performs logging of failed signals handlers or fails the test
+ * depending upon the current context exception tolerance.
  */
 final class FailedHandlerGuard extends AbstractEventSubscriber implements DiagnosticLogging {
 
@@ -60,9 +62,10 @@ final class FailedHandlerGuard extends AbstractEventSubscriber implements Diagno
     }
 
     @Override
-    protected void handle(EventEnvelope eventEnvelope) {
+    protected DispatchOutcome handle(EventEnvelope eventEnvelope) {
         var event = (HandlerFailedUnexpectedly) eventEnvelope.message();
         on(event);
+        return successfulOutcome(eventEnvelope);
     }
 
     /**

--- a/testutil-server/src/main/java/io/spine/testing/server/blackbox/UnsupportedCommandGuard.java
+++ b/testutil-server/src/main/java/io/spine/testing/server/blackbox/UnsupportedCommandGuard.java
@@ -30,6 +30,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import io.spine.base.Error;
 import io.spine.core.CommandValidationError;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.event.AbstractEventSubscriber;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
@@ -38,6 +39,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static io.spine.core.CommandValidationError.UNSUPPORTED_COMMAND_VALUE;
 import static io.spine.server.commandbus.CommandException.ATTR_COMMAND_TYPE_NAME;
+import static io.spine.server.dispatch.DispatchOutcomes.successfulOutcome;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -113,8 +115,12 @@ final class UnsupportedCommandGuard extends AbstractEventSubscriber {
      * {@linkplain #canDispatch(EventEnvelope) is detected}.
      */
     @Override
-    protected void handle(EventEnvelope event) {
+    protected DispatchOutcome handle(EventEnvelope event) {
         failTest();
+
+        // This return statement is unreachable,
+        // since the previous statement throws an {@code Error}.
+        return successfulOutcome(event);
     }
 
     /**

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/BlackBoxTest.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/BlackBoxTest.java
@@ -93,9 +93,11 @@ import static io.spine.testing.core.given.GivenUserId.newUuid;
 import static io.spine.testing.server.blackbox.given.Given.addProjectAssignee;
 import static io.spine.testing.server.blackbox.given.Given.addTask;
 import static io.spine.testing.server.blackbox.given.Given.assignSelf;
+import static io.spine.testing.server.blackbox.given.Given.commandListener;
 import static io.spine.testing.server.blackbox.given.Given.createProject;
 import static io.spine.testing.server.blackbox.given.Given.createReport;
 import static io.spine.testing.server.blackbox.given.Given.createdProjectState;
+import static io.spine.testing.server.blackbox.given.Given.eventListener;
 import static io.spine.testing.server.blackbox.given.Given.failProject;
 import static io.spine.testing.server.blackbox.given.Given.finalizeProject;
 import static io.spine.testing.server.blackbox.given.Given.initProject;
@@ -475,8 +477,8 @@ abstract class BlackBoxTest<T extends BlackBox> {
 
         private final CommandClass commandClass =
                 CommandClass.from(BbRegisterCommandDispatcher.class);
-        private final Listener<CommandEnvelope> commandListener = envelope -> {};
-        private final Listener<EventEnvelope> eventListener = envelope -> {};
+        private final Listener<CommandEnvelope> commandListener = commandListener();
+        private final Listener<EventEnvelope> eventListener = eventListener();
         private final Set<TypeName> types = toTypes(repositories);
         private final TenantIndex tenantIndex = new StubTenantIndex();
 

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbCommandDispatcher.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/BbCommandDispatcher.java
@@ -29,8 +29,11 @@ package io.spine.testing.server.blackbox.given;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.spine.server.command.AbstractCommandDispatcher;
+import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.type.CommandClass;
 import io.spine.server.type.CommandEnvelope;
+
+import static io.spine.server.dispatch.DispatchOutcomes.successfulOutcome;
 
 /**
  * Increments a counter on receiving a command of the specified type.
@@ -38,8 +41,6 @@ import io.spine.server.type.CommandEnvelope;
  * @see io.spine.testing.server.blackbox.BlackBoxTest
  */
 public final class BbCommandDispatcher extends AbstractCommandDispatcher {
-
-    private int commandsReceived = 0;
     private final CommandClass commandToDispatch;
 
     public BbCommandDispatcher(CommandClass commandToDispatch) {
@@ -54,7 +55,7 @@ public final class BbCommandDispatcher extends AbstractCommandDispatcher {
 
     @CanIgnoreReturnValue
     @Override
-    public void dispatch(CommandEnvelope envelope) {
-        commandsReceived++;
+    public DispatchOutcome dispatch(CommandEnvelope envelope) {
+        return successfulOutcome(envelope);
     }
 }

--- a/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/Given.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/blackbox/given/Given.java
@@ -28,8 +28,11 @@ package io.spine.testing.server.blackbox.given;
 
 import io.spine.core.MessageId;
 import io.spine.core.UserId;
+import io.spine.server.bus.Listener;
 import io.spine.server.commandbus.CommandDispatcher;
 import io.spine.server.event.EventDispatcher;
+import io.spine.server.type.CommandEnvelope;
+import io.spine.server.type.EventEnvelope;
 import io.spine.testing.TestValues;
 import io.spine.testing.core.given.GivenVersion;
 import io.spine.testing.server.blackbox.BbProject;
@@ -198,5 +201,13 @@ public class Given {
                                    .value())
                 .setId(pack(newUuidValue()))
                 .build();
+    }
+
+    public static Listener<CommandEnvelope> commandListener() {
+        return envelope -> {};
+    }
+
+    public static Listener<EventEnvelope> eventListener() {
+        return envelope -> {};
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.internal.dependency.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.143")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.144")


### PR DESCRIPTION
This PR is a port of #1496 into `master` branch. Here is a full description, for reviewer's convenience.

This changeset addresses #1472 and brings other improvements into the codebase.

## Failure of signal reception, and `DeliveryMonitor` to respond

`InboxMessage`s which are processed in scope of each `Delivery` run, are eventually unpacked, and the respective signals are dispatched to their targets. In case a signal target is an `Entity`, it is possible that the signal reception does not go well for various reasons. In particular, an aggregate may have "broken" `@Apply`-er, making it impossible to load the aggregate state. Or, some other unexpected error may occur upon loading or storing an entity.

Previously, it was impossible to trace such failures of signal reception. And the `InboxMessage`s causing the errors were left in their inboxes in `TO_DELIVER` status forever, being delivered over and over again — most likely with the same reception failure repeating.

Now, the `Delivery` API allows to subscribe for any failures which occur during the reception of each signal. Additionally, end-users may now choose the way to handle the reception failures in terms of action in respect to the `InboxMessage` of interest. 

Out-of-the-box, there are two actions provided:
* mark the `InboxMessage` as delivered — so that it does not block further delivery of messages;
* repeat the dispatching of the `InboxMessage`. Please note, this is a _synchronous_ and immediate action in terms of a delivery run.

Alternatively, end-users may implement their own way of handling the reception failure.


The corresponding functionality is provided via the API of `DeliveryMonitor`.

Here is a code sample:

```java

public final class MarkFailureDelivered extends DeliveryMonitor {

    /**
     * In case the reception of the {@code InboxMessage} failed,
     * mark it as {@code DELIVERED} anyway.
     */
    @Override
    public FailedReception.Action onReceptionFailure(FailedReception reception) {

    	//// Error details are available as well:
        // InboxMessage msg = reception.message();
        // Error error = reception.error();
        // notifyOf(msg, error);

        return reception.markDelivered();
    }
}

// ...

// Plugging the monitor into the Delivery:

var monitor = new MarkFailureDelivered();

var delivery = Delivery.newBuilder()
        .setMonitor(monitor)
        // ...
        .build();

ServerEnvironment
        .when(MyEnvironment.class)
        .use(delivery);
```

By default, `InboxMessage`s are marked as `DELIVERED` in case of failure of their reception. This is so, because otherwise the issue described in #1472 arises.

Internally, such a functionality became possible by making `MessageDispatcher.dispatch(envelope)` to return `DispatchOutcome`. Previously, it was `void`, which was not suitable for handling any of the issues synchronously — as it was required for `InboxMessage` to allow users choose the way to handle the reception failures.

## Other changes

It was reported, that at run-time the routing of events by their interfaces may lead to `ConcurrentModificationException`. 
This PR addresses the issue by making the `Map` of signal routes concurrency-friendly. See [`io.spine.server.route.MessageRouting`](https://github.com/SpineEventEngine/core-java/pull/1512/files#diff-e25c04493dd2dccb2090c2ae6038eff8b0ecfadd2bc7f96ea42196a1b61550f6) for more details.

Even more minor changes are made to fix typos and remove the chunks of unused code.

The library version is set to `2.0.0-SNAPSHOT.144`.