### PR TITLE
Context extensions

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1058,7 +1058,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 08 16:33:31 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 08 17:13:28 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2073,7 +2073,7 @@ This report was generated on **Thu May 08 16:33:31 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 08 16:33:31 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 08 17:13:28 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3148,7 +3148,7 @@ This report was generated on **Thu May 08 16:33:31 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 08 16:33:32 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 08 17:13:28 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4314,7 +4314,7 @@ This report was generated on **Thu May 08 16:33:32 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 08 16:33:32 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 08 17:13:29 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5480,7 +5480,7 @@ This report was generated on **Thu May 08 16:33:32 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 08 16:33:32 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 08 17:13:29 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6698,4 +6698,4 @@ This report was generated on **Thu May 08 16:33:32 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 08 16:33:33 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 08 17:13:29 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.312`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.313`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1058,12 +1058,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 07 17:38:02 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 08 16:33:31 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.312`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.313`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2073,12 +2073,12 @@ This report was generated on **Wed May 07 17:38:02 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 07 17:38:02 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 08 16:33:31 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.312`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.313`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3148,12 +3148,12 @@ This report was generated on **Wed May 07 17:38:02 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 07 17:38:03 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 08 16:33:32 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.312`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.313`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4314,12 +4314,12 @@ This report was generated on **Wed May 07 17:38:03 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 07 17:38:03 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 08 16:33:32 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.312`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.313`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5480,12 +5480,12 @@ This report was generated on **Wed May 07 17:38:03 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 07 17:38:03 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 08 16:33:32 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.312`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.313`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -6698,4 +6698,4 @@ This report was generated on **Wed May 07 17:38:03 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed May 07 17:38:04 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 08 16:33:33 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.312</version>
+<version>2.0.0-SNAPSHOT.313</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/kotlin/io/spine/server/Contexts.kt
+++ b/server/src/main/kotlin/io/spine/server/Contexts.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -24,10 +24,28 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@file:JvmName("Contexts")
+
 package io.spine.server
 
 import io.spine.base.EntityState
 import io.spine.server.entity.Entity
+import kotlin.reflect.KClass
+
+/**
+ * Adds specified entity class to this `BoundedContextBuilder`.
+ *
+ * A default repository instance will be created for this class.
+ * This instance will be added to the repository registration list for
+ * the bounded context being built.
+ *
+ * @param I The type of entity identifiers.
+ * @param E The type of entities.
+ */
+public inline fun <reified I : Any, reified S : EntityState<I>, reified E : Entity<I, out S>>
+        BoundedContextBuilder.add(entity: KClass<out E>) {
+    add(entity.java)
+}
 
 /**
  * Tells if the bounded context has entities of the given type.
@@ -40,3 +58,4 @@ public inline fun <reified E: Entity<*, *>> BoundedContext.hasEntitiesOfType(): 
  */
 public inline fun <reified S: EntityState<*>> BoundedContext.hasEntitiesWithState(): Boolean =
     hasEntitiesWithState(S::class.java)
+

--- a/server/src/main/kotlin/io/spine/server/Contexts.kt
+++ b/server/src/main/kotlin/io/spine/server/Contexts.kt
@@ -58,4 +58,3 @@ public inline fun <reified E: Entity<*, *>> BoundedContext.hasEntitiesOfType(): 
  */
 public inline fun <reified S: EntityState<*>> BoundedContext.hasEntitiesWithState(): Boolean =
     hasEntitiesWithState(S::class.java)
-

--- a/server/src/main/kotlin/io/spine/server/Contexts.kt
+++ b/server/src/main/kotlin/io/spine/server/Contexts.kt
@@ -33,7 +33,7 @@ import io.spine.server.entity.Entity
 import kotlin.reflect.KClass
 
 /**
- * Adds specified entity class to this `BoundedContextBuilder`.
+ * Adds the specified entity class to this `BoundedContextBuilder`.
  *
  * A default repository instance will be created for this class.
  * This instance will be added to the repository registration list for

--- a/server/src/testFixtures/proto/spine/test/client/users/active_users.proto
+++ b/server/src/testFixtures/proto/spine/test/client/users/active_users.proto
@@ -43,5 +43,5 @@ message ActiveUsers {
 
     ActiveUsersId id = 1;
 
-    uint64 count = 2 [(min).value = "0"];
+    int64 count = 2 [(min).value = "0"];
 }

--- a/server/src/testFixtures/proto/spine/test/model/handler/commands.proto
+++ b/server/src/testFixtures/proto/spine/test/model/handler/commands.proto
@@ -37,5 +37,5 @@ option java_outer_classname = "CommandsProto";
 // The command for a bot to start moving.
 message Start {
     uint32 bot_id = 1;
-    uint32 number_of_moves = 2 [(min).value = "1"];
+    int32 number_of_moves = 2 [(min).value = "1"];
 }

--- a/server/src/testFixtures/proto/spine/test/tuple/quintet.proto
+++ b/server/src/testFixtures/proto/spine/test/tuple/quintet.proto
@@ -50,7 +50,7 @@ option java_multiple_files = true;
 message InstrumentNumber {
 
     // Valid values are `1` and `2`.
-    uint32 value = 1 [(min).value = "1", (max).value = "2"];
+    int32 value = 1 [(min).value = "1", (max).value = "2"];
 }
 
 message Viola {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.dependency.local.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.312")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.313")


### PR DESCRIPTION
This PR brings `BoundedContextBuilder.add(KClass)` extension adopted in ProtoData, and consolidates extensions for `BoundedContext` and `BoundedContextBuilder` under the same Kotlin file (and Java class) called `Contexts`.

### Other notable changes
 * Avoided using unsigned types in stub protos to reduce the console noise.
