### PR TITLE
Avoid casts to `GeneratedMessageV3`

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.314`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.315`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1058,12 +1058,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 16 21:02:33 GMT+01:00 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon May 19 11:45:42 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.314`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.315`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2073,12 +2073,12 @@ This report was generated on **Fri May 16 21:02:33 GMT+01:00 2025** using [Gradl
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 16 21:02:33 GMT+01:00 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon May 19 11:45:42 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.314`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.315`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -3148,12 +3148,12 @@ This report was generated on **Fri May 16 21:02:33 GMT+01:00 2025** using [Gradl
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 16 21:02:33 GMT+01:00 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon May 19 11:45:42 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.314`
+# Dependencies of `io.spine.tools:spine-testutil-client:2.0.0-SNAPSHOT.315`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4314,12 +4314,12 @@ This report was generated on **Fri May 16 21:02:33 GMT+01:00 2025** using [Gradl
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 16 21:02:33 GMT+01:00 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon May 19 11:45:42 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.314`
+# Dependencies of `io.spine.tools:spine-testutil-core:2.0.0-SNAPSHOT.315`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5480,12 +5480,12 @@ This report was generated on **Fri May 16 21:02:33 GMT+01:00 2025** using [Gradl
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 16 21:02:33 GMT+01:00 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon May 19 11:45:42 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.314`
+# Dependencies of `io.spine.tools:spine-testutil-server:2.0.0-SNAPSHOT.315`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -6698,4 +6698,4 @@ This report was generated on **Fri May 16 21:02:33 GMT+01:00 2025** using [Gradl
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 16 21:02:33 GMT+01:00 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon May 19 11:45:42 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-java</artifactId>
-<version>2.0.0-SNAPSHOT.314</version>
+<version>2.0.0-SNAPSHOT.315</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/entity/EntityVisibility.java
+++ b/server/src/main/java/io/spine/server/entity/EntityVisibility.java
@@ -60,8 +60,9 @@ import static io.spine.option.EntityOption.Visibility.SUBSCRIBE;
  *     <li>{@code FULL} - the entity is visible for both subscription and querying.
  * </ol>
  *
- * <p>The visibility of an entity is defined by the {@code (entity)} option. By default, any entity
- * is has the {@code NONE} level except for projections, which have the {@code FULL} level.
+ * <p>The visibility of an entity is defined by the {@code (entity)} option.
+ * By default, any entity has the {@code NONE} level except for projections,
+ * which have the {@code FULL} level.
  */
 @Immutable
 @Internal
@@ -194,7 +195,7 @@ public final class EntityVisibility implements Serializable {
     }
 
     /**
-     * Builds the graph of the visibilities hierarchy.
+     * Builds the graph of the visibility hierarchy.
      *
      * @see #VISIBILITIES
      */

--- a/server/src/main/java/io/spine/server/entity/EntityVisibility.java
+++ b/server/src/main/java/io/spine/server/entity/EntityVisibility.java
@@ -30,7 +30,6 @@ import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.ImmutableGraph;
 import com.google.common.graph.MutableGraph;
 import com.google.errorprone.annotations.Immutable;
-import com.google.protobuf.GeneratedMessageV3;
 import io.spine.annotation.Internal;
 import io.spine.base.EntityState;
 import io.spine.code.proto.EntityStateOption;

--- a/server/src/main/java/io/spine/server/stand/InvalidRequestException.java
+++ b/server/src/main/java/io/spine/server/stand/InvalidRequestException.java
@@ -25,10 +25,11 @@
  */
 package io.spine.server.stand;
 
-import com.google.protobuf.GeneratedMessageV3;
 import com.google.protobuf.Message;
 import io.spine.base.Error;
 import io.spine.server.MessageError;
+
+import java.io.Serial;
 
 /**
  * A base class for exceptions fired in case an invalid request
@@ -36,9 +37,10 @@ import io.spine.server.MessageError;
  */
 public class InvalidRequestException extends RuntimeException implements MessageError {
 
+    @Serial
     private static final long serialVersionUID = 0L;
 
-    private final GeneratedMessageV3 request;
+    private final Message request;
     private final Error error;
 
     /**
@@ -48,7 +50,7 @@ public class InvalidRequestException extends RuntimeException implements Message
      * @param request     the related actor request
      * @param error       the error occurred
      */
-    InvalidRequestException(String messageText, GeneratedMessageV3 request, Error error) {
+    InvalidRequestException(String messageText, Message request, Error error) {
         super(messageText);
         this.request = request;
         this.error = error;

--- a/server/src/main/java/io/spine/server/tuple/Either.java
+++ b/server/src/main/java/io/spine/server/tuple/Either.java
@@ -26,14 +26,13 @@
 
 package io.spine.server.tuple;
 
-import com.google.protobuf.GeneratedMessageV3;
 import com.google.protobuf.Message;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -44,16 +43,14 @@ import static java.lang.String.format;
  */
 public abstract class Either implements Iterable<Message>, Serializable {
 
+    @Serial
     private static final long serialVersionUID = 0L;
 
-    private final GeneratedMessageV3 value;
+    private final Message value;
     private final int index;
 
     protected Either(Message value, int index) {
-        /* We need instances of GeneratedMessageV3 as they are Serializable.
-           The only known case of message class which does not descend from
-           GeneratedMessageV3 is DynamicMessage, and Spine SDK does not support it. */
-        this.value = (GeneratedMessageV3) checkNotNull(value);
+        this.value = checkNotNull(value);
         checkArgument(index >= 0, "Index must be greater or equal zero");
         this.index = index;
     }
@@ -86,7 +83,7 @@ public abstract class Either implements Iterable<Message>, Serializable {
             throw new IllegalStateException(errMsg);
         }
 
-        @SuppressWarnings("unchecked") // It's the caller responsibility to ensure correct type.
+        @SuppressWarnings("unchecked") // It's the caller's responsibility to ensure a correct type.
         var result = (T) either.value();
         return result;
 
@@ -102,17 +99,16 @@ public abstract class Either implements Iterable<Message>, Serializable {
         if (this == obj) {
             return true;
         }
-        if (!(obj instanceof Either)) {
+        if (!(obj instanceof Either other)) {
             return false;
         }
-        var other = (Either) obj;
         return Objects.equals(this.value, other.value)
                 && (this.index == other.index);
     }
 
     @Override
     public final Iterator<Message> iterator() {
-        Set<Message> singleton = Collections.singleton(value);
+        var singleton = Collections.singleton(value);
         return singleton.iterator();
     }
 }

--- a/server/src/main/java/io/spine/server/tuple/Element.java
+++ b/server/src/main/java/io/spine/server/tuple/Element.java
@@ -27,7 +27,6 @@
 package io.spine.server.tuple;
 
 import com.google.protobuf.Empty;
-import com.google.protobuf.GeneratedMessageV3;
 import com.google.protobuf.Message;
 import io.spine.base.EventMessage;
 import io.spine.server.event.NoReaction;
@@ -36,6 +35,7 @@ import io.spine.server.model.Nothing;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.Optional;
@@ -52,13 +52,14 @@ import static io.spine.util.Preconditions2.checkNotDefaultArg;
  */
 final class Element implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 0L;
 
     private Object value;
     private Type type;
 
     /**
-     * Creates a tuple element with a value which can be {@link GeneratedMessageV3},
+     * Creates a tuple element with a value which can be {@link Message},
      * {@link Optional}, or {@link Either}.
      */
     @SuppressWarnings({
@@ -70,13 +71,12 @@ final class Element implements Serializable {
             this.type = Type.EITHER;
         } else if (value instanceof Optional) {
             this.type = Type.OPTIONAL;
-        } else if (value instanceof GeneratedMessageV3) {
-            var messageV3 = (GeneratedMessageV3) value;
+        } else if (value instanceof Message message) {
             // Treat `Nothing` (deprecated) and `NoReaction` as a special case,
             // allowing its default instance so that `Just<NoReaction>` is possible.
             var noReaction = value instanceof Nothing || value instanceof NoReaction;
             if (!noReaction) {
-                checkNotDefault(messageV3);
+                checkNotDefault(message);
             }
             this.type = Type.MESSAGE;
         } else {
@@ -134,6 +134,7 @@ final class Element implements Serializable {
         throw newIllegalStateException("Unsupported element type encountered: `%s`.", this.type);
     }
 
+    @Serial
     private void writeObject(ObjectOutputStream out) throws IOException {
         out.writeObject(type);
         final Serializable obj;
@@ -147,6 +148,7 @@ final class Element implements Serializable {
         out.writeObject(obj);
     }
 
+    @Serial
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         type = (Type) in.readObject();
         if (type == Type.OPTIONAL) {

--- a/server/src/main/java/io/spine/server/tuple/IndexOf.java
+++ b/server/src/main/java/io/spine/server/tuple/IndexOf.java
@@ -29,7 +29,7 @@ package io.spine.server.tuple;
 /**
  * Defines the indexes of the elements in tuples.
  *
- * <p>Serves to replace a numerous "magic numbers" across the codebase.
+ * <p>Serves to replace numerous "magic numbers" across the codebase.
  *
  * <p>Each index is put into a correspondence to the capital letter which is used as to name
  * a generic parameter in the tuple's declaration.

--- a/server/src/main/java/io/spine/server/tuple/Tuple.java
+++ b/server/src/main/java/io/spine/server/tuple/Tuple.java
@@ -147,6 +147,7 @@ public abstract class Tuple implements Iterable<Message>, Serializable {
     }
 
     @Override
+    @SuppressWarnings("PMD.SimplifyBooleanReturns")
     public final boolean equals(Object obj) {
         if (this == obj) {
             return true;

--- a/server/src/main/java/io/spine/server/tuple/Tuple.java
+++ b/server/src/main/java/io/spine/server/tuple/Tuple.java
@@ -160,10 +160,8 @@ public abstract class Tuple implements Iterable<Message>, Serializable {
      */
     static boolean isOptionalPresent(Object value) {
         checkNotNull(value);
-        if(!(value instanceof Optional<?> asOptional)) {
-            return true;
-        }
-        return asOptional.isPresent();
+        return !(value instanceof Optional<?> asOptional)
+                || asOptional.isPresent();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/tuple/Tuple.java
+++ b/server/src/main/java/io/spine/server/tuple/Tuple.java
@@ -30,11 +30,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.UnmodifiableIterator;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Empty;
-import com.google.protobuf.GeneratedMessageV3;
 import com.google.protobuf.Message;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.List;
@@ -49,14 +49,13 @@ import static io.spine.util.Exceptions.newIllegalArgumentException;
  */
 public abstract class Tuple implements Iterable<Message>, Serializable {
 
+    @Serial
     private static final long serialVersionUID = 0L;
 
     /**
      * Immutable list of tuple values.
      *
-     * <p>The first entry must be a {@link GeneratedMessageV3}.
-     *
-     * <p>Other entries can be either {@link GeneratedMessageV3} or {@link Optional}.
+     * <p>Other entries can be either {@link Message} or {@link Optional}.
      */
     private final List<Element> values;
 
@@ -152,10 +151,9 @@ public abstract class Tuple implements Iterable<Message>, Serializable {
         if (this == obj) {
             return true;
         }
-        if (!(obj instanceof Tuple)) {
+        if (!(obj instanceof Tuple other)) {
             return false;
         }
-        var other = (Tuple) obj;
         return Objects.equals(this.values, other.values);
     }
 

--- a/server/src/main/java/io/spine/server/tuple/Tuple.java
+++ b/server/src/main/java/io/spine/server/tuple/Tuple.java
@@ -147,15 +147,12 @@ public abstract class Tuple implements Iterable<Message>, Serializable {
     }
 
     @Override
-    @SuppressWarnings("PMD.SimplifyBooleanReturns")
     public final boolean equals(Object obj) {
         if (this == obj) {
             return true;
         }
-        if (!(obj instanceof Tuple other)) {
-            return false;
-        }
-        return Objects.equals(this.values, other.values);
+        return (obj instanceof Tuple other) &&
+                Objects.equals(this.values, other.values);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/tuple/Tuple.java
+++ b/server/src/main/java/io/spine/server/tuple/Tuple.java
@@ -160,10 +160,9 @@ public abstract class Tuple implements Iterable<Message>, Serializable {
      */
     static boolean isOptionalPresent(Object value) {
         checkNotNull(value);
-        if(!(value instanceof Optional)) {
+        if(!(value instanceof Optional<?> asOptional)) {
             return true;
         }
-        var asOptional = (Optional<?>) value;
         return asOptional.isPresent();
     }
 

--- a/server/src/main/java/io/spine/server/tuple/Tuple.java
+++ b/server/src/main/java/io/spine/server/tuple/Tuple.java
@@ -148,11 +148,9 @@ public abstract class Tuple implements Iterable<Message>, Serializable {
 
     @Override
     public final boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        return (obj instanceof Tuple other) &&
-                Objects.equals(this.values, other.values);
+        return (this == obj) ||
+                ((obj instanceof Tuple other) &&
+                        Objects.equals(this.values, other.values));
     }
 
     /**

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.dependency.local.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.314")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.315")


### PR DESCRIPTION
This PR eliminates the casts and usage of `GeneratedMessageV3` class so that we can migrate to Protobuf v4.31.0, in which this type is deprecated, and the code generated by `protoc` no longer extends this class.

### Other notable changes
 * Pattern variables were used in the code when suggested by IDEA.