### PR TITLE
Pull down `unicast()` with `BiFunction` parameter

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.204`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.205`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -846,12 +846,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 18 16:20:29 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 17:49:41 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.204`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.205`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1649,12 +1649,12 @@ This report was generated on **Tue Feb 18 16:20:29 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 18 16:20:29 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 17:49:41 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.204`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.205`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2508,12 +2508,12 @@ This report was generated on **Tue Feb 18 16:20:29 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 18 16:20:30 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 17:49:42 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.204`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.205`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3470,12 +3470,12 @@ This report was generated on **Tue Feb 18 16:20:30 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 18 16:20:30 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 17:49:42 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.204`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.205`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4432,12 +4432,12 @@ This report was generated on **Tue Feb 18 16:20:30 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 18 16:20:30 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 17:49:42 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.204`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.205`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5442,4 +5442,4 @@ This report was generated on **Tue Feb 18 16:20:30 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 18 16:20:31 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 18 17:49:42 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.204</version>
+<version>2.0.0-SNAPSHOT.205</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/kotlin/io/spine/server/route/EventRouting.kt
+++ b/server/src/main/kotlin/io/spine/server/route/EventRouting.kt
@@ -32,6 +32,7 @@ import io.spine.base.EventMessage
 import io.spine.core.EventContext
 import io.spine.server.route.EventRoute.Companion.withId
 import io.spine.system.server.event.EntityStateChanged
+import java.util.function.BiFunction
 
 /**
  * A [routing schema][MessageRouting] for events.
@@ -94,6 +95,25 @@ public class EventRouting<I : Any> private constructor(
         Set<I>,
         EventRouting<I>
         >(defaultRoute), EventRoute<I, EventMessage> {
+
+    /**
+     * Adds a route for the events with the given type [E].
+     *
+     * This function is for backward compatibility with the previous versions.
+     *
+     * @param E The type of the event message to route.
+     *
+     * @param cls The class of the routed events.
+     * @param via The route function for this type of event.
+     * @return `this` to allow chained calls when configuring the routing.
+     * @throws IllegalStateException if the route for this message class is already set either
+     *   directly or via a super-interface.
+     */
+    @Deprecated(message = "Please use `unicast(Class<N>, via: (N, C) -> I)` function instead.")
+    public fun <E : EventMessage> unicast(
+        cls: Class<E>,
+        via: BiFunction<E, EventContext, I>
+    ): EventRouting<I> = unicast(cls, { m, c, -> via.apply(m, c) } )
 
     override fun self(): EventRouting<I> = this
 

--- a/server/src/main/kotlin/io/spine/server/route/MulticastRouting.kt
+++ b/server/src/main/kotlin/io/spine/server/route/MulticastRouting.kt
@@ -28,7 +28,6 @@ package io.spine.server.route
 
 import io.spine.base.Routable
 import io.spine.core.SignalContext
-import java.util.function.BiFunction
 
 /**
  * An abstract base for routing schemas that route a message to potentially more than one entity.
@@ -40,7 +39,7 @@ import java.util.function.BiFunction
  *
  * ## Unicast routing
  *
- * In some cases a routing function returns only one identifier.
+ * In some cases, a routing function returns only one identifier.
  * This class provides convenience methods called [unicast] that allow to adapt
  * function returning a single identifier to the general contract of the schema.
  *
@@ -105,24 +104,6 @@ public abstract class MulticastRouting<
         msgType: Class<N>,
         via: (N, C) -> I
     ): S = route(msgType, createUnicastRoute(via))
-
-    /**
-     * Adds a route for the messages with the given type [N].
-     *
-     * This function is for backward compatibility with the previous versions.
-     *
-     * @param N The type of the message which descends from
-     *   the super-interface [M] served by this routing schema.
-     *
-     * @param cls The class of the routed messages.
-     * @param via The route function to be used for this type of messages.
-     * @return `this` to allow chained calls when configuring the routing.
-     * @throws IllegalStateException if the route for this message class is already set either
-     *   directly or via a super-interface.
-     */
-    @Deprecated(message = "Please use `unicast(Class<N>, via: (N, C) -> I)` function instead.")
-    public fun <N : M> unicast(cls: Class<N>, via: BiFunction<M, C, I>): S =
-        unicast(cls, { m, c, -> via.apply(m, c) } )
 
     /**
      * Adds a route for the messages with the given type [N].

--- a/server/src/test/java/io/spine/server/trace/given/airport/TimetableRepository.java
+++ b/server/src/test/java/io/spine/server/trace/given/airport/TimetableRepository.java
@@ -27,7 +27,6 @@
 package io.spine.server.trace.given.airport;
 
 import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
-import io.spine.base.EventMessage;
 import io.spine.core.EventContext;
 import io.spine.server.projection.ProjectionRepository;
 import io.spine.server.route.EventRouting;
@@ -48,10 +47,10 @@ public final class TimetableRepository
         super.setupEventRouting(routing);
         routing.unicast(FlightScheduled.class, (e) -> e.getFrom().getId())
                .unicast(FlightRescheduled.class,
-                        (BiFunction<EventMessage, EventContext, AirportId>) (e, ctx) -> ctx.get(
-                                AirportId.class))
+                        (BiFunction<FlightRescheduled, EventContext, AirportId>) (e, ctx) ->
+                                ctx.get(AirportId.class))
                .unicast(FlightCanceled.class,
-                        (BiFunction<EventMessage, EventContext, AirportId>) (e, ctx) -> ctx.get(
-                                AirportId.class));
+                        (BiFunction<FlightCanceled, EventContext, AirportId>) (e, ctx) ->
+                                ctx.get(AirportId.class));
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.dependency.local.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.204")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.205")


### PR DESCRIPTION
This PR continues providing backward compatibility for `EventRouting` which used to accept `BiFunction` as the 2nd parameter.
