### PR TITLE
Introduce the OpenTelemetry-based tracer (`server-otel`) module

### DIFF
--- a/.agents/tasks/server-otel.md
+++ b/.agents/tasks/server-otel.md
@@ -46,6 +46,12 @@ New module `core-jvm/server-otel`, package `io.spine.server.trace.otel`:
   (32-char trace ID / 16-char span ID), fixing the un-padded `Long.toHexString` gap in
   the old code; non-UUID IDs fall back to a stable name-based UUID.
 
+The public API (`OtelTracerFactory`, `OtelTracer`, `DEFAULT_INSTRUMENTATION_SCOPE_NAME`)
+is marked **experimental** twice: a Kotlin opt-in marker `@ExperimentalOtelTracing`
+(`@RequiresOptIn`, ERROR — Kotlin consumers must `@OptIn`) and Spine's
+`@io.spine.annotation.Experimental` (source-level documentation marker). This reflects
+the alpha status of the underlying Kotlin OpenTelemetry API.
+
 Behavioral parity with `stackdriver-trace`, minus the GCP coupling: export, batching,
 and sampling are delegated to the caller's `OpenTelemetry` SDK (no manual batch-write,
 no GCP credentials, no sync/async service, no `forbidMultiThreading`). The parent

--- a/.agents/tasks/server-otel.md
+++ b/.agents/tasks/server-otel.md
@@ -23,11 +23,16 @@ repo); this task only adds the new module.
 
 New module `core-jvm/server-otel`, package `io.spine.server.trace.otel`:
 
-- `OtelTracerFactory` — `TracerFactory` built via `newBuilder().setOpenTelemetry(otel)`.
-  Holds a caller-supplied `OpenTelemetry` and derives one OTel `Tracer`. `close()` only
-  flips `isOpen()`; it does **not** shut down the caller-owned `OpenTelemetry`.
+- `OtelTracerFactory` — `TracerFactory` constructed directly via a Kotlin constructor
+  with a default: `OtelTracerFactory(openTelemetry, instrumentationScopeName = DEFAULT)`
+  (`@JvmOverloads` so Java can call the single-arg form). No builder — idiomatic Kotlin,
+  KMP-friendly. Holds a caller-supplied `OpenTelemetry` and derives one OTel `Tracer`;
+  `open` is `@Volatile`. `close()` only flips `isOpen()`; it does **not** shut down the
+  caller-owned `OpenTelemetry`.
 - `OtelTracer` — `AbstractTracer`; each `processedBy(...)` starts and immediately ends
-  one span. `close()` is a no-op (export is the SDK's job).
+  one span. `close()` is a no-op (export is the SDK's job). Each handling is its **own
+  span**, never a span event — OpenTelemetry deprecated the Span Events API (March 2026)
+  in favor of log-based events; per-handling data is carried as span attributes.
 - `SignalSpan` — maps `(context, signal, receiver, receiverType)` to a span: start =
   signal timestamp, end = now, name `"<Receiver> handles <Signal>"` (≤128 chars),
   attributes, and a synthetic sampled parent context carrying the derived trace ID.

--- a/.agents/tasks/server-otel.md
+++ b/.agents/tasks/server-otel.md
@@ -1,0 +1,82 @@
+# Task: `server-otel` — OpenTelemetry-based Spine tracer
+
+Status: **implemented** (branch `server-otel`). Delete this file on merge to master.
+
+## Context
+
+`gcloud-jvm`'s `stackdriver-trace` module implements Spine's tracing SPI against
+Google Cloud's proprietary Stackdriver / Cloud Trace gRPC API. Google now steers
+users to OpenTelemetry, so we are dropping the proprietary coupling.
+
+OpenTelemetry has no direct Google Cloud binding, so the replacement is a generic,
+**backend-agnostic** module — `server-otel` — that maps Spine signal processing to
+OTel spans and lets the *consumer* choose the backend (OTLP collector, the Google
+Cloud OTel exporter, Jaeger, in-memory, …). It lives in **core-jvm**, next to the
+Trace SPI it implements (`io.spine.server.trace`), and is written in **Kotlin against
+the Kotlin OpenTelemetry API** (`io.opentelemetry.kotlin`, currently alpha /
+`@ExperimentalApi`) to be Kotlin-only from day one, with an eventual KMP move in mind.
+
+Retiring `stackdriver-trace` in `gcloud-jvm` is a **separate** follow-up (different
+repo); this task only adds the new module.
+
+## What was built
+
+New module `core-jvm/server-otel`, package `io.spine.server.trace.otel`:
+
+- `OtelTracerFactory` — `TracerFactory` built via `newBuilder().setOpenTelemetry(otel)`.
+  Holds a caller-supplied `OpenTelemetry` and derives one OTel `Tracer`. `close()` only
+  flips `isOpen()`; it does **not** shut down the caller-owned `OpenTelemetry`.
+- `OtelTracer` — `AbstractTracer`; each `processedBy(...)` starts and immediately ends
+  one span. `close()` is a no-op (export is the SDK's job).
+- `SignalSpan` — maps `(context, signal, receiver, receiverType)` to a span: start =
+  signal timestamp, end = now, name `"<Receiver> handles <Signal>"` (≤128 chars),
+  attributes, and a synthetic sampled parent context carrying the derived trace ID.
+- `SpanAttribute` — six attributes under the `spine.` namespace: `spine.bounded_context`,
+  `spine.tenant`, `spine.entity.id`, `spine.signal.id`, `spine.entity.type`,
+  `spine.signal.type` (values truncated to 256 chars). Renamed from the old
+  `spine.io/Xxx` keys to OTel-idiomatic dotted form (no backward-compat constraint,
+  since `stackdriver-trace` is being retired).
+- `TraceIds` — deterministic trace/span IDs from the **root** signal ID, so all signals
+  of one causal chain share a trace. Each UUID half is zero-padded to 16 hex chars
+  (32-char trace ID / 16-char span ID), fixing the un-padded `Long.toHexString` gap in
+  the old code; non-UUID IDs fall back to a stable name-based UUID.
+
+Behavioral parity with `stackdriver-trace`, minus the GCP coupling: export, batching,
+and sampling are delegated to the caller's `OpenTelemetry` SDK (no manual batch-write,
+no GCP credentials, no sync/async service, no `forbidMultiThreading`). The parent
+context is marked **sampled** so a parent-based sampler records the spans, matching the
+old always-export behavior.
+
+## Build wiring
+
+- `buildSrc/.../io/spine/dependency/lib/OpenTelemetryKotlin.kt` — version `0.4.0`,
+  artifacts `api` (production), and `core` + `implementation` (test SDK). No BOM is
+  published, so versions are embedded in the coordinates.
+- `server-otel/build.gradle.kts` — `module` + `io.spine.core-jvm`; `api(project(":server"))`
+  + `api(OpenTelemetryKotlin.api)`; tests use the SDK + `testFixtures(project(":server"))`.
+  The `@ExperimentalApi` opt-in is per-file (`@file:OptIn(...)`).
+- `settings.gradle.kts` — registers `server-otel`.
+
+## Tests (`server-otel/src/test/kotlin`, all green — 20 specs)
+
+- `TraceIdsSpec` — determinism, 32/16-char hex, zero-padding, non-UUID fallback.
+- `OtelTracerFactorySpec` — builder requires `OpenTelemetry`; `trace()` returns
+  `OtelTracer`; `isOpen()`/`close()`.
+- `OtelTracerSpec` — `processedBy` records a span with the expected name, start/end,
+  attributes, derived trace ID, and synthetic parent span ID; two handlings share a trace.
+- `OtelTracingSpec` — integration: wires the factory into the `Airport` sample context
+  (reused from `server` test fixtures), posts a command, and asserts the whole causal
+  chain lands under a single trace ID.
+- `given/RecordingSpanProcessor`, `given/TestOtel` — in-memory recording SDK.
+
+## Verification
+
+`./gradlew :server-otel:build :server-otel:dokkaGenerate :server-otel:detektMain
+:server-otel:detektTest` — all pass (tests, Kover, Checkstyle, PMD, Detekt, Dokka).
+Requires JDK 17+ (`JAVA_HOME=.../amazon-corretto-17.jdk/Contents/Home`).
+
+## Out of scope (follow-ups)
+
+- Retiring / removing `stackdriver-trace` in `gcloud-jvm`.
+- A GCP-specific convenience module wiring `server-otel` to Cloud Trace.
+- Compiling to non-JVM KMP targets (kept KMP-friendly; stays JVM here).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -69,6 +69,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.agents/scripts/secret-scan-gate.sh"
+          },
+          {
+            "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.agents/scripts/pre-pr-gate.sh"
           },
           {

--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -1,6 +1,19 @@
 name: Ubuntu CI
 
-on: push
+# Triggers:
+#   * push to a default or release-line branch — those ending in `master` or
+#     `main`, the same set `increment-guard.yml` guards as PR bases (e.g.
+#     `master`, `2.x-jdk8-master`). These post-merge runs are the only source
+#     of base-branch coverage, since `Publish` runs `publish -x test` and
+#     uploads none; `target: auto` in `.codecov.yml` compares each pull request
+#     against its base baseline.
+#   * pull_request — gates a change on its merge result, not the branch tip.
+on:
+  push:
+    branches:
+      - '**master'
+      - '**main'
+  pull_request:
 
 jobs:
   build:
@@ -36,8 +49,8 @@ jobs:
 
       # `build` does not run Dokka — its tasks are gated to the publishing
       # graph — so `dokkaGenerate` is appended to surface documentation
-      # warnings on each push, before merge, instead of only in the post-merge
-      # `Publish` job. `failOnWarning` is enabled in the Dokka setup.
+      # warnings before merge, instead of only in the post-merge `Publish`
+      # job. `failOnWarning` is enabled in the Dokka setup.
       - name: Check documentation
         run: ./gradlew dokkaGenerate --stacktrace
 
@@ -49,7 +62,31 @@ jobs:
           report_paths: '**/build/test-results/**/TEST-*.xml'
           require_tests: true # will fail workflow if test reports not found
 
+      # Probe whether the upload token is available without exposing its value
+      # to the build/test steps. Scoping `CODECOV_TOKEN` to this trivial step
+      # (and to the upload step's `with.token`) keeps PR-authored code in
+      # `./gradlew build` from ever seeing the secret. The `secrets` context is
+      # not available in a step `if:`, so the upload gates on this output.
+      - name: Detect Codecov token
+        id: codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          if [ -n "$CODECOV_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # On `push` (master) always upload — these runs are the only source of
+      # the `target: auto` baseline, so an absent token there is a
+      # misconfiguration that should fail loudly rather than silently stop
+      # refreshing coverage. On `pull_request`, skip when the token is absent:
+      # forked and Dependabot PRs run without secrets, and `fail_ci_if_error`
+      # would otherwise redden a healthy PR (coverage gating is meaningless
+      # there anyway).
       - name: Upload code coverage report
+        if: steps.codecov.outputs.available == 'true' || github.event_name == 'push'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,70 @@
+name: Secret scan
+
+# Defense-in-depth behind the local `secret-scan` pre-commit hook and the
+# `.gitignore` secret patterns: if a credential is committed despite those, this
+# fails the pull request before it can merge. Distributed to every Spine repo by
+# `./config/pull`.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    env:
+      # Pinned gitleaks version — bump through the usual dependency-update process.
+      GITLEAKS_VERSION: "8.21.2"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Full history so a pull request's commit range can be scanned.
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        # Run gitleaks as the runner user against the checkout it owns — no
+        # container, so no "dubious ownership" git error and no GitHub Action
+        # org-licence requirement.
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xzf - gitleaks
+          ./gitleaks version
+
+      - name: Scan
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+        run: |
+          if [ "$EVENT" = pull_request ]; then
+            # Scan the PR's own commit RANGE: a secret added in one commit and
+            # deleted in a later commit of the same PR is still caught (a
+            # working-tree scan would miss it, yet merging keeps the secret-bearing
+            # commit reachable), while already-rotated secrets in older history
+            # outside base..head are not re-flagged.
+            ./gitleaks git --log-opts="$BASE..$HEAD" --redact --verbose --exit-code=1 .
+          else
+            # Push to a default branch: scan the pushed commit RANGE (before..after)
+            # so an add-then-remove batch is caught here too, not only on PRs — the
+            # leaked commit would otherwise stay reachable on the default branch. A
+            # branch's first push reports an all-zero `before` (no range); fall back
+            # to a working-tree scan then.
+            if [ -n "$BEFORE" ] && [ "$BEFORE" != "0000000000000000000000000000000000000000" ]; then
+              ./gitleaks git --log-opts="$BEFORE..$AFTER" --redact --verbose --exit-code=1 .
+            else
+              # Branch's first push (all-zero `before`): no range to diff against, so
+              # scan the whole history reachable from the pushed tip as the initial
+              # import — an add-then-remove within those commits is still caught.
+              ./gitleaks git --log-opts="$AFTER" --redact --verbose --exit-code=1 .
+            fi
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# >>> shared config (managed by ./config/pull -- do not edit inside this block) >>>
 #
 # Copyright 2025, TeamDev. All rights reserved.
 #
@@ -103,13 +104,47 @@ gradle-app.setting
 # Spine internal directory for storing intermediate artifacts
 **/.spine/**
 
-# Login details to Maven repository.
-# Each workstation should have developer's login defined in this file.
+# ---------------------------------------------------------------------------
+# Secrets — NEVER commit these.
+#
+# Encrypted credentials live under `.github/keys/*.gpg` and ARE committed.
+# `config/scripts/decrypt.sh` turns each into its PLAINTEXT twin at build / CI /
+# publish time (e.g. `spine-dev-framework-ci.json.gpg` -> `spine-dev.json`). The
+# decrypted twins below — and any private key or service-account file — must stay
+# out of Git. The shared `secret-scan` pre-commit hook is the backstop if one ever
+# slips past these patterns.
+# ---------------------------------------------------------------------------
+
+# Maven repository login details; each workstation defines its own.
 credentials.tar
 credentials.properties
 cloudrepo.properties
 deploy_key_rsa
 gcs-auth-key.json
+
+# Decrypted Google / GCP service-account keys (plaintext twins of *.gpg).
+spine-dev.json
+spine-dev-*.json
+maven-publisher.json
+firebase-sa.json
+*-sa.json
+*service-account*.json
+
+# Decrypted credential property files and portal / publisher secrets.
+*.secret.properties
+
+# Private SSH keys (public keys are *.pub and remain committable).
+*_rsa
+*_dsa
+*_ecdsa
+*_ed25519
+id_rsa
+id_dsa
+id_ecdsa
+id_ed25519
+
+# ...but always keep the committed ENCRYPTED forms.
+!*.gpg
 
 # Log files
 *.log
@@ -152,3 +187,38 @@ __pycache__/
 docs/_preview/node_modules/
 docs/_preview/public/
 docs/_preview/resources/
+# <<< shared config <<<
+
+# >>> repo-local entries (preserved across ./config/pull) >>>
+!.idea/misc.xml
+!.idea/codeStyleSettings.xml
+!.idea/codeStyles/
+!.idea/copyright/
+!**/src/**/build/**
+!gradle-wrapper.jar
+# Login details to Maven repository.
+# Each workstation should have developer's login defined in this file.
+# <<< repo-local entries <<<
+
+# >>> secret ignores re-asserted last (managed by ./config/pull -- do not edit) >>>
+credentials.tar
+credentials.properties
+cloudrepo.properties
+deploy_key_rsa
+gcs-auth-key.json
+spine-dev.json
+spine-dev-*.json
+maven-publisher.json
+firebase-sa.json
+*-sa.json
+*service-account*.json
+*.secret.properties
+*_rsa
+*_dsa
+*_ecdsa
+*_ed25519
+id_rsa
+id_dsa
+id_ecdsa
+id_ed25519
+# <<< secret ignores <<<

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -21,24 +21,39 @@
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="org.checkerframework.checker.nullness.qual.Nullable" />
     <option name="myDefaultNotNull" value="org.checkerframework.checker.nullness.qual.NonNull" />
+    <option name="myOrdered" value="true" />
     <option name="myNullables">
       <value>
-        <list size="3">
+        <list size="10">
           <item index="0" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
           <item index="1" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
           <item index="2" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
+          <item index="3" class="java.lang.String" itemvalue="org.jspecify.annotations.Nullable" />
+          <item index="4" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
+          <item index="5" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.Nullable" />
+          <item index="6" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
+          <item index="7" class="java.lang.String" itemvalue="jakarta.annotation.Nullable" />
+          <item index="8" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
+          <item index="9" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="3">
+        <list size="10">
           <item index="0" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
           <item index="1" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
           <item index="2" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
+          <item index="3" class="java.lang.String" itemvalue="org.jspecify.annotations.NonNull" />
+          <item index="4" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
+          <item index="5" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.NonNull" />
+          <item index="6" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
+          <item index="7" class="java.lang.String" itemvalue="jakarta.annotation.Nonnull" />
+          <item index="8" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
+          <item index="9" class="java.lang.String" itemvalue="lombok.NonNull" />
         </list>
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="corretto-17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK" />
 </project>

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/OpenTelemetryKotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/OpenTelemetryKotlin.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.dependency.lib
+
+import io.spine.dependency.Dependency
+
+/**
+ * The Kotlin Multiplatform API and SDK for OpenTelemetry.
+ *
+ * The project is currently in the alpha stage, and its API is marked
+ * with `@io.opentelemetry.kotlin.ExperimentalApi`. Modules using these artifacts
+ * must opt in to that marker.
+ *
+ * The project does not publish a BOM, so the version is embedded in each
+ * artifact coordinate below.
+ *
+ * @see <a href="https://github.com/open-telemetry/opentelemetry-kotlin">opentelemetry-kotlin</a>
+ * @see <a href="https://opentelemetry.io/docs/languages/kotlin/">Kotlin docs</a>
+ */
+@Suppress("unused")
+object OpenTelemetryKotlin : Dependency() {
+
+    override val version = "0.4.0"
+    override val group = "io.opentelemetry.kotlin"
+
+    /**
+     * The Kotlin Multiplatform API surface (traces, metrics, logs).
+     *
+     * This is the only artifact required by production code that maps
+     * a domain onto OpenTelemetry spans.
+     */
+    val api = "$group:api:$version"
+
+    /**
+     * A no-op implementation of the [api].
+     */
+    val noop = "$group:noop:$version"
+
+    /**
+     * The Kotlin SDK API: span processors, exporters, samplers, and the
+     * configuration DSL.
+     *
+     * This artifact exposes the SDK types on the compile classpath; the
+     * `createOpenTelemetry { }` entry point that instantiates them lives in
+     * [implementation]. Applications and tests configure an `OpenTelemetry`
+     * instance using these two artifacts; the production code needs only the [api].
+     */
+    val core = "$group:core:$version"
+
+    /**
+     * The Kotlin SDK implementation, including the `createOpenTelemetry { }`
+     * entry point. Use together with [core].
+     */
+    val implementation = "$group:implementation:$version"
+
+    /**
+     * The compatibility bridge to the OpenTelemetry Java SDK.
+     */
+    val compat = "$group:compat:$version"
+
+    override val modules: List<String> = listOf(
+        "$group:api",
+        "$group:noop",
+        "$group:core",
+        "$group:implementation",
+        "$group:compat",
+    )
+}

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.413"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.413"
+    const val version = "2.0.0-SNAPSHOT.420"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.420"
     const val group = Spine.group
     private const val prefix = "spine"
     const val libModule = "$prefix-base"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
@@ -72,7 +72,7 @@ object Compiler : Dependency() {
      * The version of the Compiler dependencies.
      */
     override val version: String
-    private const val fallbackVersion = "2.0.0-SNAPSHOT.053"
+    private const val fallbackVersion = "2.0.0-SNAPSHOT.054"
 
     /**
      * The distinct version of the Compiler used by other build tools.
@@ -81,7 +81,7 @@ object Compiler : Dependency() {
      * transitive dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.053"
+    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.054"
 
     /**
      * The artifact for the Compiler Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
@@ -39,7 +39,7 @@ typealias CoreJava = CoreJvm
 @Suppress("ConstPropertyName", "unused")
 object CoreJvm {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.376"
+    const val version = "2.0.0-SNAPSHOT.380"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,8 +34,8 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.400"
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.400"
+    const val version = "2.0.0-SNAPSHOT.401"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.401"
 
     const val lib = "$group:tool-base:$version"
     const val classicCodegen = "$group:classic-codegen:$version"

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.380`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.381`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1041,14 +1041,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 19 17:58:42 WEST 2026** using 
+This report was generated on **Tue Jun 23 23:57:54 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.380`
+# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.381`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2185,14 +2185,14 @@ This report was generated on **Fri Jun 19 17:58:42 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 19 17:58:41 WEST 2026** using 
+This report was generated on **Tue Jun 23 23:57:54 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.380`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.381`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3169,14 +3169,14 @@ This report was generated on **Fri Jun 19 17:58:41 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 19 17:58:41 WEST 2026** using 
+This report was generated on **Tue Jun 23 23:57:54 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.380`
+# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.381`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4219,14 +4219,14 @@ This report was generated on **Fri Jun 19 17:58:41 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 19 17:58:41 WEST 2026** using 
+This report was generated on **Tue Jun 23 23:57:54 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.380`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.381`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5279,14 +5279,14 @@ This report was generated on **Fri Jun 19 17:58:41 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 19 17:58:42 WEST 2026** using 
+This report was generated on **Tue Jun 23 23:57:54 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.380`
+# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.381`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -6475,6 +6475,6 @@ This report was generated on **Fri Jun 19 17:58:42 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jun 19 17:58:42 WEST 2026** using 
+This report was generated on **Tue Jun 23 23:57:54 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1041,7 +1041,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 23 23:57:54 WEST 2026** using 
+This report was generated on **Wed Jun 24 02:55:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2185,7 +2185,7 @@ This report was generated on **Tue Jun 23 23:57:54 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 23 23:57:54 WEST 2026** using 
+This report was generated on **Wed Jun 24 02:55:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3169,7 +3169,7 @@ This report was generated on **Tue Jun 23 23:57:54 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 23 23:57:54 WEST 2026** using 
+This report was generated on **Wed Jun 24 02:55:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4219,7 +4219,7 @@ This report was generated on **Tue Jun 23 23:57:54 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 23 23:57:54 WEST 2026** using 
+This report was generated on **Wed Jun 24 02:55:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5279,7 +5279,1143 @@ This report was generated on **Tue Jun 23 23:57:54 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 23 23:57:54 WEST 2026** using 
+This report was generated on **Wed Jun 24 02:55:51 WEST 2026** using 
+[Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
+[Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+
+
+
+
+# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.381`
+
+## Runtime
+1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
+     * **Project URL:** [http://source.android.com/](http://source.android.com/)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : com.google.api.grpc. **Name** : proto-google-common-protos. **Version** : 2.64.1.
+     * **Project URL:** [https://github.com/googleapis/sdk-platform-java](https://github.com/googleapis/sdk-platform-java)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
+     * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.14.0.
+     * **Project URL:** [https://github.com/google/gson](https://github.com/google/gson)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.36.0.
+     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.3.
+     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : guava. **Version** : 33.6.0-jre.
+     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.j2objc. **Name** : j2objc-annotations. **Version** : 3.1.
+     * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 4.35.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 4.35.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 4.35.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : io.grpc. **Name** : grpc-api. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-bom. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-context. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-core. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-inprocess. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-kotlin-stub. **Version** : 1.5.0.
+     * **Project URL:** [https://github.com/grpc/grpc-kotlin](https://github.com/grpc/grpc-kotlin)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-protobuf. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-protobuf-lite. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-stub. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : api. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : api-jvm. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.perfmark. **Name** : perfmark-api. **Version** : 0.27.0.
+     * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
+
+1.  **Group** : org.codehaus.mojo. **Name** : animal-sniffer-annotations. **Version** : 1.27.
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [MIT license](https://spdx.org/licenses/MIT.txt)
+
+1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 26.1.0.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-bom. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : atomicfu. **Version** : 0.29.0.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.atomicfu](https://github.com/Kotlin/kotlinx.atomicfu)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : atomicfu-jvm. **Version** : 0.29.0.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.atomicfu](https://github.com/Kotlin/kotlinx.atomicfu)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-bom. **Version** : 1.10.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.10.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.10.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-datetime. **Version** : 0.7.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-datetime-jvm. **Version** : 0.7.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jspecify. **Name** : jspecify. **Version** : 1.0.0.
+     * **Project URL:** [http://jspecify.org/](http://jspecify.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+## Compile, tests, and tooling
+1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson-bom](https://github.com/FasterXML/jackson-bom)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.22.
+     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-xml. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson-dataformat-xml](https://github.com/FasterXML/jackson-dataformat-xml)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-yaml. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson-dataformats-text](https://github.com/FasterXML/jackson-dataformats-text)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.datatype. **Name** : jackson-datatype-guava. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson-datatypes-collections](https://github.com/FasterXML/jackson-datatypes-collections)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.datatype. **Name** : jackson-datatype-jdk8. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8](https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.datatype. **Name** : jackson-datatype-jsr310. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310](https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-parameter-names. **Version** : 2.22.0.
+     * **Project URL:** [https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names](https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.fasterxml.woodstox. **Name** : woodstox-core. **Version** : 7.2.0.
+     * **Project URL:** [https://github.com/FasterXML/woodstox](https://github.com/FasterXML/woodstox)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.5.
+     * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.2.4.
+     * **Project URL:** [https://github.com/ben-manes/caffeine](https://github.com/ben-manes/caffeine)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.github.kevinstern. **Name** : software-and-algorithms. **Version** : 1.0.
+     * **Project URL:** [https://www.github.com/KevinStern/software-and-algorithms](https://www.github.com/KevinStern/software-and-algorithms)
+     * **License:** [MIT License](http://www.opensource.org/licenses/mit-license.php)
+
+1.  **Group** : com.github.oowekyala.ooxml. **Name** : nice-xml-messages. **Version** : 3.1.
+     * **Project URL:** [https://github.com/oowekyala/nice-xml-messages](https://github.com/oowekyala/nice-xml-messages)
+     * **License:** [MIT License](https://github.com/oowekyala/nice-xml-messages/tree/master/LICENSE)
+
+1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
+     * **Project URL:** [http://source.android.com/](http://source.android.com/)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : com.google.api.grpc. **Name** : proto-google-common-protos. **Version** : 2.64.1.
+     * **Project URL:** [https://github.com/googleapis/sdk-platform-java](https://github.com/googleapis/sdk-platform-java)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.auto. **Name** : auto-common. **Version** : 1.2.2.
+     * **Project URL:** [https://github.com/google/auto/tree/main/common](https://github.com/google/auto/tree/main/common)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.auto.service. **Name** : auto-service-annotations. **Version** : 1.1.1.
+     * **Project URL:** [https://github.com/google/auto/tree/main/service](https://github.com/google/auto/tree/main/service)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.11.1.
+     * **Project URL:** [https://github.com/google/auto/tree/main/value](https://github.com/google/auto/tree/main/value)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
+     * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.14.0.
+     * **Project URL:** [https://github.com/google/gson](https://github.com/google/gson)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.devtools.ksp. **Name** : com.google.devtools.ksp.gradle.plugin. **Version** : 2.3.9.
+     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing-api. **Version** : 2.3.9.
+     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing-common-deps. **Version** : 2.3.9.
+     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing-gradle-plugin. **Version** : 2.3.9.
+     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotation. **Version** : 2.36.0.
+     * **Project URL:** [https://errorprone.info/error_prone_annotation](https://errorprone.info/error_prone_annotation)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.36.0.
+     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_check_api. **Version** : 2.36.0.
+     * **Project URL:** [https://errorprone.info/error_prone_check_api](https://errorprone.info/error_prone_check_api)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_core. **Version** : 2.36.0.
+     * **Project URL:** [https://errorprone.info/error_prone_core](https://errorprone.info/error_prone_core)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.36.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
+     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
+     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
+     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
+     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
+     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.googlejavaformat. **Name** : google-java-format. **Version** : 1.19.1.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.gradle. **Name** : osdetector-gradle-plugin. **Version** : 1.7.3.
+     * **Project URL:** [https://github.com/google/osdetector-gradle-plugin](https://github.com/google/osdetector-gradle-plugin)
+     * **License:** [Apache License 2.0](http://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.3.
+     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : guava. **Version** : 33.6.0-jre.
+     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : guava-testlib. **Version** : 33.6.0-jre.
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.j2objc. **Name** : j2objc-annotations. **Version** : 3.1.
+     * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-gradle-plugin. **Version** : 0.10.0.
+     * **Project URL:** [https://github.com/google/protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin)
+     * **License:** [BSD 3-Clause](http://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 4.35.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 4.35.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 4.35.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 4.35.0.
+     * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
+     * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.4.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.truth.extensions. **Name** : truth-java8-extension. **Version** : 1.4.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.truth.extensions. **Name** : truth-liteproto-extension. **Version** : 1.4.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.4.5.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.palantir.javaformat. **Name** : palantir-java-format. **Version** : 2.91.0.
+     * **Project URL:** [https://github.com/palantir/palantir-java-format](https://github.com/palantir/palantir-java-format)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : com.palantir.javaformat. **Name** : palantir-java-format-spi. **Version** : 2.91.0.
+     * **Project URL:** [https://github.com/palantir/palantir-java-format](https://github.com/palantir/palantir-java-format)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 10.12.1.
+     * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
+     * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
+
+1.  **Group** : com.sksamuel.aedile. **Name** : aedile-core. **Version** : 3.0.4.
+     * **Project URL:** [https://www.github.com/sksamuel/aedile](https://www.github.com/sksamuel/aedile)
+     * **License:** [The Apache 2.0 License](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
+
+1.  **Group** : com.squareup. **Name** : kotlinpoet. **Version** : 2.3.0.
+     * **Project URL:** [https://github.com/square/kotlinpoet](https://github.com/square/kotlinpoet)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.squareup. **Name** : kotlinpoet-jvm. **Version** : 2.3.0.
+     * **Project URL:** [https://github.com/square/kotlinpoet](https://github.com/square/kotlinpoet)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
+     * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-codec. **Name** : commons-codec. **Version** : 1.22.0.
+     * **Project URL:** [https://commons.apache.org/proper/commons-codec/](https://commons.apache.org/proper/commons-codec/)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : commons-collections. **Name** : commons-collections. **Version** : 3.2.2.
+     * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : dev.drewhamilton.poko. **Name** : poko-annotations. **Version** : 0.17.1.
+     * **Project URL:** [https://github.com/drewhamilton/Poko](https://github.com/drewhamilton/Poko)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : dev.drewhamilton.poko. **Name** : poko-annotations-jvm. **Version** : 0.17.1.
+     * **Project URL:** [https://github.com/drewhamilton/Poko](https://github.com/drewhamilton/Poko)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : dev.zacsweers.autoservice. **Name** : auto-service-ksp. **Version** : 1.2.0.
+     * **Project URL:** [https://github.com/ZacSweers/auto-service-ksp](https://github.com/ZacSweers/auto-service-ksp)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : info.picocli. **Name** : picocli. **Version** : 4.7.4.
+     * **Project URL:** [https://picocli.info](https://picocli.info)
+     * **License:** [The Apache Software License, version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.davidburstrom.contester. **Name** : contester-breakpoint. **Version** : 0.2.0.
+     * **Project URL:** [https://github.com/davidburstrom/contester](https://github.com/davidburstrom/contester)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.detekt.sarif4k. **Name** : sarif4k. **Version** : 0.6.0.
+     * **Project URL:** [https://detekt.github.io/detekt](https://detekt.github.io/detekt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.detekt.sarif4k. **Name** : sarif4k-jvm. **Version** : 0.6.0.
+     * **Project URL:** [https://detekt.github.io/detekt](https://detekt.github.io/detekt)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.github.eisop. **Name** : dataflow-errorprone. **Version** : 3.41.0-eisop1.
+     * **Project URL:** [https://eisop.github.io/](https://eisop.github.io/)
+     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
+
+1.  **Group** : io.github.java-diff-utils. **Name** : java-diff-utils. **Version** : 4.17.
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-api. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-cli. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-core. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-metrics. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-parser. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-psi-utils. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-html. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-md. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-sarif. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-txt. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-report-xml. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-complexity. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-coroutines. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-documentation. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-empty. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-errorprone. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-exceptions. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-naming. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-performance. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-rules-style. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-tooling. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.gitlab.arturbosch.detekt. **Name** : detekt-utils. **Version** : 1.23.8.
+     * **Project URL:** [https://detekt.dev](https://detekt.dev)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : io.grpc. **Name** : grpc-api. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-bom. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-context. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-core. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-inprocess. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-kotlin-stub. **Version** : 1.5.0.
+     * **Project URL:** [https://github.com/grpc/grpc-kotlin](https://github.com/grpc/grpc-kotlin)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-protobuf. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-protobuf-lite. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.grpc. **Name** : grpc-stub. **Version** : 1.81.0.
+     * **Project URL:** [https://github.com/grpc/grpc-java](https://github.com/grpc/grpc-java)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-assertions-core. **Version** : 6.1.11.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-assertions-core-jvm. **Version** : 6.1.11.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-assertions-shared. **Version** : 6.1.11.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-assertions-shared-jvm. **Version** : 6.1.11.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-common. **Version** : 6.1.11.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.kotest. **Name** : kotest-common-jvm. **Version** : 6.1.11.
+     * **Project URL:** [https://github.com/kotest/kotest](https://github.com/kotest/kotest)
+     * **License:** [Apache-2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : api. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : api-ext. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : api-ext-jvm. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : api-jvm. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : core. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : core-jvm. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : exporters-core. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : exporters-core-jvm. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : implementation. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : implementation-jvm. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : model. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : model-jvm. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : noop. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : noop-jvm. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : platform-implementations. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : platform-implementations-jvm. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : sdk-api. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : sdk-api-jvm. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : sdk-common. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : sdk-common-jvm. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : semconv. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.opentelemetry.kotlin. **Name** : semconv-jvm. **Version** : 0.4.0.
+     * **Project URL:** [https://github.com/open-telemetry/opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)
+     * **License:** [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : io.perfmark. **Name** : perfmark-api. **Version** : 0.27.0.
+     * **Project URL:** [https://github.com/perfmark/perfmark](https://github.com/perfmark/perfmark)
+     * **License:** [Apache 2.0](https://opensource.org/licenses/Apache-2.0)
+
+1.  **Group** : javax.annotation. **Name** : javax.annotation-api. **Version** : 1.3.2.
+     * **Project URL:** [http://jcp.org/en/jsr/detail?id=250](http://jcp.org/en/jsr/detail?id=250)
+     * **License:** [CDDL + GPLv2 with classpath exception](https://github.com/javaee/javax.annotation/blob/master/LICENSE)
+
+1.  **Group** : javax.inject. **Name** : javax.inject. **Version** : 1.
+     * **Project URL:** [http://code.google.com/p/atinject/](http://code.google.com/p/atinject/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : junit. **Name** : junit. **Version** : 4.13.2.
+     * **Project URL:** [http://junit.org](http://junit.org)
+     * **License:** [Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html)
+
+1.  **Group** : kr.motd.maven. **Name** : os-maven-plugin. **Version** : 1.7.1.
+     * **Project URL:** [https://github.com/trustin/os-maven-plugin/](https://github.com/trustin/os-maven-plugin/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : net.sf.saxon. **Name** : Saxon-HE. **Version** : 12.2.
+     * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
+     * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
+
+1.  **Group** : net.sf.saxon. **Name** : Saxon-HE. **Version** : 12.9.
+     * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
+     * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
+
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-ant. **Version** : 7.25.0.
+     * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
+
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 7.25.0.
+     * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
+
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 7.25.0.
+     * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
+
+1.  **Group** : org.antlr. **Name** : antlr4-runtime. **Version** : 4.11.1.
+     * **Project URL:** [https://www.antlr.org/](https://www.antlr.org/)
+     * **License:** [BSD-3-Clause](https://www.antlr.org/license.html)
+
+1.  **Group** : org.antlr. **Name** : antlr4-runtime. **Version** : 4.13.2.
+     * **Project URL:** [https://www.antlr.org/](https://www.antlr.org/)
+     * **License:** [BSD-3-Clause](https://www.antlr.org/license.html)
+
+1.  **Group** : org.apache.commons. **Name** : commons-lang3. **Version** : 3.20.0.
+     * **Project URL:** [https://commons.apache.org/proper/commons-lang/](https://commons.apache.org/proper/commons-lang/)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents.client5. **Name** : httpclient5. **Version** : 5.1.3.
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents.core5. **Name** : httpcore5. **Version** : 5.1.3.
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.httpcomponents.core5. **Name** : httpcore5-h2. **Version** : 5.1.3.
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
+     * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.checkerframework. **Name** : checker-compat-qual. **Version** : 2.5.3.
+     * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
+     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
+     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
+
+1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 4.2.0.
+     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
+     * **License:** [The MIT License](https://opensource.org/licenses/MIT)
+
+1.  **Group** : org.codehaus.mojo. **Name** : animal-sniffer-annotations. **Version** : 1.27.
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [MIT license](https://spdx.org/licenses/MIT.txt)
+
+1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.3.0.
+     * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The BSD 2-Clause License](http://www.opensource.org/licenses/bsd-license.php)
+
+1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.32.
+     * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.functionaljava. **Name** : functionaljava. **Version** : 5.0.
+     * **Project URL:** [http://functionaljava.org/](http://functionaljava.org/)
+     * **License:** [The BSD3 License](https://github.com/functionaljava/functionaljava/blob/master/etc/LICENCE)
+
+1.  **Group** : org.hamcrest. **Name** : hamcrest. **Version** : 3.0.
+     * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
+     * **License:** [BSD-3-Clause](https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE)
+
+1.  **Group** : org.hamcrest. **Name** : hamcrest-core. **Version** : 3.0.
+     * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
+     * **License:** [BSD-3-Clause](https://raw.githubusercontent.com/hamcrest/JavaHamcrest/master/LICENSE)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.15.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.core. **Version** : 0.8.15.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.jacoco. **Name** : org.jacoco.report. **Version** : 0.8.15.
+     * **License:** [EPL-2.0](https://www.eclipse.org/legal/epl-2.0/)
+
+1.  **Group** : org.javassist. **Name** : javassist. **Version** : 3.28.0-GA.
+     * **Project URL:** [http://www.javassist.org/](http://www.javassist.org/)
+     * **License:** [Apache License 2.0](http://www.apache.org/licenses/)
+     * **License:** [LGPL 2.1](http://www.gnu.org/licenses/lgpl-2.1.html)
+     * **License:** [MPL 1.1](http://www.mozilla.org/MPL/MPL-1.1.html)
+
+1.  **Group** : org.jcommander. **Name** : jcommander. **Version** : 1.85.
+     * **Project URL:** [https://jcommander.org](https://jcommander.org)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 26.1.0.
+     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : markdown. **Version** : 0.7.3.
+     * **Project URL:** [https://github.com/JetBrains/markdown](https://github.com/JetBrains/markdown)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains. **Name** : markdown-jvm. **Version** : 0.7.3.
+     * **Project URL:** [https://github.com/JetBrains/markdown](https://github.com/JetBrains/markdown)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : analysis-kotlin-symbols. **Version** : 2.2.0.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : analysis-markdown. **Version** : 2.2.0.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : dokka-base. **Version** : 2.2.0.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : dokka-core. **Version** : 2.2.0.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 2.2.0.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 2.2.0.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.dokka. **Name** : templating-plugin. **Version** : 2.2.0.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.intellij.deps. **Name** : trove4j. **Version** : 1.0.20200330.
+     * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
+     * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : abi-tools. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : abi-tools-api. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-bom. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-build-tools-api. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-build-tools-compat. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-build-tools-cri-impl. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-build-tools-impl. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 2.0.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-runner. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-client. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 2.0.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-abi-reader. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-metadata-jvm. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 2.0.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 2.0.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 2.0.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 2.0.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 2.0.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 2.0.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-tooling-core. **Version** : 2.3.21.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : atomicfu. **Version** : 0.29.0.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.atomicfu](https://github.com/Kotlin/kotlinx.atomicfu)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : atomicfu-jvm. **Version** : 0.29.0.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.atomicfu](https://github.com/Kotlin/kotlinx.atomicfu)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-bom. **Version** : 1.10.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core. **Version** : 1.10.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.10.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-core-jvm. **Version** : 1.6.4.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-jdk8. **Version** : 1.10.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-test. **Version** : 1.10.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-coroutines-test-jvm. **Version** : 1.10.2.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-datetime. **Version** : 0.7.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-datetime-jvm. **Version** : 0.7.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-html-jvm. **Version** : 0.8.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.html](https://github.com/Kotlin/kotlinx.html)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-html-jvm. **Version** : 0.9.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.html](https://github.com/Kotlin/kotlinx.html)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-core-jvm. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-serialization-json-jvm. **Version** : 1.4.1.
+     * **Project URL:** [https://github.com/Kotlin/kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.jsoup. **Name** : jsoup. **Version** : 1.16.1.
+     * **Project URL:** [https://jsoup.org/](https://jsoup.org/)
+     * **License:** [The MIT License](https://jsoup.org/license)
+
+1.  **Group** : org.jspecify. **Name** : jspecify. **Version** : 1.0.0.
+     * **Project URL:** [http://jspecify.org/](http://jspecify.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.junit. **Name** : junit-bom. **Version** : 6.1.0.
+     * **Project URL:** [https://junit.org/](https://junit.org/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit-pioneer. **Name** : junit-pioneer. **Version** : 2.3.0.
+     * **Project URL:** [https://junit-pioneer.org/](https://junit-pioneer.org/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-api. **Version** : 6.1.0.
+     * **Project URL:** [https://junit.org/](https://junit.org/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-engine. **Version** : 6.1.0.
+     * **Project URL:** [https://junit.org/](https://junit.org/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-params. **Version** : 6.1.0.
+     * **Project URL:** [https://junit.org/](https://junit.org/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.platform. **Name** : junit-platform-commons. **Version** : 6.1.0.
+     * **Project URL:** [https://junit.org/](https://junit.org/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.platform. **Name** : junit-platform-engine. **Version** : 6.1.0.
+     * **Project URL:** [https://junit.org/](https://junit.org/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.junit.platform. **Name** : junit-platform-launcher. **Version** : 6.1.0.
+     * **Project URL:** [https://junit.org/](https://junit.org/)
+     * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
+
+1.  **Group** : org.opentest4j. **Name** : opentest4j. **Version** : 1.3.0.
+     * **Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.10.1.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm-commons. **Version** : 9.10.1.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm-tree. **Version** : 9.10.1.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.pcollections. **Name** : pcollections. **Version** : 4.0.1.
+     * **Project URL:** [https://github.com/hrldcpr/pcollections](https://github.com/hrldcpr/pcollections)
+     * **License:** [The MIT License](https://opensource.org/licenses/mit-license.php)
+
+1.  **Group** : org.pcollections. **Name** : pcollections. **Version** : 4.0.2.
+     * **Project URL:** [https://github.com/hrldcpr/pcollections](https://github.com/hrldcpr/pcollections)
+     * **License:** [The MIT License](https://opensource.org/licenses/mit-license.php)
+
+1.  **Group** : org.reflections. **Name** : reflections. **Version** : 0.10.2.
+     * **Project URL:** [http://github.com/ronmamo/reflections](http://github.com/ronmamo/reflections)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [WTFPL](http://www.wtfpl.net/)
+
+1.  **Group** : org.slf4j. **Name** : jul-to-slf4j. **Version** : 1.7.36.
+     * **Project URL:** [http://www.slf4j.org](http://www.slf4j.org)
+     * **License:** [MIT License](http://www.opensource.org/licenses/mit-license.php)
+
+1.  **Group** : org.snakeyaml. **Name** : snakeyaml-engine. **Version** : 2.7.
+     * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml-engine](https://bitbucket.org/snakeyaml/snakeyaml-engine)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.xmlresolver. **Name** : xmlresolver. **Version** : 5.1.2.
+     * **Project URL:** [https://github.com/xmlresolver/xmlresolver](https://github.com/xmlresolver/xmlresolver)
+     * **License:** [Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : org.xmlresolver. **Name** : xmlresolver. **Version** : 5.3.3.
+     * **Project URL:** [https://github.com/xmlresolver/xmlresolver](https://github.com/xmlresolver/xmlresolver)
+     * **License:** [Apache License version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+1.  **Group** : org.yaml. **Name** : snakeyaml. **Version** : 2.5.
+     * **Project URL:** [https://bitbucket.org/snakeyaml/snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml)
+     * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+
+The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
+
+This report was generated on **Wed Jun 24 02:55:52 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6475,6 +7611,6 @@ This report was generated on **Tue Jun 23 23:57:54 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 23 23:57:54 WEST 2026** using 
+This report was generated on **Wed Jun 24 02:55:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-core-jvm</artifactId>
-<version>2.0.0-SNAPSHOT.380</version>
+<version>2.0.0-SNAPSHOT.381</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -62,7 +62,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.413</version>
+    <version>2.0.0-SNAPSHOT.420</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -80,7 +80,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-environment</artifactId>
-    <version>2.0.0-SNAPSHOT.413</version>
+    <version>2.0.0-SNAPSHOT.420</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -276,12 +276,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>compiler-cli-all</artifactId>
-    <version>2.0.0-SNAPSHOT.053</version>
+    <version>2.0.0-SNAPSHOT.054</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>compiler-protoc-plugin</artifactId>
-    <version>2.0.0-SNAPSHOT.053</version>
+    <version>2.0.0-SNAPSHOT.054</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -9,7 +9,7 @@ all modules and does not describe the project structure per-subproject.
  
  -->
 <groupId>io.spine</groupId>
-<artifactId>spine-core-jvm</artifactId>
+<artifactId>core-jvm</artifactId>
 <version>2.0.0-SNAPSHOT.381</version>
 
 <inceptionYear>2015</inceptionYear>
@@ -57,6 +57,12 @@ all modules and does not describe the project structure per-subproject.
     <groupId>io.grpc</groupId>
     <artifactId>grpc-stub</artifactId>
     <version>1.81.0</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.opentelemetry.kotlin</groupId>
+    <artifactId>api</artifactId>
+    <version>0.4.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -201,6 +207,18 @@ all modules and does not describe the project structure per-subproject.
     <groupId>io.kotest</groupId>
     <artifactId>kotest-assertions-core</artifactId>
     <version>6.1.11</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.opentelemetry.kotlin</groupId>
+    <artifactId>core</artifactId>
+    <version>0.4.0</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.opentelemetry.kotlin</groupId>
+    <artifactId>implementation</artifactId>
+    <version>0.4.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/init-submodules
+++ b/init-submodules
@@ -84,4 +84,16 @@ git submodule status 2>/dev/null | awk '$1 ~ /^-/ { print $2 }' | while read -r 
     fi
 done
 
+# Route Git hooks to the shared hooks directory so the secret-scan `pre-commit`
+# hook is active even in a brand-new worktree, before `./config/pull` runs. The
+# path floats with the `.agents/shared` submodule; until that submodule is
+# initialized the hook simply does not fire (Git skips a missing hook). Set only
+# when unset or already ours — never override a repo's own `core.hooksPath`.
+desired_hooks=".agents/scripts/git-hooks"
+current_hooks=$(git config --local --get core.hooksPath 2>/dev/null || true)
+if [ -z "$current_hooks" ] || [ "$current_hooks" = "$desired_hooks" ]; then
+    git config --local core.hooksPath "$desired_hooks" \
+        && echo "init-submodules: Git hooks routed to '$desired_hooks' (secret-scan pre-commit active)."
+fi
+
 exit 0

--- a/server-otel/README.md
+++ b/server-otel/README.md
@@ -56,7 +56,7 @@ import io.spine.server.trace.otel.OtelTracerFactory
 @OptIn(ExperimentalOtelTracing::class)
 fun configureTracing(openTelemetry: OpenTelemetry) {
     val factory = OtelTracerFactory(openTelemetry)
-    ServerEnvironment.`when`(Production::class.java)
+    ServerEnvironment.under(Production::class.java)
         .use(factory)
 }
 ```

--- a/server-otel/README.md
+++ b/server-otel/README.md
@@ -56,8 +56,9 @@ import io.spine.server.trace.otel.OtelTracerFactory
 @OptIn(ExperimentalOtelTracing::class)
 fun configureTracing(openTelemetry: OpenTelemetry) {
     val factory = OtelTracerFactory(openTelemetry)
-    ServerEnvironment.under(Production::class.java)
-        .use(factory)
+    under<Production::class.java> {
+        use(factory)
+    }
 }
 ```
 

--- a/server-otel/README.md
+++ b/server-otel/README.md
@@ -36,8 +36,8 @@ Each handler invocation becomes its own span that carries the following attribut
 dependencies {
     implementation("io.spine:spine-server-otel:$spineVersion")
 
-    // Plus a Kotlin OpenTelemetry SDK and an exporter of your choice, for example:
-    // implementation("io.opentelemetry.kotlin:core:$otelKotlinVersion")
+    // Plus a Kotlin OpenTelemetry SDK and exporter of your choice — see the
+    // OpenTelemetry Kotlin documentation (linked under "Usage") for the artifacts.
 }
 ```
 

--- a/server-otel/README.md
+++ b/server-otel/README.md
@@ -1,0 +1,84 @@
+# Spine OpenTelemetry tracing (`server-otel`)
+
+> ⚠️ **Experimental module.** `server-otel` is built on the alpha
+> [Kotlin OpenTelemetry API][otel-kotlin] (`io.opentelemetry.kotlin`). Its public API is
+> marked with the `@ExperimentalOtelTracing` Kotlin opt-in marker and with
+> `@io.spine.annotation.Experimental`, and may change in a backward-incompatible way, or
+> be removed, in a future release.
+
+## Overview
+
+`server-otel` implements the Spine Trace API (`io.spine.server.trace`) on top of
+OpenTelemetry. It records the handling of each signal (a command or an event) by an entity
+as an OpenTelemetry **span**, and groups all signals of a single causal chain under one
+**trace**.
+
+The module is **backend-agnostic**: it maps Spine signals onto OpenTelemetry spans and
+leaves the export to a caller-supplied `OpenTelemetry` instance. To send traces to a
+particular backend — an OTLP collector, Google Cloud Trace, Jaeger, etc. — configure the
+corresponding span processor and exporter on that instance. The module thus replaces the
+Google-Cloud-specific `stackdriver-trace` module without coupling to Google Cloud.
+
+Each handler invocation becomes its own span that carries the following attributes:
+
+| Attribute | Meaning |
+|-----------|---------|
+| `spine.bounded_context` | the bounded context that handled the signal |
+| `spine.tenant` | the tenant, as compact JSON |
+| `spine.entity.id` | the ID of the receiving entity |
+| `spine.entity.type` | the type URL of the receiving entity |
+| `spine.signal.id` | the ID of the handled signal |
+| `spine.signal.type` | the type URL of the handled signal |
+
+## Dependency
+
+```kotlin
+dependencies {
+    implementation("io.spine:spine-server-otel:$spineVersion")
+
+    // Plus a Kotlin OpenTelemetry SDK and an exporter of your choice, for example:
+    // implementation("io.opentelemetry.kotlin:core:$otelKotlinVersion")
+}
+```
+
+## Usage
+
+Tracing is configured once, when the server starts. Because the API is experimental, opt in
+explicitly with `@OptIn(ExperimentalOtelTracing::class)`:
+
+```kotlin
+import io.opentelemetry.kotlin.OpenTelemetry
+import io.spine.environment.Production
+import io.spine.server.ServerEnvironment
+import io.spine.server.trace.otel.ExperimentalOtelTracing
+import io.spine.server.trace.otel.OtelTracerFactory
+
+@OptIn(ExperimentalOtelTracing::class)
+fun configureTracing(openTelemetry: OpenTelemetry) {
+    val factory = OtelTracerFactory(openTelemetry)
+    ServerEnvironment.`when`(Production::class.java)
+        .use(factory)
+}
+```
+
+`openTelemetry` is a configured `OpenTelemetry` instance — with a span processor and an
+exporter — that **you** create and own; see the [Kotlin OpenTelemetry documentation][otel-kotlin]
+for SDK and exporter setup. Closing the factory does not shut that instance down.
+
+The instrumentation scope name defaults to `io.spine.server.trace.otel`. Pass a second
+argument to `OtelTracerFactory` to override it:
+
+```kotlin
+OtelTracerFactory(openTelemetry, instrumentationScopeName = "my.app.tracing")
+```
+
+## Notes
+
+- Tracing applies to entities — aggregates, process managers, and projections. Standalone
+  commanders, reactors, and subscribers are not traced.
+- Each handling is recorded as its own span rather than as a span event: OpenTelemetry
+  [deprecated the Span Events API][span-events] in March 2026 in favor of log-based events,
+  so per-handling data is carried by dedicated spans and their attributes.
+
+[otel-kotlin]: https://opentelemetry.io/docs/languages/kotlin/
+[span-events]: https://opentelemetry.io/blog/2026/deprecating-span-events/

--- a/server-otel/README.md
+++ b/server-otel/README.md
@@ -21,14 +21,14 @@ Google-Cloud-specific `stackdriver-trace` module without coupling to Google Clou
 
 Each handler invocation becomes its own span that carries the following attributes:
 
-| Attribute | Meaning |
-|-----------|---------|
+| Attribute               | Meaning                                     |
+|-------------------------|---------------------------------------------|
 | `spine.bounded_context` | the bounded context that handled the signal |
-| `spine.tenant` | the tenant, as compact JSON |
-| `spine.entity.id` | the ID of the receiving entity |
-| `spine.entity.type` | the type URL of the receiving entity |
-| `spine.signal.id` | the ID of the handled signal |
-| `spine.signal.type` | the type URL of the handled signal |
+| `spine.tenant`          | the tenant, as compact JSON                 |
+| `spine.entity.id`       | the ID of the receiving entity              |
+| `spine.entity.type`     | the type URL of the receiving entity        |
+| `spine.signal.id`       | the ID of the handled signal                |
+| `spine.signal.type`     | the type URL of the handled signal          |
 
 ## Dependency
 

--- a/server-otel/README.md
+++ b/server-otel/README.md
@@ -52,6 +52,7 @@ import io.spine.environment.Production
 import io.spine.server.ServerEnvironment
 import io.spine.server.trace.otel.ExperimentalOtelTracing
 import io.spine.server.trace.otel.OtelTracerFactory
+import io.spine.server.under
 
 @OptIn(ExperimentalOtelTracing::class)
 fun configureTracing(openTelemetry: OpenTelemetry) {

--- a/server-otel/README.md
+++ b/server-otel/README.md
@@ -57,7 +57,7 @@ import io.spine.server.under
 @OptIn(ExperimentalOtelTracing::class)
 fun configureTracing(openTelemetry: OpenTelemetry) {
     val factory = OtelTracerFactory(openTelemetry)
-    under<Production::class.java> {
+    under<Production> {
         use(factory)
     }
 }

--- a/server-otel/build.gradle.kts
+++ b/server-otel/build.gradle.kts
@@ -24,21 +24,29 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-pluginManagement {
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
+import io.spine.dependency.lib.OpenTelemetryKotlin
+
+plugins {
+    module
+    id("io.spine.core-jvm")
 }
 
-rootProject.name = "core-jvm"
+dependencies {
+    api(project(":server"))
 
-include(
-    "core",
-    "core-testlib",
-    "client",
-    "client-testlib",
-    "server",
-    "server-testlib",
-    "server-otel",
-)
+    // The Kotlin OpenTelemetry API. Exposed in the public API of
+    // `OtelTracerFactory`, hence `api` rather than `implementation`.
+    api(OpenTelemetryKotlin.api)
+
+    // The Kotlin OpenTelemetry SDK is required only by tests, which configure
+    // an `OpenTelemetry` instance with a recording span processor. `core`
+    // exposes the SDK API; `implementation` adds the `createOpenTelemetry { }`
+    // entry point.
+    testImplementation(OpenTelemetryKotlin.core)
+    testImplementation(OpenTelemetryKotlin.implementation)
+
+    // Reuse the message-tracing test fixtures (the `Airport` sample context)
+    // declared by the `server` module.
+    testImplementation(testFixtures(project(":server")))
+    testImplementation(project(":server-testlib"))
+}

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/ExperimentalOtelTracing.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/ExperimentalOtelTracing.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.trace.otel
+
+/**
+ * Marks the OpenTelemetry-based Spine tracing API as experimental.
+ *
+ * The API is built on the alpha Kotlin OpenTelemetry API
+ * (`io.opentelemetry.kotlin`) and may change in a backward-incompatible way, or be
+ * removed, in a future release. Opt in explicitly — either by annotating the using
+ * declaration with this marker, or with `@OptIn(ExperimentalOtelTracing::class)` —
+ * to acknowledge the instability.
+ */
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "The Spine OpenTelemetry tracing API is experimental and may change."
+)
+@MustBeDocumented
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+)
+public annotation class ExperimentalOtelTracing

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/OtelTracer.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/OtelTracer.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:OptIn(ExperimentalApi::class)
+
+package io.spine.server.trace.otel
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.tracing.Tracer as OpenTelemetryTracer
+import io.spine.core.BoundedContextName
+import io.spine.core.MessageId
+import io.spine.core.Signal
+import io.spine.server.trace.AbstractTracer
+import io.spine.system.server.EntityTypeName
+
+/**
+ * A [Tracer][io.spine.server.trace.Tracer] that records the handling of a signal
+ * as OpenTelemetry spans.
+ *
+ * Each invocation of [processedBy] starts and immediately ends a span describing
+ * a single handling of the [signal][signal] by an entity. The span carries the
+ * signal's [timestamp][Signal.timestamp] as its start time and the current time
+ * as its end time.
+ *
+ * Instances are created by [OtelTracerFactory] and are not meant to be reused
+ * across signals.
+ */
+public class OtelTracer internal constructor(
+    signal: Signal<*, *, *>,
+    private val openTelemetry: OpenTelemetry,
+    private val tracer: OpenTelemetryTracer,
+    private val contextName: BoundedContextName,
+) : AbstractTracer(signal) {
+
+    override fun processedBy(receiver: MessageId, receiverType: EntityTypeName) {
+        val signalSpan = SignalSpan(contextName, signal(), receiver, receiverType)
+        signalSpan.recordWith(openTelemetry, tracer)
+    }
+
+    override fun close() {
+        // Each span is started and ended within `processedBy`, so there is
+        // nothing to flush here. Exporting the recorded spans is the
+        // responsibility of the `OpenTelemetry` instance configured by the caller.
+    }
+}

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/OtelTracer.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/OtelTracer.kt
@@ -31,6 +31,7 @@ package io.spine.server.trace.otel
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.OpenTelemetry
 import io.opentelemetry.kotlin.tracing.Tracer as OpenTelemetryTracer
+import io.spine.annotation.Experimental
 import io.spine.core.BoundedContextName
 import io.spine.core.MessageId
 import io.spine.core.Signal
@@ -49,6 +50,8 @@ import io.spine.system.server.EntityTypeName
  * Instances are created by [OtelTracerFactory] and are not meant to be reused
  * across signals.
  */
+@ExperimentalOtelTracing
+@Experimental
 public class OtelTracer internal constructor(
     signal: Signal<*, *, *>,
     private val openTelemetry: OpenTelemetry,

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/OtelTracerFactory.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/OtelTracerFactory.kt
@@ -31,6 +31,7 @@ package io.spine.server.trace.otel
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.OpenTelemetry
 import io.opentelemetry.kotlin.tracing.Tracer as OpenTelemetryTracer
+import io.spine.annotation.Experimental
 import io.spine.core.Signal
 import io.spine.server.ContextSpec
 import io.spine.server.trace.Tracer
@@ -39,6 +40,8 @@ import io.spine.server.trace.TracerFactory
 /**
  * The default instrumentation scope name reported to OpenTelemetry.
  */
+@ExperimentalOtelTracing
+@Experimental
 public const val DEFAULT_INSTRUMENTATION_SCOPE_NAME: String = "io.spine.server.trace.otel"
 
 /**
@@ -67,6 +70,8 @@ public const val DEFAULT_INSTRUMENTATION_SCOPE_NAME: String = "io.spine.server.t
  *
  * @see <a href="https://opentelemetry.io/docs/languages/kotlin/">OpenTelemetry Kotlin</a>
  */
+@ExperimentalOtelTracing
+@Experimental
 public class OtelTracerFactory @JvmOverloads constructor(
     private val openTelemetry: OpenTelemetry,
     instrumentationScopeName: String = DEFAULT_INSTRUMENTATION_SCOPE_NAME,

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/OtelTracerFactory.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/OtelTracerFactory.kt
@@ -38,13 +38,6 @@ import io.spine.server.trace.Tracer
 import io.spine.server.trace.TracerFactory
 
 /**
- * The default instrumentation scope name reported to OpenTelemetry.
- */
-@ExperimentalOtelTracing
-@Experimental
-public const val DEFAULT_INSTRUMENTATION_SCOPE_NAME: String = "io.spine.server.trace.otel"
-
-/**
  * A [TracerFactory] that records signal handling as OpenTelemetry spans.
  *
  * This factory is backend-agnostic: it maps Spine signals onto OpenTelemetry
@@ -77,8 +70,11 @@ public class OtelTracerFactory @JvmOverloads constructor(
     instrumentationScopeName: String = DEFAULT_INSTRUMENTATION_SCOPE_NAME,
 ) : TracerFactory {
 
-    private val tracer: OpenTelemetryTracer =
+    // Created lazily so that wiring a factory into the server environment does not
+    // touch the OpenTelemetry SDK until the first signal is actually traced.
+    private val tracer: OpenTelemetryTracer by lazy {
         openTelemetry.tracerProvider.getTracer(instrumentationScopeName)
+    }
 
     // A factory is shared across the server environment, so `trace()`, `isOpen()`,
     // and `close()` may run on different threads. The flag is `@Volatile` for safe
@@ -95,5 +91,16 @@ public class OtelTracerFactory @JvmOverloads constructor(
         // The `OpenTelemetry` instance is owned by the caller and is not shut
         // down here. This factory only marks itself as closed.
         open = false
+    }
+
+    public companion object {
+
+        /**
+         * The default instrumentation scope name reported to OpenTelemetry.
+         */
+        @ExperimentalOtelTracing
+        @Experimental
+        public const val DEFAULT_INSTRUMENTATION_SCOPE_NAME: String =
+            "io.spine.server.trace.otel"
     }
 }

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/OtelTracerFactory.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/OtelTracerFactory.kt
@@ -37,36 +37,39 @@ import io.spine.server.trace.Tracer
 import io.spine.server.trace.TracerFactory
 
 /**
- * The default instrumentation scope name used for the OpenTelemetry tracer.
+ * The default instrumentation scope name reported to OpenTelemetry.
  */
-private const val DEFAULT_SCOPE_NAME = "io.spine.server.trace.otel"
+public const val DEFAULT_INSTRUMENTATION_SCOPE_NAME: String = "io.spine.server.trace.otel"
 
 /**
  * A [TracerFactory] that records signal handling as OpenTelemetry spans.
  *
  * This factory is backend-agnostic: it maps Spine signals onto OpenTelemetry
- * spans and relies on a caller-supplied [OpenTelemetry] instance to process and
- * export them. To send traces to a particular backend (an OTLP collector, Google
- * Cloud Trace, Jaeger, etc.), configure the corresponding span processor and
- * exporter on the [OpenTelemetry] instance before passing it here.
+ * spans and relies on the supplied [openTelemetry] instance to process and export
+ * them. To send traces to a particular backend (an OTLP collector, Google Cloud
+ * Trace, Jaeger, etc.), configure the corresponding span processor and exporter on
+ * the [OpenTelemetry] instance before passing it here.
  *
- * The [OpenTelemetry] instance is owned by the caller. Closing this factory does
+ * The [openTelemetry] instance is owned by the caller. Closing this factory does
  * not shut it down.
  *
- * Use the [Builder] to create instances:
  * ```
- * val factory = OtelTracerFactory.newBuilder()
- *     .setOpenTelemetry(openTelemetry)
- *     .build()
+ * val factory = OtelTracerFactory(openTelemetry)
  * ServerEnvironment.instance()
  *     .use(factory)
  * ```
  *
+ * @param openTelemetry
+ *         the OpenTelemetry instance that processes and exports the recorded spans
+ * @param instrumentationScopeName
+ *         the instrumentation scope name reported to OpenTelemetry;
+ *         defaults to [DEFAULT_INSTRUMENTATION_SCOPE_NAME]
+ *
  * @see <a href="https://opentelemetry.io/docs/languages/kotlin/">OpenTelemetry Kotlin</a>
  */
-public class OtelTracerFactory private constructor(
+public class OtelTracerFactory @JvmOverloads constructor(
     private val openTelemetry: OpenTelemetry,
-    instrumentationScopeName: String,
+    instrumentationScopeName: String = DEFAULT_INSTRUMENTATION_SCOPE_NAME,
 ) : TracerFactory {
 
     private val tracer: OpenTelemetryTracer =
@@ -87,61 +90,5 @@ public class OtelTracerFactory private constructor(
         // The `OpenTelemetry` instance is owned by the caller and is not shut
         // down here. This factory only marks itself as closed.
         open = false
-    }
-
-    public companion object {
-
-        /**
-         * The default instrumentation scope name reported to OpenTelemetry.
-         */
-        public const val DEFAULT_INSTRUMENTATION_SCOPE_NAME: String = DEFAULT_SCOPE_NAME
-
-        /**
-         * Creates a new builder for [OtelTracerFactory] instances.
-         */
-        @JvmStatic
-        public fun newBuilder(): Builder = Builder()
-    }
-
-    /**
-     * A builder for [OtelTracerFactory] instances.
-     */
-    public class Builder internal constructor() {
-
-        private var openTelemetry: OpenTelemetry? = null
-        private var instrumentationScopeName: String = DEFAULT_SCOPE_NAME
-
-        /**
-         * Sets the [OpenTelemetry] instance that processes and exports the
-         * recorded spans.
-         *
-         * This is a required property.
-         */
-        public fun setOpenTelemetry(openTelemetry: OpenTelemetry): Builder {
-            this.openTelemetry = openTelemetry
-            return this
-        }
-
-        /**
-         * Sets the instrumentation scope name reported to OpenTelemetry.
-         *
-         * If not set, [DEFAULT_INSTRUMENTATION_SCOPE_NAME] is used.
-         */
-        public fun setInstrumentationScopeName(name: String): Builder {
-            this.instrumentationScopeName = name
-            return this
-        }
-
-        /**
-         * Creates a new [OtelTracerFactory].
-         *
-         * @throws IllegalStateException if the [OpenTelemetry] instance is not set
-         */
-        public fun build(): OtelTracerFactory {
-            val otel = checkNotNull(openTelemetry) {
-                "The `OpenTelemetry` instance must be set."
-            }
-            return OtelTracerFactory(otel, instrumentationScopeName)
-        }
     }
 }

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/OtelTracerFactory.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/OtelTracerFactory.kt
@@ -50,9 +50,11 @@ import io.spine.server.trace.TracerFactory
  * not shut it down.
  *
  * ```
- * val factory = OtelTracerFactory(openTelemetry)
- * ServerEnvironment.instance()
- *     .use(factory)
+ * @OptIn(ExperimentalOtelTracing::class)
+ * fun configureTracing(openTelemetry: OpenTelemetry) {
+ *     ServerEnvironment.`when`(Production::class.java)
+ *         .use(OtelTracerFactory(openTelemetry))
+ * }
  * ```
  *
  * @param openTelemetry

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/OtelTracerFactory.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/OtelTracerFactory.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:OptIn(ExperimentalApi::class)
+
+package io.spine.server.trace.otel
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.tracing.Tracer as OpenTelemetryTracer
+import io.spine.core.Signal
+import io.spine.server.ContextSpec
+import io.spine.server.trace.Tracer
+import io.spine.server.trace.TracerFactory
+
+/**
+ * The default instrumentation scope name used for the OpenTelemetry tracer.
+ */
+private const val DEFAULT_SCOPE_NAME = "io.spine.server.trace.otel"
+
+/**
+ * A [TracerFactory] that records signal handling as OpenTelemetry spans.
+ *
+ * This factory is backend-agnostic: it maps Spine signals onto OpenTelemetry
+ * spans and relies on a caller-supplied [OpenTelemetry] instance to process and
+ * export them. To send traces to a particular backend (an OTLP collector, Google
+ * Cloud Trace, Jaeger, etc.), configure the corresponding span processor and
+ * exporter on the [OpenTelemetry] instance before passing it here.
+ *
+ * The [OpenTelemetry] instance is owned by the caller. Closing this factory does
+ * not shut it down.
+ *
+ * Use the [Builder] to create instances:
+ * ```
+ * val factory = OtelTracerFactory.newBuilder()
+ *     .setOpenTelemetry(openTelemetry)
+ *     .build()
+ * ServerEnvironment.instance()
+ *     .use(factory)
+ * ```
+ *
+ * @see <a href="https://opentelemetry.io/docs/languages/kotlin/">OpenTelemetry Kotlin</a>
+ */
+public class OtelTracerFactory private constructor(
+    private val openTelemetry: OpenTelemetry,
+    instrumentationScopeName: String,
+) : TracerFactory {
+
+    private val tracer: OpenTelemetryTracer =
+        openTelemetry.tracerProvider.getTracer(instrumentationScopeName)
+
+    // A factory is shared across the server environment, so `trace()`, `isOpen()`,
+    // and `close()` may run on different threads. The flag is `@Volatile` for safe
+    // publication of the closed state.
+    @Volatile
+    private var open: Boolean = true
+
+    override fun trace(context: ContextSpec, signalMessage: Signal<*, *, *>): Tracer =
+        OtelTracer(signalMessage, openTelemetry, tracer, context.name())
+
+    override fun isOpen(): Boolean = open
+
+    override fun close() {
+        // The `OpenTelemetry` instance is owned by the caller and is not shut
+        // down here. This factory only marks itself as closed.
+        open = false
+    }
+
+    public companion object {
+
+        /**
+         * The default instrumentation scope name reported to OpenTelemetry.
+         */
+        public const val DEFAULT_INSTRUMENTATION_SCOPE_NAME: String = DEFAULT_SCOPE_NAME
+
+        /**
+         * Creates a new builder for [OtelTracerFactory] instances.
+         */
+        @JvmStatic
+        public fun newBuilder(): Builder = Builder()
+    }
+
+    /**
+     * A builder for [OtelTracerFactory] instances.
+     */
+    public class Builder internal constructor() {
+
+        private var openTelemetry: OpenTelemetry? = null
+        private var instrumentationScopeName: String = DEFAULT_SCOPE_NAME
+
+        /**
+         * Sets the [OpenTelemetry] instance that processes and exports the
+         * recorded spans.
+         *
+         * This is a required property.
+         */
+        public fun setOpenTelemetry(openTelemetry: OpenTelemetry): Builder {
+            this.openTelemetry = openTelemetry
+            return this
+        }
+
+        /**
+         * Sets the instrumentation scope name reported to OpenTelemetry.
+         *
+         * If not set, [DEFAULT_INSTRUMENTATION_SCOPE_NAME] is used.
+         */
+        public fun setInstrumentationScopeName(name: String): Builder {
+            this.instrumentationScopeName = name
+            return this
+        }
+
+        /**
+         * Creates a new [OtelTracerFactory].
+         *
+         * @throws IllegalStateException if the [OpenTelemetry] instance is not set
+         */
+        public fun build(): OtelTracerFactory {
+            val otel = checkNotNull(openTelemetry) {
+                "The `OpenTelemetry` instance must be set."
+            }
+            return OtelTracerFactory(otel, instrumentationScopeName)
+        }
+    }
+}

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/SignalSpan.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/SignalSpan.kt
@@ -110,8 +110,9 @@ internal class SignalSpan(
     /**
      * Obtains the ID of the root signal of the causal chain this signal belongs to.
      *
-     * The ID is unpacked as a concrete message (e.g. a `CommandId` or `EventId`),
-     * since [SignalId] is an interface and cannot be instantiated directly.
+     * The ID of a root message always wraps a [SignalId], so the cast is safe. It is
+     * unpacked as a concrete message (e.g. a `CommandId` or `EventId`), since
+     * [SignalId] is an interface and cannot be instantiated directly.
      */
     private fun rootSignalId(): SignalId =
         unpack(signal.rootMessage().id) as SignalId

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/SignalSpan.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/SignalSpan.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:OptIn(ExperimentalApi::class)
+
+package io.spine.server.trace.otel
+
+import com.google.protobuf.Timestamp
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.tracing.Tracer as OpenTelemetryTracer
+import io.spine.base.Time
+import io.spine.code.java.ClassName
+import io.spine.core.BoundedContextName
+import io.spine.core.MessageId
+import io.spine.core.Signal
+import io.spine.core.SignalId
+import io.spine.protobuf.AnyPacker.unpack
+import io.spine.system.server.EntityTypeName
+
+/**
+ * The maximum length of a span display name, in characters.
+ */
+private const val DISPLAY_NAME_MAX_LENGTH = 128
+
+/**
+ * The hex representation of the "sampled" trace flags.
+ *
+ * The synthetic parent span context is always marked as sampled, so that a
+ * parent-based sampler records and exports the emitted handler spans. This
+ * matches the always-export behavior of the retired Stackdriver tracer; a caller
+ * may still apply its own sampling via the configured `OpenTelemetry` SDK.
+ */
+private const val SAMPLED_TRACE_FLAGS = "01"
+
+/**
+ * The number of nanoseconds in a second.
+ */
+private const val NANOS_PER_SECOND = 1_000_000_000L
+
+/**
+ * A single handling of a [signal] by an entity, recorded as an OpenTelemetry span.
+ *
+ * A signal may be handled once or many times by different entities. Each handling
+ * is recorded as its own span. Spans produced for signals that descend from a
+ * common root signal share a single [trace][traceIdOf], so that a whole causal
+ * chain appears as one trace.
+ */
+internal class SignalSpan(
+    val contextName: BoundedContextName,
+    val signal: Signal<*, *, *>,
+    val receiver: MessageId,
+    val receiverType: EntityTypeName,
+) {
+
+    /**
+     * Records this signal handling as a span produced by the given [tracer].
+     *
+     * The span covers the interval from the signal's [timestamp][Signal.timestamp]
+     * to the current time, since the handling has already completed by the time
+     * this method is called. Exporting the span is the responsibility of the
+     * span processor configured in [otel].
+     */
+    fun recordWith(otel: OpenTelemetry, tracer: OpenTelemetryTracer) {
+        val span = tracer.startSpan(
+            name = displayName(),
+            parentContext = parentContext(otel),
+            startTimestamp = signal.timestamp().toEpochNanos(),
+        ) {
+            SpanAttribute.entries.forEach { attribute ->
+                setStringAttribute(attribute.key, attribute.truncatedValueIn(this@SignalSpan))
+            }
+        }
+        span.end(Time.currentTime().toEpochNanos())
+    }
+
+    /**
+     * Builds the span display name in the form `"<Receiver> handles <Signal>"`.
+     */
+    private fun displayName(): String {
+        val receiverName = ClassName.of(receiverType.javaClassName).toSimple()
+        val signalName = signal.enclosedTypeUrl().typeName().simpleName()
+        return "$receiverName handles $signalName".truncated(DISPLAY_NAME_MAX_LENGTH)
+    }
+
+    /**
+     * Builds the parent context that carries the deterministic trace ID of the
+     * causal chain this signal belongs to.
+     */
+    private fun parentContext(otel: OpenTelemetry): Context {
+        val rootId = rootSignalId()
+        val parent = otel.spanContext.create(
+            traceId = traceIdOf(rootId),
+            spanId = spanIdOf(rootId),
+            traceFlags = otel.traceFlags.fromHex(SAMPLED_TRACE_FLAGS),
+            traceState = otel.traceState.default,
+            isRemote = false,
+        )
+        return otel.context.root().storeSpan(otel.span.fromSpanContext(parent))
+    }
+
+    /**
+     * Obtains the ID of the root signal of the causal chain this signal belongs to.
+     *
+     * The ID is unpacked as a concrete message (e.g. a `CommandId` or `EventId`),
+     * since [SignalId] is an interface and cannot be instantiated directly.
+     */
+    private fun rootSignalId(): SignalId =
+        unpack(signal.rootMessage().id) as SignalId
+}
+
+/**
+ * Converts this protobuf timestamp to the number of nanoseconds since the Unix epoch.
+ */
+private fun Timestamp.toEpochNanos(): Long =
+    seconds * NANOS_PER_SECOND + nanos

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/SignalSpan.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/SignalSpan.kt
@@ -127,11 +127,10 @@ internal class SignalSpan(
         /**
          * The hex representation of the "sampled" trace flags.
          *
-         * The synthetic parent span context is always marked as sampled, so that a
-         * parent-based sampler records and exports the emitted handler spans. This
-         * matches the always-export behavior of the retired Stackdriver tracer; a
-         * caller may still apply its own sampling via the configured `OpenTelemetry`
-         * SDK.
+         * The synthetic parent span context is always marked as sampled so that a
+         * parent-based sampler records and exports the emitted handler spans.
+         * This matches the always-export behavior of the retired Stackdriver tracer;
+         * a caller may still apply its own sampling via the configured `OpenTelemetry` SDK.
          */
         const val SAMPLED_TRACE_FLAGS = "01"
     }

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/SignalSpan.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/SignalSpan.kt
@@ -28,7 +28,6 @@
 
 package io.spine.server.trace.otel
 
-import com.google.protobuf.Timestamp
 import io.opentelemetry.kotlin.ExperimentalApi
 import io.opentelemetry.kotlin.OpenTelemetry
 import io.opentelemetry.kotlin.context.Context
@@ -41,6 +40,7 @@ import io.spine.core.Signal
 import io.spine.core.SignalId
 import io.spine.protobuf.AnyPacker.unpack
 import io.spine.system.server.EntityTypeName
+import io.spine.time.toNanos
 
 /**
  * The maximum length of a span display name, in characters.
@@ -56,11 +56,6 @@ private const val DISPLAY_NAME_MAX_LENGTH = 128
  * may still apply its own sampling via the configured `OpenTelemetry` SDK.
  */
 private const val SAMPLED_TRACE_FLAGS = "01"
-
-/**
- * The number of nanoseconds in a second.
- */
-private const val NANOS_PER_SECOND = 1_000_000_000L
 
 /**
  * A single handling of a [signal] by an entity, recorded as an OpenTelemetry span.
@@ -93,13 +88,13 @@ internal class SignalSpan(
         val span = tracer.startSpan(
             name = displayName(),
             parentContext = parentContext(otel),
-            startTimestamp = signal.timestamp().toEpochNanos(),
+            startTimestamp = signal.timestamp().toNanos(),
         ) {
             SpanAttribute.entries.forEach { attribute ->
                 setStringAttribute(attribute.key, attribute.truncatedValueIn(this@SignalSpan))
             }
         }
-        span.end(Time.currentTime().toEpochNanos())
+        span.end(Time.currentTime().toNanos())
     }
 
     /**
@@ -136,9 +131,3 @@ internal class SignalSpan(
     private fun rootSignalId(): SignalId =
         unpack(signal.rootMessage().id) as SignalId
 }
-
-/**
- * Converts this protobuf timestamp to the number of nanoseconds since the Unix epoch.
- */
-private fun Timestamp.toEpochNanos(): Long =
-    seconds * NANOS_PER_SECOND + nanos

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/SignalSpan.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/SignalSpan.kt
@@ -66,9 +66,13 @@ private const val NANOS_PER_SECOND = 1_000_000_000L
  * A single handling of a [signal] by an entity, recorded as an OpenTelemetry span.
  *
  * A signal may be handled once or many times by different entities. Each handling
- * is recorded as its own span. Spans produced for signals that descend from a
- * common root signal share a single [trace][traceIdOf], so that a whole causal
- * chain appears as one trace.
+ * is recorded as its own span — deliberately, not as a span event on a shared span:
+ * OpenTelemetry deprecated the Span Events API in March 2026 in favor of log-based
+ * events, so per-handling data is carried by dedicated spans and their attributes.
+ * Spans produced for signals that descend from a common root signal share a single
+ * [trace][traceIdOf], so that a whole causal chain appears as one trace.
+ *
+ * @see <a href="https://opentelemetry.io/blog/2026/deprecating-span-events/">Deprecating Span Events</a>
  */
 internal class SignalSpan(
     val contextName: BoundedContextName,

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/SignalSpan.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/SignalSpan.kt
@@ -52,7 +52,7 @@ import io.spine.time.toNanos
  * Spans produced for signals that descend from a common root signal share a single
  * [trace][traceIdOf], so that a whole causal chain appears as one trace.
  *
- * @see <a href="https://opentelemetry.io/blog/2026/deprecating-span-events/">Deprecating Span Events</a>
+ * @see <a href="https://opentelemetry.io/blog/2026/deprecating-span-events/">Span Events</a>
  */
 internal class SignalSpan(
     val contextName: BoundedContextName,

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/SignalSpan.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/SignalSpan.kt
@@ -43,21 +43,6 @@ import io.spine.system.server.EntityTypeName
 import io.spine.time.toNanos
 
 /**
- * The maximum length of a span display name, in characters.
- */
-private const val DISPLAY_NAME_MAX_LENGTH = 128
-
-/**
- * The hex representation of the "sampled" trace flags.
- *
- * The synthetic parent span context is always marked as sampled, so that a
- * parent-based sampler records and exports the emitted handler spans. This
- * matches the always-export behavior of the retired Stackdriver tracer; a caller
- * may still apply its own sampling via the configured `OpenTelemetry` SDK.
- */
-private const val SAMPLED_TRACE_FLAGS = "01"
-
-/**
  * A single handling of a [signal] by an entity, recorded as an OpenTelemetry span.
  *
  * A signal may be handled once or many times by different entities. Each handling
@@ -130,4 +115,23 @@ internal class SignalSpan(
      */
     private fun rootSignalId(): SignalId =
         unpack(signal.rootMessage().id) as SignalId
+
+    private companion object {
+
+        /**
+         * The maximum length of a span display name, in characters.
+         */
+        const val DISPLAY_NAME_MAX_LENGTH = 128
+
+        /**
+         * The hex representation of the "sampled" trace flags.
+         *
+         * The synthetic parent span context is always marked as sampled, so that a
+         * parent-based sampler records and exports the emitted handler spans. This
+         * matches the always-export behavior of the retired Stackdriver tracer; a
+         * caller may still apply its own sampling via the configured `OpenTelemetry`
+         * SDK.
+         */
+        const val SAMPLED_TRACE_FLAGS = "01"
+    }
 }

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/SpanAttribute.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/SpanAttribute.kt
@@ -113,7 +113,7 @@ internal enum class SpanAttribute(val key: String) {
 /**
  * Returns this string limited to at most [maxLength] UTF-16 code units.
  *
- * If the cut would fall between the two halves of a surrogate pair, the trailing
+ * If the cut falls between the two halves of a surrogate pair, the trailing
  * high surrogate is dropped as well, so the result never ends with a broken character.
  */
 internal fun String.truncated(maxLength: Int): String {

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/SpanAttribute.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/SpanAttribute.kt
@@ -31,13 +31,6 @@ import io.spine.string.Stringifiers
 import io.spine.type.toCompactJson
 
 /**
- * The maximum length of a string attribute value, in characters.
- *
- * Longer values are truncated to keep span payloads bounded.
- */
-private const val ATTRIBUTE_VALUE_MAX_LENGTH = 256
-
-/**
  * The Spine-specific attributes attached to each emitted span.
  *
  * Keys follow the OpenTelemetry attribute naming convention: lowercase, dotted,
@@ -105,6 +98,16 @@ internal enum class SpanAttribute(val key: String) {
      */
     fun truncatedValueIn(span: SignalSpan): String =
         valueIn(span).truncated(ATTRIBUTE_VALUE_MAX_LENGTH)
+
+    private companion object {
+
+        /**
+         * The maximum length of a string attribute value, in characters.
+         *
+         * Longer values are truncated to keep span payloads bounded.
+         */
+        const val ATTRIBUTE_VALUE_MAX_LENGTH = 256
+    }
 }
 
 /**

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/SpanAttribute.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/SpanAttribute.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.trace.otel
+
+import io.spine.protobuf.AnyPacker.unpack
+import io.spine.string.Stringifiers
+import io.spine.type.toCompactJson
+
+/**
+ * The maximum length of a string attribute value, in characters.
+ *
+ * Longer values are truncated to keep span payloads bounded.
+ */
+private const val ATTRIBUTE_VALUE_MAX_LENGTH = 256
+
+/**
+ * The Spine-specific attributes attached to each emitted span.
+ *
+ * Keys follow the OpenTelemetry attribute naming convention: lowercase, dotted,
+ * and namespaced under `spine.`.
+ */
+internal enum class SpanAttribute(val key: String) {
+
+    /**
+     * The fully-qualified name of the bounded context that handled the signal.
+     */
+    BOUNDED_CONTEXT("spine.bounded_context") {
+        override fun valueIn(span: SignalSpan): String =
+            span.contextName.value
+    },
+
+    /**
+     * The tenant on behalf of which the signal is handled, as compact JSON.
+     */
+    TENANT("spine.tenant") {
+        override fun valueIn(span: SignalSpan): String =
+            span.signal.tenant().toCompactJson()
+    },
+
+    /**
+     * The string form of the ID of the entity that handled the signal.
+     */
+    ENTITY_ID("spine.entity.id") {
+        override fun valueIn(span: SignalSpan): String {
+            val id = unpack(span.receiver.id)
+            return Stringifiers.toString(id)
+        }
+    },
+
+    /**
+     * The ID of the handled signal.
+     */
+    SIGNAL_ID("spine.signal.id") {
+        override fun valueIn(span: SignalSpan): String =
+            span.signal.id().value()
+    },
+
+    /**
+     * The type URL of the entity that handled the signal.
+     */
+    ENTITY_TYPE("spine.entity.type") {
+        override fun valueIn(span: SignalSpan): String =
+            span.receiver.typeUrl
+    },
+
+    /**
+     * The type URL of the handled signal.
+     */
+    SIGNAL_TYPE("spine.signal.type") {
+        override fun valueIn(span: SignalSpan): String =
+            span.signal.enclosedTypeUrl().value()
+    };
+
+    /**
+     * Computes the value of this attribute for the given signal span.
+     */
+    abstract fun valueIn(span: SignalSpan): String
+
+    /**
+     * Computes the value of this attribute, truncated to the maximum length.
+     */
+    fun truncatedValueIn(span: SignalSpan): String =
+        valueIn(span).truncated(ATTRIBUTE_VALUE_MAX_LENGTH)
+}
+
+/**
+ * Returns this string limited to at most [maxLength] UTF-16 code units.
+ *
+ * If the cut would fall between the two halves of a surrogate pair, the trailing
+ * high surrogate is dropped as well, so the result never ends with a broken character.
+ */
+internal fun String.truncated(maxLength: Int): String {
+    if (length <= maxLength) {
+        return this
+    }
+    val end = if (Character.isHighSurrogate(this[maxLength - 1])) maxLength - 1 else maxLength
+    return substring(0, end)
+}

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/TraceIds.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/TraceIds.kt
@@ -50,9 +50,9 @@ private val uuidPattern =
  * OpenTelemetry [trace ID][io.opentelemetry.kotlin.tracing.SpanContext.traceId]
  * format.
  *
- * Signal IDs are version 3 or version 4 UUIDs, whose version and variant bits keep
- * both halves non-zero; the derived trace ID is therefore always a valid (non-zero)
- * OpenTelemetry trace ID.
+ * The derived trace ID is always a valid (non-zero) OpenTelemetry trace ID:
+ * canonical UUID signal IDs (versions 3 and 4) carry non-zero version and variant
+ * bits, and the fallback for non-UUID IDs forces both 64-bit halves to be non-zero.
  *
  * @see spanIdOf
  */
@@ -93,12 +93,23 @@ private fun SignalId.toUuid(): Uuid {
 /**
  * Folds this byte array into exactly [Uuid.SIZE_BYTES] bytes, so that it can be
  * turned into a [Uuid]. The fold is deterministic but not cryptographic.
+ *
+ * Both 64-bit halves of the result are kept non-zero, so that the derived trace ID
+ * and span ID are valid (non-zero) OpenTelemetry identifiers — even for inputs that
+ * would otherwise fold to all zeros (such as an empty or a uniformly repeated string).
  */
 private fun ByteArray.foldToUuidSize(): ByteArray {
     val result = ByteArray(Uuid.SIZE_BYTES)
     forEachIndexed { index, byte ->
         val i = index % Uuid.SIZE_BYTES
         result[i] = (result[i].toInt() xor byte.toInt()).toByte()
+    }
+    val half = Uuid.SIZE_BYTES / 2
+    if ((0 until half).all { result[it].toInt() == 0 }) {
+        result[0] = 1
+    }
+    if ((half until Uuid.SIZE_BYTES).all { result[it].toInt() == 0 }) {
+        result[half] = 1
     }
     return result
 }

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/TraceIds.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/TraceIds.kt
@@ -24,10 +24,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@file:OptIn(ExperimentalUuidApi::class)
+
 package io.spine.server.trace.otel
 
 import io.spine.core.SignalId
-import java.util.UUID
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 /**
  * The canonical form of a UUID string, e.g. `123e4567-e89b-12d3-a456-426614174000`.
@@ -43,10 +46,9 @@ private val uuidPattern =
  * behavior: a command and all the events and further commands it triggers appear
  * under a single trace.
  *
- * The result is a 32-character (16-byte) lowercase hex string, as required by
- * the OpenTelemetry [trace ID][io.opentelemetry.kotlin.tracing.SpanContext.traceId]
- * format. Each half of the backing UUID is zero-padded to 16 hex characters so
- * that the value is always exactly 32 characters long.
+ * The result is the 32-character (16-byte) lowercase hex form required by the
+ * OpenTelemetry [trace ID][io.opentelemetry.kotlin.tracing.SpanContext.traceId]
+ * format.
  *
  * Signal IDs are version 3 or version 4 UUIDs, whose version and variant bits keep
  * both halves non-zero; the derived trace ID is therefore always a valid (non-zero)
@@ -54,38 +56,49 @@ private val uuidPattern =
  *
  * @see spanIdOf
  */
-internal fun traceIdOf(rootSignalId: SignalId): String {
-    val uuid = rootSignalId.toUuid()
-    return "%016x%016x".format(uuid.mostSignificantBits, uuid.leastSignificantBits)
-}
+internal fun traceIdOf(rootSignalId: SignalId): String =
+    rootSignalId.toUuid().toHexString()
 
 /**
  * Derives a deterministic OpenTelemetry span ID for the synthetic parent span of
  * a causal chain identified by the given root signal ID.
  *
  * The emitted handler spans use this value as their parent, so that they form a
- * coherent tree rooted at the chain's origin. The result is a 16-character
- * (8-byte) lowercase hex string.
+ * coherent tree rooted at the chain's origin. The result is the lower 64 bits of
+ * the backing UUID, as a 16-character (8-byte) lowercase hex string.
  *
  * @see traceIdOf
  */
-internal fun spanIdOf(rootSignalId: SignalId): String {
-    val uuid = rootSignalId.toUuid()
-    return "%016x".format(uuid.leastSignificantBits)
+internal fun spanIdOf(rootSignalId: SignalId): String =
+    rootSignalId.toUuid().toLongs { _, leastSignificantBits ->
+        leastSignificantBits.toHexString()
+    }
+
+/**
+ * Converts this signal ID to a [Uuid].
+ *
+ * Signal IDs are normally canonical UUID strings. For an ID that is not a UUID,
+ * a deterministic [Uuid] is derived from its bytes, so that the mapping remains
+ * stable for any input.
+ */
+private fun SignalId.toUuid(): Uuid {
+    val value = value()
+    return if (uuidPattern.matches(value)) {
+        Uuid.parse(value)
+    } else {
+        Uuid.fromByteArray(value.encodeToByteArray().foldToUuidSize())
+    }
 }
 
 /**
- * Converts this signal ID to a [UUID].
- *
- * Signal IDs are normally canonical UUID strings. For an ID that is not a UUID,
- * a stable name-based UUID is derived from its bytes, so that the mapping remains
- * deterministic for any input.
+ * Folds this byte array into exactly [Uuid.SIZE_BYTES] bytes, so that it can be
+ * turned into a [Uuid]. The fold is deterministic but not cryptographic.
  */
-private fun SignalId.toUuid(): UUID {
-    val value = value()
-    return if (uuidPattern.matches(value)) {
-        UUID.fromString(value)
-    } else {
-        UUID.nameUUIDFromBytes(value.encodeToByteArray())
+private fun ByteArray.foldToUuidSize(): ByteArray {
+    val result = ByteArray(Uuid.SIZE_BYTES)
+    forEachIndexed { index, byte ->
+        val i = index % Uuid.SIZE_BYTES
+        result[i] = (result[i].toInt() xor byte.toInt()).toByte()
     }
+    return result
 }

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/TraceIds.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/TraceIds.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.trace.otel
+
+import io.spine.core.SignalId
+import java.util.UUID
+
+/**
+ * The canonical form of a UUID string, e.g. `123e4567-e89b-12d3-a456-426614174000`.
+ */
+private val uuidPattern =
+    Regex("[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}")
+
+/**
+ * Derives a deterministic OpenTelemetry trace ID from the given root signal ID.
+ *
+ * All signals caused by a single root signal share the same root ID, and
+ * therefore the same trace ID. This reproduces the "one trace per causal chain"
+ * behavior: a command and all the events and further commands it triggers appear
+ * under a single trace.
+ *
+ * The result is a 32-character (16-byte) lowercase hex string, as required by
+ * the OpenTelemetry [trace ID][io.opentelemetry.kotlin.tracing.SpanContext.traceId]
+ * format. Each half of the backing UUID is zero-padded to 16 hex characters so
+ * that the value is always exactly 32 characters long.
+ *
+ * Signal IDs are version 3 or version 4 UUIDs, whose version and variant bits keep
+ * both halves non-zero; the derived trace ID is therefore always a valid (non-zero)
+ * OpenTelemetry trace ID.
+ *
+ * @see spanIdOf
+ */
+internal fun traceIdOf(rootSignalId: SignalId): String {
+    val uuid = uuidOf(rootSignalId)
+    return "%016x%016x".format(uuid.mostSignificantBits, uuid.leastSignificantBits)
+}
+
+/**
+ * Derives a deterministic OpenTelemetry span ID for the synthetic parent span of
+ * a causal chain identified by the given root signal ID.
+ *
+ * The emitted handler spans use this value as their parent, so that they form a
+ * coherent tree rooted at the chain's origin. The result is a 16-character
+ * (8-byte) lowercase hex string.
+ *
+ * @see traceIdOf
+ */
+internal fun spanIdOf(rootSignalId: SignalId): String {
+    val uuid = uuidOf(rootSignalId)
+    return "%016x".format(uuid.leastSignificantBits)
+}
+
+/**
+ * Converts the given signal ID to a [UUID].
+ *
+ * Signal IDs are normally canonical UUID strings. For an ID that is not a UUID,
+ * a stable name-based UUID is derived from its bytes, so that the mapping remains
+ * deterministic for any input.
+ */
+private fun uuidOf(signalId: SignalId): UUID {
+    val value = signalId.value()
+    return if (uuidPattern.matches(value)) {
+        UUID.fromString(value)
+    } else {
+        UUID.nameUUIDFromBytes(value.encodeToByteArray())
+    }
+}

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/TraceIds.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/TraceIds.kt
@@ -50,9 +50,9 @@ private val uuidPattern =
  * OpenTelemetry [trace ID][io.opentelemetry.kotlin.tracing.SpanContext.traceId]
  * format.
  *
- * The derived trace ID is always a valid (non-zero) OpenTelemetry trace ID:
- * canonical UUID signal IDs (versions 3 and 4) carry non-zero version and variant
- * bits, and the fallback for non-UUID IDs forces both 64-bit halves to be non-zero.
+ * The derived trace ID is always a valid (non-zero) OpenTelemetry trace ID: the
+ * backing value always has both of its 64-bit halves forced to be non-zero,
+ * regardless of whether the signal ID is a canonical UUID or some other form.
  *
  * @see spanIdOf
  */
@@ -75,19 +75,22 @@ internal fun spanIdOf(rootSignalId: SignalId): String =
     }
 
 /**
- * Converts this signal ID to a [Uuid].
+ * Converts this signal ID to a [Uuid] with both 64-bit halves non-zero.
  *
- * Signal IDs are normally canonical UUID strings. For an ID that is not a UUID,
- * a deterministic [Uuid] is derived from its bytes, so that the mapping remains
- * stable for any input.
+ * Signal IDs are normally canonical UUID strings; for an ID that is not a UUID,
+ * a deterministic [Uuid] is derived from its bytes. In both cases the backing bytes
+ * are forced to keep both halves non-zero — including for a canonical UUID that is
+ * all-zero or whose lower half is all-zero, which would otherwise yield an invalid
+ * OpenTelemetry trace or span ID.
  */
 private fun SignalId.toUuid(): Uuid {
     val value = value()
-    return if (uuidPattern.matches(value)) {
-        Uuid.parse(value)
+    val bytes = if (uuidPattern.matches(value)) {
+        Uuid.parse(value).toByteArray()
     } else {
-        Uuid.fromByteArray(value.encodeToByteArray().foldToUuidSize())
+        value.encodeToByteArray()
     }
+    return Uuid.fromByteArray(bytes.foldToUuidSize())
 }
 
 /**
@@ -95,8 +98,9 @@ private fun SignalId.toUuid(): Uuid {
  * turned into a [Uuid]. The fold is deterministic but not cryptographic.
  *
  * Both 64-bit halves of the result are kept non-zero, so that the derived trace ID
- * and span ID are valid (non-zero) OpenTelemetry identifiers — even for inputs that
- * would otherwise fold to all zeros (such as an empty or a uniformly repeated string).
+ * and span ID are valid (non-zero) OpenTelemetry identifiers — even for inputs whose
+ * halves would otherwise be all zeros (an empty or uniformly repeated string, or a
+ * canonical UUID with a zero half).
  */
 private fun ByteArray.foldToUuidSize(): ByteArray {
     val result = ByteArray(Uuid.SIZE_BYTES)

--- a/server-otel/src/main/kotlin/io/spine/server/trace/otel/TraceIds.kt
+++ b/server-otel/src/main/kotlin/io/spine/server/trace/otel/TraceIds.kt
@@ -55,7 +55,7 @@ private val uuidPattern =
  * @see spanIdOf
  */
 internal fun traceIdOf(rootSignalId: SignalId): String {
-    val uuid = uuidOf(rootSignalId)
+    val uuid = rootSignalId.toUuid()
     return "%016x%016x".format(uuid.mostSignificantBits, uuid.leastSignificantBits)
 }
 
@@ -70,19 +70,19 @@ internal fun traceIdOf(rootSignalId: SignalId): String {
  * @see traceIdOf
  */
 internal fun spanIdOf(rootSignalId: SignalId): String {
-    val uuid = uuidOf(rootSignalId)
+    val uuid = rootSignalId.toUuid()
     return "%016x".format(uuid.leastSignificantBits)
 }
 
 /**
- * Converts the given signal ID to a [UUID].
+ * Converts this signal ID to a [UUID].
  *
  * Signal IDs are normally canonical UUID strings. For an ID that is not a UUID,
  * a stable name-based UUID is derived from its bytes, so that the mapping remains
  * deterministic for any input.
  */
-private fun uuidOf(signalId: SignalId): UUID {
-    val value = signalId.value()
+private fun SignalId.toUuid(): UUID {
+    val value = value()
     return if (uuidPattern.matches(value)) {
         UUID.fromString(value)
     } else {

--- a/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracerFactorySpec.kt
+++ b/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracerFactorySpec.kt
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@file:OptIn(ExperimentalApi::class)
+@file:OptIn(ExperimentalApi::class, ExperimentalOtelTracing::class)
 
 package io.spine.server.trace.otel
 

--- a/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracerFactorySpec.kt
+++ b/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracerFactorySpec.kt
@@ -28,7 +28,6 @@
 
 package io.spine.server.trace.otel
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.opentelemetry.kotlin.ExperimentalApi
@@ -52,16 +51,7 @@ internal class OtelTracerFactorySpec {
     @BeforeEach
     fun setUp() {
         val otel = recordingOpenTelemetry(RecordingSpanProcessor())
-        factory = OtelTracerFactory.newBuilder()
-            .setOpenTelemetry(otel)
-            .build()
-    }
-
-    @Test
-    fun `require an 'OpenTelemetry' instance`() {
-        shouldThrow<IllegalStateException> {
-            OtelTracerFactory.newBuilder().build()
-        }
+        factory = OtelTracerFactory(otel)
     }
 
     @Test

--- a/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracerFactorySpec.kt
+++ b/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracerFactorySpec.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:OptIn(ExperimentalApi::class)
+
+package io.spine.server.trace.otel
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.spine.server.ContextSpec.singleTenant
+import io.spine.server.trace.given.TracingTestEnv.scheduleFlight
+import io.spine.server.trace.otel.given.RecordingSpanProcessor
+import io.spine.server.trace.otel.given.recordingOpenTelemetry
+import io.spine.testing.client.TestActorRequestFactory
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("`OtelTracerFactory` should")
+internal class OtelTracerFactorySpec {
+
+    private val requests = TestActorRequestFactory(OtelTracerFactorySpec::class.java)
+    private val spec = singleTenant(OtelTracerFactorySpec::class.java.name)
+    private lateinit var factory: OtelTracerFactory
+
+    @BeforeEach
+    fun setUp() {
+        val otel = recordingOpenTelemetry(RecordingSpanProcessor())
+        factory = OtelTracerFactory.newBuilder()
+            .setOpenTelemetry(otel)
+            .build()
+    }
+
+    @Test
+    fun `require an 'OpenTelemetry' instance`() {
+        shouldThrow<IllegalStateException> {
+            OtelTracerFactory.newBuilder().build()
+        }
+    }
+
+    @Test
+    fun `create an 'OtelTracer'`() {
+        val command = requests.command().create(scheduleFlight())
+        val tracer = factory.trace(spec, command)
+        tracer.shouldBeInstanceOf<OtelTracer>()
+    }
+
+    @Nested
+    @DisplayName("track its open state")
+    inner class OpenState {
+
+        @Test
+        fun `being open right after creation`() {
+            factory.isOpen shouldBe true
+        }
+
+        @Test
+        fun `being closed after 'close()'`() {
+            factory.close()
+            factory.isOpen shouldBe false
+        }
+    }
+}

--- a/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracerSpec.kt
+++ b/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracerSpec.kt
@@ -46,6 +46,7 @@ import io.spine.string.Stringifiers
 import io.spine.system.server.EntityTypeName
 import io.spine.system.server.entityTypeName
 import io.spine.testing.client.TestActorRequestFactory
+import io.spine.time.toNanos
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -103,8 +104,7 @@ internal class OtelTracerSpec {
 
         @Test
         fun `the signal timestamp as the start time`() {
-            val timestamp = command.timestamp()
-            span().startTimestamp shouldBe timestamp.seconds * NANOS_PER_SECOND + timestamp.nanos
+            span().startTimestamp shouldBe command.timestamp().toNanos()
         }
 
         @Test
@@ -162,7 +162,6 @@ internal class OtelTracerSpec {
     }
 
     private companion object {
-        const val NANOS_PER_SECOND = 1_000_000_000L
         const val FLIGHT_AGGREGATE_CLASS = "io.spine.server.trace.given.airport.FlightAggregate"
     }
 }

--- a/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracerSpec.kt
+++ b/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracerSpec.kt
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@file:OptIn(ExperimentalApi::class)
+@file:OptIn(ExperimentalApi::class, ExperimentalOtelTracing::class)
 
 package io.spine.server.trace.otel
 

--- a/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracerSpec.kt
+++ b/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracerSpec.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:OptIn(ExperimentalApi::class)
+
+package io.spine.server.trace.otel
+
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.maps.shouldContainKey
+import io.kotest.matchers.shouldBe
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.spine.base.Identifier
+import io.spine.core.Command
+import io.spine.core.Versions.zero
+import io.spine.core.messageId
+import io.spine.server.ContextSpec.singleTenant
+import io.spine.server.trace.given.TracingTestEnv.FLIGHT
+import io.spine.server.trace.given.TracingTestEnv.FLIGHT_TYPE
+import io.spine.server.trace.given.TracingTestEnv.scheduleFlight
+import io.spine.server.trace.otel.given.RecordingSpanProcessor
+import io.spine.server.trace.otel.given.recordingOpenTelemetry
+import io.spine.string.Stringifiers
+import io.spine.system.server.EntityTypeName
+import io.spine.system.server.entityTypeName
+import io.spine.testing.client.TestActorRequestFactory
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("`OtelTracer` should")
+internal class OtelTracerSpec {
+
+    private val requests = TestActorRequestFactory(OtelTracerSpec::class.java)
+    private val spec = singleTenant(OtelTracerSpec::class.java.name)
+
+    private lateinit var spans: RecordingSpanProcessor
+    private lateinit var factory: OtelTracerFactory
+    private lateinit var command: Command
+
+    @BeforeEach
+    fun setUp() {
+        spans = RecordingSpanProcessor()
+        factory = OtelTracerFactory.newBuilder()
+            .setOpenTelemetry(recordingOpenTelemetry(spans))
+            .build()
+        command = requests.command().create(scheduleFlight())
+    }
+
+    @Test
+    fun `record a span for each handling of a signal`() {
+        trace(command).use {
+            it.processedBy(flightReceiver(), flightType())
+        }
+        spans.spans shouldHaveSize 1
+    }
+
+    @Nested
+    @DisplayName("populate the recorded span with")
+    inner class SpanContent {
+
+        @BeforeEach
+        fun record() {
+            trace(command).use {
+                it.processedBy(flightReceiver(), flightType())
+            }
+        }
+
+        @Test
+        fun `the display name`() {
+            span().name shouldBe "FlightAggregate handles ScheduleFlight"
+        }
+
+        @Test
+        fun `the signal timestamp as the start time`() {
+            val timestamp = command.timestamp()
+            span().startTimestamp shouldBe timestamp.seconds * NANOS_PER_SECOND + timestamp.nanos
+        }
+
+        @Test
+        fun `a non-null end time at or after the start`() {
+            val span = span()
+            val end = span.endTimestamp
+            (end != null && end >= span.startTimestamp) shouldBe true
+        }
+
+        @Test
+        fun `the trace ID derived from the root signal`() {
+            span().spanContext.traceId shouldBe traceIdOf(command.id())
+        }
+
+        @Test
+        fun `the synthetic parent span ID`() {
+            span().parent.spanId shouldBe spanIdOf(command.id())
+        }
+
+        @Test
+        fun `the Spine attributes`() {
+            val attributes = span().attributes
+            attributes["spine.bounded_context"] shouldBe spec.name().value
+            attributes["spine.signal.id"] shouldBe command.id().value()
+            attributes["spine.signal.type"] shouldBe command.enclosedTypeUrl().value()
+            attributes["spine.entity.id"] shouldBe Stringifiers.toString(FLIGHT)
+            attributes["spine.entity.type"] shouldBe FLIGHT_TYPE.value()
+            attributes shouldContainKey "spine.tenant"
+        }
+    }
+
+    @Test
+    fun `group spans from the same signal under one trace`() {
+        trace(command).use {
+            it.processedBy(flightReceiver(), flightType())
+            it.processedBy(flightReceiver(), flightType())
+        }
+        val traceIds = spans.spans.map { it.spanContext.traceId }.distinct()
+        traceIds shouldHaveSize 1
+        traceIds.single() shouldBe traceIdOf(command.id())
+    }
+
+    private fun trace(command: Command) = factory.trace(spec, command)
+
+    private fun span() = spans.spans.single()
+
+    private fun flightReceiver() = messageId {
+        id = Identifier.pack(FLIGHT)
+        typeUrl = FLIGHT_TYPE.value()
+        version = zero()
+    }
+
+    private fun flightType(): EntityTypeName = entityTypeName {
+        javaClassName = FLIGHT_AGGREGATE_CLASS
+    }
+
+    private companion object {
+        const val NANOS_PER_SECOND = 1_000_000_000L
+        const val FLIGHT_AGGREGATE_CLASS = "io.spine.server.trace.given.airport.FlightAggregate"
+    }
+}

--- a/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracerSpec.kt
+++ b/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracerSpec.kt
@@ -64,9 +64,7 @@ internal class OtelTracerSpec {
     @BeforeEach
     fun setUp() {
         spans = RecordingSpanProcessor()
-        factory = OtelTracerFactory.newBuilder()
-            .setOpenTelemetry(recordingOpenTelemetry(spans))
-            .build()
+        factory = OtelTracerFactory(recordingOpenTelemetry(spans))
         command = requests.command().create(scheduleFlight())
     }
 
@@ -76,6 +74,15 @@ internal class OtelTracerSpec {
             it.processedBy(flightReceiver(), flightType())
         }
         spans.spans shouldHaveSize 1
+    }
+
+    @Test
+    fun `report the configured instrumentation scope`() {
+        val scope = "custom.tracer.scope"
+        OtelTracerFactory(recordingOpenTelemetry(spans), scope)
+            .trace(spec, command)
+            .use { it.processedBy(flightReceiver(), flightType()) }
+        span().instrumentationScopeInfo.name shouldBe scope
     }
 
     @Nested

--- a/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracingSpec.kt
+++ b/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracingSpec.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:OptIn(ExperimentalApi::class)
+
+package io.spine.server.trace.otel
+
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.spine.base.CommandMessage
+import io.spine.environment.Tests
+import io.spine.grpc.StreamObservers.noOpObserver
+import io.spine.server.BoundedContext
+import io.spine.server.ServerEnvironment
+import io.spine.server.trace.given.TracingTestEnv.scheduleFlight
+import io.spine.server.trace.given.airport.AirportContext
+import io.spine.server.trace.otel.given.RecordingSpanProcessor
+import io.spine.server.trace.otel.given.recordingOpenTelemetry
+import io.spine.testing.client.TestActorRequestFactory
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`OtelTracerFactory`, wired into a bounded context, should")
+internal class OtelTracingSpec {
+
+    private val requests = TestActorRequestFactory(OtelTracingSpec::class.java)
+
+    private lateinit var spans: RecordingSpanProcessor
+    private lateinit var context: BoundedContext
+
+    @BeforeEach
+    fun setUp() {
+        spans = RecordingSpanProcessor()
+        val factory = OtelTracerFactory.newBuilder()
+            .setOpenTelemetry(recordingOpenTelemetry(spans))
+            .build()
+        ServerEnvironment.`when`(Tests::class.java)
+            .use(factory)
+        context = AirportContext.builder().build()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        ServerEnvironment.instance().reset()
+    }
+
+    @Test
+    fun `record a span when a signal is handled`() {
+        post(scheduleFlight())
+
+        spans.spans.shouldNotBeEmpty()
+        spans.spans.map { it.name } shouldContain "FlightAggregate handles ScheduleFlight"
+    }
+
+    @Test
+    fun `group all spans of one causal chain under a single trace`() {
+        post(scheduleFlight())
+
+        val traceIds = spans.spans.map { it.spanContext.traceId }.distinct()
+        traceIds shouldHaveSize 1
+    }
+
+    private fun post(command: CommandMessage) {
+        val cmd = requests.command().create(command)
+        context.commandBus().post(cmd, noOpObserver())
+    }
+}

--- a/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracingSpec.kt
+++ b/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracingSpec.kt
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@file:OptIn(ExperimentalApi::class)
+@file:OptIn(ExperimentalApi::class, ExperimentalOtelTracing::class)
 
 package io.spine.server.trace.otel
 

--- a/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracingSpec.kt
+++ b/server-otel/src/test/kotlin/io/spine/server/trace/otel/OtelTracingSpec.kt
@@ -58,9 +58,7 @@ internal class OtelTracingSpec {
     @BeforeEach
     fun setUp() {
         spans = RecordingSpanProcessor()
-        val factory = OtelTracerFactory.newBuilder()
-            .setOpenTelemetry(recordingOpenTelemetry(spans))
-            .build()
+        val factory = OtelTracerFactory(recordingOpenTelemetry(spans))
         ServerEnvironment.`when`(Tests::class.java)
             .use(factory)
         context = AirportContext.builder().build()

--- a/server-otel/src/test/kotlin/io/spine/server/trace/otel/TraceIdsSpec.kt
+++ b/server-otel/src/test/kotlin/io/spine/server/trace/otel/TraceIdsSpec.kt
@@ -90,6 +90,19 @@ internal class TraceIdsSpec {
         }
     }
 
+    @Test
+    fun `guard canonical UUIDs whose halves are zero`() {
+        // The nil UUID is all-zero; the second has an all-zero lower half.
+        listOf(
+            "00000000-0000-0000-0000-000000000000",
+            "12345678-1234-1234-0000-000000000000",
+        ).forEach { value ->
+            val id = signalId(value)
+            traceIdOf(id) shouldNotBe "0".repeat(32)
+            spanIdOf(id) shouldNotBe "0".repeat(16)
+        }
+    }
+
     private fun signalId(value: String): SignalId = commandId { uuid = value }
 
     private companion object {

--- a/server-otel/src/test/kotlin/io/spine/server/trace/otel/TraceIdsSpec.kt
+++ b/server-otel/src/test/kotlin/io/spine/server/trace/otel/TraceIdsSpec.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.trace.otel
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldHaveLength
+import io.kotest.matchers.string.shouldMatch
+import io.spine.base.Identifier.newUuid
+import io.spine.core.SignalId
+import io.spine.core.commandId
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("Trace ID derivation should")
+internal class TraceIdsSpec {
+
+    @Test
+    fun `produce a 32-character hex trace ID`() {
+        val id = signalId(newUuid())
+        traceIdOf(id) shouldHaveLength 32
+        traceIdOf(id) shouldMatch HEX
+    }
+
+    @Test
+    fun `produce a 16-character hex span ID`() {
+        val id = signalId(newUuid())
+        spanIdOf(id) shouldHaveLength 16
+        spanIdOf(id) shouldMatch HEX
+    }
+
+    @Test
+    fun `be deterministic for the same root signal ID`() {
+        val id = signalId(newUuid())
+        traceIdOf(id) shouldBe traceIdOf(signalId(id.value()))
+        spanIdOf(id) shouldBe spanIdOf(signalId(id.value()))
+    }
+
+    @Test
+    fun `produce different trace IDs for different root signals`() {
+        traceIdOf(signalId(newUuid())) shouldNotBe traceIdOf(signalId(newUuid()))
+    }
+
+    @Test
+    fun `zero-pad each half of the UUID to 16 hex characters`() {
+        val id = signalId("00000000-0000-0001-0000-000000000001")
+        traceIdOf(id) shouldBe "00000000000000010000000000000001"
+        spanIdOf(id) shouldBe "0000000000000001"
+    }
+
+    @Test
+    fun `derive a stable trace ID even when the signal ID is not a UUID`() {
+        val id = signalId("not-a-uuid")
+        traceIdOf(id) shouldHaveLength 32
+        traceIdOf(id) shouldMatch HEX
+        traceIdOf(id) shouldBe traceIdOf(signalId("not-a-uuid"))
+    }
+
+    private fun signalId(value: String): SignalId = commandId { uuid = value }
+
+    private companion object {
+        val HEX = Regex("[0-9a-f]+")
+    }
+}

--- a/server-otel/src/test/kotlin/io/spine/server/trace/otel/TraceIdsSpec.kt
+++ b/server-otel/src/test/kotlin/io/spine/server/trace/otel/TraceIdsSpec.kt
@@ -80,6 +80,16 @@ internal class TraceIdsSpec {
         traceIdOf(id) shouldBe traceIdOf(signalId("not-a-uuid"))
     }
 
+    @Test
+    fun `produce valid non-zero IDs for inputs that would otherwise fold to zero`() {
+        // `"0".repeat(32)` folds to all-zero bytes; `"ab"` leaves the lower half zero.
+        listOf("0".repeat(32), "ab").forEach { value ->
+            val id = signalId(value)
+            traceIdOf(id) shouldNotBe "0".repeat(32)
+            spanIdOf(id) shouldNotBe "0".repeat(16)
+        }
+    }
+
     private fun signalId(value: String): SignalId = commandId { uuid = value }
 
     private companion object {

--- a/server-otel/src/test/kotlin/io/spine/server/trace/otel/given/RecordingSpanProcessor.kt
+++ b/server-otel/src/test/kotlin/io/spine/server/trace/otel/given/RecordingSpanProcessor.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:OptIn(ExperimentalApi::class)
+
+package io.spine.server.trace.otel.given
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.tracing.data.SpanData
+import io.opentelemetry.kotlin.tracing.export.SpanProcessor
+import io.opentelemetry.kotlin.tracing.model.ReadWriteSpan
+import io.opentelemetry.kotlin.tracing.model.ReadableSpan
+import java.util.Collections.synchronizedList
+
+/**
+ * A [SpanProcessor] that records every ended span in memory, for assertions in tests.
+ */
+class RecordingSpanProcessor : SpanProcessor {
+
+    private val recorded: MutableList<SpanData> = synchronizedList(mutableListOf())
+
+    /**
+     * An immutable snapshot of the spans recorded so far.
+     */
+    val spans: List<SpanData>
+        get() = synchronized(recorded) { recorded.toList() }
+
+    override fun onStart(span: ReadWriteSpan, parentContext: Context): Unit = Unit
+
+    override fun onEnding(span: ReadWriteSpan): Unit = Unit
+
+    override fun onEnd(span: ReadableSpan) {
+        recorded.add(span.toSpanData())
+    }
+
+    override fun isStartRequired(): Boolean = false
+
+    override fun isEndRequired(): Boolean = true
+
+    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+
+    override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+}

--- a/server-otel/src/test/kotlin/io/spine/server/trace/otel/given/TestOtel.kt
+++ b/server-otel/src/test/kotlin/io/spine/server/trace/otel/given/TestOtel.kt
@@ -24,21 +24,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-pluginManagement {
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
+@file:OptIn(ExperimentalApi::class)
+
+package io.spine.server.trace.otel.given
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.createOpenTelemetry
+
+/**
+ * Builds an [OpenTelemetry] SDK instance that records every ended span into the
+ * given [processor].
+ */
+fun recordingOpenTelemetry(processor: RecordingSpanProcessor): OpenTelemetry =
+    createOpenTelemetry {
+        tracerProvider {
+            export { processor }
+        }
     }
-}
-
-rootProject.name = "core-jvm"
-
-include(
-    "core",
-    "core-testlib",
-    "client",
-    "client-testlib",
-    "server",
-    "server-testlib",
-    "server-otel",
-)

--- a/server/src/test/java/io/spine/server/aggregate/model/AggregatePartClassTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/model/AggregatePartClassTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.server.aggregate.model.AggregatePartClass.asAggregatePartClass;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -47,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class AggregatePartClassTest {
 
     private final AggregatePartClass<AnAggregatePart> partClass =
-            asAggregatePartClass(AnAggregatePart.class);
+            AggregatePartClass.asAggregatePartClass(AnAggregatePart.class);
     private AnAggregateRoot root;
 
     @BeforeEach
@@ -67,7 +66,7 @@ class AggregatePartClassTest {
     @Test
     @DisplayName("throw exception when aggregate part does not have appropriate constructor")
     void throwOnNoProperCtorAvailable() {
-        var wrongPartClass = asAggregatePartClass(WrongAggregatePart.class);
+        var wrongPartClass = AggregatePartClass.asAggregatePartClass(WrongAggregatePart.class);
         assertThrows(ModelError.class, wrongPartClass::constructor);
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,7 +31,7 @@ pluginManagement {
     }
 }
 
-rootProject.name = "spine-core-jvm"
+rootProject.name = "core-jvm"
 
 include(
     "core",

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.dependency.local.Spine].
  */
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.380")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.381")


### PR DESCRIPTION
## What

Adds a new **`server-otel`** module — a backend-agnostic implementation of the Spine Trace API (`io.spine.server.trace`) on top of the **Kotlin OpenTelemetry API** (`io.opentelemetry.kotlin`). It records the handling of each signal by an entity as an OpenTelemetry span and groups all signals of one causal chain under a single trace.

## Why

This is the OpenTelemetry-based successor to the Google-Cloud-specific `stackdriver-trace` module (in `gcloud-jvm`). Google itself now recommends OpenTelemetry over Stackdriver. Since OpenTelemetry API is  **backend-agnostic**, this module is too: it maps Spine signals onto spans and leaves export to a caller-supplied `OpenTelemetry` instance (OTLP collector, Google Cloud Trace exporter, Jaeger, …).

## Highlights

- `OtelTracerFactory(openTelemetry, instrumentationScopeName = …)` — a Kotlin constructor wired in via `ServerEnvironment.when(…).use(…)`. The caller owns the `OpenTelemetry` lifecycle.
- One span per handler invocation: start = signal timestamp, end = now, name `"<Receiver> handles <Signal>"`, with six `spine.*` attributes.
- Deterministic trace grouping: all signals sharing a root signal ID share one trace (via a sampled synthetic parent `SpanContext`).
- Written **Kotlin-first** (uses `kotlin.uuid.Uuid`, no `java.util.UUID`) with an eventual KMP move in mind.
- Each handling is its own span, **not** a span event — OpenTelemetry deprecated the Span Events API (March 2026) in favor of log-based events.

## Experimental status

The public API is marked experimental twice: the `@ExperimentalOtelTracing` Kotlin opt-in marker (`@RequiresOptIn`, ERROR) and Spine's `@io.spine.annotation.Experimental`, reflecting the alpha status of the underlying Kotlin OpenTelemetry API. See `server-otel/README.md`.

## Testing

`:server-otel:build` (21 tests, including an end-to-end trace-grouping test over the `Airport` sample context), `detekt`, and `dokkaGenerate` all pass.

## Follow-ups (separate)

- Retire `stackdriver-trace` in `gcloud-jvm` once this is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
