### PR TITLE
Expose the definitions of Storage columns

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -75,7 +75,7 @@ object Spine {
          * @see [Spine.CoreJava.server]
          * @see <a href="https://github.com/SpineEventEngine/core-java">core-java</a>
          */
-        const val core = "2.0.0-SNAPSHOT.155"
+        const val core = "2.0.0-SNAPSHOT.157"
 
         /**
          * The version of [Spine.modelCompiler].

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.157`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.158`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -804,12 +804,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 26 16:31:38 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Sep 02 18:01:27 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.157`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.158`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1573,12 +1573,12 @@ This report was generated on **Sat Aug 26 16:31:38 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 26 16:31:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Sep 02 18:01:28 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.157`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.158`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2390,12 +2390,12 @@ This report was generated on **Sat Aug 26 16:31:39 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 26 16:31:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Sep 02 18:01:29 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.157`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.158`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3327,12 +3327,12 @@ This report was generated on **Sat Aug 26 16:31:39 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 26 16:31:39 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Sep 02 18:01:29 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.157`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.158`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4264,12 +4264,12 @@ This report was generated on **Sat Aug 26 16:31:39 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 26 16:31:40 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Sep 02 18:01:30 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.157`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.158`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5249,4 +5249,4 @@ This report was generated on **Sat Aug 26 16:31:40 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Aug 26 16:31:40 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Sep 02 18:01:30 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.157</version>
+<version>2.0.0-SNAPSHOT.158</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateEventRecordColumn.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateEventRecordColumn.java
@@ -49,31 +49,31 @@ public final class AggregateEventRecordColumn {
     /**
      * Stores the identifier of an aggregate.
      */
-    static final RecordColumn<AggregateEventRecord, Any>
+    public static final RecordColumn<AggregateEventRecord, Any>
             aggregate_id = create("aggregate_id", Any.class, AggregateEventRecord::getAggregateId);
 
     /**
      * Stores the time when the event record was created.
      */
-    static final RecordColumn<AggregateEventRecord, Timestamp>
+    public static final RecordColumn<AggregateEventRecord, Timestamp>
             created = create("created", Timestamp.class, AggregateEventRecord::getTimestamp);
 
     /**
      * Stores the version of the record, either of the stored event, or the snapshot.
      */
-    static final RecordColumn<AggregateEventRecord, Integer>
+    public static final RecordColumn<AggregateEventRecord, Integer>
             version = create("version", Integer.class, new GetVersion());
 
     /**
      * Stores {@code true} for the records which hold snapshots, {@code false} otherwise.
      */
-    static final RecordColumn<AggregateEventRecord, Boolean>
+    public static final RecordColumn<AggregateEventRecord, Boolean>
             snapshot = create("snapshot", Boolean.class, AggregateEventRecord::hasSnapshot);
 
     /**
      * Prevents this type from instantiation.
      *
-     * <p>This class exists exclusively as a container of the column definitions. Thus it isn't
+     * <p>This class exists exclusively as a container of the column definitions. Thus, it isn't
      * expected to be instantiated at all. See the {@link RecordColumns} docs for more details on
      * this approach.
      */
@@ -83,7 +83,7 @@ public final class AggregateEventRecordColumn {
     /**
      * Returns all the column definitions.
      */
-    static Columns<AggregateEventRecord> definitions() {
+    public static Columns<AggregateEventRecord> definitions() {
         return Columns.of(aggregate_id, created, version, snapshot);
     }
 

--- a/server/src/main/java/io/spine/server/aggregate/AggregateEventRecordColumn.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateEventRecordColumn.java
@@ -40,10 +40,11 @@ import static io.spine.query.RecordColumn.create;
  * Columns stored along with an {@link AggregateEventRecord}.
  */
 @RecordColumns(ofType = AggregateEventRecord.class)
-@SuppressWarnings(
-        {"DuplicateStringLiteralInspection",  /* Column names may repeat across records. */
-                "BadImport"})                 /* `create` looks fine in this context. */
-final class AggregateEventRecordColumn {
+@SuppressWarnings({
+        "DuplicateStringLiteralInspection"  /* Column names may repeat across records. */,
+        "BadImport" /* `create` looks fine in this context. */,
+        "WeakerAccess" /* This type is used in downstream Spine libraries. */})
+public final class AggregateEventRecordColumn {
 
     /**
      * Stores the identifier of an aggregate.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.internal.dependency.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.157")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.158")


### PR DESCRIPTION
This PR makes the definitions of some Storage columns `public`.

It is required for the downstream libraries (such as `rdbms`), for configuration.