### PR TITLE
Update local dependencies and bump version to 2.0.0-SNAPSHOT.412

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
@@ -39,7 +39,7 @@ typealias CoreJava = CoreJvm
 @Suppress("ConstPropertyName", "unused")
 object CoreJvm {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.383"
+    const val version = "2.0.0-SNAPSHOT.411"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.448"
+    const val version = "2.0.0-SNAPSHOT.449"
 
     const val group = Spine.toolsGroup
     private const val prefix = "validation"

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.411`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1085,14 +1085,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 07 15:53:05 WEST 2026** using 
+This report was generated on **Tue Jul 07 17:54:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.411`
+# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2273,14 +2273,14 @@ This report was generated on **Tue Jul 07 15:53:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 07 15:53:05 WEST 2026** using 
+This report was generated on **Tue Jul 07 17:54:29 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.411`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3301,14 +3301,14 @@ This report was generated on **Tue Jul 07 15:53:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 07 15:53:05 WEST 2026** using 
+This report was generated on **Tue Jul 07 17:54:29 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.411`
+# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4363,14 +4363,14 @@ This report was generated on **Tue Jul 07 15:53:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 07 15:53:05 WEST 2026** using 
+This report was generated on **Tue Jul 07 17:54:29 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.411`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5467,14 +5467,14 @@ This report was generated on **Tue Jul 07 15:53:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 07 15:53:05 WEST 2026** using 
+This report was generated on **Tue Jul 07 17:54:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.411`
+# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -6647,14 +6647,14 @@ This report was generated on **Tue Jul 07 15:53:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 07 15:53:05 WEST 2026** using 
+This report was generated on **Tue Jul 07 17:54:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.411`
+# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.412`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -7887,6 +7887,6 @@ This report was generated on **Tue Jul 07 15:53:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 07 15:53:05 WEST 2026** using 
+This report was generated on **Tue Jul 07 17:54:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>core-jvm</artifactId>
-<version>2.0.0-SNAPSHOT.411</version>
+<version>2.0.0-SNAPSHOT.412</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -122,7 +122,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-validation-jvm-runtime</artifactId>
-    <version>2.0.0-SNAPSHOT.448</version>
+    <version>2.0.0-SNAPSHOT.449</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -194,13 +194,11 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.grpc</groupId>
     <artifactId>grpc-netty</artifactId>
-    <version>1.81.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.grpc</groupId>
     <artifactId>grpc-netty-shaded</artifactId>
-    <version>1.81.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -242,7 +240,6 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-engine</artifactId>
-    <version>6.1.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -319,7 +316,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>validation-java-bundle</artifactId>
-    <version>2.0.0-SNAPSHOT.448</version>
+    <version>2.0.0-SNAPSHOT.449</version>
   </dependency>
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -194,11 +194,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.grpc</groupId>
     <artifactId>grpc-netty</artifactId>
+    <version>1.81.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>io.grpc</groupId>
     <artifactId>grpc-netty-shaded</artifactId>
+    <version>1.81.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -240,6 +242,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-engine</artifactId>
+    <version>6.1.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of this library.
  */
-extra.set("versionToPublish", "2.0.0-SNAPSHOT.411")
+extra.set("versionToPublish", "2.0.0-SNAPSHOT.412")


### PR DESCRIPTION
## What

Routine `local`-scope dependency refresh plus the required version bump.

- **CoreJvm** `2.0.0-SNAPSHOT.383` → `2.0.0-SNAPSHOT.411` — self-reference to this repo's own artifacts (`spine-core` / `spine-client` / `spine-server`), used in `resolutionStrategy.force(...)` alignment lists; `.411` is the latest published snapshot.
- **Validation** `2.0.0-SNAPSHOT.448` → `2.0.0-SNAPSHOT.449`.
- **Version** `2.0.0-SNAPSHOT.411` → `2.0.0-SNAPSHOT.412`.
- Regenerated `docs/dependencies/pom.xml` and `docs/dependencies/dependencies.md` (`generatePom` / `mergeAllLicenseReports`).

## Why

`/dependency-update local`: these two artifacts had newer snapshots in the Spine Artifact Registry (`europe-maven.pkg.dev/spine-event-engine/snapshots`); the other 13 `local` artifacts were already current, and external scopes were left untouched. The version bump is required by the Version Guard.

## Notes for reviewers

- The regenerated `pom.xml` drops the explicit `<version>` element on three test-scope transitive deps (`grpc-netty`, `grpc-netty-shaded`, `junit-jupiter-engine`) — they now resolve via a platform/BOM. This is faithful `generatePom` output, not a truncated report.
- `./gradlew build` passes locally (all module tests green). Reviewed locally by `dependency-audit`, `spine-code-review`, and `review-docs` — all APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
