### PR TITLE
Import events from 3rd-party with respect for tenancy

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.145`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.146`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -814,12 +814,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 03 16:47:10 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jun 04 15:01:26 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.145`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.146`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1593,12 +1593,12 @@ This report was generated on **Sat Jun 03 16:47:10 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 03 16:47:11 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jun 04 15:01:26 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.145`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.146`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2420,12 +2420,12 @@ This report was generated on **Sat Jun 03 16:47:11 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 03 16:47:11 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jun 04 15:01:27 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.145`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.146`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3364,12 +3364,12 @@ This report was generated on **Sat Jun 03 16:47:11 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 03 16:47:11 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jun 04 15:01:27 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.145`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.146`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4308,12 +4308,12 @@ This report was generated on **Sat Jun 03 16:47:11 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 03 16:47:12 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jun 04 15:01:27 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.145`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.146`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5300,4 +5300,4 @@ This report was generated on **Sat Jun 03 16:47:12 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 03 16:47:12 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jun 04 15:01:28 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.145</version>
+<version>2.0.0-SNAPSHOT.146</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/integration/IncomingEventObserver.java
+++ b/server/src/main/java/io/spine/server/integration/IncomingEventObserver.java
@@ -28,6 +28,7 @@ package io.spine.server.integration;
 import io.spine.core.BoundedContextName;
 import io.spine.core.Event;
 import io.spine.protobuf.AnyPacker;
+import io.spine.server.tenant.TenantAwareRunner;
 import io.spine.server.type.EventClass;
 
 import static io.spine.grpc.StreamObservers.noOpObserver;
@@ -59,6 +60,7 @@ final class IncomingEventObserver extends AbstractChannelObserver {
     @Override
     protected void handle(ExternalMessage message) {
         var event = AnyPacker.unpack(message.getOriginalMessage(), Event.class);
-        bus.dispatch(event, noOpObserver());
+        TenantAwareRunner.with(event.tenant())
+                         .run(() -> bus.dispatch(event, noOpObserver()));
     }
 }

--- a/server/src/main/java/io/spine/server/integration/ThirdPartyContext.java
+++ b/server/src/main/java/io/spine/server/integration/ThirdPartyContext.java
@@ -51,7 +51,7 @@ import static io.spine.util.Preconditions2.checkNotEmptyOrBlank;
  * @implSpec Note that a {@code ThirdPartyContext} sends a request for external messages to
  *         other contexts. The {@code ThirdPartyContext} never consumes external messages itself,
  *         but requires the other Bounded Contexts to send their requests, so that the publishing
- *         channels are open. Depending of the implementation of
+ *         channels are open. Depending on the implementation of
  *         {@linkplain io.spine.server.transport.TransportFactory transport}, creating
  *         a {@code ThirdPartyContext} may be an expensive operation. Thus, it is recommended that
  *         the instances of this class are reused and {@linkplain #close() closed} when they are

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.internal.dependency.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.145")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.146")


### PR DESCRIPTION
This changeset is a port of #1503 to `master`. Here is a full PR description for reviewer's convenience.

When it comes about importing the third-party events, the framework provides a `ThirdPartyContext` tool. 

However, in a multi-tenant application, the imported events were dispatched in a straightforward manner, without specifying the `TenantId` via `TenantAwareRunner`.

The corresponding test was also flawed: in fact, it was dispatching the events to a single-tenant Bounded Context.

This PR addresses the issue by fixing the test and making `IncomingEventObserver` (part of `IntegrationBroker`, an intermediary between `ThirdPartyContext` and "domestic" Bounded Contexts) to explicitly use `TenantAwareOperation` during the event dispatch.

The version is set to `2.0.0-SNAPSHOT.146`.
