### PR TITLE
Prohibit calling `state()` from `Aggregate`'s `@Apply`-er methods

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.144`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.145`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -814,12 +814,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 03 15:50:43 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 03 16:47:10 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.144`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.145`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1593,12 +1593,12 @@ This report was generated on **Sat Jun 03 15:50:43 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 03 15:50:43 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 03 16:47:11 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.144`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.145`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2420,12 +2420,12 @@ This report was generated on **Sat Jun 03 15:50:43 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 03 15:50:44 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 03 16:47:11 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.144`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.145`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3364,12 +3364,12 @@ This report was generated on **Sat Jun 03 15:50:44 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 03 15:50:44 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 03 16:47:11 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.144`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.145`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4308,12 +4308,12 @@ This report was generated on **Sat Jun 03 15:50:44 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 03 15:50:45 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 03 16:47:12 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.144`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.145`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5300,4 +5300,4 @@ This report was generated on **Sat Jun 03 15:50:45 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 03 15:50:45 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 03 16:47:12 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.144</version>
+<version>2.0.0-SNAPSHOT.145</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -57,6 +57,7 @@ import static io.spine.protobuf.AnyPacker.unpack;
 import static io.spine.protobuf.Messages.isNotDefault;
 import static io.spine.server.Ignored.ignored;
 import static io.spine.server.aggregate.model.AggregateClass.asAggregateClass;
+import static io.spine.util.Exceptions.newIllegalStateException;
 
 /**
  * Abstract base for aggregates.
@@ -104,7 +105,18 @@ import static io.spine.server.aggregate.model.AggregateClass.asAggregateClass;
  * Please see {@link Apply} for more details.
  *
  * <p>The modification of the state is done using a builder instance obtained
- * from {@link #builder()}.
+ * from {@link #builder()}. All changes to state become reflected in {@code state()},
+ * after <em>all</em> events (obtained from aggregate's history when loading
+ * an aggregate, or emitted by command handlers during the command dispatching)
+ * are played.
+ *
+ * <p>End-users must not call {@code state()} method within an event applier.
+ * It is so, because event appliers are invoked in scope of an active transaction,
+ * which accumulates the model updates in aggregate's {@code builder()},
+ * and not in {@code state()}. Therefore, {@code state()} invocation from
+ * the applier's code may return some inconsistent result,
+ * and in general is prone to errors.
+ * All such attempts will result in a {@code RuntimeException}.
  *
  * <p>An {@code Aggregate} class must have applier methods for
  * <em>all</em> types of the events that it produces.
@@ -135,6 +147,12 @@ public abstract class Aggregate<I,
      * A guard for ensuring idempotency of messages dispatched by this aggregate.
      */
     private IdempotencyGuard idempotencyGuard;
+
+    /**
+     * Tells whether any applier method is being invoked
+     * right now for this instance of aggregate.
+     */
+    private final ApplierWatcher applierWatcher = new ApplierWatcher();
 
     /**
      * Creates a new instance.
@@ -215,6 +233,27 @@ public abstract class Aggregate<I,
     }
 
     /**
+     * Prohibits invoking {@link #state() state()} method from within an applier method.
+     *
+     * <p>All applier methods are always invoked in scope of an active transaction.
+     * Until this transaction is completed, the {@code state()} of the corresponding aggregate
+     * is not up-to-date. Therefore, relying upon it in code is prone to errors,
+     * and is prohibited for good sake.
+     *
+     * @throws IllegalStateException
+     *         if this method is called from within an event applier
+     */
+    @Override
+    protected void ensureAccessToState() {
+        if (applierWatcher.inProgress()) {
+            throw newIllegalStateException(
+                    "Aggregate `state()` method must not be used from `@Apply`-marked method." +
+                            " Use `builder()` instead. The issue detected in `%s` aggregate class.",
+                    getClass().getName());
+        }
+    }
+
+    /**
      * Obtains a method for the passed command and invokes it.
      *
      * <p>Dispatching the commands results in emitting event messages. All the
@@ -276,7 +315,8 @@ public abstract class Aggregate<I,
      */
     final DispatchOutcome invokeApplier(EventEnvelope event) {
         var method = thisClass().applierOf(event);
-        return method.invoke(this, event);
+        var outcome = applierWatcher.perform(() -> method.invoke(this, event));
+        return outcome;
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/aggregate/AggregateTransaction.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateTransaction.java
@@ -41,7 +41,7 @@ import io.spine.validate.ValidatingBuilder;
  *
  * @param <I> the type of aggregate IDs
  * @param <S> the type of aggregate state
- * @param <B> the type of a {@code ValidatingBuilder} for the aggregate state
+ * @param <B> the type of {@code ValidatingBuilder} for the aggregate state
  */
 @Internal
 public class AggregateTransaction<I,

--- a/server/src/main/java/io/spine/server/aggregate/ApplierWatcher.java
+++ b/server/src/main/java/io/spine/server/aggregate/ApplierWatcher.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.aggregate;
+
+import io.spine.server.aggregate.model.Applier;
+import io.spine.server.dispatch.DispatchOutcome;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+/**
+ * Watches for the event {@link Applier} methods being invoked on an aggregate instance.
+ */
+final class ApplierWatcher {
+
+    private final AtomicBoolean inProgress = new AtomicBoolean(false);
+
+    /**
+     * Tells whether any applier method on a watched aggregate is being called right now.
+     */
+    boolean inProgress() {
+        return inProgress.get();
+    }
+
+    /**
+     * Performs the call, recording the invocation start and completion.
+     *
+     * @param call
+     *         the call of an {@code Applier} method
+     * @return the outcome of calling the {@code Applier}
+     */
+    synchronized DispatchOutcome perform(Supplier<DispatchOutcome> call) {
+        try {
+            inProgress.set(true);
+            return call.get();
+        } finally {
+            inProgress.set(false);
+        }
+    }
+}

--- a/server/src/main/java/io/spine/server/entity/AbstractEntity.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractEntity.java
@@ -91,7 +91,7 @@ public abstract class AbstractEntity<I, S extends EntityState<I>>
     /**
      * The ID of the entity.
      *
-     * <p>Assigned either through the {@linkplain #AbstractEntity(Object)} constructor which
+     * <p>Assigned either through the {@linkplain #AbstractEntity(Object) constructor which
      * accepts the ID}, or via {@link #setId(Object)}. Is never {@code null}.
      */
     private @MonotonicNonNull I id;
@@ -189,6 +189,7 @@ public abstract class AbstractEntity<I, S extends EntityState<I>>
      */
     @Override
     public final S state() {
+        ensureAccessToState();
         var result = state;
         if (result == null) {
             synchronized (this) {
@@ -200,6 +201,24 @@ public abstract class AbstractEntity<I, S extends EntityState<I>>
             }
         }
         return result;
+    }
+
+    /**
+     * Ensures that the callee is allowed to access Entity's {@link #state() state()} method.
+     *
+     * <p>In case the access is prohibited, throws a {@code RuntimeException}.
+     *
+     * <p>In some scenarios, the state of Entity may be not up-to-date,
+     * so descendants of {@code AbstractEntity} are able to put the corresponding restrictions
+     * on this method invocation.
+     *
+     * <p>By default, this method performs no checks,
+     * thus allowing to access Entity's {@code state()} at any point of time.
+     */
+    @Internal
+    @SuppressWarnings("NoopMethodInAbstractClass" /* By design. */)
+    protected void ensureAccessToState() {
+        // Do nothing by default.
     }
 
     /**
@@ -386,7 +405,7 @@ public abstract class AbstractEntity<I, S extends EntityState<I>>
      * Ensures that the entity is not marked as {@code archived}.
      *
      * @throws CannotModifyArchivedEntity
-     *         if the entity in in the archived status
+     *         if the entity in the archived status
      * @see #lifecycleFlags()
      * @see io.spine.server.entity.LifecycleFlags#getArchived()
      */

--- a/server/src/main/java/io/spine/server/entity/EventPlayer.java
+++ b/server/src/main/java/io/spine/server/entity/EventPlayer.java
@@ -88,8 +88,8 @@ public interface EventPlayer {
         checkNotNull(entity);
         Transaction<?, ?, ?, ?> tx = entity.tx();
         checkArgument(tx instanceof EventPlayingTransaction,
-                      "EventPlayer can only be created for the entity whose transaction type is " +
-                              "EventPlayingTransaction");
+                      "`EventPlayer` can only be created for the entity " +
+                              "whose transaction type is `EventPlayingTransaction`.");
         EventPlayingTransaction<?, ?, ?, ?> cast = (EventPlayingTransaction<?, ?, ?, ?>) tx;
         return new TransactionalEventPlayer(cast);
     }

--- a/server/src/main/java/io/spine/server/entity/TransactionalEntity.java
+++ b/server/src/main/java/io/spine/server/entity/TransactionalEntity.java
@@ -35,6 +35,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A base for entities, perform transactions {@linkplain Event events}.
@@ -155,7 +156,7 @@ class TransactionalEntity<I, S extends EntityState<I>, B extends ValidatingBuild
         if (!isTransactionInProgress()) {
             throw new IllegalStateException(missingTxMessage());
         }
-        return checkNotNull(transaction);
+        return requireNonNull(transaction);
     }
 
     /**

--- a/server/src/test/java/io/spine/server/aggregate/AggregateTestSupport.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateTestSupport.java
@@ -27,12 +27,14 @@
 package io.spine.server.aggregate;
 
 import io.spine.base.EntityState;
+import io.spine.logging.Logging;
 import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.type.CommandEnvelope;
 import io.spine.server.type.EventEnvelope;
 import io.spine.server.type.MessageEnvelope;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.json.Json.toJson;
 
 /**
  * Internal utility class for assisting in aggregate tests.
@@ -41,6 +43,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *          Calling it other code would result in run-time error.
  */
 public final class AggregateTestSupport {
+
+    private static final Logger logger = new Logger();
 
     /** Prevents instantiation of this utility class. */
     private AggregateTestSupport() {
@@ -57,7 +61,11 @@ public final class AggregateTestSupport {
     public static <I, A extends Aggregate<I, S, ?>, S extends EntityState<I>> DispatchOutcome
     dispatchCommand(AggregateRepository<I, A, S> repository, A aggregate, CommandEnvelope command) {
         checkArguments(repository, aggregate, command);
-        return dispatchAndCollect(new AggregateCommandEndpoint<>(repository, command),aggregate);
+        var outcome = dispatchAndCollect(
+                new AggregateCommandEndpoint<>(repository, command), aggregate
+        );
+        logger.warnIfErroneous(outcome);
+        return outcome;
     }
 
     /**
@@ -71,7 +79,11 @@ public final class AggregateTestSupport {
     public static <I, A extends Aggregate<I, S, ?>, S extends EntityState<I>> DispatchOutcome
     dispatchEvent(AggregateRepository<I, A, S> repository, A instance, EventEnvelope event) {
         checkArguments(repository, instance, event);
-        return dispatchAndCollect(new AggregateEventReactionEndpoint<>(repository, event),instance);
+        var outcome = dispatchAndCollect(
+                new AggregateEventReactionEndpoint<>(repository, event), instance
+        );
+        logger.warnIfErroneous(outcome);
+        return outcome;
     }
 
     private static <I, A extends Aggregate<I, ?, ?>> DispatchOutcome
@@ -86,5 +98,22 @@ public final class AggregateTestSupport {
         checkNotNull(repository);
         checkNotNull(aggregate);
         checkNotNull(envelope);
+    }
+
+    /**
+     * A window into Spine's logging from the {@code static} execution context
+     * of this {@code AggregateTestSupport} utility.
+     */
+    private static final class Logger implements Logging {
+
+        /**
+         * Prints the {@code Error} details as a warning-level log message,
+         * if the provided outcome has one.
+         */
+        private void warnIfErroneous(DispatchOutcome outcome) {
+            if(outcome.hasError()) {
+                _warn().log(toJson(outcome.getError()));
+            }
+        }
     }
 }

--- a/server/src/test/java/io/spine/server/aggregate/given/aggregate/FaultyAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/aggregate/FaultyAggregate.java
@@ -33,10 +33,13 @@ import io.spine.server.command.Assign;
 import io.spine.test.aggregate.AggProject;
 import io.spine.test.aggregate.ProjectId;
 import io.spine.test.aggregate.Status;
+import io.spine.test.aggregate.command.AggAddTask;
 import io.spine.test.aggregate.command.AggCreateProject;
 import io.spine.test.aggregate.event.AggProjectCreated;
+import io.spine.test.aggregate.event.AggTaskAdded;
 
 import static io.spine.server.aggregate.given.Given.EventMessage.projectCreated;
+import static io.spine.server.aggregate.given.Given.EventMessage.taskAdded;
 
 /**
  * The test environment class for checking raising and catching exceptions.
@@ -70,5 +73,17 @@ public final class FaultyAggregate
             throw new IllegalStateException(BROKEN_APPLIER);
         }
         builder().setStatus(Status.CREATED);
+    }
+
+    @Assign
+    AggTaskAdded handle(AggAddTask cmd) {
+        return taskAdded(cmd.getProjectId());
+    }
+
+    @Apply
+    private void event(AggTaskAdded event) {
+        /* This call to `state()` is prohibited from `Apply`-marked method. */
+        var id = state().getId();
+        builder().setId(id);
     }
 }

--- a/server/src/test/java/io/spine/server/aggregate/given/importado/Dot.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/importado/Dot.java
@@ -50,14 +50,14 @@ final class Dot extends Aggregate<ObjectId, Point, Point.Builder> {
 
     @Apply(allowImport = true)
     private void event(Moved event) {
-        var newPosition = move(id(), state(), event.getDirection());
+        var newPosition = move(id(), builder(), event.getDirection());
 
         builder().setId(event.getObject())
                  .setX(newPosition.getX())
                  .setY(newPosition.getY());
     }
 
-    private static Point move(ObjectId id, Point p, Direction direction) {
+    private static Point move(ObjectId id, PointOrBuilder p, Direction direction) {
         var result = Point.newBuilder()
                 .setId(id)
                 .setX(p.getX())

--- a/server/src/test/java/io/spine/server/aggregate/given/repo/FailingAggregate.java
+++ b/server/src/test/java/io/spine/server/aggregate/given/repo/FailingAggregate.java
@@ -51,10 +51,10 @@ import static java.util.Collections.emptyList;
 /**
  * The aggregate which throws {@link IllegalArgumentException} in response to negative numbers.
  *
- * <p>Normally aggregates should reject commands via command rejections. This class is test
- * environment for testing of now
+ * <p>Normally aggregates should reject commands via rejections. This class does not do so,
+ * because it is a test environment for checking how
  * {@linkplain io.spine.server.aggregate.AggregateRepository#logError(String, MessageEnvelope, RuntimeException)
- * logs errors}.
+ * AggregateRepository logs errors}.
  *
  * @see FailingAggregateRepository
  */
@@ -113,7 +113,7 @@ class FailingAggregate extends Aggregate<Long, LongIdAggregate, LongIdAggregate.
                 .from(event.getWhen())
                 .toInstant()
                 .get(ChronoField.MILLI_OF_SECOND);
-        builder().setValue(state().getValue() + whichSecond);
+        builder().setValue(builder().getValue() + whichSecond);
     }
 
     private static NumberPassed now() {

--- a/server/src/test/java/io/spine/server/model/handler/given/RoverBot.java
+++ b/server/src/test/java/io/spine/server/model/handler/given/RoverBot.java
@@ -85,11 +85,11 @@ public class RoverBot extends Aggregate<Integer, Position, Position.Builder> {
     }
 
     private int currentX() {
-        return state().getX();
+        return builder().getX();
     }
 
     private int currentY() {
-        return state().getY();
+        return builder().getY();
     }
 
     @Apply

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.internal.dependency.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.144")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.145")


### PR DESCRIPTION
This is a port of #1501 into `master` branch. Here is a full description of the ported PR.

This changeset addresses #1499 by disallowing to call `state()` method from aggregate appliers.

Previously, end-users could rely on `Aggregate.state()` from `@Apply`-ers. However, in some cases (such as the one described in #1499) `state()` does not reflect the last state of an aggregate. This is so because appliers are invoked in scope of a single transaction — be it when loading an aggregate instance from storage, or when applying the just-emitted events during the command dispatching. Until such a transaction is completed, `state()` does not reflect the model updates corresponding to the respective domain events. Using the returned state value most likely leads to bugs.

The designed way has always been to use `builder()` instead of `state()`, because it is kept up-to-date throughout the active aggregate transaction.

Therefore, once this PR is merged, any calls to `state()` from `@Apply`-annotated method will lead to an `IllegalStateException`.

The library version is set to `2.0.0-SNAPSHOT.145`.

