### PR TITLE
Migrate `RecordSpec.ExtractId` off Guava's `Function`

### DIFF
--- a/.agents/tasks/guava-function-migration.md
+++ b/.agents/tasks/guava-function-migration.md
@@ -2,6 +2,11 @@
 
 **Status:** implemented and verified on `claude/guava-function-nullability-474d2d`
 (2026-07-10); `./gradlew build dokkaGenerate` passes (3m 45s, all tests green).
+PR [#1651](https://github.com/SpineEventEngine/core-jvm/pull/1651) OPEN.
+Version `2.0.0-SNAPSHOT.431` (2026-07-11, corrected from an initial `.440`:
+owner judged the `ExtractId` supertype swap isolated/non-breaking rather than
+worth the round-up-to-10 treatment; a separate branch — PR #1650, currently
+also on `.431` — will rebase onto this PR and renumber past it).
 **Goal:** remove the nullability noise forced on every `RecordSpec` call site
 by Guava's `com.google.common.base.Function`.
 
@@ -55,4 +60,6 @@ Out of scope: Guava `Supplier`/`Predicate` usages (mostly
 `ExtractId` no longer `instanceof` Guava `Function`. Lambda / method-ref
 call sites (all known ones) are unaffected; only code assigning an
 `ExtractId` to a Guava `Function`-typed variable would break, and none
-exists in this repo or is known downstream.
+exists in this repo or is known downstream. This is why the version was
+corrected to a plain snapshot bump (`.431`) rather than the breaking
+round-up (`.440`) initially applied.

--- a/.agents/tasks/guava-function-migration.md
+++ b/.agents/tasks/guava-function-migration.md
@@ -1,0 +1,58 @@
+# Migrate `ExtractId` off Guava's `Function`
+
+**Status:** implemented and verified on `claude/guava-function-nullability-474d2d`
+(2026-07-10); `./gradlew build dokkaGenerate` passes (3m 45s, all tests green).
+**Goal:** remove the nullability noise forced on every `RecordSpec` call site
+by Guava's `com.google.common.base.Function`.
+
+## Root cause
+
+`RecordSpec.ExtractId` (`server/src/main/java/io/spine/server/storage/RecordSpec.java`)
+extends Guava's `Function<R, I>` and, to stay compatible with the parent's
+nullness contract, declares its `apply` parameter `@Nullable`:
+
+```java
+public interface ExtractId<R extends Message, I> extends Function<R, I> {
+    @Override
+    @CanIgnoreReturnValue
+    I apply(@Nullable R input);
+}
+```
+
+The framework never passes `null`, yet the `@Nullable` parameter leaks into
+every implementation site:
+
+- Kotlin SAM lambdas see a nullable parameter and need
+  `requireNotNull(...)` plus an explanatory comment
+  (`EntityEventStorage.kt`).
+- Java method references (`CatchUp::getId` etc.) trip IDEA's
+  `ConstantConditions` inspection, suppressed with a
+  "Protobuf getters do not return null" comment in five places.
+
+This is the only use of Guava's `Function` in the repository.
+
+## Plan
+
+1. `RecordSpec.java`: extend `java.util.function.Function` instead;
+   `apply(R input)` with no `@Nullable` (package is `@NullMarked`).
+2. `SpecScanner.java`: anonymous `ExtractId` — drop `@Nullable` from the
+   `apply` parameter, drop the now-dead `requireNonNull(input)`, drop the
+   redundant `@NonNull` on `idFromRecord()`.
+3. `EntityEventStorage.kt`: `{ event -> requireNotNull(event).id }` →
+   `{ event -> event.id }`; delete the comment.
+4. Remove the `@SuppressWarnings("ConstantConditions")` + comment tied to
+   this in `CatchUpStorage`, `InboxStorage`, `MirrorStorage`,
+   `DefaultTenantStorage`, `StgProjectStorage` (testFixtures).
+5. Compile `server` (Java + Kotlin, all source sets), run storage-focused
+   tests.
+
+Out of scope: Guava `Supplier`/`Predicate` usages (mostly
+`Suppliers.memoize`, a deliberate Guava API); `io.spine.query.Column.Getter`
+(lives in spine-base, not this repo).
+
+## Compatibility note
+
+`ExtractId` no longer `instanceof` Guava `Function`. Lambda / method-ref
+call sites (all known ones) are unaffected; only code assigning an
+`ExtractId` to a Guava `Function`-typed variable would break, and none
+exists in this repo or is known downstream.

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.440`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.431`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1085,14 +1085,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using 
+This report was generated on **Fri Jul 10 18:24:48 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.440`
+# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.431`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2273,14 +2273,14 @@ This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using 
+This report was generated on **Fri Jul 10 18:24:47 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.440`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.431`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3301,14 +3301,14 @@ This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using 
+This report was generated on **Fri Jul 10 18:24:48 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.440`
+# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.431`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4363,14 +4363,14 @@ This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using 
+This report was generated on **Fri Jul 10 18:24:47 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.440`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.431`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5467,14 +5467,14 @@ This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using 
+This report was generated on **Fri Jul 10 18:24:48 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.440`
+# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.431`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -6647,14 +6647,14 @@ This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using 
+This report was generated on **Fri Jul 10 18:24:48 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.440`
+# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.431`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -7887,6 +7887,6 @@ This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using 
+This report was generated on **Fri Jul 10 18:24:48 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.430`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.440`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1085,14 +1085,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 10 01:34:20 WEST 2026** using 
+This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.430`
+# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.440`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2273,14 +2273,14 @@ This report was generated on **Fri Jul 10 01:34:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 10 01:34:20 WEST 2026** using 
+This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.430`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.440`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3301,14 +3301,14 @@ This report was generated on **Fri Jul 10 01:34:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 10 01:34:20 WEST 2026** using 
+This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.430`
+# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.440`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4363,14 +4363,14 @@ This report was generated on **Fri Jul 10 01:34:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 10 01:34:20 WEST 2026** using 
+This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.430`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.440`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5467,14 +5467,14 @@ This report was generated on **Fri Jul 10 01:34:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 10 01:34:20 WEST 2026** using 
+This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.430`
+# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.440`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -6647,14 +6647,14 @@ This report was generated on **Fri Jul 10 01:34:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 10 01:34:20 WEST 2026** using 
+This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.430`
+# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.440`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -7887,6 +7887,6 @@ This report was generated on **Fri Jul 10 01:34:20 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 10 01:34:20 WEST 2026** using 
+This report was generated on **Fri Jul 10 21:45:36 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>core-jvm</artifactId>
-<version>2.0.0-SNAPSHOT.440</version>
+<version>2.0.0-SNAPSHOT.431</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>core-jvm</artifactId>
-<version>2.0.0-SNAPSHOT.430</version>
+<version>2.0.0-SNAPSHOT.440</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/delivery/CatchUpStorage.java
+++ b/server/src/main/java/io/spine/server/delivery/CatchUpStorage.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -62,7 +62,6 @@ public class CatchUpStorage extends MessageStorage<CatchUpId, CatchUp> {
               factory.createRecordStorage(Delivery.contextSpec(multitenant), getSpec()));
     }
 
-    @SuppressWarnings("ConstantConditions")     // Protobuf getters do not return {@code null}.
     private static RecordSpec<CatchUpId, CatchUp> getSpec() {
         return new RecordSpec<>(CatchUpId.class,
                                 CatchUp.class,

--- a/server/src/main/java/io/spine/server/delivery/InboxStorage.java
+++ b/server/src/main/java/io/spine/server/delivery/InboxStorage.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -77,12 +77,10 @@ public class InboxStorage extends MessageStorage<InboxMessageId, InboxMessage> {
     }
 
     private static RecordSpec<InboxMessageId, InboxMessage> spec() {
-        @SuppressWarnings("ConstantConditions")     // Protobuf getters do not return {@code null}s.
-        var spec = new RecordSpec<>(InboxMessageId.class,
-                                    InboxMessage.class,
-                                    InboxMessage::getId,
-                                    InboxColumn.definitions());
-        return spec;
+        return new RecordSpec<>(InboxMessageId.class,
+                                InboxMessage.class,
+                                InboxMessage::getId,
+                                InboxColumn.definitions());
     }
 
     /**

--- a/server/src/main/java/io/spine/server/entity/storage/SpecScanner.java
+++ b/server/src/main/java/io/spine/server/entity/storage/SpecScanner.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -27,7 +27,6 @@
 package io.spine.server.entity.storage;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Any;
 import io.spine.annotation.Internal;
 import io.spine.annotation.VisibleForTesting;
@@ -43,7 +42,6 @@ import io.spine.server.entity.EntityRecord;
 import io.spine.server.entity.model.EntityClass;
 import io.spine.server.storage.RecordSpec;
 import io.spine.server.storage.RecordSpec.ExtractId;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import java.util.HashMap;
@@ -217,17 +215,9 @@ public final class SpecScanner {
         };
     }
 
-    @NonNull
+    @SuppressWarnings("unchecked")
     private static <I> ExtractId<EntityRecord, I> idFromRecord() {
-        return new ExtractId<>() {
-            @SuppressWarnings("unchecked")
-            @CanIgnoreReturnValue
-            @Override
-            public I apply(@Nullable EntityRecord input) {
-                requireNonNull(input);
-                return (I) Identifier.unpack(input.getEntityId());
-            }
-        };
+        return input -> (I) Identifier.unpack(input.getEntityId());
     }
 
     /**

--- a/server/src/main/java/io/spine/server/migration/mirror/MirrorStorage.java
+++ b/server/src/main/java/io/spine/server/migration/mirror/MirrorStorage.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -62,9 +62,8 @@ public final class MirrorStorage extends MessageStorage<MirrorId, Mirror> {
         super(context, factory.createRecordStorage(context, messageSpec()));
     }
 
-    @SuppressWarnings("ConstantConditions")
     private static RecordSpec<MirrorId, Mirror> messageSpec() {
-        var spec = new RecordSpec<>(
+        return new RecordSpec<>(
                 MirrorId.class,
                 Mirror.class,
                 Mirror::getId,
@@ -73,7 +72,6 @@ public final class MirrorStorage extends MessageStorage<MirrorId, Mirror> {
                         Mirror.Column.wasMigrated()
                 )
         );
-        return spec;
     }
 
     @Override

--- a/server/src/main/java/io/spine/server/storage/RecordSpec.java
+++ b/server/src/main/java/io/spine/server/storage/RecordSpec.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -26,7 +26,6 @@
 
 package io.spine.server.storage;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -43,6 +42,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -293,10 +293,10 @@ public final class RecordSpec<I, R extends Message> {
         /**
          * {@inheritDoc}
          *
-         * This method differs from its parent by the fact it never returns {@code null}.
+         * <p>Neither the argument nor the returned value may be {@code null}.
          */
         @Override
         @CanIgnoreReturnValue
-        I apply(@Nullable R input);
+        I apply(R input);
     }
 }

--- a/server/src/main/java/io/spine/server/tenant/DefaultTenantStorage.java
+++ b/server/src/main/java/io/spine/server/tenant/DefaultTenantStorage.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -49,7 +49,6 @@ final class DefaultTenantStorage extends TenantStorage<Tenant> {
         super(contextSpec, factory.createRecordStorage(contextSpec, spec()));
     }
 
-    @SuppressWarnings("ConstantConditions")     // Protobuf getters do not return {@code null}s.
     private static RecordSpec<TenantId, Tenant> spec() {
         return new RecordSpec<>(TenantId.class, Tenant.class, Tenant::getId);
     }

--- a/server/src/main/kotlin/io/spine/server/entity/storage/EntityEventStorage.kt
+++ b/server/src/main/kotlin/io/spine/server/entity/storage/EntityEventStorage.kt
@@ -231,8 +231,6 @@ public class EntityEventStorage(
 private val spec: RecordSpec<EventId, Event> = RecordSpec(
     EventId::class.java,
     Event::class.java,
-    // The parameter is nullable only because the SAM inherits Guava's `Function`;
-    // the framework never passes `null` records.
-    { event -> requireNotNull(event).id },
+    { event -> event.id },
     EntityEventColumn.definitions()
 )

--- a/server/src/testFixtures/java/io/spine/server/storage/given/StgProjectStorage.java
+++ b/server/src/testFixtures/java/io/spine/server/storage/given/StgProjectStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,9 +52,7 @@ public class StgProjectStorage extends RecordStorageUnderTest<StgProjectId, StgP
     }
 
     private static RecordSpec<StgProjectId, StgProject> spec() {
-        @SuppressWarnings("ConstantConditions")     // Proto getters return non-{@code null} values.
-        var spec = new RecordSpec<>(StgProjectId.class, StgProject.class, StgProject::getId,
-                                           StgProjectColumns.definitions());
-        return spec;
+        return new RecordSpec<>(StgProjectId.class, StgProject.class, StgProject::getId,
+                                StgProjectColumns.definitions());
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of this library.
  */
-extra.set("versionToPublish", "2.0.0-SNAPSHOT.440")
+extra.set("versionToPublish", "2.0.0-SNAPSHOT.431")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of this library.
  */
-extra.set("versionToPublish", "2.0.0-SNAPSHOT.430")
+extra.set("versionToPublish", "2.0.0-SNAPSHOT.440")


### PR DESCRIPTION
## What

- `RecordSpec.ExtractId` now extends `java.util.function.Function` instead of Guava's `com.google.common.base.Function`, and declares its `apply` parameter non-null (`I apply(R input)`; the package is `@NullMarked`). This was the only use of Guava's `Function` in the repository.
- All workarounds forced by the old `@Nullable` parameter are removed:
  - `EntityEventStorage.kt`: the SAM lambda is now `{ event -> event.id }` — no `requireNotNull`, no explanatory comment.
  - `@SuppressWarnings("ConstantConditions") // Protobuf getters do not return null` dropped in `CatchUpStorage`, `InboxStorage`, `MirrorStorage`, `DefaultTenantStorage`, and `StgProjectStorage` (test fixtures).
  - The anonymous `ExtractId` in `SpecScanner` existed only to carry the nullability annotations; it is now a one-line lambda.

## Why

Guava's `Function.apply` accepts a nullable argument, and an override may not strengthen a parameter contract, so `ExtractId` had to declare `apply(@Nullable R input)`. That single declaration leaked nullability noise into every implementation site — Kotlin lambdas needed `requireNotNull(...)` plus a comment, and Java method references tripped IDE inspections. The JDK's `Function` leaves nullness unspecified, so the `@NullMarked` override can pin the contract to non-null.

## Notes for reviewers

- `ExtractId` is no longer assignable to Guava's `Function`. Lambda and method-reference call sites are unaffected; Kotlin implementations carrying the old nullable-parameter workaround simplify as above. The type is an internal SPI with no known Guava-typed consumers, so the version bump is a plain snapshot increment (`.430` → `.431`), not a breaking round-up.
- Runtime null-safety is unchanged: `RecordSpec.idValueIn` still `checkNotNull`s before delegating, and Kotlin SAM bridges emit `checkNotNullParameter`.
- Verified with `./gradlew clean build dokkaGenerate --no-build-cache` (all tests green); reviewed by `spine-code-review`, `kotlin-engineer`, and `review-docs` — all approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
