### PR TITLE
[1.x] Cancel `Subscription`s properly

### DIFF
--- a/server/src/main/java/io/spine/server/stand/SubscriptionValidator.java
+++ b/server/src/main/java/io/spine/server/stand/SubscriptionValidator.java
@@ -34,6 +34,7 @@ import io.spine.server.tenant.TenantAwareFunction;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Validates the {@linkplain Subscription} instances submitted to {@linkplain Stand}.
@@ -94,7 +95,7 @@ final class SubscriptionValidator extends RequestValidator<Subscription> {
 
             @Override
             public Boolean apply(@Nullable Subscription input) {
-                checkNotNull(input);
+                requireNonNull(input);
                 boolean result = registry.containsId(input.getId());
                 return result;
             }

--- a/server/src/test/java/io/spine/server/dispatch/DispatchOutcomesTest.java
+++ b/server/src/test/java/io/spine/server/dispatch/DispatchOutcomesTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.DisplayName;
 import static io.spine.server.dispatch.given.Given.commandEnvelope;
 import static io.spine.server.dispatch.given.Given.eventEnvelope;
 
-@DisplayName("`DispatchOutcomes` shoult")
+@DisplayName("`DispatchOutcomes` should")
 class DispatchOutcomesTest extends UtilityClassTest<DispatchOutcomes> {
 
     DispatchOutcomesTest() {


### PR DESCRIPTION
This changeset is meant to address a production-discovered issue related to `Subscription` cancellation.

It addresses [web#202](https://github.com/SpineEventEngine/web/issues/202), and also it is a counterpart of [web#203](https://github.com/SpineEventEngine/web/pull/203).

General idea is to make the `Subscription` cancellation operate the ID of the subscription, not the `Subscription` instance as a whole. Previous approach was based on attempting to find the exact `Subscription` instance before it can be cancelled. However, as `Subscription` instances are received as arguments from outside `core-java` libraries, they may be modified, and thus may differ from those stored in `SubscriptionRegistry`. One of the discovered use-cases was a subscription keep-up process, which led to the changes in the timestamp of corresponding `Subscription` instances.

Public API of `SubscriptionRegistry` was not changed. Therefore, this update is fully compatible with the rest of 1.9.0 binaries.

Other minor changes include addressing a typo, and using `requireNonNull` instead of `checkNotNull` where it belongs.

Once this PR is merged, the codebase still have the same 1.9.0 version. That is an intentional action, because we want to replace the existing 1.9.0 release version for end-user convenience — rather than advance every library of the framework to something like 1.9.1, and keep consistency.