### PR TITLE
Make `RouteFn` implement `BiFunction` again

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.202`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.203`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -846,12 +846,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 14 16:35:23 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 16:42:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.202`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.203`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1649,12 +1649,12 @@ This report was generated on **Fri Feb 14 16:35:23 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 14 16:35:23 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 16:42:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.202`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.203`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2508,12 +2508,12 @@ This report was generated on **Fri Feb 14 16:35:23 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 14 16:35:24 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 16:42:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.202`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.203`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3470,12 +3470,12 @@ This report was generated on **Fri Feb 14 16:35:24 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 14 16:35:24 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 16:42:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.202`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.203`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4432,12 +4432,12 @@ This report was generated on **Fri Feb 14 16:35:24 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 14 16:35:24 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 16:42:10 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.202`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.203`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5442,4 +5442,4 @@ This report was generated on **Fri Feb 14 16:35:24 CET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 14 16:35:26 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 17 16:42:10 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.202</version>
+<version>2.0.0-SNAPSHOT.203</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/kotlin/io/spine/server/route/RouteFn.kt
+++ b/server/src/main/kotlin/io/spine/server/route/RouteFn.kt
@@ -61,7 +61,7 @@ public fun interface RouteFn<M : Routable, C : SignalContext, R : Any> : (M, C) 
     /**
      * Obtains entity ID(s) from the passed message and its context.
      *
-     * This function is provided for compatibility with the previous version routing API.
+     * This function is provided for compatibility with the previous version of the routing API.
      *
      * @param message The message to route.
      * @param context The context of the message.

--- a/server/src/main/kotlin/io/spine/server/route/RouteFn.kt
+++ b/server/src/main/kotlin/io/spine/server/route/RouteFn.kt
@@ -28,6 +28,7 @@ package io.spine.server.route
 
 import io.spine.base.Routable
 import io.spine.core.SignalContext
+import java.util.function.BiFunction
 
 /**
  * A common interface for routing functions for calculating identifiers of entities to which
@@ -45,7 +46,8 @@ import io.spine.core.SignalContext
  * @see Multicast
  */
 @FunctionalInterface
-public fun interface RouteFn<M : Routable, C : SignalContext, R : Any> : (M, C) -> R {
+public fun interface RouteFn<M : Routable, C : SignalContext, R : Any> : (M, C) -> R,
+    BiFunction<M, C, R> {
 
     /**
      * Obtains entity ID(s) from the passed message and its context.
@@ -55,4 +57,15 @@ public fun interface RouteFn<M : Routable, C : SignalContext, R : Any> : (M, C) 
      * @return identifier(s) of the target entities.
      */
     override fun invoke(message: M, context: C): R
+
+    /**
+     * Obtains entity ID(s) from the passed message and its context.
+     *
+     * This function is provided for compatibility with the previous version routing API.
+     *
+     * @param message The message to route.
+     * @param context The context of the message.
+     * @return identifier(s) of the target entities.
+     */
+    override fun apply(messagse: M, context: C): R = invoke(messagse, context)
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.dependency.local.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.202")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.203")


### PR DESCRIPTION
This PR makes `RouteFn` extends the `BiFunction` interface so that it is compatible with the previous routing API.