### PR TITLE
Distinguish `Shard` pick-up results

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.147`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.148`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -814,12 +814,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 05 15:21:46 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jun 05 17:07:29 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.147`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.148`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1593,12 +1593,12 @@ This report was generated on **Mon Jun 05 15:21:46 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 05 15:21:47 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jun 05 17:07:30 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.147`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.148`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2420,12 +2420,12 @@ This report was generated on **Mon Jun 05 15:21:47 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 05 15:21:47 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jun 05 17:07:30 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.147`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.148`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3364,12 +3364,12 @@ This report was generated on **Mon Jun 05 15:21:47 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 05 15:21:48 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jun 05 17:07:31 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.147`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.148`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4308,12 +4308,12 @@ This report was generated on **Mon Jun 05 15:21:48 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 05 15:21:48 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jun 05 17:07:31 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.147`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.148`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5300,4 +5300,4 @@ This report was generated on **Mon Jun 05 15:21:48 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 05 15:21:48 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jun 05 17:07:31 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.147</version>
+<version>2.0.0-SNAPSHOT.148</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/delivery/AlreadyPickedUp.java
+++ b/server/src/main/java/io/spine/server/delivery/AlreadyPickedUp.java
@@ -26,14 +26,11 @@
 
 package io.spine.server.delivery;
 
-import java.util.Optional;
-import java.util.function.Supplier;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Represents a scenario when shard could not be picked,
- * as it's already picked by another worker.
+ * Represents a scenario when shard could not be picked up,
+ * as it's already picked up by another worker.
  */
 public final class AlreadyPickedUp extends FailedPickUp {
 
@@ -51,18 +48,10 @@ public final class AlreadyPickedUp extends FailedPickUp {
      */
     AlreadyPickedUp(ShardIndex shard,
                     ShardAlreadyPickedUp pickedUp,
-                    Supplier<Optional<DeliveryStats>> retry) {
+                    RetryDelivery retry) {
         super(shard, retry);
         checkNotNull(pickedUp);
         alreadyPickedUp = pickedUp;
-    }
-
-    /**
-     * Returns an action that makes the delivery process
-     * to finish without any processing done.
-     */
-    public Action doNothing() {
-        return Optional::empty;
     }
 
     /**

--- a/server/src/main/java/io/spine/server/delivery/AlreadyPickedUp.java
+++ b/server/src/main/java/io/spine/server/delivery/AlreadyPickedUp.java
@@ -32,7 +32,8 @@ import java.util.function.Supplier;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Represents a scenario when shard could not be picked as it's already picked by another worker.
+ * Represents a scenario when shard could not be picked,
+ * as it's already picked by another worker.
  */
 public final class AlreadyPickedUp extends FailedPickUp {
 
@@ -44,7 +45,7 @@ public final class AlreadyPickedUp extends FailedPickUp {
      * @param shard
      *         a shard that could not be picked
      * @param pickedUp
-     *         a message containing info about owner and the time when the shard was picked
+     *         a message containing info about owner, and the time when the shard was picked
      * @param retry
      *         a way to retry delivery
      */
@@ -57,14 +58,15 @@ public final class AlreadyPickedUp extends FailedPickUp {
     }
 
     /**
-     * Returns an action that will make the delivery process to finish without any processing done.
+     * Returns an action that makes the delivery process
+     * to finish without any processing done.
      */
     public Action doNothing() {
         return Optional::empty;
     }
 
     /**
-     * Returns the {@code ShardAlreadyPickedUp} outcome.
+     * Returns the outcome telling the shard was already picked up.
      */
     public ShardAlreadyPickedUp outcome() {
         return alreadyPickedUp;

--- a/server/src/main/java/io/spine/server/delivery/AlreadyPickedUp.java
+++ b/server/src/main/java/io/spine/server/delivery/AlreadyPickedUp.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.delivery;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Represents a scenario when shard could not be picked as it's already picked by another worker.
+ */
+public final class AlreadyPickedUp extends FailedPickUp {
+
+    private final ShardAlreadyPickedUp alreadyPickedUp;
+
+    /**
+     * Creates a new {@code AlreadyPickedUp} instance.
+     *
+     * @param shard
+     *         a shard that could not be picked
+     * @param pickedUp
+     *         a message containing info about owner and the time when the shard was picked
+     * @param retry
+     *         a way to retry delivery
+     */
+    AlreadyPickedUp(ShardIndex shard,
+                    ShardAlreadyPickedUp pickedUp,
+                    Supplier<Optional<DeliveryStats>> retry) {
+        super(shard, retry);
+        checkNotNull(pickedUp);
+        alreadyPickedUp = pickedUp;
+    }
+
+    /**
+     * Returns an action that will make the delivery process to finish without any processing done.
+     */
+    public Action doNothing() {
+        return Optional::empty;
+    }
+
+    /**
+     * Returns the {@code ShardAlreadyPickedUp} outcome.
+     */
+    public ShardAlreadyPickedUp outcome() {
+        return alreadyPickedUp;
+    }
+}

--- a/server/src/main/java/io/spine/server/delivery/Delivery.java
+++ b/server/src/main/java/io/spine/server/delivery/Delivery.java
@@ -460,11 +460,16 @@ public final class Delivery implements Logging {
     public Optional<DeliveryStats> deliverMessagesFrom(ShardIndex index) {
         var currentNode = ServerEnvironment.instance()
                                            .nodeId();
-        var picked = workRegistry.pickUp(index, currentNode);
-        if (picked.isEmpty()) {
-            return Optional.empty();
+        PickUpOutcome outcome;
+        try {
+            outcome = workRegistry.pickUp(index, currentNode);
+        } catch (RuntimeException e) {
+            return onRuntimeFailure(index, e);
         }
-        var session = picked.get();
+        if (outcome.hasAlreadyPicked()) {
+            return onAlreadyPickedUp(index, outcome.getAlreadyPicked());
+        }
+        var session = outcome.getSession();
         monitor.onDeliveryStarted(index);
 
         RunResult runResult;
@@ -475,7 +480,7 @@ public final class Delivery implements Logging {
                 totalDelivered += runResult.deliveredCount();
             } while (runResult.shouldRunAgain());
         } finally {
-            session.complete();
+            workRegistry.release(session);
         }
         var stats = new DeliveryStats(index, totalDelivered);
         monitor.onDeliveryCompleted(stats);
@@ -483,6 +488,28 @@ public final class Delivery implements Logging {
         lateMessage.ifPresent(this::onNewMessage);
 
         return Optional.of(stats);
+    }
+
+    /**
+     * Notifies the {@code DeliveryMonitor} about the technical failure and executes
+     * the failure handler {@code Action}.
+     */
+    private Optional<DeliveryStats> onRuntimeFailure(ShardIndex shard, RuntimeException e) {
+        var failure = new RuntimeFailure(shard, e, () -> deliverMessagesFrom(shard));
+        var result = monitor.onShardPickUpFailure(failure)
+                            .execute();
+        return result;
+    }
+
+    /**
+     * Notifies the {@code DeliveryMonitor} that shard is already picked up and executes
+     * the failure handler {@code Action}.
+     */
+    private Optional<DeliveryStats> onAlreadyPickedUp(ShardIndex shard, ShardAlreadyPickedUp pickedUp) {
+        var failure = new AlreadyPickedUp(shard, pickedUp, () -> deliverMessagesFrom(shard));
+        var result = monitor.onShardAlreadyPicked(failure)
+                            .execute();
+        return result;
     }
 
     /**
@@ -496,8 +523,8 @@ public final class Delivery implements Logging {
      *
      * @return the results of the run
      */
-    private RunResult runDelivery(ShardProcessingSession session) {
-        var index = session.shardIndex();
+    private RunResult runDelivery(ShardSessionRecord session) {
+        var index = session.getIndex();
 
         var startingPage = inboxStorage.readAll(index, pageSize);
         var maybePage = Optional.of(startingPage);
@@ -656,7 +683,8 @@ public final class Delivery implements Logging {
      *
      * <p>The registration of the dispatchers allows to handle the {@code Delivery}-specific events.
      *
-     * @param context Bounded Context in which the message dispatchers should be registered
+     * @param context
+     *         Bounded Context in which the message dispatchers should be registered
      */
     @Internal
     public void registerDispatchersIn(BoundedContext context) {

--- a/server/src/main/java/io/spine/server/delivery/Delivery.java
+++ b/server/src/main/java/io/spine/server/delivery/Delivery.java
@@ -491,8 +491,13 @@ public final class Delivery implements Logging {
     }
 
     /**
-     * Notifies the {@code DeliveryMonitor} about the technical failure and executes
-     * the failure handler {@code Action}.
+     * Notifies the {@code DeliveryMonitor} telling about the runtime error
+     * occurred while performing the delivery from certain shard.
+     *
+     * <p>Executes the failure handler {@code Action} returned by the monitor.
+     *
+     * <p>If the monitor tells to repeat the delivery, returns the stats of the repeated
+     * delivery process, if any.
      */
     private Optional<DeliveryStats> onRuntimeFailure(ShardIndex shard, RuntimeException e) {
         var failure = new RuntimeFailure(shard, e, () -> deliverMessagesFrom(shard));
@@ -502,8 +507,13 @@ public final class Delivery implements Logging {
     }
 
     /**
-     * Notifies the {@code DeliveryMonitor} that shard is already picked up and executes
-     * the failure handler {@code Action}.
+     * Notifies the {@code DeliveryMonitor} telling the shard from which the delivery
+     * was asked to run, is already picked up.
+     *
+     * <p>Executes the failure handler {@code Action} returned by the monitor.
+     *
+     * <p>If the monitor tells to repeat the delivery, returns the stats of the repeated
+     * delivery process, if any.
      */
     private Optional<DeliveryStats> onAlreadyPickedUp(ShardIndex shard, ShardAlreadyPickedUp pickedUp) {
         var failure = new AlreadyPickedUp(shard, pickedUp, () -> deliverMessagesFrom(shard));

--- a/server/src/main/java/io/spine/server/delivery/DeliveryMonitor.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryMonitor.java
@@ -120,6 +120,45 @@ public class DeliveryMonitor {
         return reception.markDelivered();
     }
 
+    /**
+     * Called if an {@code Exception} occurred when the {@code Delivery} attempted
+     * to pick up a shard.
+     *
+     * <p>Please note, this callback is <em>not</em> invoked in case the shard cannot be picked up
+     * if it's already picked up by another worker. It is so, because such a use case is a part
+     * of normal flow, and thus does not provoke a {@code RuntimeException}.
+     *
+     * <p>Returns an action to take in relation to the failure.
+     *
+     * <p>By default this callback returns an {@code Action} that propagates
+     * the occurred exception.
+     *
+     * @param failure
+     *         contains an information about the occurred failure, and gives access to
+     *         predefined {@code Action}s to handle the error
+     */
+    @SuppressWarnings({"WeakerAccess", "unused" /* Part of public API. */})
+    public FailedPickUp.Action onShardPickUpFailure(RuntimeFailure failure) {
+        return failure.propagate();
+    }
+
+    /**
+     * Called if {@code Delivery} could not pick up a shard because it was already picked up
+     * by another worker.
+     *
+     * <p>Returns an action to take in relation to the failure.
+     *
+     * <p>By default this callback returns an Action that does nothing. This means that
+     * an empty {@code Optional} will be returned from the {@code deliverMessagesFrom()} method.
+     *
+     * @param failure
+     *         contains an information about the worker who owns the session and gives access
+     *         to predefined {@code Action}s to handle the error
+     */
+    @SuppressWarnings({"WeakerAccess", "unused"})  /* Part of public API. */
+    public FailedPickUp.Action onShardAlreadyPicked(AlreadyPickedUp failure) {
+        return failure.doNothing();
+    }
 
     /**
      * Returns an instance of {@code DeliveryMonitor} which always says to continue.

--- a/server/src/main/java/io/spine/server/delivery/DeliveryMonitor.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryMonitor.java
@@ -84,7 +84,7 @@ public class DeliveryMonitor {
      * @param stats
      *         the statistics of the performed delivery
      */
-    @SuppressWarnings("unused" /* This SPI method is designed for descendants. */)
+    @SuppressWarnings({"WeakerAccess" /* Part of public API. */, "unused"})
     public void onDeliveryCompleted(DeliveryStats stats) {
         // Do nothing.
     }
@@ -96,7 +96,7 @@ public class DeliveryMonitor {
      * @param index
      *         the index of the shard, the delivery from which has been started
      */
-    @SuppressWarnings({"unused", "WeakerAccess" /* This SPI method is designed for descendants. */})
+    @SuppressWarnings({"WeakerAccess" /* Part of public API. */, "unused"})
     public void onDeliveryStarted(ShardIndex index) {
         // Do nothing.
     }
@@ -137,7 +137,7 @@ public class DeliveryMonitor {
      *         contains an information about the occurred failure, and gives access to
      *         predefined {@code Action}s to handle the error
      */
-    @SuppressWarnings({"WeakerAccess", "unused" /* Part of public API. */})
+    @SuppressWarnings("WeakerAccess" /* Part of public API. */)
     public FailedPickUp.Action onShardPickUpFailure(RuntimeFailure failure) {
         return failure.propagate();
     }
@@ -155,7 +155,7 @@ public class DeliveryMonitor {
      *         contains an information about the worker who owns the session and gives access
      *         to predefined {@code Action}s to handle the error
      */
-    @SuppressWarnings({"WeakerAccess", "unused"})  /* Part of public API. */
+    @SuppressWarnings("WeakerAccess" /* Part of public API. */)
     public FailedPickUp.Action onShardAlreadyPicked(AlreadyPickedUp failure) {
         return failure.doNothing();
     }

--- a/server/src/main/java/io/spine/server/delivery/FailedPickUp.java
+++ b/server/src/main/java/io/spine/server/delivery/FailedPickUp.java
@@ -46,7 +46,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * users to provide a custom behaviour for pickup failures in the {@linkplain DeliveryMonitor}
  * in addition to predefined behaviours provided by the inheritors of this class.
  */
-@SuppressWarnings("AbstractClassWithoutAbstractMethods" /* To emphasize the design intention.*/)
+@SuppressWarnings("AbstractClassWithoutAbstractMethods" /* To emphasize the design intention. */)
 public abstract class FailedPickUp {
 
     private final ShardIndex shard;

--- a/server/src/main/java/io/spine/server/delivery/FailedPickUp.java
+++ b/server/src/main/java/io/spine/server/delivery/FailedPickUp.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.delivery;
+
+import io.spine.annotation.SPI;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * An abstract base for shard pick-up-related failures.
+ *
+ * <p>Although not marked {@code Internal} explicitly, this type <em>is</em> internal to framework
+ * in terms of extensibility. End-users should not extend it directly.
+ * Its descendants are provided by the framework itself.
+ *
+ * <p>On the other hand, nested {@link Action} is designed to be implemented by the framework
+ * users to provide a custom behaviour for pickup failures in the {@linkplain DeliveryMonitor}
+ * in addition to predefined behaviours provided by the inheritors of this class.
+ */
+@SuppressWarnings("AbstractClassWithoutAbstractMethods" /* To emphasize the design intention.*/)
+public abstract class FailedPickUp {
+
+    private final ShardIndex shard;
+
+    private final Supplier<Optional<DeliveryStats>> retryDelivery;
+
+    /**
+     * Creates a new {@code FailedPickUp} with the given {@code shard}
+     * and {@code retryDelivery} action.
+     */
+    FailedPickUp(ShardIndex shard, Supplier<Optional<DeliveryStats>> retryDelivery) {
+        checkNotNull(shard);
+        checkNotNull(retryDelivery);
+        this.retryDelivery = retryDelivery;
+        this.shard = shard;
+    }
+
+    /**
+     * Returns an {@code Action} that will retry the delivery from the shard.
+     */
+    public final Action retry() {
+        return retryDelivery::get;
+    }
+
+    /**
+     * Returns a {@code ShardIndex} of the not picked shard.
+     */
+    public final ShardIndex shard() {
+        return shard;
+    }
+
+    /**
+     * Action to take in relation to failed shard pick-up.
+     */
+    @SPI
+    @FunctionalInterface
+    public interface Action {
+
+        /**
+         * Executes the {@code Action}.
+         */
+        Optional<DeliveryStats> execute();
+    }
+}

--- a/server/src/main/java/io/spine/server/delivery/PickUpOutcomeMixin.java
+++ b/server/src/main/java/io/spine/server/delivery/PickUpOutcomeMixin.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.delivery;
+
+import com.google.protobuf.Timestamp;
+import io.spine.annotation.GeneratedMixin;
+
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A mixin of the {@link PickUpOutcome} providing a convenience API over the Proto message.
+ */
+@GeneratedMixin
+public interface PickUpOutcomeMixin extends PickUpOutcomeOrBuilder {
+
+    /**
+     * Creates a new {@code PickUpOutcome} of successfully picked up shard
+     * with the given {@code ShardSessionRecord}.
+     */
+    @SuppressWarnings("ClassReferencesSubclass" /* This is a mixin of the type. */)
+    static PickUpOutcome pickedUp(ShardSessionRecord session) {
+        checkNotNull(session);
+        return PickUpOutcome.newBuilder()
+                .setSession(session)
+                .build();
+    }
+
+    /**
+     * Creates a new {@code PickUpOutcome} indicating that the shard is already picked up
+     * by the given worker in {@code pickedUp} message.
+     */
+    @SuppressWarnings("ClassReferencesSubclass" /* This is a mixin of the type. */)
+    static PickUpOutcome alreadyPicked(WorkerId worker, Timestamp whenPicked) {
+        checkNotNull(worker);
+        checkNotNull(whenPicked);
+        var pickedUp = ShardAlreadyPickedUp.newBuilder()
+                .setWorker(worker)
+                .setWhenPicked(whenPicked)
+                .build();
+        return PickUpOutcome.newBuilder()
+                .setAlreadyPicked(pickedUp)
+                .build();
+    }
+
+    /**
+     * Returns {@code ShardProcessingSession} if this outcome indicates that shard is successfully
+     * picked up, or empty {@code Optional} otherwise.
+     */
+    default Optional<ShardSessionRecord> session() {
+        var session = getSession();
+        if (ShardSessionRecord.getDefaultInstance().equals(session)) {
+            return Optional.empty();
+        }
+        return Optional.of(session);
+    }
+
+    /**
+     * Returns {@code ShardAlreadyPickedUp} if this outcome indicates that shard could not be
+     * picked up as it's already picked up by another worker, or empty {@code Optional} otherwise.
+     */
+    default Optional<ShardAlreadyPickedUp> alreadyPicked() {
+        var pickedUp = getAlreadyPicked();
+        if (ShardAlreadyPickedUp.getDefaultInstance().equals(pickedUp)) {
+            return Optional.empty();
+        }
+        return Optional.of(pickedUp);
+    }
+}

--- a/server/src/main/java/io/spine/server/delivery/RuntimeFailure.java
+++ b/server/src/main/java/io/spine/server/delivery/RuntimeFailure.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.delivery;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Represents a scenario when shard could not be picked because of some {@code RuntimeException}.
+ */
+public final class RuntimeFailure extends FailedPickUp {
+
+    private final RuntimeException exception;
+
+    /**
+     * Creates a new {@code RuntimeFailure}.
+     *
+     * @param shard
+     *         a shard that could not be picked
+     * @param exception
+     *         an occurred exception
+     * @param retry
+     *         a way to retry delivery
+     */
+    RuntimeFailure(ShardIndex shard,
+                   RuntimeException exception,
+                   Supplier<Optional<DeliveryStats>> retry) {
+        super(shard, retry);
+        checkNotNull(exception);
+        this.exception = exception;
+    }
+
+    /**
+     * Returns an {@code Action} that propagates the occurred exception.
+     */
+    public Action propagate() {
+        return () -> {
+            throw exception;
+        };
+    }
+
+    /**
+     * Returns the occurred exception.
+     */
+    public RuntimeException exception() {
+        return exception;
+    }
+}

--- a/server/src/main/java/io/spine/server/delivery/RuntimeFailure.java
+++ b/server/src/main/java/io/spine/server/delivery/RuntimeFailure.java
@@ -26,9 +26,6 @@
 
 package io.spine.server.delivery;
 
-import java.util.Optional;
-import java.util.function.Supplier;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -50,14 +47,14 @@ public final class RuntimeFailure extends FailedPickUp {
      */
     RuntimeFailure(ShardIndex shard,
                    RuntimeException exception,
-                   Supplier<Optional<DeliveryStats>> retry) {
+                   RetryDelivery retry) {
         super(shard, retry);
         checkNotNull(exception);
         this.exception = exception;
     }
 
     /**
-     * Returns an {@code Action} that propagates the occurred exception.
+     * Returns an {@code Action} that re-throws the occurred exception.
      */
     public Action propagate() {
         return () -> {

--- a/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
+++ b/server/src/main/java/io/spine/server/delivery/memory/InMemoryShardedWorkRegistry.java
@@ -29,8 +29,8 @@ package io.spine.server.delivery.memory;
 import com.google.protobuf.Duration;
 import io.spine.server.NodeId;
 import io.spine.server.delivery.AbstractWorkRegistry;
+import io.spine.server.delivery.PickUpOutcome;
 import io.spine.server.delivery.ShardIndex;
-import io.spine.server.delivery.ShardProcessingSession;
 import io.spine.server.delivery.ShardSessionRecord;
 import io.spine.server.delivery.ShardedWorkRegistry;
 import io.spine.server.delivery.WorkerId;
@@ -53,8 +53,14 @@ public final class InMemoryShardedWorkRegistry extends AbstractWorkRegistry {
     private final Map<ShardIndex, ShardSessionRecord> workByNode = newConcurrentMap();
 
     @Override
-    public synchronized Optional<ShardProcessingSession> pickUp(ShardIndex index, NodeId node) {
+    public synchronized PickUpOutcome pickUp(ShardIndex index, NodeId node) {
         return super.pickUp(index, node);
+    }
+
+    @Override
+    public synchronized void release(ShardSessionRecord session) {
+        var record = workByNode.get(session.getIndex());
+        clearNode(record);
     }
 
     /**
@@ -68,8 +74,7 @@ public final class InMemoryShardedWorkRegistry extends AbstractWorkRegistry {
     @Override
     protected WorkerId currentWorkerFor(NodeId node) {
         var currentThread = Thread.currentThread().getId();
-        var worker = WorkerId
-                .newBuilder()
+        var worker = WorkerId.newBuilder()
                 .setNodeId(node)
                 .setValue(String.valueOf(currentThread))
                 .build();
@@ -99,27 +104,5 @@ public final class InMemoryShardedWorkRegistry extends AbstractWorkRegistry {
     @Override
     protected Optional<ShardSessionRecord> find(ShardIndex index) {
         return Optional.ofNullable(workByNode.get(index));
-    }
-
-    @Override
-    protected ShardProcessingSession asSession(ShardSessionRecord record) {
-        return new InMemoryShardSession(record);
-    }
-
-    /**
-     * Implementation of shard processing session, based on in-memory storage mechanism.
-     */
-    public class InMemoryShardSession extends ShardProcessingSession {
-
-        private InMemoryShardSession(ShardSessionRecord record) {
-            super(record);
-        }
-
-        @Override
-        protected void complete() {
-            var record = workByNode.get(shardIndex());
-            // Clear the node ID value and release the session.
-            clearNode(record);
-        }
     }
 }

--- a/server/src/main/proto/spine/server/delivery/delivery.proto
+++ b/server/src/main/proto/spine/server/delivery/delivery.proto
@@ -60,14 +60,16 @@ message ShardSessionRecord {
     // The index of a shard processed in this session.
     ShardIndex index = 1 [(required) = true];
 
-    // When the shard processed within the session was last picked by the node.
+    // When the shard processed within the session was last picked up by the node.
     //
-    // This field is unset if no nodes ever picked the session.
+    // This field is unset if no nodes ever picked up the session.
+    //
     google.protobuf.Timestamp when_last_picked = 3;
 
     // An identifier of an application worker, which picked up the shard and processes it.
     //
     // Unset until a worker picks the shard.
+    //
     WorkerId worker = 4;
 
     reserved 2;
@@ -120,4 +122,43 @@ message WorkerId {
     //
     // An example of such an identifier could be ID of the thread which processes a shard.
     string value = 2 [(required) = true];
+}
+
+// An outcome of a shard pick-up request, stating that the shard is already picked up
+// by another worker.
+message ShardAlreadyPickedUp {
+
+    // A worker that owns the session at the moment.
+    WorkerId worker = 1 [(required) = true];
+
+    // Time when the worker has picked up the shard.
+    //
+    // Note, this value is not synchronized between application servers by default.
+    // The wall clock on each instance is generally slightly different.
+    // Comparing this value (potentially instantiated on another application node)
+    // with the wall clock on your current application node may give
+    // some misleading results.
+    //
+    google.protobuf.Timestamp when_picked = 2 [(required) = true];
+}
+
+// An outcome of a shard pick-up attempt.
+message PickUpOutcome {
+
+    option (is).java_type = "io.spine.server.delivery.PickUpOutcomeMixin";
+
+    oneof value {
+        option (is_required) = true;
+
+        // Shard was picked up successfully, and this value points to the
+        // delivery session owned by the node requested to pick up the shard.
+        ShardSessionRecord session = 1;
+
+        // Shard could not be picked up as it's already picked up by another worker.
+        //
+        // This value brings some additional information about the currently
+        // ongoing session owned by another worker node.
+        //
+        ShardAlreadyPickedUp already_picked = 2;
+    }
 }

--- a/server/src/test/java/io/spine/server/delivery/given/ThrowingWorkRegistry.java
+++ b/server/src/test/java/io/spine/server/delivery/given/ThrowingWorkRegistry.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.delivery.given;
+
+import com.google.protobuf.Duration;
+import io.spine.server.NodeId;
+import io.spine.server.delivery.PickUpOutcome;
+import io.spine.server.delivery.ShardIndex;
+import io.spine.server.delivery.ShardSessionRecord;
+import io.spine.server.delivery.ShardedWorkRegistry;
+
+import static io.spine.util.Exceptions.newIllegalStateException;
+
+/**
+ * Throws the {@code IllegalStateException} on each operation.
+ *
+ * <p>Used in tests of error handling in {@code Delivery}.
+ */
+public final class ThrowingWorkRegistry implements ShardedWorkRegistry {
+
+    private static final String MESSAGE =
+            "Thrown from `ThrowingWorkRegistry` that always throws an exception.";
+
+    @Override
+    public PickUpOutcome pickUp(ShardIndex index, NodeId node) {
+        throw newIllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public void release(ShardSessionRecord session) {
+        throw newIllegalStateException(MESSAGE);
+    }
+
+    @Override
+    public Iterable<ShardIndex> releaseExpiredSessions(Duration inactivityPeriod) {
+        throw newIllegalStateException(MESSAGE);
+    }
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.internal.dependency.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.147")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.148")


### PR DESCRIPTION
This is a port of #1505 to `master`. Here is the full description of PR.

:warning: This PR introduces some breaking changes to public API.

# What is Done

In this PR we start to distinguish the shard pick-up results. In particular, it is now possible to find out the reason of an unsuccessful shard pick-up. In particular, there may be some runtime issues, or the shard may already be picked-up by another worker.

Two new API endpoints were added to the `DeliveryMonitor` to provide end-users with some control over such cases:

1. `FailedPickUp.Action onShardAlreadyPicked(AlreadyPickedUp failure)`

This method will be invoked if the shard could not be picked as it's already picked by another worker. This method receives the `ShardIndex` of the shard that could not be picked, the `WorkerId` of the worker who owns the delivery session, and the `Timestamp` when the shard was picked. It is required to return an action to take in relation to this case. By default, it returns an action which just accepts this case (and ends the delivery session without any processing), but end-users may return a predefined action retrying the shard pick-up:
```java
final class MyDeliveryMonitor extends DeliveryMonitor {

    ...

    @Override
    public FailedPickUp.Action onShardAlreadyPicked(AlreadyPickedUp failure) {
        return failure.retry();
    }

    ...

}
```

2. `FailedPickUp.Action onShardPickUpFailure(RuntimeFailure failure)`

This method is invoked if the shard could not be picked for some runtime technical reason, such as a runtime exception. This method receives the `ShardIndex` of the shard that could not be picked, and the instance of the occurred `Exception`. It also requires to return an action to handle this case. By default, such failures are just rethrown as `RuntimeException`, but end-users may choose to retry the pick-up:
```java
final class MyDeliveryMonitor extends DeliveryMonitor {

    ...

    @Override
    public FailedPickUp.Action onShardPickUpFailure(RuntimeFailure failure) {
        return failure.retry();
    }

    ...

}
```

# Breaking changes

The API of the `ShardedWorkRegistry` has been changed.

In particular, a new `PickUpOutcome pickUp(ShardIndex index, NodeId node)` method is introduced. Note, it returns an explicit result instead of `Optional`, as previously. This outcome contains **either of two**:
* a `ShardSessionRecord` — meaning that the shard is picked successfully,  
* a `ShardAlreadyPickedUp` — a message that contains a `WorkerId` of the worker who owns the session at the moment, and the `Timestamp` when the shard was picked. This outcome means the session cannot be obtained as it's already picked.

Also, there is a new `void release(ShardSessionRecord session)` method that releases the passed session. 

Here is a summary of code changes for those using `ShardedWorkRegistry`:

## Before:
``` java
Optional<ShardProcessingSession> session = workRegistry.pickUp(index, currentNode);
if (session.isPresent()) { // Check if shard is picked.
   // ...
   session.get().complete(); // Release shard.
}
```

## After:
``` java
PickUpOutcome outcome = workRegistry.pickUp(index, currentNode);
if (outcome.hasSession()) { // Check if shard is picked.
    // ...
    workRegistry.release(outcome.getSession()); // Release shard.
}
```
Also, the new API allows getting the `WorkerId` of the worker who owns the session in case if the shard is already picked by someone else and the `Timestamp` when the shard was picked:
``` java
PickUpOutcome outcome = workRegistry.pickUp(index, currentNode);
if (outcome.hasAlreadyPickedBy()) {
    WorkerId worker = outcome.getAlreadyPicked().getWorker();
    Timestamp whenPicked = outcome.getAlreadyPicked().getWhenPicked();
    // ...
}
```