### PR TITLE
Avoid `MIN_VALUE` and `MAX_VALUE` from `Timestamps`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.174`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.175`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -817,12 +817,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 08 14:13:56 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 13 17:56:28 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.174`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.175`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1591,12 +1591,12 @@ This report was generated on **Wed Nov 08 14:13:56 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 08 14:13:56 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 13 17:56:28 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.174`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.175`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2421,12 +2421,12 @@ This report was generated on **Wed Nov 08 14:13:56 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 08 14:13:57 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 13 17:56:29 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.174`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.175`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3358,12 +3358,12 @@ This report was generated on **Wed Nov 08 14:13:57 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 08 14:13:57 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 13 17:56:29 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.174`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.175`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4295,12 +4295,12 @@ This report was generated on **Wed Nov 08 14:13:57 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 08 14:13:57 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 13 17:56:30 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.174`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.175`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5280,4 +5280,4 @@ This report was generated on **Wed Nov 08 14:13:57 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 08 14:13:58 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 13 17:56:30 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.174</version>
+<version>2.0.0-SNAPSHOT.175</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/test/java/io/spine/server/aggregate/AggregateStorageTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateStorageTest.java
@@ -29,7 +29,7 @@ package io.spine.server.aggregate;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.google.protobuf.Timestamp;
-import com.google.protobuf.util.Timestamps;
+import com.google.protobuf.util.Durations;
 import io.spine.base.EntityState;
 import io.spine.base.Time;
 import io.spine.core.ActorContext;
@@ -381,8 +381,8 @@ public class AggregateStorageTest
             var state = AggProject.getDefaultInstance();
             var minVersion = zero();
             var maxVersion = increment(minVersion);
-            var minTimestamp = Timestamps.MIN_VALUE;
-            var maxTimestamp = Timestamps.MAX_VALUE;
+            var minTimestamp = currentTime();
+            var maxTimestamp = add(minTimestamp, Durations.fromHours(1));
 
             // The first event is an event, which is the oldest, i.e. with the minimal version.
             var expectedFirst = eventFactory.createEvent(event(state), minVersion, maxTimestamp);

--- a/testutil-server/src/test/java/io/spine/testing/server/entity/given/GivenEntityVersion.java
+++ b/testutil-server/src/test/java/io/spine/testing/server/entity/given/GivenEntityVersion.java
@@ -26,12 +26,17 @@
 
 package io.spine.testing.server.entity.given;
 
-import com.google.protobuf.util.Timestamps;
+import com.google.protobuf.Duration;
+import com.google.protobuf.util.Durations;
 import io.spine.core.Version;
 
+import static com.google.protobuf.util.Timestamps.add;
+import static com.google.protobuf.util.Timestamps.subtract;
 import static io.spine.base.Time.currentTime;
 
 public final class GivenEntityVersion {
+
+    private static final Duration TEN_DAYS = Durations.fromDays(10);
 
     /** Prevents instantiation of this test env class. */
     private GivenEntityVersion() {
@@ -48,7 +53,7 @@ public final class GivenEntityVersion {
     public static Version olderVersion() {
         var version = Version.newBuilder()
                 .setNumber(15)
-                .setTimestamp(Timestamps.MIN_VALUE)
+                .setTimestamp(subtract(currentTime(), TEN_DAYS))
                 .build();
         return version;
     }
@@ -56,7 +61,7 @@ public final class GivenEntityVersion {
     public static Version newerVersion() {
         var version = Version.newBuilder()
                 .setNumber(125)
-                .setTimestamp(Timestamps.MAX_VALUE)
+                .setTimestamp(add(currentTime(), TEN_DAYS))
                 .build();
         return version;
     }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.internal.dependency.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.174")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.175")


### PR DESCRIPTION
This changeset addresses test code, which used easily-reached constants `Timestamps.MIN_VALUE` and `Timestamps.MAX_VALUE`.

The problem with using these constants is that on a Storage level, we convert those to nanoseconds — as it is a part of our mechanism on providing signal ordering within a single JVM (see emulated nanos in `Time`). But the mentioned constants defined by `Timestamps` cannot be converted to nanos, as the proposed Java type is `long`, and it is not long enough to store such values.

Ultimately, in Storage implementations, using these constants led to `long` overflow.

Besides, `MIN_VALUE` corresponds to 1 CE, and `MAX_VALUE` corresponds to year 9999. Both of which aren't widely used in event-sourced applications at the moment. We'll see how it goes, but for now it's definitely an overkill.

This PR migrates the test code to using more meaningful `Timestamp` values.