### PR TITLE
Fix Dokka link warning in `RoutingSetup`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
@@ -46,12 +46,12 @@ object CoreJvmCompiler {
     /**
      * The version used in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.070"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.072"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.070"
+    const val version = "2.0.0-SNAPSHOT.072"
 
     /**
      * The ID of the Gradle plugin.

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.374`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.375`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1059,7 +1059,7 @@ This report was generated on **Wed Apr 08 18:39:06 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.374`
+# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.375`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2214,7 +2214,7 @@ This report was generated on **Wed Apr 08 18:39:06 WEST 2026** using
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.374`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.375`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3209,7 +3209,7 @@ This report was generated on **Wed Apr 08 18:39:06 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.374`
+# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.375`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4266,7 +4266,7 @@ This report was generated on **Wed Apr 08 18:39:05 WEST 2026** using
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.374`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.375`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5337,7 +5337,7 @@ This report was generated on **Wed Apr 08 18:39:06 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.374`
+# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.375`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.374`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.375`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1052,7 +1052,7 @@ This report was generated on **Mon Jun 15 01:31:33 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.374`
+# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.375`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2200,7 +2200,7 @@ This report was generated on **Mon Jun 15 01:31:33 WEST 2026** using
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.374`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.375`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3188,7 +3188,7 @@ This report was generated on **Mon Jun 15 01:31:33 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.374`
+# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.375`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4238,7 +4238,7 @@ This report was generated on **Mon Jun 15 01:31:33 WEST 2026** using
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.374`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.375`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5302,7 +5302,7 @@ This report was generated on **Mon Jun 15 01:31:33 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.374`
+# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.375`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1045,7 +1045,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 15 01:31:33 WEST 2026** using 
+This report was generated on **Mon Jun 15 13:28:47 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2193,7 +2193,7 @@ This report was generated on **Mon Jun 15 01:31:33 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 15 01:31:33 WEST 2026** using 
+This report was generated on **Mon Jun 15 13:28:47 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3181,7 +3181,7 @@ This report was generated on **Mon Jun 15 01:31:33 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 15 01:31:33 WEST 2026** using 
+This report was generated on **Mon Jun 15 13:28:47 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4231,7 +4231,7 @@ This report was generated on **Mon Jun 15 01:31:33 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 15 01:31:33 WEST 2026** using 
+This report was generated on **Mon Jun 15 13:28:47 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5295,7 +5295,7 @@ This report was generated on **Mon Jun 15 01:31:33 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 15 01:31:33 WEST 2026** using 
+This report was generated on **Mon Jun 15 13:28:47 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6495,6 +6495,6 @@ This report was generated on **Mon Jun 15 01:31:33 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 15 01:31:33 WEST 2026** using 
+This report was generated on **Mon Jun 15 13:28:47 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -286,7 +286,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>core-jvm-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.070</version>
+    <version>2.0.0-SNAPSHOT.072</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-jvm</artifactId>
-<version>2.0.0-SNAPSHOT.374</version>
+<version>2.0.0-SNAPSHOT.375</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-jvm</artifactId>
-<version>2.0.0-SNAPSHOT.374</version>
+<version>2.0.0-SNAPSHOT.375</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/kotlin/io/spine/server/route/setup/RoutingSetup.kt
+++ b/server/src/main/kotlin/io/spine/server/route/setup/RoutingSetup.kt
@@ -42,7 +42,7 @@ import io.spine.server.route.MessageRouting
  *
  * @param I The type of the identifiers of the target entities.
  * @param M The type of routed messages.
- * @param S The type of the context of the routed messages.
+ * @param C The type of the context of the routed messages.
  * @param R The type of the result of routing functions participated in the schema.
  * @param U The type of the routing schema filled by the setup class.
  */

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.dependency.local.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.374")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.375")


### PR DESCRIPTION
## Problem

The `Publish` job failed ([run 27541687499](https://github.com/SpineEventEngine/core-jvm/actions/runs/27541687499/job/81404805192)) on a Dokka warning:

```
w: [:server:dokkaGeneratePublicationHtml] Couldn't resolve link: [S] in RoutingSetup.kt/io.spine.server.route.setup.RoutingSetup (:server/main)
```

`RoutingSetup` declares its context type parameter as `C` (`C : SignalContext`), but the KDoc documented it as `@param S`. Dokka cannot resolve the `[S]` link, and since `failOnWarning` is enabled for the HTML publication, the warning fails the publish job.

## Fix

Rename the parameter doc from `@param S` to `@param C` to match the actual type-parameter name.

## Why it wasn't caught during PR preparation

Documentation is generated only as a *publishing artifact*. PR CI runs `./gradlew build` (`assemble` + `check`), and no Dokka task is wired into that lifecycle — `dokkaGeneratePublicationHtml` runs only to build `htmlDocsJar`, which is attached as a publication artifact and produced solely by `./gradlew publish`. That job runs only on push to `master` after merge, so the `failOnWarning` check (and thus this KDoc error) never ran during PR review.

The KDoc/declaration mismatch has existed since the file was introduced (Feb 2025, `faa7186`); it only began failing the build once the stricter Dokka publication config landed via the shared `config` submodule.

This is going to be addressed in [config shortly](https://github.com/SpineEventEngine/config/pull/689).

https://claude.ai/code/session_016psHnmcZSqDR1Tsd6coxhC

---
_Generated by [Claude Code](https://claude.ai/code/session_016psHnmcZSqDR1Tsd6coxhC)_