### PR TITLE
Document aggregates without event sourcing (PR-B3)

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -9,3 +9,4 @@ Each entry is a memory file with YAML frontmatter and a body. Types: `feedback`,
 - [Java→Kotlin visibility traps](java-to-kotlin-visibility-traps.md) — protected/package-private mapping, `@JvmName` for Java callers, `HasVersionColumn.getVersion()` clash
 - [KDoc tag descriptions: sentence case](feedback_kdoc_tag_descriptions_sentence_case.md) — `@param I The type...`; don't carry lowercase over from legacy Javadoc
 - [Document `internal` members](feedback_document_internal_members.md) — every Kotlin `internal` method gets KDoc; project convention
+- [New proto types: separate file](feedback_proto_one_message_per_file.md) — one message per file recommended; don't append new types to existing multi-message protos

--- a/.agents/memory/feedback_proto_one_message_per_file.md
+++ b/.agents/memory/feedback_proto_one_message_per_file.md
@@ -1,0 +1,23 @@
+---
+name: feedback-proto-one-message-per-file
+description: New proto types go into their own .proto file — do not append to existing multi-message files
+metadata:
+  type: feedback
+---
+
+When introducing new Protobuf types, put them into a new, separate `.proto`
+file (named after the leading message) instead of appending to an existing
+multi-message file such as `entity.proto`.
+
+**Why:** Product owner (2026-07-08, deciding where `EntityEventHistory`
+lives): "Google Protobuf authors recommend to have one message per file
+(which we don't follow yet). This makes the refactoring of proto types
+easier."
+
+**How to apply:**
+- New type family → new file: e.g. `EntityEventHistory` and its record pair
+  go to `spine/server/entity/event_history.proto`, not into `entity.proto`.
+- Closely-coupled helper messages (a record and its ID type) may share the
+  new file; the point is to stop growing legacy multi-message files.
+- Do not reorganize existing multi-message files as a side effect — the rule
+  targets new types; legacy layout changes are a task of their own.

--- a/.agents/tasks/de-event-sourcing-plan.md
+++ b/.agents/tasks/de-event-sourcing-plan.md
@@ -38,8 +38,8 @@ a side effect of playing events** — are called out inline; do not lose them.
    a new receptor annotation" — see ADR D1, revised)*. `ImportBus`, the import
    endpoint/routing, and `BlackBox.importsEvent` are removed in PR-B2;
    `InboxLabel.IMPORT_EVENT` and the `EventImported` system event are
-   deprecated for wire compatibility. External facts enter via
-   `(external) = true` reactions or context gateways.
+   deprecated for wire compatibility. External facts enter via reactions to
+   `@External` events or context gateways.
 5. **State history (`EntityHistoryStorage`; renamed
    `EntityStateHistoryStorage`, 2026-07-08)** is in this plan as a later,
    decoupled phase (Phase D). The cutover must not depend on it.
@@ -367,7 +367,7 @@ green-per-commit sequence.
 17. Migration guide: `docs/` note covering the handler migration recipe,
     the preventive-validation recipe (`tryAlter` and `builder().validate()`,
     ADR D9), the removal of event import with its replacement idioms
-    (`(external) = true` reactions, gateways, storage-level seeding —
+    (`@External` event reactions, gateways, storage-level seeding —
     revised D1), removed snapshot config,
     the idempotency-window semantics change (A5),
     the history-window change (`historyBackward(depth)` explicit; the

--- a/.agents/tasks/de-event-sourcing-plan.md
+++ b/.agents/tasks/de-event-sourcing-plan.md
@@ -40,7 +40,8 @@ a side effect of playing events** — are called out inline; do not lose them.
    `InboxLabel.IMPORT_EVENT` and the `EventImported` system event are
    deprecated for wire compatibility. External facts enter via
    `(external) = true` reactions or context gateways.
-5. **State history (`EntityHistoryStorage`)** is in this plan as a later,
+5. **State history (`EntityHistoryStorage`; renamed
+   `EntityStateHistoryStorage`, 2026-07-08)** is in this plan as a later,
    decoupled phase (Phase D). The cutover must not depend on it.
 6. **Plan scope:** deep detail for `core-jvm`; dependency-ordered rollout
    checklists for downstream repos; org-wide `@Apply` verification gate.
@@ -131,6 +132,8 @@ These are the sharp edges; both are behavioral changes, not refactors.
 - `StorageFactory` SPI shape: `createAggregateStorage`,
   `createAggregateEventStorage`, `createEntityRecordStorage` all remain
   (the journal is still written). Storage vendors recompile, not rewrite.
+  *(Phase D's journal cleanup — the opener of that phase — deprecates
+  `createAggregateEventStorage` in favor of `createEntityEventStorage`.)*
 - Client query path (`QueryService` → `Stand` → `EntityQueryProcessor` →
   `AggregateRepository.findRecords` → `AggregateStorage.readStates`).
 - `BlackBox` / `EventSubject` / `CommandSubject` public testing APIs.
@@ -393,11 +396,17 @@ green-per-commit sequence.
      both implementing `StorageFactory.createRecordStorage`. It is a storage
      vendor, not only a service.
 
-## Phase D — `EntityHistoryStorage` (state history to depth)
+## Phase D — entity history: journal cleanup & state history to depth
 
-Decoupled; starts after Phase B is merged and stable.
+Decoupled; starts after Phase B is merged and stable. Delivery order within
+the phase (decided 2026-07-08): the journal cleanup (see the phase opener
+below) lands first as its own PR, so that D3 trimming is built against
+`EntityEventStorage` from the start; the state-history items (D1/D2) are
+independent and may land in parallel or after.
 
-1. New Kotlin storage contract `EntityHistoryStorage` in
+1. New Kotlin storage contract `EntityStateHistoryStorage` (renamed from the
+   brief's `EntityHistoryStorage`, 2026-07-08 — "state history" stays
+   unambiguous next to the `EntityEventStorage` event journal below) in
    `server/src/main/kotlin/io/spine/server/entity/history/` storing recent
    `EntityRecord` versions per entity to a configured depth, over the
    standard `RecordStorage` SPI (works on all backends without vendor code).
@@ -409,14 +418,31 @@ Decoupled; starts after Phase B is merged and stable.
    must not be aggregate-specific; actual PM wiring is out of scope.
 5. Read API for debugging/analysis (state history alongside the journal).
 
-### Follow-up: journal type cleanup (`EventHistory`)
+### Phase opener: journal cleanup (`EntityEventHistory` / `EntityEventStorage`)
 
-Introduce a snapshot-free `EventHistory` type and deprecate `AggregateHistory` —
-its `snapshot` field is dead weight after the cutover, and the "history =
-snapshot + tail" semantics no longer hold. Detailed task:
-[`introduce-event-history-type.md`](introduce-event-history-type.md). Coordinate
-with the count/date journal trimming in D3 above, since both touch the journal
-representation.
+Naming locked 2026-07-08 (product owner): the journal types move to the
+**entity** level — events are emitted by entities, not by aggregates alone.
+
+- Introduce a snapshot-free **`EntityEventHistory`** message and deprecate
+  `AggregateHistory` — its `snapshot` field is dead weight after the cutover,
+  and the "history = snapshot + tail" semantics no longer hold.
+- Introduce **`EntityEventStorage`** — the journal of events emitted by an
+  entity — and deprecate `AggregateEventStorage`, with
+  `StorageFactory.createAggregateEventStorage` superseded by a new
+  `createEntityEventStorage`. Initial rollout covers aggregates;
+  `ProcessManager` journaling is planned for a near-future PR, so nothing in
+  the new types may be aggregate-specific (the same constraint as D4).
+  Record level settled 2026-07-08: **clean replacement** — a new
+  `EntityEventRecord` supersedes the deprecated `AggregateEventRecord`;
+  pre-upgrade journal rows stay in the legacy record kind, invisible to the
+  new reads (see the data caveat in the detailed task).
+
+Detailed task:
+[`introduce-event-history-type.md`](introduce-event-history-type.md).
+Coordinate with the count/date journal trimming in D3 above: D3 is built
+against `EntityEventStorage`, while the deprecated snapshot-index truncation
+stays wired to the deprecated `AggregateEventStorage` (already inert on
+post-cutover journals, which contain no snapshot records).
 
 ## Phase E — Downstream rollout (dependency order)
 
@@ -494,6 +520,8 @@ repos except the deprecated annotation type itself.**
 ## Out of scope
 
 - Data migration tooling (decision 2).
-- `ProcessManager` state history wiring (Phase D designs for it only).
+- `ProcessManager` wiring for both state history and event journaling
+  (Phase D designs for them only; PM journaling is planned for a
+  near-future PR).
 - Removing the deprecated `@Apply` annotation itself and the other
   deprecations — happens at v2.0.0 (final), tracked separately.

--- a/.agents/tasks/introduce-event-history-type.md
+++ b/.agents/tasks/introduce-event-history-type.md
@@ -1,8 +1,17 @@
-# Introduce `EventHistory` and deprecate `AggregateHistory`
+# Introduce `EntityEventHistory` and `EntityEventStorage`
 
-**Status:** planned — a follow-up phase after PR-B2 (the event-sourcing cutover) merges.
+**Status:** planned — opens Phase D as its own PR (decided 2026-07-08);
+follows PR-B2 (the event-sourcing cutover, merged in #1647).
 **Effort:** part of the "migrate Aggregates off event sourcing" line of work
 (see [`de-event-sourcing-plan.md`](de-event-sourcing-plan.md)).
+
+> **Naming locked (product owner, 2026-07-08):** the new history type is named
+> **`EntityEventHistory`** (not `EventHistory`, as earlier drafts said), and
+> the journal storage moves to the entity level as **`EntityEventStorage`**,
+> replacing `AggregateEventStorage`. Events are emitted by entities, not by
+> aggregates alone: the initial rollout covers aggregates, with
+> `ProcessManager` journaling planned for a near-future PR — so nothing in the
+> new types may be aggregate-specific.
 
 ## Context
 
@@ -26,60 +35,140 @@ journal is now a plain append-only **event** log kept for traceability and the
 opt-in `IdempotencyGuard`. The type name and shape mislead readers about how
 aggregates are stored and loaded.
 
+The same applies one level down. The journal is persisted by
+`AggregateEventStorage` as `AggregateEventRecord`s — both aggregate-named, and
+the record still carries the `oneof {event, snapshot}` arm. Nothing in
+"a journal of events emitted by an entity" is aggregate-specific; process
+managers emit events too and will journal them next.
+
 ## Goal
 
-Introduce a clean **`EventHistory`** type (events only) as the journal
-representation used across the runtime, migrate the code to it, and **deprecate
-`AggregateHistory`** — retaining the proto for wire compatibility, not removing
-it.
+Introduce the entity-level journal pair:
+
+- **`EntityEventHistory`** — a snapshot-free message (events only) used as the
+  journal representation across the runtime;
+- **`EntityEventStorage`** — the append-only journal storing the events
+  emitted by an entity, over the standard `RecordStorage` SPI.
+
+Migrate the aggregate runtime to them, and **deprecate the aggregate-specific
+pair** — `AggregateHistory`, `AggregateEventRecord` (with its id type and
+columns), and `AggregateEventStorage` — retaining the protos and the storage
+class for wire/SPI compatibility, not removing them.
 
 ## Scope
 
 Current `AggregateHistory` users in main source (all in the `server` module):
 
 - `server/src/main/java/io/spine/server/aggregate/AggregateStorage.java` —
-  `read(I, int)` returns `Optional<AggregateHistory>`; `writeAll(...)` consumes
-  one. This is the primary seam.
+  `extends AbstractStorage<I, AggregateHistory>`; `read(I, int)` returns
+  `Optional<AggregateHistory>`; `write(I, AggregateHistory)` and
+  `writeAll(...)` consume it. This is the primary seam. Also owns the journal
+  reads/writes: `writeEvent`, `historyBackward(...)`,
+  `readHistoryBackward(...)` against `AggregateEventStorage`.
 - `server/src/main/java/io/spine/server/aggregate/UncommittedHistory.java` —
   `get()` returns a single-segment `AggregateHistory` (already collapsed to a
-  plain event list internally by PR-B2; it just re-wraps into `AggregateHistory`
-  for `writeAll`).
+  plain event list internally by PR-B2; it just re-wraps into
+  `AggregateHistory` for `writeAll`).
 - `server/src/main/java/io/spine/server/aggregate/ReadOperation.java` —
-  reconstructs an `AggregateHistory` (holds a `Snapshot snapshot` field).
-- `server/src/main/java/io/spine/server/entity/EntityLifecycle.java`.
+  reconstructs an `AggregateHistory` (still threads a `Snapshot` field).
+
+Journal-storage users to migrate to `EntityEventStorage`:
+
+- `server/src/main/java/io/spine/server/aggregate/AggregateEventStorage.java`
+  — the storage itself (deprecate).
+- `server/src/main/java/io/spine/server/aggregate/AggregateRecords.java` —
+  the `newEventRecord(...)` factories.
+- `server/src/main/java/io/spine/server/aggregate/AggregateEventRecordColumn.java`
+  — `aggregate_id` / `created` / `version` / `snapshot` columns; `public` and
+  used by downstream storage libraries, so deprecate rather than remove.
+- `server/src/main/java/io/spine/server/aggregate/HistoryBackwardOperation.java`
+  and `server/src/main/java/io/spine/server/aggregate/TruncateOperation.java`.
+- `StorageFactory.createAggregateEventStorage(...)` — the SPI default method
+  (`server/src/main/java/io/spine/server/storage/StorageFactory.java`).
+
+*(`EntityLifecycle.java`, listed in earlier drafts, references only the
+already-deprecated `AggregateHistoryCorrupted` diagnostic event — not the
+history type. No change there.)*
 
 ## Sketch of the steps
 
-1. **Define `EventHistory`** in `aggregate.proto` (or a new proto) — essentially
-   `repeated core.Event event = 1;`, with room for journal metadata if needed.
-   No `Snapshot` field.
-2. **Migrate `UncommittedHistory.get()`** to return `EventHistory`, and
-   **`AggregateStorage.writeAll`/`read`** to produce/consume `EventHistory`.
-   The storage-level snapshot/truncation methods (still exercised by the
-   `Truncate` tests, retained for wire compat) can keep dealing with
-   `AggregateEventRecord`s; only the aggregate-facing history type changes.
-3. **Update `ReadOperation`** to stop threading a `Snapshot` and to build an
-   `EventHistory`.
-4. **Deprecate `AggregateHistory`** — mark the proto message deprecated with a
-   migration note pointing to `EventHistory`; keep it (and `Snapshot`) for wire
-   compatibility, mirroring how the cutover kept the snapshot protos.
-5. **Migrate tests/fixtures** that reference `AggregateHistory`
-   (`AggregateStorageTest`, `AggregateHistoryTruncationTest`, etc.).
+1. **Define the protos** in a new, separate file
+   `server/src/main/proto/spine/server/entity/event_history.proto` (Java
+   package `io.spine.server.entity`): `EntityEventHistory` — essentially
+   `repeated core.Event event = 1;` with room for journal metadata if needed;
+   plus the record pair `EntityEventRecord` / `EntityEventRecordId` —
+   `entity_id`, `timestamp`, `event`. **No snapshot arm anywhere.**
+2. **New Kotlin `EntityEventStorage`** (suggested package:
+   `io.spine.server.entity.storage`, beside `EntityRecordStorage`; new code is
+   Kotlin per locked decision 7) over `StorageFactory.createRecordStorage`,
+   with columns `entity_id`, `created`, `version` — no `snapshot` column. Add
+   `StorageFactory.createEntityEventStorage(context)`; deprecate
+   `createAggregateEventStorage`.
+3. **Re-point the `AggregateStorage` journal** to `EntityEventStorage`:
+   `writeEvent`, `historyBackward`, `readHistoryBackward`, and
+   `HistoryBackwardOperation` (or an entity-level replacement for the latter).
+4. **Migrate the history type**: re-type `AggregateStorage` to
+   `AbstractStorage<I, EntityEventHistory>`; `UncommittedHistory.get()`
+   returns `EntityEventHistory`; `write`/`writeAll`/`read` produce/consume it;
+   `ReadOperation` stops threading a `Snapshot` and builds an
+   `EntityEventHistory`.
+5. **Deprecate `AggregateHistory`** and the record protos — mark them
+   deprecated with migration notes pointing to the new types; keep them (and
+   `Snapshot`) for wire compatibility, mirroring how the cutover kept the
+   snapshot protos. The snapshot-index truncation (`TruncateOperation`, the
+   deprecated `truncateOlderThan` overloads) stays wired to the deprecated
+   `AggregateEventStorage`: it is already inert on post-cutover journals — a
+   journal without snapshot records never satisfies the snapshot-index
+   condition — while the D3 count/date trimming is designed against
+   `EntityEventStorage`.
+6. **Migrate tests/fixtures** that reference the old types
+   (`AggregateStorageTest`, `AggregateHistoryTruncationTest`,
+   `ReadOperationTest`, `TestAggregateStorage`, and friends).
 
-## Design questions to settle first
+## Data caveat
 
-- Does `EventHistory` live in `aggregate.proto`, or should the journal type move
-  to a storage-neutral proto (it is no longer aggregate-specific in spirit)?
-- Relationship to `AggregateEventRecord` (the per-record storage type) — does
-  `EventHistory` wrap those, or plain `core.Event`s?
-- Whether this rides with, or precedes, Phase D
-  (`EntityHistoryStorage` / journal trimming) in the delivery plan — they both
-  touch the journal representation and should not conflict.
+`EntityEventRecord` is a new record kind: storage backends persist it
+separately from the legacy `AggregateEventRecord`s, so pre-existing journal
+entries are invisible to `EntityEventStorage` reads — the `IdempotencyGuard`
+window and `historyBackward(depth)` start empty after the upgrade. Spine 2.x
+is pre-GA and ships no data-migration tooling (locked decision 2); state this
+in the migration notes the way the `NONE`-visibility caveat is stated.
+
+## Design questions (all settled 2026-07-08)
+
+- ~~Does `EventHistory` live in `aggregate.proto`, or a storage-neutral
+  proto?~~ **Settled 2026-07-08:** the type is entity-level
+  (`EntityEventHistory`) and lives in the `spine.server.entity` proto package,
+  in a new, separate `event_history.proto` — not appended to `entity.proto`.
+  Rationale (product owner): the Protobuf authors recommend one message per
+  file — not yet followed in this codebase — and separate files keep future
+  refactoring of proto types easier.
+- ~~Relationship to `AggregateEventRecord` — wrap those, or plain
+  `core.Event`s?~~ **Settled:** plain `core.Event`s; the storage-level record
+  is the new `EntityEventRecord`.
+- ~~Transform vs. replace at the record level~~ **Settled 2026-07-08 (product
+  owner): clean replacement.** A new `EntityEventRecord` supersedes
+  `AggregateEventRecord` (deprecated, kept for wire compatibility), accepting
+  the data caveat above. The rejected alternative — keeping
+  `AggregateEventRecord` as the record type inside `EntityEventStorage` —
+  would have preserved reads of pre-upgrade journals at the cost of dragging
+  the snapshot arm and aggregate naming into the entity-level API.
+- ~~Naming of the Phase D state-history contract next to
+  `EntityEventStorage`~~ **Settled 2026-07-08:** renamed to
+  `EntityStateHistoryStorage` — "state history" vs. the event journal.
+- ~~Whether this rides with, or precedes, Phase D items D1–D3~~ **Settled
+  2026-07-08 (product owner): this task opens Phase D as its own PR.** D3
+  trimming is then built directly against `EntityEventStorage`; the
+  state-history items (D1/D2) are independent and may land in parallel or
+  after.
 
 ## Verification
 
 - `./gradlew clean build` green (proto change ⇒ clean build).
-- Wire compatibility preserved: `AggregateHistory` and `Snapshot` still
-  serializable; no removed fields/messages.
-- No main-source references to `AggregateHistory` remain except the deprecated
-  shim path kept for compatibility.
+- Wire compatibility preserved: `AggregateHistory`, `AggregateEventRecord`,
+  and `Snapshot` still serializable; no removed fields/messages.
+- No main-source references to the deprecated types remain except the
+  deprecated shim paths kept for compatibility.
+- Storage vendors smoke-build against the new core snapshot (the Phase C
+  list): the `AggregateStorage` type-parameter change and the new SPI method
+  affect them.

--- a/docs/adr/0001-aggregates-without-event-sourcing.md
+++ b/docs/adr/0001-aggregates-without-event-sourcing.md
@@ -56,7 +56,7 @@ The runtime facts this ADR is grounded in (verified against the tree
 
 | #   | Decision                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 |-----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| D1  | **Revised 2026-07-05: event import is dropped.** No `@Import` receptor; `ImportBus`, the import endpoint/routing, and `BlackBox.importsEvent` are removed in PR-B2; `InboxLabel.IMPORT_EVENT` and the `EventImported` system event are deprecated for wire compatibility. External facts enter via `(external) = true` reactions or context gateways.                                                                                                                                      |
+| D1  | **Revised 2026-07-05: event import is dropped.** No `@Import` receptor; `ImportBus`, the import endpoint/routing, and `BlackBox.importsEvent` are removed in PR-B2; `InboxLabel.IMPORT_EVENT` and the `EventImported` system event are deprecated for wire compatibility. External facts enter via reactions to `@External` events or context gateways.                                                                                                                                      |
 | D2  | `@Apply` on any aggregate (incl. `AggregatePart`) is a **`ModelError` at model-building time** after cutover — fail fast, never a silent no-op.                                                                                                                                                                                                                                                                                                                                            |
 | D3  | Aggregate version advances **+1 per command dispatch**, not per event — `ProcessManager` semantics via `CommandDispatchingPhase` + `VersionIncrement.sequentially`.                                                                                                                                                                                                                                                                                                                        |
 | D4  | State update is never forced in any handler. Only `@Assign` must emit ≥1 event (or reject); `@React` emission is optional. Persistence must trigger on a business-state change, not only on events/lifecycle.                                                                                                                                                                                                                                                                              |
@@ -113,7 +113,7 @@ substance. What remains is journal provenance (adopting a foreign fact as the
 aggregate's own journal entry) and the no-intermediate-message entry point —
 conveniences with standard replacements:
 
-- facts from another Bounded Context — `@React` on `(external) = true` events;
+- facts from another Bounded Context — `@React` methods accepting `@External` events;
 - facts from a third-party or legacy system — a gateway (adapter, process
   manager, or a plain command) turns them into the context's own commands or
   events;
@@ -855,7 +855,7 @@ a no-op retain buys nothing). Tracked in plan PR-B2 steps 12/15.
   immediately.
 - Event import is gone (revised D1): a whole unicast bus, an endpoint, a
   routing schema, and a receptor kind vanish from the runtime; external facts
-  flow through the standard `(external) = true` reactions and gateway idioms.
+  flow through the standard `@External` event reactions and gateway idioms.
 - History reads state their window at the call site (`historyBackward(depth)`,
   D10), decoupling domain logic from the `historyDepth` operational knob.
 

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.420`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.421`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1085,14 +1085,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 08 16:21:17 WEST 2026** using 
+This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.420`
+# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.421`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2273,14 +2273,14 @@ This report was generated on **Wed Jul 08 16:21:17 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 08 16:21:17 WEST 2026** using 
+This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.420`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.421`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3301,14 +3301,14 @@ This report was generated on **Wed Jul 08 16:21:17 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 08 16:21:17 WEST 2026** using 
+This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.420`
+# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.421`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4363,14 +4363,14 @@ This report was generated on **Wed Jul 08 16:21:17 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 08 16:21:17 WEST 2026** using 
+This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.420`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.421`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5467,14 +5467,14 @@ This report was generated on **Wed Jul 08 16:21:17 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 08 16:21:17 WEST 2026** using 
+This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.420`
+# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.421`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -6647,14 +6647,14 @@ This report was generated on **Wed Jul 08 16:21:17 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 08 16:21:17 WEST 2026** using 
+This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.420`
+# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.421`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -7887,6 +7887,6 @@ This report was generated on **Wed Jul 08 16:21:17 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 08 16:21:17 WEST 2026** using 
+This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.421`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.422`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1085,14 +1085,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using 
+This report was generated on **Thu Jul 09 18:25:13 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.421`
+# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.422`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2273,14 +2273,14 @@ This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using 
+This report was generated on **Thu Jul 09 18:25:13 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.421`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.422`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3301,14 +3301,14 @@ This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using 
+This report was generated on **Thu Jul 09 18:25:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.421`
+# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.422`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4363,14 +4363,14 @@ This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using 
+This report was generated on **Thu Jul 09 18:25:12 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.421`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.422`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5467,14 +5467,14 @@ This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using 
+This report was generated on **Thu Jul 09 18:25:13 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.421`
+# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.422`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -6647,14 +6647,14 @@ This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using 
+This report was generated on **Thu Jul 09 18:25:13 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.421`
+# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.422`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -7887,6 +7887,6 @@ This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jul 08 19:57:30 WEST 2026** using 
+This report was generated on **Thu Jul 09 18:25:13 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>core-jvm</artifactId>
-<version>2.0.0-SNAPSHOT.421</version>
+<version>2.0.0-SNAPSHOT.422</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>core-jvm</artifactId>
-<version>2.0.0-SNAPSHOT.420</version>
+<version>2.0.0-SNAPSHOT.421</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/docs/migration/aggregates-without-event-sourcing.md
+++ b/docs/migration/aggregates-without-event-sourcing.md
@@ -195,7 +195,7 @@ Route external facts through standard idioms instead:
 | Old use of import | Replacement |
 |-------------------|-------------|
 | Facts from another Bounded Context | a `@React(external = true)` reactor |
-| Facts from a third-party / legacy system | a gateway (adapter, process manager, or plain command) that converts them into this context's commands or events |
+| Facts from a third-party / legacy system | a gateway (adapter, process manager, or command) that converts them into this context's commands or events |
 | Bulk seeding / data migration | storage-level state writes (the record is the source of truth) |
 | Test arrangement | real commands and events through `BlackBox` |
 

--- a/docs/migration/aggregates-without-event-sourcing.md
+++ b/docs/migration/aggregates-without-event-sourcing.md
@@ -76,16 +76,22 @@ fun handle(c: AddItem): ItemAdded {
 ### Lifecycle flags move too
 
 If an applier flipped a lifecycle flag with `setArchived(true)` / `setDeleted(true)`, that
-call moves into the handler body that emits the event (D4). Both `@Assign` and `@React` may
+call moves into the command handler or reactor body (D4). Both `@Assign` and `@React` may
 set lifecycle flags directly:
 
 ```java
-@React
-AggProjectArchived on(AggProjectArchived e) {
+@Assign
+ProjectArchived handle(ArchiveProject c) {
     setArchived(true);   // was in the @Apply applier
-    return e;            // still emitted, e.g. to reach child aggregates
+    return ProjectArchived.newBuilder()
+                          .setProject(id())
+                          .build();
 }
 ```
+
+A reactor that only flips a flag emits nothing (`return noReaction()`); if it must also notify
+other aggregates, emit a *distinct* event rather than re-emitting the one it reacted to (which
+would route straight back into the same reactor).
 
 ### What the framework does for you
 
@@ -194,7 +200,7 @@ Route external facts through standard idioms instead:
 
 | Old use of import | Replacement |
 |-------------------|-------------|
-| Facts from another Bounded Context | a `@React(external = true)` reactor |
+| Facts from another Bounded Context | a `@React` reactor whose event parameter is marked `@External` |
 | Facts from a third-party / legacy system | a gateway (adapter, process manager, or command) that converts them into this context's commands or events |
 | Bulk seeding / data migration | storage-level state writes (the record is the source of truth) |
 | Test arrangement | real commands and events through `BlackBox` |

--- a/docs/migration/aggregates-without-event-sourcing.md
+++ b/docs/migration/aggregates-without-event-sourcing.md
@@ -1,0 +1,321 @@
+# Migrating aggregates off event sourcing
+
+This guide walks you through upgrading application code to the non-event-sourced
+`Aggregate`. It is the practical companion to
+[ADR 0001 — Aggregates without event sourcing](../adr/0001-aggregates-without-event-sourcing.md),
+which records the design decisions (referenced below as **D1**–**D10**).
+
+## What changed, in one paragraph
+
+An aggregate no longer reconstructs its state by replaying events. It loads from its
+**latest persisted state** (an `EntityRecord`) and mutates that state **inside the command
+handler or event reactor** that emits the events. Events remain first-class — versioned,
+stored in an append-only journal, and posted to the `EventBus` — but they are traceability
+records, never replayed into state. Event appliers (`@Apply`) are gone: a class that still
+declares one now fails fast at model-building time.
+
+## At a glance
+
+| Area | Before (event-sourced) | After (this release) |
+|------|------------------------|----------------------|
+| State change | `@Apply` applier mutates state from a played event | `@Assign` / `@React` mutates `builder()` in-body |
+| Loading | replay the journal (± a snapshot) | read the latest `EntityRecord` |
+| `@Apply` | required for every state transition | **`ModelError` at model build** — deprecated, removed in v2.0.0 |
+| Version | advanced per emitted event (`v+1..v+N`) | **+1 per command**, like a `ProcessManager` |
+| Event import | `@Apply(allowImport = true)` + `ImportBus` | **removed** — use external reactions / gateways |
+| Dedup | always-on aggregate `IdempotencyGuard` | delivery layer owns it; guard is **opt-in, off** |
+| Recent history | `historyBackward()` (window = last snapshot) | `historyBackward(depth)` — explicit window |
+| Snapshots | `setSnapshotTrigger()`, `toSnapshot()` | **removed** — use `setHistoryDepth()` |
+
+## 1. Move applier bodies into handlers
+
+This is the core migration. For every `@Apply` method, move its body into the `@Assign`
+command handler or `@React` reactor that emits the corresponding event, mutating state
+through `builder()`. Then delete the `@Apply` method.
+
+**Before** — the handler returns the event; a separate applier mutates state:
+
+```java
+@Assign
+ItemAdded handle(AddItem c) {
+    return ItemAdded.newBuilder()
+                    .setItem(c.getItem())
+                    .build();
+}
+
+@Apply
+private void on(ItemAdded e) {
+    builder().addItem(e.getItem());   // state change lived here
+}
+```
+
+**After** — the handler mutates state and returns the event:
+
+```java
+@Assign
+ItemAdded handle(AddItem c) {
+    builder().addItem(c.getItem());   // moved into the handler
+    return ItemAdded.newBuilder()
+                    .setItem(c.getItem())
+                    .build();
+}
+```
+
+In Kotlin, prefer the builder DSL inherited from `TransactionalEntity` over calling
+`builder()` directly — `alter { }` applies changes, while `update { }` applies and
+returns the builder:
+
+```kotlin
+@Assign
+fun handle(c: AddItem): ItemAdded {
+    alter { addItem(c.item) }
+    return itemAdded { item = c.item }
+}
+```
+
+### Lifecycle flags move too
+
+If an applier flipped a lifecycle flag with `setArchived(true)` / `setDeleted(true)`, that
+call moves into the handler body that emits the event (D4). Both `@Assign` and `@React` may
+set lifecycle flags directly:
+
+```java
+@React
+AggProjectArchived on(AggProjectArchived e) {
+    setArchived(true);   // was in the @Apply applier
+    return e;            // still emitted, e.g. to reach child aggregates
+}
+```
+
+### What the framework does for you
+
+The framework opens an `AggregateTransaction` **before** invoking the receptor (exactly as
+for a `ProcessManager`), validates the built state **once** when the receptor returns, and
+commits. A handler exception, a rejection, or an invalid built state rolls the whole
+dispatch back — nothing is stored, nothing is posted. Because all mutations of a dispatch
+accumulate in one builder and are validated atomically, an aggregate can no longer be left
+"partially valid" (the historical event-sourcing hazard this release removes).
+
+### Emission rules (unchanged in spirit, D4)
+
+- `@Assign` **must emit at least one event, or reject.** Updating state is optional.
+- `@React` **may emit zero events** (`NoReaction`). It may update state, set lifecycle
+  flags, both, or neither.
+
+A zero-event reactor that only changes business state **is** persisted — the store gate was
+widened to fire on a state change, not only on emitted events or lifecycle changes.
+
+### `@Apply` now fails fast
+
+Declaring any `@Apply` method (on an `Aggregate` **or** an `AggregatePart`) raises a
+`ModelError` when the context is built:
+
+```
+The aggregate class `<Class>` declares `@Apply`-annotated event applier(s) for <events>.
+Event sourcing has been removed: move each applier's body into the `@Assign` / `@React`
+receptor that emits the event (mutating the state via `builder()`), and delete the
+`@Apply` method(s).
+```
+
+`AggregatePart`s were event-sourced no differently and migrate the same way. The `@Apply`
+annotation is retained only so the model can detect it and fail; it is removed in v2.0.0.
+
+## 2. Preventive validation (optional): `tryAlter` and `validate()`
+
+When a state transition might violate a declared constraint, guard it **before** the change
+touches the live builder, instead of relying on the commit-time rollback (D9). `tryAlter { }`
+runs the mutation on a scratch copy of the builder, validates the candidate, and merges it
+only when clean — otherwise it leaves the live state untouched and returns the constraint
+violations. It is available on any `TransactionalEntity`, so process managers get it too.
+
+A command handler turns violations into a **rejection**:
+
+```kotlin
+@Assign
+@Throws(OutOfStock::class)
+fun handle(cmd: ReserveItems): ItemsReserved {
+    val violations = tryAlter { inStock = state.inStock - cmd.quantity }
+    if (violations.isNotEmpty()) {            // would go negative
+        throw OutOfStock.newBuilder()
+            .setStock(id())
+            .setRequested(cmd.quantity)
+            .build()
+    }
+    return itemsReserved { stock = id(); quantity = cmd.quantity }
+}
+```
+
+A reactor **skips the update** — an event is a fact and cannot be rejected. Returning
+`NoReaction` speaks only about emission; the state stays untouched because `tryAlter`
+withheld the change:
+
+```kotlin
+@React
+fun on(event: BulkOrderPlaced): EitherOf2<ItemsReserved, NoReaction> {
+    val violations = tryAlter { inStock = state.inStock - event.quantity }
+    return if (violations.isEmpty())
+        EitherOf2.withA(itemsReserved { stock = id(); quantity = event.quantity })
+    else
+        EitherOf2.withB(noReaction())         // no events; the change was withheld
+}
+```
+
+> ⚠️ The `block` of `tryAlter` operates on the scratch builder (its receiver). Do not nest
+> `alter { }` / `update { }` inside it — those mutate the **live** builder and defeat
+> the guard.
+
+Its in-place companion, `builder().validate()`, probes the builder's *current* content
+(including content that is already invalid) and returns the violations without building. A
+command handler about to reject can mutate live and probe, since the rejection rolls the
+transaction back anyway:
+
+```kotlin
+alter { inStock = state.inStock - cmd.quantity }
+val violations = builder().validate()
+if (violations.isNotEmpty()) { /* throw the rejection */ }
+```
+
+Prefer `tryAlter` in a reactor (there is no way to un-mutate the live builder); prefer
+`validate()` when you are going to reject anyway.
+
+## 3. Event import is removed
+
+Event import is gone with event sourcing (D1, revised). Its replay-era purpose —
+rebuilding state from imported events — no longer exists. Removed from the runtime:
+
+- `@Apply(allowImport = true)` (the attribute is ignored),
+- `ImportBus`, `EventImportEndpoint`, `EventImportDispatcher`,
+  `UnsupportedImportEventException`,
+- `AggregateRepository.setupImportRouting` / `eventImportRouting`,
+- `AggregateClass.importableEvents()` / `importsEvents()`,
+- the testing API `BlackBox.importsEvent`.
+
+Route external facts through standard idioms instead:
+
+| Old use of import | Replacement |
+|-------------------|-------------|
+| Facts from another Bounded Context | a `@React(external = true)` reactor |
+| Facts from a third-party / legacy system | a gateway (adapter, process manager, or plain command) that converts them into this context's commands or events |
+| Bulk seeding / data migration | storage-level state writes (the record is the source of truth) |
+| Test arrangement | real commands and events through `BlackBox` |
+
+**Retained for wire compatibility** (proto/journal readers keep working): the
+`InboxLabel.IMPORT_EVENT` label, the `EventImported` system event and its emitter
+`EntityLifecycle.onEventImported`. New code should not use them.
+
+## 4. Version advances +1 per command, not per event
+
+An aggregate's version now advances **by one per command (or reaction) dispatch**,
+regardless of how many events the handler emits — the same rule a `ProcessManager` already
+uses (D3). Every event of one dispatch carries the aggregate's **pre-dispatch** version.
+
+**Observable change.** Previously, the events of one command bore distinct versions
+`v+1..v+N` and the aggregate ended at `v+N`. Now those events share one version and the
+aggregate ends at `v+1`. If any consumer relied on distinct per-event aggregate versions,
+revisit it.
+
+**Ordering is unaffected under the default time source.** Same-command events are ordered by
+their per-event timestamps, which the framework stamps at microsecond spacing in emission
+order; the version is only a tiebreaker and is effectively never reached. Ordering can fall
+back to event-id order only under a custom coarse `Time.Provider` that hands out identical
+timestamps, or a dispatch emitting more than 1000 events in a single millisecond — both
+deterministic across reads, just not necessarily emission order.
+
+## 5. Deduplication and the idempotency guard
+
+Deduplication is now primarily the **delivery layer's** job (keyed on the incoming signal
+and the target entity), which does not falsely deduplicate one event fanned out to many
+aggregates (D5).
+
+The aggregate-level `IdempotencyGuard` becomes an **opt-in, per-repository backstop, off
+by default**:
+
+```java
+final class OrdersRepository extends AggregateRepository<OrderId, Order, OrderState> {
+    OrdersRepository() {
+        useIdempotencyGuard();   // enable the journal-backed guard for this repository
+    }
+}
+```
+
+Semantics when enabled: each dispatch scans the last `historyDepth()` journal events
+(default 100) rather than "everything since the last snapshot." High-throughput aggregates
+that enable it should tune `historyDepth`.
+
+**In production with the guard off (the default), configure a delivery `deduplicationWindow`**
+sized to your realistic redelivery/retry horizon. Otherwise a redelivery after a JVM restart
+or cache eviction could apply a state mutation twice, since state now changes directly
+in the handler.
+
+## 6. Recent-history access states its window
+
+Business logic that reads recent history now states how far back it looks, in events (D10):
+
+```java
+protected final Iterator<Event> historyBackward(int depth);
+protected final boolean historyContains(int depth, Predicate<Event> predicate);
+```
+
+The count is **events**, not commands — after the version change above, one command may emit
+several events sharing one version. History is loaded lazily from the journal tail, sized to
+the request.
+
+The parameterless `historyBackward()` and `historyContains(Predicate)` are **deprecated but
+still work**, delegating with a fixed `depth` of 100 — regardless of any `setHistoryDepth(n)`
+you configure. Their effective window changes from "everything since the last snapshot" to
+"the last 100 events." Move to the explicit forms and state the window your logic needs.
+
+## 7. Snapshot configuration is removed
+
+Snapshots no longer exist, so their configuration is gone (not merely deprecated):
+
+| Removed | Replacement |
+|---------|-------------|
+| `AggregateRepository.setSnapshotTrigger(int)` | `AggregateRepository.setHistoryDepth(int)` |
+| `AggregateRepository.snapshotTrigger()` | `AggregateRepository.historyDepth()` |
+| `Aggregate.toSnapshot()` | — (loading reads the state record) |
+
+The `Snapshot` and `AggregateHistory` proto messages are **retained** for journal wire
+compatibility. Snapshot-index journal trimming (`AggregateStorage.truncateOlderThan`) is
+meaningless without snapshots; until count/date-based trimming ships (a later, decoupled
+phase), **the event journal is append-only and grows unbounded**. This is acceptable for the
+pre-GA window; plan storage accordingly for high-volume aggregates.
+
+## 8. Data caveat — `NONE`-visibility aggregates are a hard break
+
+Read this before upgrading a running system.
+
+Because the persisted state record is now the source of truth, an aggregate can only be
+loaded if it **has** a materialized state record. Before this release, state was persisted
+only for aggregates that were **visible for querying** (`(entity).visibility != NONE`). An
+aggregate whose state message is `(entity).visibility = NONE` and that relied on event replay
+has **no materialized state** — no snapshot, no pre-cutover state record, and no Mirror to
+recover from. Such aggregates are a **hard break** on upgrade, and **no migration tooling is
+shipped** to close the gap (product decision — Spine 2.x is pre-GA).
+
+Going forward the problem cannot recur: state persistence is decoupled from visibility, so
+every aggregate's business state is now stored unconditionally. `queryingEnabled` continues
+to gate only the read-side query exposure, not whether state is stored. But this fixes new
+data only; it cannot reconstruct state that was never persisted before the cutover.
+
+## Removed and deprecated API — quick reference
+
+**Removed** (compile errors — migrate the call site):
+
+- `Aggregate` `@Apply` appliers → move bodies into `@Assign` / `@React` (§1)
+- `AggregateRepository.setSnapshotTrigger(int)` / `snapshotTrigger()` → `setHistoryDepth` /
+  `historyDepth` (§7)
+- `Aggregate.toSnapshot()` (§7)
+- `ImportBus`, `EventImportEndpoint`, `EventImportDispatcher`,
+  `UnsupportedImportEventException`,
+  `AggregateRepository.setupImportRouting` / `eventImportRouting`,
+  `AggregateClass.importableEvents()` / `importsEvents()`, `BlackBox.importsEvent` (§3)
+
+**Deprecated** (still compile; removed in v2.0.0):
+
+- `@Apply` and `@Apply#allowImport` — detection-only; a declared applier is a `ModelError`
+- `Aggregate.historyBackward()` / `historyContains(Predicate)` → the `depth` forms (§6)
+
+**Retained for wire compatibility** (do not use in new code): the `Snapshot` and
+`AggregateHistory` proto messages; the `EventImported` and `AggregateHistoryCorrupted` system
+events with their emitters; the `InboxLabel.IMPORT_EVENT` label.

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -133,9 +133,8 @@ public abstract class Aggregate<I,
         implements EventReactor, HasLifecycleColumns<I, S> {
 
     /**
-     * The number of the most recent journal events exposed by the deprecated parameterless
-     * {@linkplain #historyBackward() history accessors} and used as the window of the opt-in
-     * {@link IdempotencyGuard}.
+     * The fixed number of the most recent journal events read by the deprecated parameterless
+     * {@linkplain #historyBackward() history accessors}.
      *
      * <p>Equal to {@code AggregateRepository.DEFAULT_HISTORY_DEPTH}.
      */
@@ -387,7 +386,7 @@ public abstract class Aggregate<I,
     }
 
     /**
-     * Returns the uncommitted events and snapshots for this aggregate.
+     * Returns the uncommitted events of this aggregate.
      */
     UncommittedHistory uncommittedHistory() {
         return uncommittedHistory;
@@ -405,12 +404,14 @@ public abstract class Aggregate<I,
     }
 
     /**
-     * Instructs to modify the state of an aggregate only within an event applier method.
+     * Returns the message shown when an aggregate's state or lifecycle flags are modified outside
+     * a receptor's transaction.
      */
     @Override
     protected final String missingTxMessage() {
         return "Modification of aggregate state or its lifecycle flags is not available this way." +
-                " Make sure to modify those only from an event applier method.";
+                " Please modify the state from a command handling (`@Assign`)" +
+                " or event reacting (`@React`) method.";
     }
 
     /**

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -410,8 +410,8 @@ public abstract class Aggregate<I,
     @Override
     protected final String missingTxMessage() {
         return "Modification of aggregate state or its lifecycle flags is not available this way." +
-                " Please modify the state from a command handling (`@Assign`)" +
-                " or event reacting (`@React`) method.";
+                " Modify it from within a command handler (`@Assign`)" +
+                " or an event reactor (`@React`).";
     }
 
     /**

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -87,6 +87,23 @@ import static java.util.Objects.requireNonNull;
 /**
  * The repository that manages instances of {@code Aggregate}s.
  *
+ * <p>The repository routes commands and events to its aggregates, stores the events they
+ * produce, and posts those events to the {@link io.spine.server.event.EventBus EventBus}.
+ *
+ * <p>Since the event-sourcing cutover, an aggregate is loaded from its latest persisted
+ * {@link io.spine.server.entity.EntityRecord EntityRecord} rather than by replaying its event
+ * journal. The journal is kept append-only for traceability and for the opt-in
+ * {@link IdempotencyGuard}.
+ *
+ * <p>Two per-repository settings tune this behavior:
+ * <ul>
+ *     <li>{@linkplain #historyDepth() historyDepth} — the number of most recent journal events
+ *         exposed as an aggregate's recent history (default {@value #DEFAULT_HISTORY_DEPTH}).
+ *     <li>{@link #useIdempotencyGuard()} — enables the journal-backed {@link IdempotencyGuard}.
+ *         The guard is <b>off by default</b>: deduplication is primarily the responsibility of
+ *         the delivery layer.
+ * </ul>
+ *
  * @param <I>
  *         the type of the aggregate IDs
  * @param <A>
@@ -103,7 +120,7 @@ public abstract class AggregateRepository<I,
         implements CommandDispatcher, EventProducingRepository,
                    EventDispatcherDelegate, QueryableRepository<I, S> {
 
-    /** The default number of events to be stored before a new snapshot is made. */
+    /** The default {@link #historyDepth()} value. */
     static final int DEFAULT_HISTORY_DEPTH = 100;
 
     /** The routing schema for commands handled by the aggregates. */
@@ -120,7 +137,7 @@ public abstract class AggregateRepository<I,
 
     private @MonotonicNonNull RepositoryCache<I, A> cache;
 
-    /** The recent-history window (formerly the snapshot trigger). */
+    /** The recent-history window. */
     private int historyDepth = DEFAULT_HISTORY_DEPTH;
 
     /** Whether the opt-in {@link IdempotencyGuard} is enabled for this repository. */
@@ -430,9 +447,8 @@ public abstract class AggregateRepository<I,
     }
 
     /**
-     * Returns the number of the most recent journal events made available to the opt-in
-     * {@link IdempotencyGuard} and to the deprecated parameterless history accessors of
-     * {@link Aggregate}.
+     * Returns the number of the most recent journal events scanned by the opt-in
+     * {@link IdempotencyGuard} when it is enabled.
      *
      * @return a positive integer value; the default is {@value #DEFAULT_HISTORY_DEPTH}
      */

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -97,11 +97,11 @@ import static java.util.Objects.requireNonNull;
  *
  * <p>Two per-repository settings tune this behavior:
  * <ul>
- *     <li>{@linkplain #historyDepth() historyDepth} — the number of most recent journal events
- *         exposed as an aggregate's recent history (default {@value #DEFAULT_HISTORY_DEPTH}).
- *     <li>{@link #useIdempotencyGuard()} — enables the journal-backed {@link IdempotencyGuard}.
- *         The guard is <b>off by default</b>: deduplication is primarily the responsibility of
- *         the delivery layer.
+ *     <li>{@link #useIdempotencyGuard()} — enables the journal-backed {@link IdempotencyGuard}, a
+ *         backstop against duplicate dispatches. It is <b>off by default</b>: deduplication is
+ *         primarily the responsibility of the delivery layer.
+ *     <li>{@linkplain #historyDepth() historyDepth} — how many recent journal events the guard
+ *         scans on each dispatch when enabled (default {@value #DEFAULT_HISTORY_DEPTH}).
  * </ul>
  *
  * @param <I>
@@ -137,7 +137,7 @@ public abstract class AggregateRepository<I,
 
     private @MonotonicNonNull RepositoryCache<I, A> cache;
 
-    /** The recent-history window. */
+    /** The window (in journal events) the opt-in {@link IdempotencyGuard} scans. */
     private int historyDepth = DEFAULT_HISTORY_DEPTH;
 
     /** Whether the opt-in {@link IdempotencyGuard} is enabled for this repository. */
@@ -457,10 +457,10 @@ public abstract class AggregateRepository<I,
     }
 
     /**
-     * Sets the {@linkplain #historyDepth() recent-history window} to the passed value.
+     * Sets the {@linkplain #historyDepth() history depth} to the passed value.
      *
      * @param depth
-     *         a positive number of the most recent events to keep available
+     *         a positive number of recent journal events the idempotency guard scans
      */
     protected void setHistoryDepth(int depth) {
         checkArgument(depth > 0);

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -97,9 +97,11 @@ import static java.util.Objects.requireNonNull;
  *
  * <p>Two per-repository settings tune this behavior:
  * <ul>
- *     <li>{@link #useIdempotencyGuard()} — enables the journal-backed {@link IdempotencyGuard}, a
- *         backstop against duplicate dispatches. It is <b>off by default</b>: deduplication is
- *         primarily the responsibility of the delivery layer.
+ *     <li>{@link #useIdempotencyGuard()} — enables the journal-backed {@link IdempotencyGuard},
+ *         which rejects a signal already seen among the last {@link #historyDepth()} dispatches
+ *         (however long ago). It is <b>off by default</b> for performance — when enabled, every
+ *         dispatch pays a bounded journal read. This is a mechanism distinct from the delivery
+ *         layer's time-windowed deduplication, not a replacement for it.
  *     <li>{@linkplain #historyDepth() historyDepth} — how many recent journal events the guard
  *         scans on each dispatch when enabled (default {@value #DEFAULT_HISTORY_DEPTH}).
  * </ul>
@@ -471,9 +473,10 @@ public abstract class AggregateRepository<I,
      * Enables the opt-in, journal-backed {@link IdempotencyGuard} for the aggregates of this
      * repository.
      *
-     * <p>The guard is <b>off by default</b> — deduplication is primarily the delivery layer's
-     * responsibility. Enable it as a durable backstop against duplicate dispatches; when enabled,
-     * each dispatch scans the last {@link #historyDepth()} journal events.
+     * <p>When enabled, each dispatch scans the last {@link #historyDepth()} journal events and
+     * rejects a signal already seen among them, however long ago it was dispatched — a mechanism
+     * distinct from the delivery layer's time-windowed deduplication. The guard is
+     * <b>off by default</b> for performance: it adds a bounded journal read to every dispatch.
      */
     protected void useIdempotencyGuard() {
         this.idempotencyGuardEnabled = true;

--- a/server/src/main/java/io/spine/server/aggregate/Apply.java
+++ b/server/src/main/java/io/spine/server/aggregate/Apply.java
@@ -52,8 +52,8 @@ public @interface Apply {
     /**
      * Formerly enabled importing of events into the aggregate.
      *
-     * @deprecated Event import has been removed. External facts now enter via
-     *         {@code (external) = true} reactions or context gateways. This attribute is ignored.
+     * @deprecated Event import has been removed. External facts now enter via reactions to
+     *         {@code @External} events or context gateways. This attribute is ignored.
      */
     @Deprecated
     boolean allowImport() default false;

--- a/server/src/main/java/io/spine/server/aggregate/package-info.java
+++ b/server/src/main/java/io/spine/server/aggregate/package-info.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -24,6 +24,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ * This package provides classes for creating and managing aggregates.
+ *
+ * <p>Since the event-sourcing cutover, an aggregate loads from its latest persisted state and
+ * keeps the events it produces as an append-only journal for traceability, rather than
+ * reconstructing its state by replaying them. See {@link io.spine.server.aggregate.Aggregate}.
+ */
 @CheckReturnValue
 @NullMarked
 package io.spine.server.aggregate;

--- a/server/src/main/proto/spine/server/aggregate/aggregate.proto
+++ b/server/src/main/proto/spine/server/aggregate/aggregate.proto
@@ -125,36 +125,3 @@ message AggregateHistory {
     repeated core.Event event = 2;
 }
 
-
-// The state of an aggregate at some point in time stored as a distinct record.
-//
-// Being persisted separately from aggregate's history (i.e. event and snapshot records),
-// state records unlock the possibility to query the storage for aggregate instances.
-//
-// The records of this type are not used to replay the aggregate history, but rather serve as
-// an eventually-consistent "read-side" of the stored aggregate instance.
-//
-message AggregateStateRecord {
-
-    // The ID of the corresponding aggregate packed as Any.
-    google.protobuf.Any value = 1 [(required) = true, (validate) = true];
-
-    // The type URL of the aggregate ID.
-    string id_type = 2 [(required) = true];
-
-    // The state of the aggregate.
-    //
-    // This field is populated if the aggregate is visible for querying.
-    //
-    google.protobuf.Any state = 3;
-
-    // The version of the aggregate.
-    core.Version version = 4;
-
-    // The aggregate type URL.
-    string aggregate_type = 5 [(column) = true];
-
-    // The lifecycle flags of the aggregate.
-    spine.server.entity.LifecycleFlags lifecycle = 6;
-}
-

--- a/server/src/main/proto/spine/server/aggregate/aggregate.proto
+++ b/server/src/main/proto/spine/server/aggregate/aggregate.proto
@@ -112,7 +112,7 @@ message AggregateEventRecord {
 
 // The recorded history of an aggregate: the sequence of events it emitted.
 //
-// Since the de-event-sourcing cutover, aggregate state is no longer restored by
+// Since the event-sourcing cutover, aggregate state is no longer restored by
 // replaying this history. It is kept as an append-only journal for
 // traceability and recent-history lookups.
 //

--- a/server/src/main/proto/spine/server/aggregate/aggregate.proto
+++ b/server/src/main/proto/spine/server/aggregate/aggregate.proto
@@ -117,7 +117,9 @@ message AggregateEventRecord {
 // traceability and recent-history lookups.
 //
 // The `snapshot` field is retained for wire compatibility with pre-cutover data
-// and is not populated by the current runtime.
+// and is not populated by the current runtime. The field-level comments below
+// describe the historical (pre-cutover) snapshot-plus-tail semantics and no
+// longer reflect how the runtime uses this message.
 //
 message AggregateHistory {
 

--- a/server/src/main/proto/spine/server/aggregate/aggregate.proto
+++ b/server/src/main/proto/spine/server/aggregate/aggregate.proto
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -23,6 +23,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 syntax = "proto3";
 
 package spine.server.aggregate;
@@ -43,7 +44,13 @@ import "spine/core/version.proto";
 import "spine/server/entity/entity.proto";
 
 
-// The message for storing an aggregate snapshot.
+// A snapshot of an aggregate's state at a point in its history.
+//
+// Retained for wire compatibility with pre-cutover journal data. The runtime no
+// longer produces snapshots: event-sourced loading was removed, so an aggregate's
+// state is restored from its latest record rather than by replaying events from
+// a snapshot.
+//
 message Snapshot {
 
     // The state of the aggregate.
@@ -103,13 +110,14 @@ message AggregateEventRecord {
     google.protobuf.Any aggregate_id = 5;
 }
 
-// A history of an aggregate is a sequence of its events that is used by the aggregate
-// to restore its state.
+// The recorded history of an aggregate: the sequence of events it emitted.
 //
-// The history may start from a snapshot of the aggregate state. If so, the snapshot will be
-// used as the starting point before playing events that occurred after the snapshot.
+// Since the de-event-sourcing cutover, aggregate state is no longer restored by
+// replaying this history. It is kept as an append-only journal for
+// traceability and recent-history lookups.
 //
-// If no snapshot is available, events represent the full history of the aggregate.
+// The `snapshot` field is retained for wire compatibility with pre-cutover data
+// and is not populated by the current runtime.
 //
 message AggregateHistory {
 

--- a/server/src/main/proto/spine/server/delivery/inbox.proto
+++ b/server/src/main/proto/spine/server/delivery/inbox.proto
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -23,6 +23,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 syntax = "proto3";
 
 package spine.server.delivery;
@@ -68,7 +69,13 @@ enum InboxLabel {
     // Pass an event message to a `@React` or `@Command`-annotated event handler.
     REACT_UPON_EVENT = 4;
 
-    // Pass an event message to a `@Apply(allowImport = "true")`-annotated event handler.
+    // Retained for wire compatibility; no longer produced by the runtime.
+    //
+    // This label used to route an event to an event-importing receptor (an
+    // `@Apply` applier with `allowImport` enabled). Event import and `@Apply`
+    // were removed during the de-event-sourcing cutover, so nothing emits this
+    // label anymore. The value is kept so that `InboxMessage` records written
+    // by earlier versions still parse.
     IMPORT_EVENT = 5;
 
     // Pass an event message to the projection in scope of a catch-up process.

--- a/server/src/main/proto/spine/server/delivery/inbox.proto
+++ b/server/src/main/proto/spine/server/delivery/inbox.proto
@@ -73,7 +73,7 @@ enum InboxLabel {
     //
     // This label used to route an event to an event-importing receptor (an
     // `@Apply` applier with `allowImport` enabled). Event import and `@Apply`
-    // were removed during the de-event-sourcing cutover, so nothing emits this
+    // were removed during the event-sourcing cutover, so nothing emits this
     // label anymore. The value is kept so that `InboxMessage` records written
     // by earlier versions still parse.
     IMPORT_EVENT = 5;

--- a/server/src/main/proto/spine/system/server/diagnostic_events.proto
+++ b/server/src/main/proto/spine/system/server/diagnostic_events.proto
@@ -121,7 +121,7 @@ message RoutingFailed {
 // replaying historical events.
 //
 // Retained for wire compatibility; no longer emitted. Aggregates no longer replay events to
-// load their state — event-sourced loading was removed during the de-event-sourcing cutover —
+// load their state — event-sourced loading was removed during the event-sourcing cutover —
 // so this kind of load-time corruption can no longer occur.
 //
 message AggregateHistoryCorrupted {

--- a/server/src/main/proto/spine/system/server/diagnostic_events.proto
+++ b/server/src/main/proto/spine/system/server/diagnostic_events.proto
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -23,6 +23,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 syntax = "proto3";
 
 package spine.system.server;
@@ -116,32 +117,12 @@ message RoutingFailed {
     base.Error error = 3;
 }
 
-// An event emitted when an Aggregate cannot load its history due to an error while applying
-// historical events.
+// Emitted when an Aggregate could not load its history because an error occurred while
+// replaying historical events.
 //
-// The event is emitted upon each attempt to load the Aggregate.
-//
-// An Aggregate with a corrupted history cannot handle new signals.
-//
-// The Aggregate state accessible to read side is undefined. It may reflect the state of the
-// Aggregate after the last successful event, or may have advanced further, including changes caused
-// by the erroneous event. An `EntityStateChanged` event must be emitted after the error is resolved
-// to catch up the read-side on the valid Aggregate state.
-//
-// The error may take place some time after the erroneous event was emitted. In this case, there may
-// be newer events in the Aggregate history. Those events cannot be applied to the Aggregate either.
-// See `interrupted_events` for the number of such events.
-//
-// The framework does not provide a turn-key solution for resolving this kind of data corruption.
-// Depending on the situation, there may be different approaches to the problem. Most common ones
-// are:
-//   - Change the logic in the event applier, so that a runtime error is not produced for the given
-//     event.
-//   - Manually change the event in the database. Note that the erroneous event may have been
-//     propagated to other entities. Re-writing part of the system's history might lead to
-//     inconsistent data.
-//   - Manually delete the event in the database. Just like the previous approach, this is
-//     a dangerous operation as the consequences of changing the history are unpredictable.
+// Retained for wire compatibility; no longer emitted. Aggregates no longer replay events to
+// load their state — event-sourced loading was removed during the de-event-sourcing cutover —
+// so this kind of load-time corruption can no longer occur.
 //
 message AggregateHistoryCorrupted {
 

--- a/server/src/main/proto/spine/system/server/diagnostic_events.proto
+++ b/server/src/main/proto/spine/system/server/diagnostic_events.proto
@@ -117,12 +117,12 @@ message RoutingFailed {
     base.Error error = 3;
 }
 
-// Emitted when an Aggregate could not load its history because an error occurred while
-// replaying historical events.
+// Retained for wire compatibility; no longer emitted.
 //
-// Retained for wire compatibility; no longer emitted. Aggregates no longer replay events to
-// load their state — event-sourced loading was removed during the event-sourcing cutover —
-// so this kind of load-time corruption can no longer occur.
+// Formerly emitted when an Aggregate could not load its history because an error occurred
+// while replaying historical events. Event-sourced loading was removed during the
+// event-sourcing cutover — aggregates no longer replay events to load their state — so this
+// kind of load-time corruption can no longer occur.
 //
 message AggregateHistoryCorrupted {
 

--- a/server/src/main/proto/spine/system/server/entity_log_events.proto
+++ b/server/src/main/proto/spine/system/server/entity_log_events.proto
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -129,6 +129,10 @@ message CommandDispatchedToHandler {
 }
 
 // An event was imported into an aggregate.
+//
+// Retained for wire compatibility; no longer emitted. Event import was removed
+// during the de-event-sourcing cutover.
+//
 message EventImported {
     option (is).java_type = "EventDispatchedMixin";
 

--- a/server/src/main/proto/spine/system/server/entity_log_events.proto
+++ b/server/src/main/proto/spine/system/server/entity_log_events.proto
@@ -131,7 +131,7 @@ message CommandDispatchedToHandler {
 // An event was imported into an aggregate.
 //
 // Retained for wire compatibility; no longer emitted. Event import was removed
-// during the de-event-sourcing cutover.
+// during the event-sourcing cutover.
 //
 message EventImported {
     option (is).java_type = "EventDispatchedMixin";

--- a/server/src/main/proto/spine/system/server/entity_log_events.proto
+++ b/server/src/main/proto/spine/system/server/entity_log_events.proto
@@ -128,9 +128,9 @@ message CommandDispatchedToHandler {
     EntityTypeName entity_type = 4 [(required) = true];
 }
 
-// An event was imported into an aggregate.
+// Retained for wire compatibility; no longer emitted.
 //
-// Retained for wire compatibility; no longer emitted. Event import was removed
+// Formerly emitted when an event was imported into an aggregate. Event import was removed
 // during the event-sourcing cutover.
 //
 message EventImported {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of this library.
  */
-extra.set("versionToPublish", "2.0.0-SNAPSHOT.421")
+extra.set("versionToPublish", "2.0.0-SNAPSHOT.422")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of this library.
  */
-extra.set("versionToPublish", "2.0.0-SNAPSHOT.420")
+extra.set("versionToPublish", "2.0.0-SNAPSHOT.421")


### PR DESCRIPTION
## What & why

Final **docs & polish** phase (PR-B3) of the aggregate de-event-sourcing train. Completes
the documentation for the cutover that landed the runtime change in #1647, and bundles the
small related changes queued during the train so the review is a single round.

## Changes

- **Migration guide** — new `docs/migration/aggregates-without-event-sourcing.md`: the
  applier→handler recipe, `tryAlter` / `builder().validate()` preventive validation, event-import
  removal and its replacement idioms, the +1-version-per-command change, dedup / idempotency-guard
  semantics, the explicit `historyBackward(depth)` window, removed snapshot config, and the
  `NONE`-visibility data caveat.
- **Javadoc polish** — expand the `AggregateRepository` class doc; fix stale snapshot-era comments;
  correct `Aggregate.missingTxMessage()` (was pointing users at the removed `@Apply` appliers),
  `uncommittedHistory()`, and the history-depth docs; add the `aggregate` package overview.
- **Proto wire-compat comments** — document `Snapshot`, `AggregateHistory`, `EventImported`,
  `AggregateHistoryCorrupted`, and `InboxLabel.IMPORT_EVENT` as retained for wire compatibility and
  no longer produced by the runtime; fix the stale `IMPORT_EVENT` comment that still referenced the
  removed `@Apply(allowImport)`. **Comment/copyright-only — no message or field structural change.**
- **Plan docs** (`.agents/**`, review-exempt) — Phase D storage naming
  (`EntityStateHistoryStorage`, `EntityEventStorage` / `EntityEventHistory`) and the
  one-message-per-proto-file convention.

## Notes for the reviewer

- **No runtime/behavior change** — this PR is documentation, comments, and a version bump.
- **Diff scope:** `origin/master` is currently a few commits behind local `master`, so this PR
  temporarily shows PR-B2's tail commits (the `.421` bump, dependency-report update, and the
  `AggregateStateRecord` proto removal) in addition to the PR-B3 commit. They drop out of the diff
  automatically once `origin/master` catches up. The PR-B3 change set proper is the "Document
  aggregates without event sourcing" commit plus the `.422` version bump.
- Design authority: the accepted ADR at `docs/adr/0001-aggregates-without-event-sourcing.md`; the new guide lives at `docs/migration/aggregates-without-event-sourcing.md`.
- Verification: `./gradlew clean build dokkaGenerate` green; `spine-code-review` and `review-docs` both APPROVE (findings addressed in the "Address review feedback" commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
