### PR TITLE
Return class based `unicast(BiFunction)` function

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.203`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.204`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -846,12 +846,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 16:42:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 16:20:29 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.203`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.204`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1649,12 +1649,12 @@ This report was generated on **Mon Feb 17 16:42:09 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 16:42:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 16:20:29 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.203`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.204`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2508,12 +2508,12 @@ This report was generated on **Mon Feb 17 16:42:09 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 16:42:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 16:20:30 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.203`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.204`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3470,12 +3470,12 @@ This report was generated on **Mon Feb 17 16:42:09 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 16:42:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 16:20:30 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.203`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.204`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4432,12 +4432,12 @@ This report was generated on **Mon Feb 17 16:42:09 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 16:42:10 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 16:20:30 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.203`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.204`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5442,4 +5442,4 @@ This report was generated on **Mon Feb 17 16:42:10 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Feb 17 16:42:10 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 16:20:31 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.203</version>
+<version>2.0.0-SNAPSHOT.204</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/kotlin/io/spine/server/route/MulticastRouting.kt
+++ b/server/src/main/kotlin/io/spine/server/route/MulticastRouting.kt
@@ -28,6 +28,7 @@ package io.spine.server.route
 
 import io.spine.base.Routable
 import io.spine.core.SignalContext
+import java.util.function.BiFunction
 
 /**
  * An abstract base for routing schemas that route a message to potentially more than one entity.
@@ -104,6 +105,24 @@ public abstract class MulticastRouting<
         msgType: Class<N>,
         via: (N, C) -> I
     ): S = route(msgType, createUnicastRoute(via))
+
+    /**
+     * Adds a route for the messages with the given type [N].
+     *
+     * This function is for backward compatibility with the previous versions.
+     *
+     * @param N The type of the message which descends from
+     *   the super-interface [M] served by this routing schema.
+     *
+     * @param cls The class of the routed messages.
+     * @param via The route function to be used for this type of messages.
+     * @return `this` to allow chained calls when configuring the routing.
+     * @throws IllegalStateException if the route for this message class is already set either
+     *   directly or via a super-interface.
+     */
+    @Deprecated(message = "Please use `unicast(Class<N>, via: (N, C) -> I)` function instead.")
+    public fun <N : M> unicast(cls: Class<N>, via: BiFunction<M, C, I>): S =
+        unicast(cls, { m, c, -> via.apply(m, c) } )
 
     /**
      * Adds a route for the messages with the given type [N].

--- a/server/src/test/java/io/spine/server/trace/given/airport/TimetableRepository.java
+++ b/server/src/test/java/io/spine/server/trace/given/airport/TimetableRepository.java
@@ -27,6 +27,8 @@
 package io.spine.server.trace.given.airport;
 
 import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
+import io.spine.base.EventMessage;
+import io.spine.core.EventContext;
 import io.spine.server.projection.ProjectionRepository;
 import io.spine.server.route.EventRouting;
 import io.spine.test.trace.AirportId;
@@ -34,6 +36,8 @@ import io.spine.test.trace.FlightCanceled;
 import io.spine.test.trace.FlightRescheduled;
 import io.spine.test.trace.FlightScheduled;
 import io.spine.test.trace.Timetable;
+
+import java.util.function.BiFunction;
 
 public final class TimetableRepository
         extends ProjectionRepository<AirportId, TimetableProjection, Timetable> {
@@ -43,7 +47,11 @@ public final class TimetableRepository
     protected void setupEventRouting(EventRouting<AirportId> routing) {
         super.setupEventRouting(routing);
         routing.unicast(FlightScheduled.class, (e) -> e.getFrom().getId())
-               .unicast(FlightRescheduled.class, (e, ctx) -> ctx.get(AirportId.class))
-               .unicast(FlightCanceled.class, (e, ctx) -> ctx.get(AirportId.class));
+               .unicast(FlightRescheduled.class,
+                        (BiFunction<EventMessage, EventContext, AirportId>) (e, ctx) -> ctx.get(
+                                AirportId.class))
+               .unicast(FlightCanceled.class,
+                        (BiFunction<EventMessage, EventContext, AirportId>) (e, ctx) -> ctx.get(
+                                AirportId.class));
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.dependency.local.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.203")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.204")


### PR DESCRIPTION
This PR adds the overload `MulticastRouting.unicast(BiFunction)` function to provide backward compatibility with the libraries build with previous versions of CoreJava.

The overload function is deprecated to encourage sooner migration with subsequent removal.