### PR TITLE
Retry delivery on `IncompleteHistoryException` after a back-off (#838 follow-up)

### DIFF
--- a/.agents/tasks/838-incomplete-history-retry.md
+++ b/.agents/tasks/838-incomplete-history-retry.md
@@ -1,0 +1,83 @@
+# Task: #838 follow-up — retry delivery on `IncompleteHistoryException`
+
+Status: **implemented & tested** on branch `claude/determined-cerf-ecbbd6`.
+Delete this file on merge to master.
+
+Issue: https://github.com/SpineEventEngine/core-jvm/issues/838
+
+## Context
+
+The #838 fix (merged here from `claude/trusting-bardeen-56899a`) makes an incomplete,
+eventually-consistent aggregate-history read throw `IncompleteHistoryException` from
+`AggregateStorage.read` instead of persisting a corrupted snapshot. But the delivery layer
+then **drops the signal**: `DeliveryMonitor.onReceptionFailure` defaults to `markDelivered()`,
+so the message is never retried. The only existing retry hook,
+`FailedReception.repeatDispatching()`, retries **immediately and synchronously**, which cannot
+let eventual consistency settle and can spin.
+
+This task adds an **opt-in** way to retry such a signal after a **backing-off delay**, without
+blocking the single-threaded-per-shard delivery. Default behavior stays "drain" (decided with
+the maintainer; see also the #1472 task notes).
+
+## What changed
+
+### Delivery core — make `onReceptionFailure` authoritative (the #1472 "Option B" clobber)
+
+`LiveDeliveryStation.process()` used to mark **every** dispatched message `DELIVERED`
+*after* the monitor already acted, so a monitor could never leave a message for a later retry.
+
+- `Conveyor` — new `keepForRedelivery(InboxMessage)` / `isKeptForRetry(InboxMessageId)`; a
+  deferred message keeps its `TO_DELIVER` status (no storage write needed).
+- `LiveDeliveryStation.process()` — marks delivered only the messages **not** kept for retry;
+  the delivered count reflects that. Non-retry path is unchanged (`delivered == toDispatch`),
+  so `ReceptionFailureTest` and the rest of the delivery suite stay green. `MonitoringDispatcher`
+  and `CatchUpStation` are untouched.
+- `FailedReception.keepForRedelivery()` — new SPI action leaving the message `TO_DELIVER`.
+- `DeliveryMonitor.shouldDeliverNow(InboxMessage)` — new default-`true` SPI predicate.
+- `Delivery.deliverMessagesFrom()` — gates the end-of-run self re-trigger through
+  `shouldDeliverNow`, so a deferred message does not hot-loop while it waits out its back-off.
+
+### The opt-in monitor
+
+- `io.spine.server.aggregate.IncompleteHistoryRetryMonitor` — recognizes
+  `IncompleteHistoryException` via `error.getType()`; keeps the message for redelivery and
+  schedules `Delivery.deliverMessagesFrom(index)` on a daemon `ScheduledExecutorService` after
+  an exponential, capped back-off; drains after a configurable max attempts; overrides
+  `shouldDeliverNow` to avoid spinning. Per-message state is a bounded Guava `Cache`; the monitor
+  is `AutoCloseable`. Overridable `isRetryable(Error)` for other transient failures.
+- `IncompleteHistoryException` Javadoc now points at the monitor as the built-in recovery.
+
+## Tests
+
+- `io.spine.server.aggregate.IncompleteHistoryRetryMonitorSpec` (Kotlin) — the default monitor
+  recognizes the real `IncompleteHistoryException` type (and rejects others, incl. its
+  superclass); exponential back-off grows and caps. Deterministic (injected clock/scheduler).
+- `io.spine.server.delivery.IncompleteHistoryRetryTest` (Java, `@SlowTest`) — end-to-end through
+  the real delivery pipeline: retries until the storage settles then handles the signal; gives up
+  and drains after max attempts; does not block another entity in the same shard; ignores an
+  unrelated (non-retryable) failure. Uses a `TransientFailure` stand-in thrown by
+  `ReceptionistAggregate` (extended additively with per-id failure control + an applier-invocation
+  counter); the real-type recognition is covered by the spec above.
+- Regression: `./gradlew :server:test --tests "io.spine.server.delivery.*" --tests
+  "io.spine.server.aggregate.*"` — 348 tests, 0 failures.
+
+## Notes / follow-ups
+
+- The mechanism simulates the failure in tests because in-memory storage is strongly consistent;
+  it engages against real reads via the #838 throw once that ships.
+- Back-off/attempt state is in-memory, per node — sufficient for eventual-consistency recovery
+  (any node re-reading after the data settles succeeds; back-off just paces one node). A
+  persistent, restart-safe variant (an `inbox.proto` `deliver_after` + attempt count and a
+  time-gated redelivery station) is a possible future enhancement.
+- One new `@SPI` method (`DeliveryMonitor.shouldDeliverNow`, default `true`) —
+  backward compatible.
+- **Catch-up scope (by design):** only `LiveDeliveryStation` honors `keepForRedelivery`;
+  `CatchUpStation` marks its messages delivered regardless. This is intentional — catch-up is
+  projection-only, so an aggregate `IncompleteHistoryException` does not arise on that path, and
+  deferring a `TO_CATCH_UP` message would interfere with the catch-up state machine. Documented on
+  `FailedReception.keepForRedelivery()` and the monitor. If a future transient failure needs retry
+  during catch-up, mirror the `isKeptForRetry` filter into `CatchUpStation.dispatch`.
+- **Monitor lifecycle:** `IncompleteHistoryRetryMonitor` is `AutoCloseable`, but the framework
+  never calls `close()`. Its scheduler is a daemon `ScheduledThreadPoolExecutor` with
+  `allowCoreThreadTimeOut(true)` (1-min keep-alive), so a monitor discarded without `close()`
+  releases its thread when idle rather than leaking it. Documented on the class.

--- a/server/src/main/java/io/spine/server/aggregate/IncompleteHistoryException.java
+++ b/server/src/main/java/io/spine/server/aggregate/IncompleteHistoryException.java
@@ -49,11 +49,14 @@ import static java.lang.String.format;
  *
  * <p>The condition is normally <b>transient</b>: retrying the operation once the storage
  * reaches consistency reads the full history and succeeds. The framework does not retry
- * automatically; a {@link io.spine.server.delivery.DeliveryMonitor DeliveryMonitor} may
- * {@linkplain io.spine.server.delivery.FailedReception#repeatDispatching() repeat the
- * dispatching} of the affected signal to recover.
+ * automatically by default. Install an {@link IncompleteHistoryRetryMonitor} to have the
+ * affected signal re-delivered after a back-off delay, or handle the failure with a custom
+ * {@link io.spine.server.delivery.DeliveryMonitor DeliveryMonitor} — for example, by
+ * {@linkplain io.spine.server.delivery.FailedReception#repeatDispatching() re-dispatching the
+ * signal immediately}.
  *
  * @see HistoryCompleteness
+ * @see IncompleteHistoryRetryMonitor
  */
 public final class IncompleteHistoryException extends IllegalStateException {
 

--- a/server/src/main/java/io/spine/server/aggregate/IncompleteHistoryRetryMonitor.java
+++ b/server/src/main/java/io/spine/server/aggregate/IncompleteHistoryRetryMonitor.java
@@ -40,6 +40,7 @@ import io.spine.server.delivery.ShardIndex;
 import io.spine.server.tenant.TenantAwareRunner;
 
 import java.time.Duration;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
@@ -152,6 +153,9 @@ public class IncompleteHistoryRetryMonitor extends DeliveryMonitor
         this.maxAttempts = builder.maxAttempts;
         this.initialDelayMillis = builder.initialDelay.toMillis();
         this.maxDelayMillis = builder.maxDelay.toMillis();
+        checkArgument(maxDelayMillis >= initialDelayMillis,
+                      "`maxDelay` (%sms) must not be smaller than `initialDelay` (%sms).",
+                      maxDelayMillis, initialDelayMillis);
         this.multiplier = builder.multiplier;
         this.scheduler = checkNotNull(scheduler);
         this.clock = checkNotNull(clock);
@@ -189,8 +193,11 @@ public class IncompleteHistoryRetryMonitor extends DeliveryMonitor
                             + "incomplete history; marking the message as delivered.");
             return reception.markDelivered();
         }
-        if (decision.scheduleDelayMillis >= 0) {
-            scheduleRetry(message, decision.scheduleDelayMillis);
+        if (decision.scheduleDelayMillis >= 0
+                && !scheduleRetry(message, decision.scheduleDelayMillis)) {
+            // The scheduler is unavailable (e.g. the monitor was closed); drain the message
+            // instead of leaving it in `TO_DELIVER` with no pending retry.
+            return reception.markDelivered();
         }
         return reception.keepForRedelivery();
     }
@@ -238,11 +245,27 @@ public class IncompleteHistoryRetryMonitor extends DeliveryMonitor
                                                .equals(error.getType());
     }
 
-    private void scheduleRetry(InboxMessage message, long delayMillis) {
+    /**
+     * Schedules the redelivery of the message's shard after the given delay.
+     *
+     * @return {@code true} if the retry was scheduled, {@code false} if the scheduler rejected it
+     *         (for example, because the monitor has been {@linkplain #close() closed})
+     */
+    private boolean scheduleRetry(InboxMessage message, long delayMillis) {
         var index = message.shardIndex();
         var tenant = message.tenant();
-        @SuppressWarnings("FutureReturnValueIgnored") // Fire-and-forget; failures are logged.
-        var unused = scheduler.schedule(() -> redeliver(index, tenant), delayMillis, MILLISECONDS);
+        try {
+            @SuppressWarnings("FutureReturnValueIgnored") // Fire-and-forget; failures are logged.
+            var unused =
+                    scheduler.schedule(() -> redeliver(index, tenant), delayMillis, MILLISECONDS);
+            return true;
+        } catch (RejectedExecutionException e) {
+            logger().atDebug()
+                    .withCause(e)
+                    .log(() -> "The retry scheduler is unavailable; draining message `"
+                            + message.getId().getUuid() + "`.");
+            return false;
+        }
     }
 
     @SuppressWarnings("OverlyBroadCatchBlock") // A scheduler task must not die on any failure.
@@ -381,10 +404,13 @@ public class IncompleteHistoryRetryMonitor extends DeliveryMonitor
 
         /**
          * Builds a new monitor with the configured settings.
+         *
+         * @throws IllegalArgumentException
+         *         if {@code maxDelay} is smaller than {@code initialDelay} (also enforced by the
+         *         {@linkplain IncompleteHistoryRetryMonitor#IncompleteHistoryRetryMonitor(Builder)
+         *         constructor})
          */
         public IncompleteHistoryRetryMonitor build() {
-            checkArgument(maxDelay.compareTo(initialDelay) >= 0,
-                          "`maxDelay` must not be smaller than `initialDelay`.");
             return new IncompleteHistoryRetryMonitor(this);
         }
     }

--- a/server/src/main/java/io/spine/server/aggregate/IncompleteHistoryRetryMonitor.java
+++ b/server/src/main/java/io/spine/server/aggregate/IncompleteHistoryRetryMonitor.java
@@ -1,0 +1,391 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.aggregate;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import io.spine.base.Error;
+import io.spine.core.TenantId;
+import io.spine.logging.WithLogging;
+import io.spine.server.ServerEnvironment;
+import io.spine.server.delivery.DeliveryMonitor;
+import io.spine.server.delivery.FailedReception;
+import io.spine.server.delivery.InboxMessage;
+import io.spine.server.delivery.InboxMessageId;
+import io.spine.server.delivery.ShardIndex;
+import io.spine.server.tenant.TenantAwareRunner;
+
+import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.function.LongSupplier;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+/**
+ * A {@link DeliveryMonitor} that retries the delivery of a signal whose reception failed with
+ * an {@link IncompleteHistoryException}, once the storage has likely reached consistency.
+ *
+ * <p>An {@code IncompleteHistoryException} signals a <em>transient</em> failure to load an
+ * aggregate: an eventually-consistent storage temporarily returned fewer events than the
+ * aggregate's authoritative version implies. Retrying the same read after a short delay normally
+ * succeeds. This monitor recognizes such a failure by its {@linkplain Error#getType() error type}
+ * and, instead of {@linkplain FailedReception#markDelivered() draining} the message (the default
+ * behavior) or {@linkplain FailedReception#repeatDispatching() re-dispatching it immediately}
+ * (which does not let consistency settle and may spin), it
+ * {@linkplain FailedReception#keepForRedelivery() keeps} the message and schedules a redelivery of
+ * the shard after an exponentially growing back-off delay.
+ *
+ * <h2>Non-blocking</h2>
+ *
+ * <p>The delivery of a shard is single-threaded, so this monitor never sleeps on the delivery
+ * thread. The back-off wait happens on a separate daemon {@link ScheduledExecutorService}, which
+ * triggers {@link io.spine.server.delivery.Delivery#deliverMessagesFrom(ShardIndex)
+ * Delivery.deliverMessagesFrom(index)} once the delay elapses. While a message is within its
+ * back-off window, {@link #shouldDeliverNow(InboxMessage)} returns {@code false}, so the
+ * framework's own immediate end-of-run re-trigger does not spin on a read that is expected to keep
+ * failing until the storage settles.
+ *
+ * <h2>Giving up</h2>
+ *
+ * <p>After {@linkplain Builder#maxAttempts(int) a configurable number of attempts} the message is
+ * {@linkplain FailedReception#markDelivered() drained} (marked delivered), so a permanently failing
+ * signal does not stay in the inbox forever.
+ *
+ * <h2>Scope of the retry state</h2>
+ *
+ * <p>The per-message attempt counters and back-off timers are held in memory, on the node that
+ * observed the failure. This is sufficient for recovering from eventual consistency: any node that
+ * re-attempts the read after the data has settled succeeds; the back-off merely paces the retries
+ * on a single node. The state does not survive a node restart and is not shared across nodes.
+ *
+ * <p>This monitor is <em>opt-in</em>: install it via
+ * {@link io.spine.server.delivery.DeliveryBuilder#setMonitor(DeliveryMonitor)
+ * DeliveryBuilder.setMonitor(...)}. Subclasses may override {@link #isRetryable(Error)} to react to
+ * additional transient failures. The deferral is honored by the live delivery; a signal dispatched
+ * during a projection {@linkplain io.spine.server.delivery.CatchUpProcess catch-up} is delivered
+ * regardless (an aggregate-loading failure does not arise on that path).
+ *
+ * <h2>Lifecycle</h2>
+ *
+ * <p>The monitor owns a daemon scheduler thread. The framework does <em>not</em> call
+ * {@link #close()}, so a caller that replaces an installed monitor should {@code close()} the
+ * previous instance. Even if it does not, the scheduler thread is a daemon and
+ * {@linkplain java.util.concurrent.ThreadPoolExecutor#allowCoreThreadTimeOut(boolean) times out}
+ * when idle, so an abandoned monitor neither leaks its thread nor blocks JVM shutdown.
+ *
+ * @see IncompleteHistoryException
+ */
+public class IncompleteHistoryRetryMonitor extends DeliveryMonitor
+        implements WithLogging, AutoCloseable {
+
+    /** The default maximum number of delivery attempts before the message is drained. */
+    public static final int DEFAULT_MAX_ATTEMPTS = 6;
+
+    /** The default delay before the first retry. */
+    public static final Duration DEFAULT_INITIAL_DELAY = Duration.ofMillis(100);
+
+    /** The default cap on the back-off delay. */
+    public static final Duration DEFAULT_MAX_DELAY = Duration.ofSeconds(2);
+
+    /** The default multiplier applied to the delay after each attempt. */
+    public static final double DEFAULT_MULTIPLIER = 2.0;
+
+    private final int maxAttempts;
+    private final long initialDelayMillis;
+    private final long maxDelayMillis;
+    private final double multiplier;
+
+    private final Cache<InboxMessageId, Attempt> attempts;
+    private final ScheduledExecutorService scheduler;
+    private final LongSupplier clock;
+
+    /**
+     * Creates a monitor with the {@linkplain Builder default settings}.
+     */
+    public IncompleteHistoryRetryMonitor() {
+        this(newBuilder());
+    }
+
+    /**
+     * Creates a monitor with the settings from the passed builder.
+     */
+    public IncompleteHistoryRetryMonitor(Builder builder) {
+        this(builder, defaultScheduler(), System::currentTimeMillis);
+    }
+
+    /**
+     * A test seam allowing to inject the scheduler and the clock.
+     */
+    IncompleteHistoryRetryMonitor(Builder builder,
+                                  ScheduledExecutorService scheduler,
+                                  LongSupplier clock) {
+        super();
+        this.maxAttempts = builder.maxAttempts;
+        this.initialDelayMillis = builder.initialDelay.toMillis();
+        this.maxDelayMillis = builder.maxDelay.toMillis();
+        this.multiplier = builder.multiplier;
+        this.scheduler = checkNotNull(scheduler);
+        this.clock = checkNotNull(clock);
+        // Keep an entry alive well past a full retry sequence; it is rewritten on every attempt,
+        // and, on a success (which is not reported to the monitor), expires on its own.
+        var expiryMillis = Math.max(60_000L, maxDelayMillis * (maxAttempts + 2L));
+        this.attempts = CacheBuilder.newBuilder()
+                                    .expireAfterWrite(Duration.ofMillis(expiryMillis))
+                                    .build();
+    }
+
+    /**
+     * If the reception failed with a {@linkplain #isRetryable(Error) retryable} error, keeps the
+     * message for a delayed redelivery and schedules the redelivery of its shard.
+     *
+     * <p>Otherwise, falls back to the
+     * {@linkplain DeliveryMonitor#onReceptionFailure(FailedReception) default} behavior.
+     *
+     * <p>Once the configured number of attempts is exhausted, the message is drained (marked
+     * delivered) to avoid keeping a permanently failing signal in the inbox.
+     */
+    @Override
+    public FailedReception.Action onReceptionFailure(FailedReception reception) {
+        if (!isRetryable(reception.error())) {
+            return super.onReceptionFailure(reception);
+        }
+        var message = reception.message();
+        var decision = new Decision();
+        attempts.asMap()
+                .compute(message.getId(), (id, existing) -> next(existing, decision));
+        if (decision.giveUp) {
+            logger().atDebug().log(() ->
+                    "Giving up the delivery of `" + message.getId().getUuid()
+                            + "` after " + maxAttempts + " attempts to load an aggregate with "
+                            + "incomplete history; marking the message as delivered.");
+            return reception.markDelivered();
+        }
+        if (decision.scheduleDelayMillis >= 0) {
+            scheduleRetry(message, decision.scheduleDelayMillis);
+        }
+        return reception.keepForRedelivery();
+    }
+
+    /**
+     * Computes the next attempt state, recording the decision to make into the passed holder.
+     *
+     * @return the updated attempt state, or {@code null} to remove it (when giving up)
+     */
+    private Attempt next(Attempt existing, Decision decision) {
+        var now = clock.getAsLong();
+        if (existing != null && now < existing.nextAttemptMillis()) {
+            // A due retry is already scheduled; this is an earlier re-attempt, e.g. caused by
+            // another message arriving to the shard. Keep the message without rescheduling.
+            return existing;
+        }
+        var thisFailure = existing == null ? 1 : existing.failures() + 1;
+        if (thisFailure >= maxAttempts) {
+            decision.giveUp = true;
+            return null;
+        }
+        var delay = backoffMillis(thisFailure);
+        decision.scheduleDelayMillis = delay;
+        return new Attempt(thisFailure, now + delay);
+    }
+
+    /**
+     * Tells the {@code Delivery} not to immediately re-run a shard whose only pending message is
+     * one currently waiting out its retry back-off.
+     */
+    @Override
+    public boolean shouldDeliverNow(InboxMessage message) {
+        var attempt = attempts.getIfPresent(message.getId());
+        return attempt == null || clock.getAsLong() >= attempt.nextAttemptMillis();
+    }
+
+    /**
+     * Tells whether the reception should be retried in response to the passed error.
+     *
+     * <p>By default, matches an {@link IncompleteHistoryException}. Override to recognize other
+     * transient failures.
+     */
+    protected boolean isRetryable(Error error) {
+        return IncompleteHistoryException.class.getCanonicalName()
+                                               .equals(error.getType());
+    }
+
+    private void scheduleRetry(InboxMessage message, long delayMillis) {
+        var index = message.shardIndex();
+        var tenant = message.tenant();
+        @SuppressWarnings("FutureReturnValueIgnored") // Fire-and-forget; failures are logged.
+        var unused = scheduler.schedule(() -> redeliver(index, tenant), delayMillis, MILLISECONDS);
+    }
+
+    @SuppressWarnings("OverlyBroadCatchBlock") // A scheduler task must not die on any failure.
+    private void redeliver(ShardIndex index, TenantId tenant) {
+        try {
+            // Re-resolve the delivery from the environment (as the framework's own re-triggers do),
+            // assuming it is the same delivery on which this monitor is installed.
+            var delivery = ServerEnvironment.instance()
+                                            .delivery();
+            TenantAwareRunner.with(tenant)
+                             .run(() -> delivery.deliverMessagesFrom(index));
+        } catch (Exception e) {
+            logger().atError()
+                    .withCause(e)
+                    .log(() -> "Failed to re-deliver the shard `" + index.getIndex()
+                            + "` for an incomplete-history retry.");
+        }
+    }
+
+    @SuppressWarnings("WeakerAccess") // Package-private for testing the back-off schedule.
+    long backoffMillis(int failure) {
+        var delay = initialDelayMillis * Math.pow(multiplier, failure - 1.0);
+        var capped = Math.min(delay, (double) maxDelayMillis);
+        return (long) capped;
+    }
+
+    /**
+     * Shuts down the scheduler used for the delayed retries.
+     *
+     * <p>The framework does not call this method; a caller that discards the monitor may call it to
+     * release the scheduler thread eagerly instead of waiting for its idle time-out.
+     */
+    @Override
+    public void close() {
+        scheduler.shutdownNow();
+    }
+
+    /**
+     * Creates a new builder for the monitor.
+     */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    private static ScheduledExecutorService defaultScheduler() {
+        ThreadFactory factory = runnable -> {
+            var thread = new Thread(runnable, "incomplete-history-retry");
+            thread.setDaemon(true);
+            return thread;
+        };
+        var executor = new ScheduledThreadPoolExecutor(1, factory);
+        // Release the worker thread when idle, so a monitor discarded without being closed
+        // (the framework does not call `close()`) does not keep a thread alive indefinitely.
+        executor.setKeepAliveTime(1, MINUTES);
+        executor.allowCoreThreadTimeOut(true);
+        return executor;
+    }
+
+    /**
+     * The state of the retries for a single {@code InboxMessage}.
+     *
+     * @param failures
+     *         the number of times the delivery of the message has failed so far
+     * @param nextAttemptMillis
+     *         the wall-clock time (in milliseconds) at which the next attempt is due
+     */
+    private record Attempt(int failures, long nextAttemptMillis) {
+    }
+
+    /**
+     * A mutable holder for the outcome of an atomic state transition.
+     */
+    private static final class Decision {
+
+        private boolean giveUp;
+        private long scheduleDelayMillis = -1;
+    }
+
+    /**
+     * A builder for {@link IncompleteHistoryRetryMonitor}.
+     */
+    public static final class Builder {
+
+        private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
+        private Duration initialDelay = DEFAULT_INITIAL_DELAY;
+        private Duration maxDelay = DEFAULT_MAX_DELAY;
+        private double multiplier = DEFAULT_MULTIPLIER;
+
+        private Builder() {
+        }
+
+        /**
+         * Sets the maximum number of delivery attempts before the message is drained.
+         *
+         * <p>Must be at least {@code 1}. A value of {@code 1} drains on the first failure
+         * (i.e. no retry).
+         */
+        public Builder maxAttempts(int maxAttempts) {
+            checkArgument(maxAttempts >= 1, "`maxAttempts` must be positive.");
+            this.maxAttempts = maxAttempts;
+            return this;
+        }
+
+        /**
+         * Sets the delay before the first retry.
+         */
+        public Builder initialDelay(Duration initialDelay) {
+            checkNotNull(initialDelay);
+            checkArgument(!initialDelay.isNegative() && !initialDelay.isZero(),
+                          "`initialDelay` must be positive.");
+            this.initialDelay = initialDelay;
+            return this;
+        }
+
+        /**
+         * Sets the cap on the back-off delay.
+         */
+        public Builder maxDelay(Duration maxDelay) {
+            checkNotNull(maxDelay);
+            checkArgument(!maxDelay.isNegative() && !maxDelay.isZero(),
+                          "`maxDelay` must be positive.");
+            this.maxDelay = maxDelay;
+            return this;
+        }
+
+        /**
+         * Sets the multiplier applied to the delay after each attempt.
+         *
+         * <p>Must be at least {@code 1.0}.
+         */
+        public Builder multiplier(double multiplier) {
+            checkArgument(multiplier >= 1.0, "`multiplier` must be at least 1.0.");
+            this.multiplier = multiplier;
+            return this;
+        }
+
+        /**
+         * Builds a new monitor with the configured settings.
+         */
+        public IncompleteHistoryRetryMonitor build() {
+            checkArgument(maxDelay.compareTo(initialDelay) >= 0,
+                          "`maxDelay` must not be smaller than `initialDelay`.");
+            return new IncompleteHistoryRetryMonitor(this);
+        }
+    }
+}

--- a/server/src/main/java/io/spine/server/delivery/Conveyor.java
+++ b/server/src/main/java/io/spine/server/delivery/Conveyor.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -64,6 +64,7 @@ final class Conveyor implements Iterable<InboxMessage> {
     private final Set<InboxMessageId> dirtyMessages = new HashSet<>();
     private final Set<InboxMessage> removals = new HashSet<>();
     private final Set<InboxMessage> duplicates = new HashSet<>();
+    private final Set<InboxMessageId> keptForRetry = new HashSet<>();
 
     /**
      * Creates an instance of conveyor with the messages to process and the cache of the previously
@@ -110,6 +111,27 @@ final class Conveyor implements Iterable<InboxMessage> {
         for (var message : messages) {
             markDelivered(message);
         }
+    }
+
+    /**
+     * Keeps the passed message in its {@code Inbox} in the
+     * {@link InboxMessageStatus#TO_DELIVER TO_DELIVER} status for a later redelivery attempt.
+     *
+     * <p>Unlike {@link #markDelivered(InboxMessage)}, this neither changes the message status
+     * nor records it as delivered, so the message is read again on a subsequent delivery run.
+     * It is used by a {@link DeliveryMonitor} that defers a failed reception for a timed retry
+     * instead of draining it.
+     */
+    void keepForRedelivery(InboxMessage message) {
+        keptForRetry.add(message.getId());
+    }
+
+    /**
+     * Tells whether the message with the passed identifier was
+     * {@linkplain #keepForRedelivery(InboxMessage) kept for redelivery} within this conveyor.
+     */
+    boolean isKeptForRetry(InboxMessageId id) {
+        return keptForRetry.contains(id);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/delivery/Delivery.java
+++ b/server/src/main/java/io/spine/server/delivery/Delivery.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -485,7 +485,8 @@ public final class Delivery implements WithLogging {
         var stats = new DeliveryStats(index, totalDelivered);
         monitor.onDeliveryCompleted(stats);
         var lateMessage = inboxStorage.newestMessageToDeliver(index);
-        lateMessage.ifPresent(this::onNewMessage);
+        lateMessage.filter(monitor::shouldDeliverNow)
+                   .ifPresent(this::onNewMessage);
 
         return Optional.of(stats);
     }

--- a/server/src/main/java/io/spine/server/delivery/DeliveryMonitor.java
+++ b/server/src/main/java/io/spine/server/delivery/DeliveryMonitor.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -118,6 +118,32 @@ public class DeliveryMonitor {
     @SuppressWarnings("WeakerAccess" /* Part of public API. */)
     public FailedReception.Action onReceptionFailure(FailedReception reception) {
         return reception.markDelivered();
+    }
+
+    /**
+     * Tells whether the shard should be re-delivered immediately because the given message
+     * is still pending delivery.
+     *
+     * <p>After a delivery run for a shard completes, if the shard still holds a message in
+     * {@link InboxMessageStatus#TO_DELIVER TO_DELIVER} status, the framework triggers another
+     * delivery run for that shard right away. A monitor that
+     * {@linkplain FailedReception#keepForRedelivery() defers} a failed message for a
+     * <em>timed</em> retry should return {@code false} while that message is within its
+     * back-off window, so the immediate re-trigger does not spin on a message whose read is
+     * expected to keep failing until the storage reaches consistency. Such a monitor is then
+     * responsible for triggering the redelivery of the shard itself once the delay elapses.
+     *
+     * <p>This gate applies only to the framework's own end-of-run re-trigger; delivery is still
+     * triggered normally when a new message is written to the shard.
+     *
+     * <p>By default returns {@code true}, preserving the immediate re-trigger.
+     *
+     * @param message
+     *         the newest message still to be delivered in the shard
+     */
+    @SuppressWarnings({"WeakerAccess" /* Part of public API. */, "unused"})
+    public boolean shouldDeliverNow(InboxMessage message) {
+        return true;
     }
 
     /**

--- a/server/src/main/java/io/spine/server/delivery/FailedReception.java
+++ b/server/src/main/java/io/spine/server/delivery/FailedReception.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -37,7 +37,8 @@ import io.spine.base.Error;
  *
  * <ul>
  *     <li>{@linkplain #markDelivered() mark} the message as delivered;
- *     <li>{@linkplain #repeatDispatching() repeat dispatching} of the message immediately.
+ *     <li>{@linkplain #repeatDispatching() repeat dispatching} of the message immediately;
+ *     <li>{@linkplain #keepForRedelivery() keep} the message for a later redelivery attempt.
  * </ul>
  *
  * <p>Alternatively, end-users may choose to define their own way of reacting
@@ -103,11 +104,33 @@ public final class FailedReception {
     }
 
     /**
-     * Returns an action immediately repeats the dispatching of the message.
+     * Returns an action that immediately repeats the dispatching of the message.
      */
     @SuppressWarnings("WeakerAccess" /* Part of the public API. */)
     public Action repeatDispatching() {
         return repeat::dispatchAgain;
+    }
+
+    /**
+     * Returns an action that keeps the message in its inbox in the
+     * {@link InboxMessageStatus#TO_DELIVER TO_DELIVER} status, so it is read again
+     * on a subsequent delivery run.
+     *
+     * <p>Unlike {@link #repeatDispatching()}, this does <em>not</em> re-dispatch the message
+     * immediately. It is intended for a {@link DeliveryMonitor} that schedules a delayed
+     * retry — for example, to let an eventually-consistent storage reach consistency — rather
+     * than marking the message delivered or retrying it synchronously. Such a monitor should
+     * also return {@code false} from
+     * {@link DeliveryMonitor#shouldDeliverNow(InboxMessage) shouldDeliverNow(message)} while the
+     * message is within its back-off window, and trigger the redelivery itself once the delay
+     * elapses.
+     *
+     * <p>This is honored by the live delivery of messages. A message dispatched during a
+     * projection catch-up is marked delivered regardless of this action.
+     */
+    @SuppressWarnings("WeakerAccess" /* Part of the public API. */)
+    public Action keepForRedelivery() {
+        return () -> conveyor.keepForRedelivery(message);
     }
 
     /**

--- a/server/src/main/java/io/spine/server/delivery/LiveDeliveryStation.java
+++ b/server/src/main/java/io/spine/server/delivery/LiveDeliveryStation.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -87,7 +87,9 @@ final class LiveDeliveryStation extends Station {
      * not propagated to the conveyor.
      *
      * <p>After the messages are dispatched, they are marked {@link InboxMessageStatus#DELIVERED
-     * DELIVERED}.
+     * DELIVERED} — except those a {@link DeliveryMonitor} chose to
+     * {@linkplain FailedReception#keepForRedelivery() keep for redelivery}, which are left in
+     * {@link InboxMessageStatus#TO_DELIVER TO_DELIVER} to be read again on a later run.
      *
      * @param conveyor
      *         the conveyor on which the messages are travelling
@@ -103,8 +105,14 @@ final class LiveDeliveryStation extends Station {
         }
         var toDispatch = deduplicateAndSort(filtered, conveyor);
         var errors = action.executeFor(toDispatch);
-        conveyor.markDelivered(toDispatch);
-        var result = new Result(toDispatch.size(), errors);
+        List<InboxMessage> delivered = new ArrayList<>();
+        for (var message : toDispatch) {
+            if (!conveyor.isKeptForRetry(message.getId())) {
+                delivered.add(message);
+            }
+        }
+        conveyor.markDelivered(delivered);
+        var result = new Result(delivered.size(), errors);
         return result;
     }
 

--- a/server/src/test/java/io/spine/server/delivery/IncompleteHistoryRetryTest.java
+++ b/server/src/test/java/io/spine/server/delivery/IncompleteHistoryRetryTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.delivery;
+
+import io.spine.base.Error;
+import io.spine.server.aggregate.IncompleteHistoryRetryMonitor;
+import io.spine.server.delivery.given.ReceptionistAggregate;
+import io.spine.server.delivery.given.TransientFailure;
+import io.spine.testing.SlowTest;
+import io.spine.testing.logging.mute.MuteLogging;
+import io.spine.testing.server.blackbox.BlackBox;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Duration;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.spine.base.Identifier.newUuid;
+import static io.spine.server.delivery.given.ReceptionFailureTestEnv.blackBox;
+import static io.spine.server.delivery.given.ReceptionFailureTestEnv.configureDelivery;
+import static io.spine.server.delivery.given.ReceptionFailureTestEnv.inboxMessages;
+import static io.spine.server.delivery.given.ReceptionFailureTestEnv.receptionist;
+import static io.spine.server.delivery.given.ReceptionFailureTestEnv.sleep;
+import static io.spine.server.delivery.given.ReceptionFailureTestEnv.tellToTurnConditioner;
+
+/**
+ * Tests the {@link IncompleteHistoryRetryMonitor} against the actual delivery pipeline.
+ *
+ * <p>The reception failure is simulated with a {@link TransientFailure}, which the monitor under
+ * test is configured to treat as retryable. The recognition of the production
+ * {@link io.spine.server.aggregate.IncompleteHistoryException} by the default monitor is covered
+ * by {@code IncompleteHistoryRetryMonitorSpec}.
+ */
+@SlowTest
+@DisplayName("`IncompleteHistoryRetryMonitor` should")
+@SuppressWarnings("resource" /* We don't care about closing black boxes in this test. */)
+final class IncompleteHistoryRetryTest extends AbstractDeliveryTest {
+
+    private @Nullable IncompleteHistoryRetryMonitor monitor;
+
+    @AfterEach
+    void cleanUp() {
+        if (monitor != null) {
+            monitor.close();
+            monitor = null;
+        }
+        ReceptionistAggregate.resetFailures();
+    }
+
+    @Test
+    @DisplayName("retry the delivery until the storage settles, then handle the signal")
+    @MuteLogging
+    void retryUntilSettles() {
+        var context = configure(5);
+        var id = newUuid();
+        ReceptionistAggregate.failTransiently(id, 2);
+
+        context.receivesCommand(tellToTurnConditioner(id));
+        sleep();
+
+        assertThat(ReceptionistAggregate.applierInvocations(id)).isEqualTo(3);
+        context.assertState(id, receptionist(id, 1));
+        assertInboxEmpty();
+    }
+
+    @Test
+    @DisplayName("give up and drain the message after the maximum number of attempts")
+    @MuteLogging
+    void giveUpAfterMaxAttempts() {
+        var context = configure(3);
+        var id = newUuid();
+        ReceptionistAggregate.failAlwaysTransiently(id);
+
+        context.receivesCommand(tellToTurnConditioner(id));
+        sleep();
+
+        assertThat(ReceptionistAggregate.applierInvocations(id)).isEqualTo(3);
+        assertInboxEmpty();
+    }
+
+    @Test
+    @DisplayName("not block the delivery of other entities in the same shard")
+    @MuteLogging
+    void notBlockOtherEntities() {
+        var context = configure(100);
+        var failing = newUuid();
+        var healthy = newUuid();
+        ReceptionistAggregate.failAlwaysTransiently(failing);
+
+        context.receivesCommand(tellToTurnConditioner(failing));
+        context.receivesCommand(tellToTurnConditioner(healthy));
+        sleep();
+
+        // The healthy entity is handled (exactly-once effect) even though its shard-mate keeps
+        // failing and being retried. The exact number of the healthy applier invocations is not
+        // asserted, as a background retry run may re-load the aggregate (replaying its history)
+        // before the delivery-level deduplication discards the redundant attempt.
+        context.assertState(healthy, receptionist(healthy, 1));
+        assertThat(ReceptionistAggregate.applierInvocations(failing)).isGreaterThan(1);
+    }
+
+    @Test
+    @DisplayName("not retry a failure of an unrelated type")
+    @MuteLogging
+    void ignoreUnrelatedFailures() {
+        var context = configure(5);
+        var id = newUuid();
+        ReceptionistAggregate.failUnrelated(id);
+
+        context.receivesCommand(tellToTurnConditioner(id));
+        sleep();
+
+        assertThat(ReceptionistAggregate.applierInvocations(id)).isEqualTo(1);
+        assertInboxEmpty();
+    }
+
+    private BlackBox configure(int maxAttempts) {
+        monitor = retryMonitor(maxAttempts);
+        configureDelivery(monitor);
+        return blackBox().tolerateFailures();
+    }
+
+    private static IncompleteHistoryRetryMonitor retryMonitor(int maxAttempts) {
+        var builder = IncompleteHistoryRetryMonitor.newBuilder()
+                .maxAttempts(maxAttempts)
+                .initialDelay(Duration.ofMillis(30))
+                .maxDelay(Duration.ofMillis(60));
+        return new IncompleteHistoryRetryMonitor(builder) {
+            @Override
+            protected boolean isRetryable(Error error) {
+                return TransientFailure.class.getCanonicalName()
+                                             .equals(error.getType());
+            }
+        };
+    }
+
+    private static void assertInboxEmpty() {
+        var messages = inboxMessages();
+        assertThat(messages.size()).isEqualTo(0);
+    }
+}

--- a/server/src/test/java/io/spine/server/delivery/IncompleteHistoryRetryTest.java
+++ b/server/src/test/java/io/spine/server/delivery/IncompleteHistoryRetryTest.java
@@ -140,6 +140,26 @@ final class IncompleteHistoryRetryTest extends AbstractDeliveryTest {
         assertInboxEmpty();
     }
 
+    @Test
+    @DisplayName("drain the message when the retry scheduler is unavailable")
+    @MuteLogging
+    void drainWhenSchedulerUnavailable() {
+        var retryMonitor = retryMonitor(5);
+        this.monitor = retryMonitor;
+        configureDelivery(retryMonitor);
+        var context = blackBox().tolerateFailures();
+        retryMonitor.close();
+        var id = newUuid();
+        ReceptionistAggregate.failAlwaysTransiently(id);
+
+        context.receivesCommand(tellToTurnConditioner(id));
+        sleep();
+
+        // The retry could not be scheduled, so the message is drained instead of left stuck.
+        assertThat(ReceptionistAggregate.applierInvocations(id)).isEqualTo(1);
+        assertInboxEmpty();
+    }
+
     private BlackBox configure(int maxAttempts) {
         monitor = retryMonitor(maxAttempts);
         configureDelivery(monitor);

--- a/server/src/test/kotlin/io/spine/server/aggregate/IncompleteHistoryRetryMonitorSpec.kt
+++ b/server/src/test/kotlin/io/spine/server/aggregate/IncompleteHistoryRetryMonitorSpec.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.aggregate
+
+import io.kotest.matchers.shouldBe
+import io.spine.base.Error
+import java.time.Duration
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.function.LongSupplier
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("`IncompleteHistoryRetryMonitor` should")
+internal class IncompleteHistoryRetryMonitorSpec {
+
+    private val scheduler: ScheduledExecutorService =
+        Executors.newSingleThreadScheduledExecutor()
+
+    @AfterEach
+    fun tearDown() {
+        scheduler.shutdownNow()
+    }
+
+    @Nested
+    inner class `recognize as retryable` {
+
+        @Test
+        fun `an incomplete-history error`() {
+            monitor().canRetry(errorOfType(incompleteHistoryType)) shouldBe true
+        }
+
+        @Test
+        fun `and reject any other error type`() {
+            // Even the superclass of `IncompleteHistoryException` must not match: the reported
+            // error type is the exact runtime class name of the thrown exception.
+            val superclassType = "java.lang.IllegalStateException"
+            val unrelatedType = "io.spine.server.aggregate.SomeOtherFailure"
+            monitor().canRetry(errorOfType(superclassType)) shouldBe false
+            monitor().canRetry(errorOfType(unrelatedType)) shouldBe false
+        }
+    }
+
+    @Nested
+    inner class `apply an exponential back-off that` {
+
+        @Test
+        fun `grows by the multiplier`() {
+            val monitor = monitor(initialMillis = 100, maxMillis = 10_000, multiplier = 2.0)
+            monitor.backoffFor(1) shouldBe 100L
+            monitor.backoffFor(2) shouldBe 200L
+            monitor.backoffFor(3) shouldBe 400L
+            monitor.backoffFor(4) shouldBe 800L
+        }
+
+        @Test
+        fun `is capped at the maximum delay`() {
+            val monitor = monitor(initialMillis = 100, maxMillis = 250, multiplier = 2.0)
+            monitor.backoffFor(1) shouldBe 100L
+            monitor.backoffFor(2) shouldBe 200L
+            monitor.backoffFor(3) shouldBe 250L
+            monitor.backoffFor(9) shouldBe 250L
+        }
+    }
+
+    private fun monitor(
+        initialMillis: Long = 100,
+        maxMillis: Long = 2_000,
+        multiplier: Double = 2.0,
+    ): TestMonitor {
+        val builder = IncompleteHistoryRetryMonitor.newBuilder()
+            .initialDelay(Duration.ofMillis(initialMillis))
+            .maxDelay(Duration.ofMillis(maxMillis))
+            .multiplier(multiplier)
+        return TestMonitor(builder, scheduler)
+    }
+
+    /**
+     * Exposes the `protected`/package-private members of the monitor for testing.
+     */
+    private class TestMonitor(
+        builder: IncompleteHistoryRetryMonitor.Builder,
+        scheduler: ScheduledExecutorService,
+    ) : IncompleteHistoryRetryMonitor(builder, scheduler, LongSupplier { 0L }) {
+
+        fun canRetry(error: Error): Boolean = isRetryable(error)
+
+        fun backoffFor(failure: Int): Long = backoffMillis(failure)
+    }
+
+    private companion object {
+
+        val incompleteHistoryType: String =
+            IncompleteHistoryException::class.java.canonicalName
+
+        fun errorOfType(type: String): Error =
+            Error.newBuilder()
+                .setType(type)
+                .buildPartial()
+    }
+}

--- a/server/src/test/kotlin/io/spine/server/aggregate/IncompleteHistoryRetryMonitorSpec.kt
+++ b/server/src/test/kotlin/io/spine/server/aggregate/IncompleteHistoryRetryMonitorSpec.kt
@@ -26,6 +26,7 @@
 
 package io.spine.server.aggregate
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.spine.base.Error
 import java.time.Duration
@@ -64,6 +65,35 @@ internal class IncompleteHistoryRetryMonitorSpec {
             val unrelatedType = "io.spine.server.aggregate.SomeOtherFailure"
             monitor().canRetry(errorOfType(superclassType)) shouldBe false
             monitor().canRetry(errorOfType(unrelatedType)) shouldBe false
+        }
+    }
+
+    @Nested
+    inner class `be constructed` {
+
+        @Test
+        fun `with default settings`() {
+            IncompleteHistoryRetryMonitor().use { }
+        }
+
+        @Test
+        fun `through its builder`() {
+            IncompleteHistoryRetryMonitor.newBuilder()
+                .maxAttempts(4)
+                .initialDelay(Duration.ofMillis(50))
+                .maxDelay(Duration.ofSeconds(1))
+                .build()
+                .use { }
+        }
+
+        @Test
+        fun `rejecting a maximum delay smaller than the initial delay`() {
+            shouldThrow<IllegalArgumentException> {
+                IncompleteHistoryRetryMonitor.newBuilder()
+                    .initialDelay(Duration.ofSeconds(10))
+                    .maxDelay(Duration.ofSeconds(1))
+                    .build()
+            }
         }
     }
 

--- a/server/src/testFixtures/java/io/spine/server/delivery/given/ReceptionistAggregate.java
+++ b/server/src/testFixtures/java/io/spine/server/delivery/given/ReceptionistAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,10 @@ import io.spine.test.delivery.command.TurnConditionerOn;
 import io.spine.test.delivery.event.ConditionerTurnedOff;
 import io.spine.test.delivery.event.ConditionerTurnedOn;
 
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import static io.spine.util.Exceptions.newIllegalStateException;
 
 public final class ReceptionistAggregate
@@ -43,6 +47,26 @@ public final class ReceptionistAggregate
     public static final String FAILURE_MESSAGE = "Receptionist failed to apply an event.";
 
     private static boolean failInAppliers = false;
+
+    /**
+     * The number of remaining {@linkplain TransientFailure transient} failures per aggregate ID.
+     *
+     * <p>A negative value means "fail every time". Used to simulate an eventually-consistent
+     * storage that recovers after a few reads.
+     */
+    private static final Map<String, Integer> transientFailures = new ConcurrentHashMap<>();
+
+    /**
+     * The IDs of aggregates that should fail with a non-retryable
+     * {@link IllegalStateException}.
+     */
+    private static final Set<String> unrelatedFailures = ConcurrentHashMap.newKeySet();
+
+    /**
+     * The number of times an applier was invoked per aggregate ID, including the invocations
+     * that failed. Used to assert how many delivery attempts were made.
+     */
+    private static final Map<String, Integer> applierInvocations = new ConcurrentHashMap<>();
 
     @Assign
     ConditionerTurnedOn handler(TurnConditionerOn cmd) {
@@ -54,7 +78,7 @@ public final class ReceptionistAggregate
     @Apply
     @SuppressWarnings("ResultOfMethodCallIgnored" /* Using Proto builder. */)
     private void apply(ConditionerTurnedOn event) {
-        maybeFail();
+        maybeFail(id());
         var newValue = builder().getHowManyCmdsHandled() + 1;
         builder().setId(event.getReceptionist())
                  .setHowManyCmdsHandled(newValue);
@@ -70,14 +94,22 @@ public final class ReceptionistAggregate
     @Apply
     @SuppressWarnings("ResultOfMethodCallIgnored" /* Using Proto builder. */)
     private void apply(ConditionerTurnedOff event) {
-        maybeFail();
+        maybeFail(id());
         var newValue = builder().getHowManyCmdsHandled() + 1;
         builder().setId(event.getReceptionist())
                  .setHowManyCmdsHandled(newValue);
     }
 
-    private static void maybeFail() throws IllegalStateException {
-        if (failInAppliers) {
+    private static void maybeFail(String id) {
+        applierInvocations.merge(id, 1, Integer::sum);
+        var remaining = transientFailures.getOrDefault(id, 0);
+        if (remaining != 0) {
+            if (remaining > 0) {
+                transientFailures.put(id, remaining - 1);
+            }
+            throw new TransientFailure();
+        }
+        if (unrelatedFailures.contains(id) || failInAppliers) {
             throw newIllegalStateException(FAILURE_MESSAGE);
         }
     }
@@ -88,5 +120,46 @@ public final class ReceptionistAggregate
 
     public static void makeApplierPass() {
         failInAppliers = false;
+    }
+
+    /**
+     * Makes the aggregate with the given ID fail with a {@link TransientFailure} the given number
+     * of times, and then succeed.
+     */
+    public static void failTransiently(String id, int times) {
+        transientFailures.put(id, times);
+    }
+
+    /**
+     * Makes the aggregate with the given ID always fail with a {@link TransientFailure}.
+     */
+    public static void failAlwaysTransiently(String id) {
+        transientFailures.put(id, -1);
+    }
+
+    /**
+     * Makes the aggregate with the given ID fail with a non-retryable
+     * {@link IllegalStateException}.
+     */
+    public static void failUnrelated(String id) {
+        unrelatedFailures.add(id);
+    }
+
+    /**
+     * Returns how many times an applier was invoked for the aggregate with the given ID,
+     * including the invocations that threw.
+     */
+    public static int applierInvocations(String id) {
+        return applierInvocations.getOrDefault(id, 0);
+    }
+
+    /**
+     * Clears all the failure settings and the recorded applier invocations.
+     */
+    public static void resetFailures() {
+        failInAppliers = false;
+        transientFailures.clear();
+        unrelatedFailures.clear();
+        applierInvocations.clear();
     }
 }

--- a/server/src/testFixtures/java/io/spine/server/delivery/given/TransientFailure.java
+++ b/server/src/testFixtures/java/io/spine/server/delivery/given/TransientFailure.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.delivery.given;
+
+import java.io.Serial;
+
+/**
+ * A retryable failure simulating a transient inability to load an aggregate — for example, an
+ * incomplete history read from an eventually-consistent storage.
+ *
+ * <p>Declared as a top-level type so that its {@linkplain Class#getCanonicalName() canonical name}
+ * equals its {@linkplain Class#getName() binary name}, making it unambiguous to match against the
+ * {@linkplain io.spine.base.Error#getType() error type} reported by the delivery.
+ *
+ * @see io.spine.server.aggregate.IncompleteHistoryException
+ */
+public final class TransientFailure extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 0L;
+
+    TransientFailure() {
+        super("Simulated transient failure while loading an aggregate.");
+    }
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -29,4 +29,4 @@
  *
  * For versions of Spine-based dependencies, please see [io.spine.dependency.local.Spine].
  */
-extra.set("versionToPublish", "2.0.0-SNAPSHOT.384")
+extra.set("versionToPublish", "2.0.0-SNAPSHOT.385")


### PR DESCRIPTION
## Summary

Follow-up to #838. This PR is **stacked on #1639** (its base is `claude/trusting-bardeen-56899a`). The #838 fix makes an incomplete, eventually-consistent aggregate-history read throw `IncompleteHistoryException` instead of persisting a corrupted snapshot — but the delivery layer then **drops the signal**: the default `DeliveryMonitor.onReceptionFailure` marks it delivered and it is never retried. The only existing retry hook, `FailedReception.repeatDispatching()`, retries **immediately and synchronously**, which cannot let eventual consistency settle and can spin.

This PR adds an **opt-in** way to retry such a signal after a non-blocking, backing-off delay, once storage has likely reached consistency. The default behavior is unchanged (drain).

## What changed

### Delivery core — make `onReceptionFailure` authoritative

`LiveDeliveryStation` used to mark **every** dispatched message `DELIVERED` *after* the monitor had already acted, so a monitor could never leave a message for a later retry (only `markDelivered()` or the synchronous `repeatDispatching()` worked). Now:

- **`Conveyor`** — `keepForRedelivery` / `isKeptForRetry`; a deferred message keeps its `TO_DELIVER` status (no storage write).
- **`LiveDeliveryStation`** — marks delivered only the messages **not** kept for retry. The non-retry path is unchanged (`delivered == toDispatch`).
- **`FailedReception.keepForRedelivery()`** — new SPI action leaving the message `TO_DELIVER`.
- **`DeliveryMonitor.shouldDeliverNow(InboxMessage)`** — new default-`true` SPI predicate.
- **`Delivery`** — gates the framework's immediate end-of-run self re-trigger through `shouldDeliverNow`, so a deferred message doesn't spin while it waits out its back-off.

`MonitoringDispatcher` and `CatchUpStation` are intentionally untouched — catch-up is projection-only, so the aggregate exception cannot arise there; this is documented on `keepForRedelivery()`.

### The opt-in monitor

**`IncompleteHistoryRetryMonitor`** (aggregate package) recognizes `IncompleteHistoryException` via `Error.type`, keeps the signal and reschedules the shard on a **daemon `ScheduledExecutorService`** (with idle time-out) after an **exponential, capped back-off**, and drains after a configurable maximum number of attempts. Per-message state is a bounded Guava cache; the monitor is `AutoCloseable`. Install it via `DeliveryBuilder.setMonitor(...)`.

## Tests

- **`IncompleteHistoryRetryMonitorSpec`** (Kotlin / Kotest) — recognizes the real exception type (rejecting others, including its superclass) and the exponential-back-off math; deterministic (injected clock and scheduler).
- **`IncompleteHistoryRetryTest`** (Java, `@SlowTest`) — end-to-end through the real delivery pipeline: retries until the storage settles then handles the signal; gives up and drains after the maximum attempts; does not block another entity in the same shard; ignores an unrelated (non-retryable) failure. `ReceptionistAggregate` gained additive per-id failure control.

## Notes for reviewers

- **Stacked on #1639.** Base is `claude/trusting-bardeen-56899a`. Only this PR's own commits appear in the diff; GitHub will retarget it to `master` when #1639 merges.
- Back-off / attempt state is **in-memory, per node** — sufficient for eventual-consistency recovery (any node re-reading after the data settles succeeds; the back-off only paces one node). A persistent, restart-safe variant (an `inbox.proto` `deliver_after` + attempt count and a time-gated redelivery station) is a possible future enhancement.
- One new `@SPI` method (`DeliveryMonitor.shouldDeliverNow`, default `true`) — backward compatible.
- Version bumped `2.0.0-SNAPSHOT.384` → `.385`.

## Verification

`./gradlew build dokkaGenerate` — green across all modules (full test suite, PMD / checkstyle / detekt, Kover coverage verification, Dokka). Reviewed by the repository's `spine-code-review`, `kotlin-engineer`, and `review-docs` reviewers — all **APPROVE**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
