### PR TITLE
Disappearing `(validate)` constraint

### DIFF
--- a/client/src/main/proto/spine/client/subscription.proto
+++ b/client/src/main/proto/spine/client/subscription.proto
@@ -190,7 +190,7 @@ message Subscription {
     SubscriptionId id = 1 [(required) = true];
 
     // Represents the original topic for this subscription.
-    Topic topic = 2 [(required) = true, (validate) = true, (if_invalid).msg_format = "Invalid topic"];
+    Topic topic = 2 [(required) = true, (validate) = true];
 }
 
 // Enumeration of possible technical error reasons occurred in topic validation.

--- a/server/src/test/java/io/spine/server/stand/StandTest.java
+++ b/server/src/test/java/io/spine/server/stand/StandTest.java
@@ -534,7 +534,7 @@ class StandTest extends TenantAwareTest {
         var nonExistingSubscription = Subscription.newBuilder()
                 .setId(Subscriptions.generateId())
                 .setTopic(Topic.newBuilder().setId(topicId).buildPartial())
-                .build();
+                .buildPartial();
         assertThrows(InvalidSubscriptionException.class,
                      () -> stand.cancel(nonExistingSubscription, noOpObserver()));
     }


### PR DESCRIPTION
This PR showcases unexpected behavior of codegen validation in `core-java`. Please note, it is based on `class-based-routing` branch.

For some reason, when `(if_invalid)` is applied for `Subscription.topic` field, its generated code doesn't contain the `(validate)` check in `validate()` method. 

In `StandTest`, the modified line should have contained `buildPartial()` from the very beginning.

Take a look at comparison of the generated `validate()` method with and without `(if_invalid)` option:

<img width="1797" alt="image" src="https://github.com/user-attachments/assets/903bf2ca-482d-412e-a8b1-c4f982b58d4d" />

Discovered in no longer needed #1563. 