### PR TITLE
Improve test `Sample` generation

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.148`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.149`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -814,12 +814,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 05 17:07:29 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 09 15:52:03 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.148`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.149`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1593,12 +1593,12 @@ This report was generated on **Mon Jun 05 17:07:29 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 05 17:07:30 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 09 15:52:03 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.148`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.149`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2420,12 +2420,12 @@ This report was generated on **Mon Jun 05 17:07:30 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 05 17:07:30 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 09 15:52:04 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.148`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.149`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3364,12 +3364,12 @@ This report was generated on **Mon Jun 05 17:07:30 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 05 17:07:31 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 09 15:52:04 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.148`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.149`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4308,12 +4308,12 @@ This report was generated on **Mon Jun 05 17:07:31 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 05 17:07:31 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 09 15:52:05 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.148`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.149`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5300,4 +5300,4 @@ This report was generated on **Mon Jun 05 17:07:31 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 05 17:07:31 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jun 09 15:52:05 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.148</version>
+<version>2.0.0-SNAPSHOT.149</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/test/java/io/spine/testdata/Sample.java
+++ b/server/src/test/java/io/spine/testdata/Sample.java
@@ -26,7 +26,6 @@
 
 package io.spine.testdata;
 
-import com.google.common.base.Charsets;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors.FieldDescriptor;
@@ -40,12 +39,14 @@ import io.spine.type.TypeUrl;
 import java.security.SecureRandom;
 import java.util.Collection;
 import java.util.Random;
+import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.protobuf.Messages.builderFor;
 import static io.spine.util.Exceptions.newIllegalStateException;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Utility for creating simple stubs for generated messages, DTOs (like {@link Event} and
@@ -169,13 +170,10 @@ public final class Sample {
             case BOOLEAN:
                 return random.nextBoolean();
             case STRING:
-                var bytes = new byte[8];
-                random.nextBytes(bytes);
-                return new String(bytes, Charsets.UTF_8);
+                return randomString();
             case BYTE_STRING:
-                var bytesPrimitive = new byte[8];
-                random.nextBytes(bytesPrimitive);
-                return ByteString.copyFrom(bytesPrimitive);
+                var randomString = randomString();
+                return ByteString.copyFrom(randomString, UTF_8);
             case ENUM:
                 return enumValueFor(field, random);
             case MESSAGE:
@@ -183,6 +181,11 @@ public final class Sample {
             default:
                 throw new IllegalArgumentException(format("Field type %s is not supported.", type));
         }
+    }
+
+    private static String randomString() {
+        return UUID.randomUUID()
+                   .toString();
     }
 
     private static int positiveInt(Random random) {

--- a/server/src/test/java/io/spine/testdata/Sample.java
+++ b/server/src/test/java/io/spine/testdata/Sample.java
@@ -47,6 +47,7 @@ import static io.spine.protobuf.Messages.builderFor;
 import static io.spine.util.Exceptions.newIllegalStateException;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.UUID.randomUUID;
 
 /**
  * Utility for creating simple stubs for generated messages, DTOs (like {@link Event} and
@@ -184,8 +185,7 @@ public final class Sample {
     }
 
     private static String randomString() {
-        return UUID.randomUUID()
-                   .toString();
+        return randomUUID().toString();
     }
 
     private static int positiveInt(Random random) {

--- a/server/src/test/java/io/spine/testdata/Sample.java
+++ b/server/src/test/java/io/spine/testdata/Sample.java
@@ -112,8 +112,10 @@ public final class Sample {
      * <p>If the required type is {@link Any}, an instance of an empty {@link Any} wrapped into
      * another {@link Any} is returned. See {@link AnyPacker}.
      *
-     * @param clazz Java class of the required stub message
-     * @param <M>   type of the required message
+     * @param clazz
+     *         Java class of the required stub message
+     * @param <M>
+     *         type of the required message
      * @return new instance of the given {@link Message} type with random fields
      * @see #builderForType(Class)
      */
@@ -152,7 +154,8 @@ public final class Sample {
      * such as {@code Version}, as only non-negative values may be accepted according
      * to their validation rules.
      *
-     * @param field {@link FieldDescriptor} to take the type info from
+     * @param field
+     *         {@link FieldDescriptor} to take the type info from
      * @return a non-default generated value of type of the given field
      */
     @SuppressWarnings({"OverlyComplexMethod", "BadImport" /* Use `Type` for brevity. */})

--- a/server/src/test/java/io/spine/testdata/Sample.java
+++ b/server/src/test/java/io/spine/testdata/Sample.java
@@ -39,7 +39,6 @@ import io.spine.type.TypeUrl;
 import java.security.SecureRandom;
 import java.util.Collection;
 import java.util.Random;
-import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/server/src/test/java/io/spine/testdata/Sample.java
+++ b/server/src/test/java/io/spine/testdata/Sample.java
@@ -49,9 +49,9 @@ import static java.lang.String.format;
 
 /**
  * Utility for creating simple stubs for generated messages, DTOs (like {@link Event} and
- * {@link Command}), storage objects and else.
+ * {@link Command}), storage objects and more.
  */
-public class Sample {
+public final class Sample {
 
     /**
      * The upper bound used for generating random {@code int} and {@code long} values.

--- a/server/src/test/java/io/spine/testdata/Sample.java
+++ b/server/src/test/java/io/spine/testdata/Sample.java
@@ -157,7 +157,7 @@ public final class Sample {
      *         {@link FieldDescriptor} to take the type info from
      * @return a non-default generated value of type of the given field
      */
-    @SuppressWarnings({"OverlyComplexMethod", "BadImport" /* Use `Type` for brevity. */})
+    @SuppressWarnings("BadImport" /* Use `Type` for brevity. */)
     private static Object valueFor(FieldDescriptor field) {
         var type = field.getType();
         var javaType = type.getJavaType();

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.internal.dependency.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.148")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.149")


### PR DESCRIPTION
This changeset is a port of #1506 into `master`. Here is the full description of changes made.

In server-side test code, there is a utility called `Sample`. It allows to generate sample values for any given Proto message. However, it does a lousy job with Proto `string`s. In particular, it just creates them as eight random bytes treated as UTF-8-encoded Java `String`.

Such an approach is problematic if such values are stored either as IDs, or as entity column values into some real DB. For instance, MySQL 5.7 is not able to store such strings as-is — which was discovered when running Spine tests against MySQL in scope of `spine-rdbms` development.

This changeset updates this `Sample` tool, so that `string`-typed fields in Proto messages get UUID-generated values instead of random bytes.

The library version is set to `2.0.0-SNAPSHOT.149`.