### PR TITLE
Cancel `Subscription`s properly

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.149`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.150`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -814,12 +814,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 09 15:52:03 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 11 15:56:38 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.149`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.150`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1593,12 +1593,12 @@ This report was generated on **Fri Jun 09 15:52:03 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 09 15:52:03 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 11 15:56:38 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.149`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.150`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2420,12 +2420,12 @@ This report was generated on **Fri Jun 09 15:52:03 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 09 15:52:04 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 11 15:56:38 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.149`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.150`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3364,12 +3364,12 @@ This report was generated on **Fri Jun 09 15:52:04 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 09 15:52:04 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 11 15:56:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.149`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.150`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4308,12 +4308,12 @@ This report was generated on **Fri Jun 09 15:52:04 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 09 15:52:05 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 11 15:56:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.149`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.150`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5300,4 +5300,4 @@ This report was generated on **Fri Jun 09 15:52:05 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 09 15:52:05 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 11 15:56:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.149</version>
+<version>2.0.0-SNAPSHOT.150</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/stand/TenantSubscriptionRegistry.java
+++ b/server/src/main/java/io/spine/server/stand/TenantSubscriptionRegistry.java
@@ -34,6 +34,7 @@ import io.spine.client.SubscriptionId;
 import io.spine.client.Subscriptions;
 import io.spine.client.Topic;
 import io.spine.type.TypeUrl;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Map;
 import java.util.Set;
@@ -42,8 +43,9 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Multimaps.synchronizedSetMultimap;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A slice with subscriptions belonging to one tenant in a multi-tenant application.
@@ -59,9 +61,12 @@ final class TenantSubscriptionRegistry implements SubscriptionRegistry {
     @Override
     public void activate(Subscription subscription, SubscriptionCallback callback) {
         lockAndRun(() -> {
-            checkState(subscriptionToAttrs.containsKey(subscription),
-                       "Cannot find the subscription in the registry.");
-            var subscriptionRecord = subscriptionToAttrs.get(subscription);
+            @Nullable Subscription knownSubscription = asKnownSubscription(subscription);
+            requireNonNull(knownSubscription,
+                           () -> format(
+                                   "Cannot find the subscription with ID `%s` in the registry.",
+                                   subscription.getId()));
+            var subscriptionRecord = subscriptionToAttrs.get(knownSubscription);
             subscriptionRecord.activate(callback);
         });
     }
@@ -88,16 +93,47 @@ final class TenantSubscriptionRegistry implements SubscriptionRegistry {
     @Override
     public void remove(Subscription subscription) {
         lockAndRun(() -> {
-            if (!subscriptionToAttrs.containsKey(subscription)) {
+            @Nullable Subscription toRemove = asKnownSubscription(subscription);
+            if (toRemove == null) {
                 return;
             }
-            var record = subscriptionToAttrs.get(subscription);
+
+            var record = subscriptionToAttrs.get(toRemove);
             var types = record.targetTypes();
             for (var type : types) {
                 typeToRecord.remove(type, record);
             }
-            subscriptionToAttrs.remove(subscription);
+            subscriptionToAttrs.remove(toRemove);
         });
+    }
+
+    /**
+     * Ensures that the given subscription is known to this subscription registry.
+     *
+     * <p>If the passed subscription is stored as-is, this method returns it.
+     *
+     * <p>Otherwise, performs a search by the subscription ID, and returns the result.
+     * Such a trick makes sense, as the framework has no control over
+     * the {@code Subscription} objects. They may arrive from client-side or other calling sites
+     * with some attributes modified (such as timestamps). Therefore, it makes sense
+     * to attempt another round of search using the ID of the given subscription.
+     */
+    private @Nullable Subscription asKnownSubscription(Subscription subscription) {
+        if(subscriptionToAttrs.containsKey(subscription)) {
+            return subscription;
+        }
+        @Nullable Subscription foundById = findById(subscription.getId());
+        return foundById;
+    }
+
+    private @Nullable Subscription findById(SubscriptionId id) {
+        var subscriptions = subscriptionToAttrs.keySet();
+        for (var s : subscriptions) {
+            if(s.getId().equals(id)) {
+                return s;
+            }
+        }
+        return null;
     }
 
     @Override
@@ -113,12 +149,8 @@ final class TenantSubscriptionRegistry implements SubscriptionRegistry {
 
     @Override
     public boolean containsId(SubscriptionId subscriptionId) {
-        for (var existingItem : subscriptionToAttrs.keySet()) {
-            if (existingItem.getId().equals(subscriptionId)) {
-                return true;
-            }
-        }
-        return false;
+        @Nullable Subscription found = findById(subscriptionId);
+        return found != null;
     }
 
     private void lockAndRun(Runnable operation) {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.internal.dependency.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.149")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.150")


### PR DESCRIPTION
This is a port of #1521 to `master` branch. Here is the full description of the original PR (modified to be in accordance with versions), for reviewer's convenience.

This changeset is meant to address a production-discovered issue related to `Subscription` cancellation.

It addresses [web#202](https://github.com/SpineEventEngine/web/issues/202), and also it is a counterpart of [web#203](https://github.com/SpineEventEngine/web/pull/203).

General idea is to make the `Subscription` cancellation operate the ID of the subscription, not the `Subscription` instance as a whole. Previous approach was based on attempting to find the exact `Subscription` instance before it can be cancelled. However, as `Subscription` instances are received as arguments from outside `core-java` libraries, they may be modified, and thus may differ from those stored in `SubscriptionRegistry`. One of the discovered use-cases was a subscription keep-up process, which led to the changes in the timestamp of corresponding `Subscription` instances.

Public API of `SubscriptionRegistry` was not changed.

The library version is set to `2.0.0-SNAPSHOT.150`.