### PR TITLE
 Make some of `CatchUpTest` tests overridable again (again!)

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -804,7 +804,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 26 15:37:37 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 26 16:31:38 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1573,7 +1573,7 @@ This report was generated on **Sat Aug 26 15:37:37 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 26 15:37:38 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 26 16:31:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2390,7 +2390,7 @@ This report was generated on **Sat Aug 26 15:37:38 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 26 15:37:38 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 26 16:31:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3327,7 +3327,7 @@ This report was generated on **Sat Aug 26 15:37:38 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 26 15:37:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 26 16:31:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4264,7 +4264,7 @@ This report was generated on **Sat Aug 26 15:37:39 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 26 15:37:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 26 16:31:40 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5249,4 +5249,4 @@ This report was generated on **Sat Aug 26 15:37:39 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 26 15:37:40 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 26 16:31:40 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.156`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.157`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -804,12 +804,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Aug 22 21:20:20 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 26 15:37:37 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.156`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.157`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1573,12 +1573,12 @@ This report was generated on **Tue Aug 22 21:20:20 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Aug 22 21:20:20 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 26 15:37:38 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.156`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.157`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2390,12 +2390,12 @@ This report was generated on **Tue Aug 22 21:20:20 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Aug 22 21:20:21 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 26 15:37:38 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.156`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.157`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3327,12 +3327,12 @@ This report was generated on **Tue Aug 22 21:20:21 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Aug 22 21:20:21 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 26 15:37:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.156`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.157`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4264,12 +4264,12 @@ This report was generated on **Tue Aug 22 21:20:21 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Aug 22 21:20:22 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 26 15:37:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.156`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.157`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5249,4 +5249,4 @@ This report was generated on **Tue Aug 22 21:20:22 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Aug 22 21:20:22 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Aug 26 15:37:40 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.156</version>
+<version>2.0.0-SNAPSHOT.157</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/test/java/io/spine/server/delivery/CatchUpTest.java
+++ b/server/src/test/java/io/spine/server/delivery/CatchUpTest.java
@@ -384,8 +384,8 @@ public class CatchUpTest extends AbstractDeliveryTest {
     }
 
     /**
-     * A time provider which provides the current time based upon JDK's wall clock, i.e. without
-     * the emulated nanoseconds.
+     * A time provider which provides the current time based upon JDK's wall clock,
+     * i.e. without the emulated nanoseconds.
      */
     private static class WithMillisOnlyResolution implements Time.Provider {
 

--- a/server/src/test/java/io/spine/server/delivery/CatchUpTest.java
+++ b/server/src/test/java/io/spine/server/delivery/CatchUpTest.java
@@ -43,7 +43,6 @@ import io.spine.test.delivery.EmitNextNumber;
 import io.spine.testing.SlowTest;
 import io.spine.testing.server.blackbox.BlackBox;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -104,45 +103,56 @@ public class CatchUpTest extends AbstractDeliveryTest {
                          .clear();
     }
 
-    @Nested
-    @DisplayName("given the time is provided with nanosecond resolution")
-    class NanosecondsResolution {
-
-        @Test
-        @DisplayName("catch up only particular instances by their IDs")
-        public void withNanosByIds() throws InterruptedException {
-            testCatchUpByIds();
-        }
-
-        @Test
-        @DisplayName("catch up all of projection instances " +
-                "and respect the order of the delivered events")
-        public void withNanosAllInOrder() throws InterruptedException {
-            testCatchUpAll();
-        }
+    /**
+     * This test is intentionally left {@code public}.
+     *
+     * <p>See the class-level docs.
+     */
+    @Test
+    @DisplayName("given the time is provided with nanosecond resolution " +
+            "catch up only particular instances by their IDs")
+    public void withNanosByIds() throws InterruptedException {
+        testCatchUpByIds();
     }
 
-    @Nested
-    @DisplayName("given the time is provided with millisecond resolution")
-    class MillisecondResolution {
+    /**
+     * This test is intentionally left {@code public}.
+     *
+     * <p>See the class-level docs.
+     */
+    @Test
+    @DisplayName("given the time is provided with nanosecond resolution" +
+            " catch up all of projection instances " +
+            "and respect the order of the delivered events")
+    public void withNanosAllInOrder() throws InterruptedException {
+        testCatchUpAll();
+    }
 
-        @BeforeEach
-        void useMillis() {
-            setupMillis();
-        }
+    /**
+     * This test is intentionally left {@code public}.
+     *
+     * <p>See the class-level docs.
+     */
+    @Test
+    @DisplayName("given the time is provided with millisecond resolution" +
+            " catch up only particular instances by their IDs")
+    public void withMillisByIds() throws InterruptedException {
+        setupMillis();
+        testCatchUpByIds();
+    }
 
-        @Test
-        @DisplayName("catch up only particular instances by their IDs")
-        public void withMillisByIds() throws InterruptedException {
-            testCatchUpByIds();
-        }
-
-        @Test
-        @DisplayName("catch up all of projection instances and " +
-                "respect the order of the delivered events")
-        public void withMillisAllInOrder() throws InterruptedException {
-            testCatchUpAll();
-        }
+    /**
+     * This test is intentionally left {@code public}.
+     *
+     * <p>See the class-level docs.
+     */
+    @Test
+    @DisplayName("given the time is provided with millisecond resolution " +
+            "catch up all of projection instances and " +
+            "respect the order of the delivered events")
+    public void withMillisAllInOrder() throws InterruptedException {
+        setupMillis();
+        testCatchUpAll();
     }
 
     @Test
@@ -333,7 +343,8 @@ public class CatchUpTest extends AbstractDeliveryTest {
             var maybeState = projectionRepo.find(identifier);
             assertThat(maybeState).isPresent();
 
-            var state = maybeState.get().state();
+            var state = maybeState.get()
+                                  .state();
             assertThat(state.getLastValue()).isEqualTo(negativeExpected);
         }
     }
@@ -345,9 +356,9 @@ public class CatchUpTest extends AbstractDeliveryTest {
     private static List<Integer> readLastValues(ConsecutiveProjection.Repo repo,
                                                 String[] ids) {
         return Arrays.stream(ids)
-                     .map((id) -> findView(repo, id).state()
-                                                    .getLastValue())
-                     .collect(toList());
+                .map((id) -> findView(repo, id).state()
+                                               .getLastValue())
+                .collect(toList());
     }
 
     private static List<EmitNextNumber> generateEmissionCommands(int howMany, String[] ids) {
@@ -364,8 +375,8 @@ public class CatchUpTest extends AbstractDeliveryTest {
     private static List<Callable<Object>>
     asPostCommandJobs(BlackBox ctx, List<EmitNextNumber> commands) {
         return commands.stream()
-                       .map(cmd -> (Callable<Object>) () -> ctx.receivesCommand(cmd))
-                       .collect(toList());
+                .map(cmd -> (Callable<Object>) () -> ctx.receivesCommand(cmd))
+                .collect(toList());
     }
 
     private static void setupMillis() {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.internal.dependency.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.156")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.157")


### PR DESCRIPTION
This is another PR on the same matter as #1531, as the previous one got stuck due to some GH Actions failure to report the status of the builds.

Previously, some of `CatchUpTest` methods were grouped into `@Nested` tests. It made impossible to override/disable them in our "descendant" libraries, such as `gcloud-java`.

This PR restores the original behavior.