### PR TITLE
Remove obsolete Maven artifacts from GitHub Packages

### DIFF
--- a/.github/workflows/remove-obsolete-artifacts-from-packages.yaml
+++ b/.github/workflows/remove-obsolete-artifacts-from-packages.yaml
@@ -1,0 +1,73 @@
+#
+# Periodically removes obsolete artifacts from GitHub Packages.
+#
+# Only non-release artifacts—those containing "SNAPSHOT" in their version name—are eligible
+# for removal. The latest non-release artifacts will be retained, with the exact number determined
+# by the `VERSION_COUNT_TO_KEEP` environment variable.
+#
+# Please note the following details:
+#
+# 1. An artifact cannot be deleted if it is public and has been downloaded more than 5,000 times.
+#   In this scenario, contact GitHub support for further assistance.
+#
+# 2. This workflow only applies to artifacts published from this repository.
+#
+# 3. A maximum of 100 artifacts can be removed per run from each package;
+#   if there are more than 100 obsolete artifacts, either manually restart the workflow
+#   or wait for the next scheduled removal.
+#
+# 4. When artifacts with version `x.x.x-SNAPSHOT` are published, GitHub automatically appends
+#   the current timestamp, resulting in versions like `x.x.x-SNAPSHOT.20241024.173759`.
+#   All such artifacts are grouped into one package and treated as a single package
+#   in GitHub Packages with the version `x.x.x-SNAPSHOT`. Consequently, it is not possible
+#   to remove obsolete versions within a package; only the entire package can be deleted.
+#
+
+name: Remove obsolete Maven artifacts from GitHub Packages
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run every day at midnight.
+
+env:
+  VERSION_COUNT_TO_KEEP: 5  # Number of most recent SNAPSHOT versions to retain.
+
+jobs:
+  retrieve-package-names:
+    name: Retrieve the package names published from this repository
+    runs-on: ubuntu-latest
+    outputs:
+      package-names: ${{ steps.request-package-names.outputs.package-names }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+
+      - name: Retrieve the names of packages
+        id: request-package-names
+        shell: bash
+        run: |
+          repoName=$(echo ${{ github.repository }} | cut -d '/' -f2)
+          chmod +x ./scripts/request-package-names.sh
+          ./scripts/request-package-names.sh ${{ github.token }} \
+                $repoName ${{ github.repository_owner }} ./package-names.json
+          echo "package-names=$(<./package-names.json)" >> $GITHUB_OUTPUT
+
+  delete-obsolete-artifacts:
+    name: Remove obsolete artifacts published from this repository to GitHub Packages
+    needs: retrieve-package-names
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package-name: ${{ fromJson(needs.retrieve-package-names.outputs.package-names) }}
+    steps:
+      - name: Remove obsolete artifacts from '${{ matrix.package-name }}' package
+        uses: actions/delete-package-versions@v5
+        with:
+          owner: ${{ github.repository_owner }}
+          package-name: ${{ matrix.package-name }}
+          package-type: 'maven'
+          token: ${{ github.token }}
+          min-versions-to-keep: ${{ env.VERSION_COUNT_TO_KEEP }}
+          # Ignores artifacts that do not contain the word "SNAPSHOT".
+          ignore-versions: '^(?!.+SNAPSHOT).*$'

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.180`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.181`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -859,12 +859,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 10 19:13:38 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 18 12:45:27 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.180`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.181`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1675,12 +1675,12 @@ This report was generated on **Sun Nov 10 19:13:38 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 10 19:13:39 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 18 12:45:29 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.180`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.181`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2547,12 +2547,12 @@ This report was generated on **Sun Nov 10 19:13:39 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 10 19:13:39 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 18 12:45:30 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.180`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.181`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3534,12 +3534,12 @@ This report was generated on **Sun Nov 10 19:13:39 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 10 19:13:39 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 18 12:45:31 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.180`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.181`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4521,12 +4521,12 @@ This report was generated on **Sun Nov 10 19:13:39 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 10 19:13:40 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 18 12:45:32 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.180`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.181`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5556,4 +5556,4 @@ This report was generated on **Sun Nov 10 19:13:40 WET 2024** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 10 19:13:40 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Nov 18 12:45:34 EET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.180</version>
+<version>2.0.0-SNAPSHOT.181</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/scripts/request-package-names.sh
+++ b/scripts/request-package-names.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+#
+# Copyright 2024, TeamDev. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Redistribution and use in source and/or binary forms, with or without
+# modification, must retain the above copyright notice and the following
+# disclaimer.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# Requests GitHub to retrieve package names published from a specific repository
+# in the Apache Maven registry on GitHub Packages.
+#
+# Parameters:
+#   1. The GitHub access token with the "read:packages" permission.
+#   2. The name of the repository from which the packages were published.
+#   3. The organization that owns the packages.
+#   4. The file path where the package names should be written.
+#
+# The output is a file containing a JSON array of package names. For example:
+# `["io.spine.config.package1","io.spine.config.package2"]`.
+#
+
+if [ "$#" -ne 4 ]; then
+    echo "Usage: request-package-names.sh <GitHub token> <repo name> <repo owner name> <output file>"
+    exit 1
+fi
+
+token=$1
+repoName=$2
+orgName=$3
+countOnThisPage=0
+page=1
+packages=''
+
+function requestPackages() {
+    url="https://api.github.com/orgs/$orgName/packages?package_type=maven&per_page=100&page=$page"
+    response=$(curl -s -H "Authorization: Bearer $token" "$url")
+    countOnThisPage=$(echo "$response" | jq -c length)
+    packagesOnThisPage=$(echo "$response" | \
+        jq -c --arg repo "$repoName" '.[] | select(.repository.name == $repo) | .name')
+    if [ "$?" -ne 0 ]; then
+        echo "An unexpected response was received and could not be parsed." \
+             "Ensure that parameters contains the correct data."
+        exit 1
+    fi
+    packages="$packages $packagesOnThisPage"
+}
+
+while true; do
+    requestPackages
+    (( page++ ))
+    if [ "$countOnThisPage" -eq 0 ]; then
+        break
+    fi
+done
+
+json=$(echo $packages | sed 's/ /,/g' | sed 's/^/[/' | sed 's/$/]/')
+echo "$json" >> "$4"

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.internal.dependency.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.180")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.181")


### PR DESCRIPTION
As noted in SpineEventEngine/config#522, many non-release artifacts in Spine's GitHub Packages are obsolete and no longer in use. 

This changeset introduces a GitHub Actions workflow to automate the removal of these obsolete non-release artifacts from GitHub Packages.

An artifact is considered non-releasable if it includes the word “SNAPSHOT” in its version name. The workflow is scheduled to run daily at midnight. The removal task retains the five most recent non-release artifacts.

The artifact removal process follows these steps:

1. Retrieves the names of packages created from this repository.

2. For each package published from this repository, initiates a separate job to remove obsolete artifacts.

Additional details:

1. Artifacts that are public and have been downloaded more than 5,000 times cannot be deleted. In such cases, contact GitHub Support for assistance.

2. Up to 100 artifacts can be removed per run per package. If more than 100 obsolete artifacts exist, manually restart the workflow or wait for the next scheduled removal.