### PR TITLE
Move the event journal from `AggregateStorage` to `AggregateRepository`

### DIFF
--- a/.agents/tasks/event-storage-at-the-repo-level.md
+++ b/.agents/tasks/event-storage-at-the-repo-level.md
@@ -1,0 +1,113 @@
+# Move the event journal from `AggregateStorage` to `AggregateRepository`
+
+## Goal
+
+Remove the unnecessary delegation level: today `AggregateStorage` extends
+`EntityRecordStorage` *and* wraps an `EntityEventStorage` (the event journal).
+Since aggregates are no longer event-sourced, the journal is not part of the
+state storage's job. Make the `EntityEventStorage` a property of
+`AggregateRepository` instead, so the repository serves events to its
+aggregates — mirroring how it already owns and serves the *state history*
+(`EntityStateHistoryStorage`).
+
+This sets up the follow-up (Phase F of the de-event-sourcing plan): the same
+"repository owns the journal + state history" shape is then propagated to
+`ProcessManagerRepository`.
+
+## Why this is safe / small
+
+- `IdempotencyGuard` and `Aggregate.eventHistoryBackward(int)` read the journal
+  **through the installed `EventHistoryLoader`**, never through storage — so
+  they are unaffected.
+- Only **two** production call sites touch the storage's journal methods, both
+  inside `AggregateRepository`:
+  - `setUpHistoryReading()` — installs the loader:
+    `aggregate.setEventHistoryLoader(depth -> aggregateStorage().eventHistoryBackward(id, depth))`
+  - `doStore()` — `aggregateStorage().writeAll(aggregate, history.get())`
+- The journal's full behavior (write/clear-enrichments/read-window/truncate/
+  delete) is already covered directly by `EntityEventStorageSpec` (in-memory),
+  so the journal tests currently routed through `AggregateStorageTest` are
+  redundant duplicates.
+
+## Design decisions
+
+1. **Repository owns the journal, created lazily via a synchronized accessor**,
+   mirroring `stateHistoryStorage()`. The journal is first touched on the first
+   dispatch (a delivery-worker thread), the same reason `stateHistoryStorage()`
+   is `synchronized`. Unlike state history it is *always on* (no opt-in gate),
+   so a single `protected final synchronized EntityEventStorage<I> eventStorage()`
+   both creates and exposes it — `protected` preserves the `truncate(...)`
+   maintenance reach that the public `AggregateStorage.truncate` gave (parity
+   with the `protected stateHistory()` accessor).
+2. **Journal write stays in `doStore()`** (cache-deferred), not `store()`:
+   under batched delivery the aggregate accumulates *all* uncommitted events
+   until `commitEvents()`, so the journal drops nothing. (State history stays in
+   `store()` because it snapshots per dispatch.)
+3. **`AggregateStorage` loses its `close()` override** — it reverts to the
+   inherited `EntityRecordStorage.close()`. The journal is closed by the
+   repository, alongside `closeStateHistory()`. The prior "preserve the journal
+   close exception as primary" logic dissolves: the two storages are no longer
+   both owned by one `AggregateStorage`.
+
+## Changes
+
+### 1. `server/.../aggregate/AggregateStorage.java` — strip the journal
+- Remove field `eventStorage` and its construction in the constructor.
+- Remove `readEvents(I,int)`, `readEvents(I)`, `writeEvent(I,Event)`,
+  `writeAll(Aggregate,List<Event>)`, `eventHistoryBackward(I,int)`,
+  `eventHistoryBackward(I,int,Version)`, `truncate(Timestamp)`,
+  `close()` override, `checkNotClosedAndArguments(...)`.
+- Keep: `extends EntityRecordStorage`, `enableStateQuerying()`,
+  `readStates(...)` ×3, `ensureStatesQueryable()`, `writeState(Aggregate)`.
+- Prune now-unused imports (`ImmutableList`, `Timestamp`, `Event`, `Version`,
+  `EntityEventStorage`, jspecify `Nullable`, `List`, `checkNotNull`,
+  `DEFAULT_HISTORY_DEPTH`, `checkPositive`).
+- Rewrite the class Javadoc to describe only the latest-state storage (drop the
+  "Journal of the emitted events" and "Legacy journal" sections).
+
+### 2. `server/.../aggregate/AggregateRepository.java` — own & serve the journal
+- Import `io.spine.server.entity.storage.EntityEventStorage`.
+- Add field `private @MonotonicNonNull EntityEventStorage<I> eventStorage;`
+- Add `protected final synchronized EntityEventStorage<I> eventStorage()`
+  (lazy create via `defaultStorageFactory().createEntityEventStorage(...)`).
+- `setUpHistoryReading()`: loader now reads
+  `eventStorage().historyBackward(id, depth)`.
+- `doStore()`: replace `writeAll(...)` with
+  `events.forEach(eventStorage()::write); aggregateStorage().writeState(aggregate);`
+  (events first, then state — same order as the old `writeAll`).
+- `close()`: add `closeEventStorage()` next to `closeStateHistory()`.
+- Add `private synchronized void closeEventStorage()` (null- and open-guarded).
+- Touch up class Javadoc: the repository owns the event journal.
+
+### 3. Tests
+- `testFixtures/.../aggregate/AggregateStorageTest.java`: remove all
+  journal-specific tests/helpers (`emptyHistory`, `emptyEvents`,
+  `NotAcceptNull`, `WriteAndReadEvent`, `throwOnReadEventsWhenClosed`,
+  `WriteRecordsAndReturn`, `WriteRecordsAndLoadHistory`, `TruncateJournal`,
+  `NotStoreEnrichment`, and the `writeEvent/readEvents/eventHistoryBackward/
+  eventFactoryFor/newEventId` helpers + `TestAggregateWithId{String,Long,Integer}`).
+  Keep the state-storage contract (`AbstractStorageTest` overrides,
+  `absentRecord`, `immutableIndex`, `indexCountingAllIds`, `givenAggregate`,
+  `TestAggregate`). Journal behavior remains covered by `EntityEventStorageSpec`.
+- `test/.../entity/storage/HistoryStorageIdentitySpec.kt`: the two tests that
+  used `createAggregateStorage` as a proxy for "create the event journal" now
+  call `createEntityEventStorage` (and, for the mixed test, add an explicit
+  `createAggregateStorage` for the group-less latest-state spec). Identity
+  assertions are unchanged.
+- `testFixtures/.../aggregate/given/repo/ProjectAggregateRepository.java`:
+  **left untouched.** Its `customStorage`/`injectStorage(...)`/`aggregateStorage()`
+  override is dead (zero callers) but lives in a *published* testFixtures class,
+  and the refactor does not break it. Removing published test-fixture API is out
+  of scope here — deferred as a separate cleanup.
+
+## Verification
+- `./gradlew :server:build` green (proto unchanged → `build`, not `clean build`).
+- `dokkaGenerate` for the KDoc/Javadoc link changes.
+- Reviewers: `kotlin-engineer`, `spine-code-review`, `review-docs`.
+- Version gate (`version-bumped`) — branch already at `.470`, so idempotent.
+
+## Out of scope
+- `ProcessManagerRepository` (Phase F, later).
+- A shared `EntityEventStorage` test *fixture* for storage vendors (vendor repos
+  previously got journal coverage via `AggregateStorageTest`; that migration is
+  a Phase-G concern, tracked separately).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.460`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.470`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1085,14 +1085,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 18:56:04 WEST 2026** using 
+This report was generated on **Tue Jul 14 20:34:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.460`
+# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.470`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2273,14 +2273,14 @@ This report was generated on **Tue Jul 14 18:56:04 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 18:56:04 WEST 2026** using 
+This report was generated on **Tue Jul 14 20:34:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.460`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.470`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3301,14 +3301,14 @@ This report was generated on **Tue Jul 14 18:56:04 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 18:56:04 WEST 2026** using 
+This report was generated on **Tue Jul 14 20:34:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.460`
+# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.470`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4363,14 +4363,14 @@ This report was generated on **Tue Jul 14 18:56:04 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 18:56:04 WEST 2026** using 
+This report was generated on **Tue Jul 14 20:34:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.460`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.470`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5467,14 +5467,14 @@ This report was generated on **Tue Jul 14 18:56:04 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 18:56:04 WEST 2026** using 
+This report was generated on **Tue Jul 14 20:34:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.460`
+# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.470`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -6647,14 +6647,14 @@ This report was generated on **Tue Jul 14 18:56:04 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 18:56:04 WEST 2026** using 
+This report was generated on **Tue Jul 14 20:34:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.460`
+# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.470`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -7887,6 +7887,6 @@ This report was generated on **Tue Jul 14 18:56:04 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 18:56:04 WEST 2026** using 
+This report was generated on **Tue Jul 14 20:34:51 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>core-jvm</artifactId>
-<version>2.0.0-SNAPSHOT.460</version>
+<version>2.0.0-SNAPSHOT.470</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server-testlib/src/test/java/io/spine/testing/client/grpc/TestClientTest.java
+++ b/server-testlib/src/test/java/io/spine/testing/client/grpc/TestClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,13 +39,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.net.ServerSocket;
 import java.util.Optional;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
-import static io.spine.client.Client.DEFAULT_CLIENT_SERVICE_PORT;
 import static io.spine.core.Responses.statusOk;
-import static io.spine.testing.TestValues.random;
 import static io.spine.testing.client.grpc.TableSide.LEFT;
 import static io.spine.testing.client.grpc.TableSide.RIGHT;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -67,8 +66,10 @@ class TestClientTest {
     void setUpAll() throws IOException {
         var context = BoundedContext.singleTenant("Tennis")
                 .add(new GameRepository());
-        // Select a port randomly to avoid the intermittent hanging port under Windows.
-        var port = random(DEFAULT_CLIENT_SERVICE_PORT, DEFAULT_CLIENT_SERVICE_PORT + 1000);
+        // Bind to a free ephemeral port chosen by the OS, rather than a fixed or randomly
+        // guessed one, so the test does not intermittently fail to bind an already-used
+        // port (notably under Windows).
+        var port = freePort();
         server = Server
                 .atPort(port)
                 .add(context)
@@ -86,6 +87,20 @@ class TestClientTest {
             client.shutdown();
         }
         server.shutdownAndWait();
+    }
+
+    /**
+     * Obtains a currently free port from the operating system's ephemeral range.
+     *
+     * <p>Opening a {@link ServerSocket} on port {@code 0} lets the OS assign a port that is free
+     * at that moment; the socket is closed immediately, so the port is available for the gRPC
+     * server to bind. Unlike a fixed or randomly guessed port, this never selects a port already
+     * in use — the cause of the intermittent bind failures on CI.
+     */
+    private static int freePort() throws IOException {
+        try (var socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
     }
 
     @Test

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -125,7 +125,7 @@ import static java.util.Objects.requireNonNull;
  */
 @SuppressWarnings({
         "ClassWithTooManyMethods", "OverlyComplexClass" /* Acknowledged complexity. */,
-        "resource" /* Accessing `AutoClosable` properties. */
+        "resource" /* Accessing `Closeable` properties. */
 })
 public abstract class AggregateRepository<I,
                                           A extends Aggregate<I, S, ?>,

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -729,12 +729,29 @@ public abstract class AggregateRepository<I,
     }
 
     /**
+     * Creates the journal of the events emitted by the aggregates of this repository.
+     *
+     * <p>Mirrors {@link #createStorage()}: the default implementation uses the
+     * {@linkplain #defaultStorageFactory() default storage factory} — the same one the default
+     * {@code createStorage()} uses for the aggregate state. A repository that overrides
+     * {@code createStorage()} to serve the aggregate state from a custom
+     * {@link io.spine.server.storage.StorageFactory} or backend should override this method as
+     * well, so the journal — feeding the {@link IdempotencyGuard} and the
+     * {@linkplain Aggregate#eventHistoryBackward(int) recent-history} reads — is served by the
+     * same backend as the state, rather than silently falling back to the default one.
+     *
+     * @return a new event journal
+     */
+    protected EntityEventStorage<I> createEventStorage() {
+        return defaultStorageFactory().createEntityEventStorage(context().spec(), entityClass());
+    }
+
+    /**
      * Returns the journal of the events emitted by the aggregates of this repository,
-     * creating it lazily on the first access.
+     * creating it lazily via {@link #createEventStorage()} on the first access.
      *
      * <p>Unlike the opt-in {@linkplain #stateHistory() state history}, the journal is always
-     * maintained, so this accessor has no fail-fast gate: it both creates the journal and
-     * exposes it — e.g., for the
+     * maintained, so this accessor has no fail-fast gate: it exposes the journal — e.g., for the
      * {@linkplain EntityEventStorage#truncate(com.google.protobuf.Timestamp) time-based
      * truncation} that bounds the journal growth as a periodic maintenance operation.
      *
@@ -746,8 +763,7 @@ public abstract class AggregateRepository<I,
      */
     protected final synchronized EntityEventStorage<I> eventStorage() {
         if (eventStorage == null) {
-            var factory = defaultStorageFactory();
-            eventStorage = factory.createEntityEventStorage(context().spec(), entityClass());
+            eventStorage = createEventStorage();
         }
         return eventStorage;
     }

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -354,10 +354,10 @@ public abstract class AggregateRepository<I,
      * Stores the passed aggregate and commits its uncommitted events.
      *
      * <p>When the state history is {@linkplain #recordStateHistory() recorded}, appends
-     * the current state record on each call — that is, once per successful dispatch. The
-     * append happens here and not in {@link #doStore}, because under a batched delivery
-     * the cache defers {@code doStore()} to the end of the batch — the history still
-     * captures every intermediate version of the batch.
+     * the current state record on each call — that is, once per successful dispatch.
+     * The append operation happens here and not in {@link #doStore}, because under
+     * a batched delivery the cache defers {@code doStore()} to the end of the batch —
+     * the history still captures every intermediate version of the batch.
      */
     @Override
     protected final void store(A aggregate) {

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -714,16 +714,42 @@ public abstract class AggregateRepository<I,
     }
 
     /**
-     * Lazily creates the state history storage.
+     * Creates the storage of the recent state history of the aggregates of this repository.
+     *
+     * <p>Mirrors {@link #createStorage()}: the default implementation uses the
+     * {@linkplain #defaultStorageFactory() default storage factory} — the same one the default
+     * {@code createStorage()} uses for the aggregate state. A repository that overrides
+     * {@code createStorage()} to serve the aggregate state from a custom
+     * {@link io.spine.server.storage.StorageFactory} or backend should override this method as
+     * well, so the recorded state history is served by the same backend as the state, rather
+     * than silently falling back to the default one.
+     *
+     * @return a new state history storage
+     */
+    protected EntityStateHistoryStorage<I> createStateHistoryStorage() {
+        var factory = defaultStorageFactory();
+        return factory.createEntityStateHistoryStorage(context().spec(), entityClass());
+    }
+
+    /**
+     * Returns the storage of the recent state history of the aggregates of this repository,
+     * creating it lazily via {@link #createStateHistoryStorage()} on the first access.
+     *
+     * <p>Unlike the fail-fast {@link #stateHistory()} accessor, this method does not require
+     * recording to be {@linkplain #recordStateHistory() enabled}: it exposes the storage for
+     * the maintenance operations — {@link EntityStateHistoryStorage#truncate(Timestamp) truncate}
+     * and {@link EntityStateHistoryStorage#trim(Object, int) trim} — which a repository may run
+     * even while the recording is off.
      *
      * <p>Synchronized: unlike the main {@linkplain #storage() storage}, which is first
      * accessed during the single-threaded registration of the repository, this storage
      * is first touched when a signal is dispatched, possibly by concurrent workers.
+     *
+     * @return the state history storage
      */
-    private synchronized EntityStateHistoryStorage<I> stateHistoryStorage() {
+    protected final synchronized EntityStateHistoryStorage<I> stateHistoryStorage() {
         if (stateHistory == null) {
-            var factory = defaultStorageFactory();
-            stateHistory = factory.createEntityStateHistoryStorage(context().spec(), entityClass());
+            stateHistory = createStateHistoryStorage();
         }
         return stateHistory;
     }

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -567,8 +567,8 @@ public abstract class AggregateRepository<I,
     }
 
     /**
-     * Enables the opt-in, journal-backed {@link IdempotencyGuard} for the aggregates of this
-     * repository.
+     * Enables the opt-in, journal-backed {@link IdempotencyGuard} for the aggregates of
+     * this repository.
      *
      * <p>When enabled, each dispatch scans the last {@link #eventHistoryDepth()} journal events and
      * rejects a signal already seen among them, however long ago it was dispatched — a mechanism
@@ -595,7 +595,7 @@ public abstract class AggregateRepository<I,
      * {@link EntityRecord} to an {@link EntityStateHistoryStorage} — e.g., for answering
      * {@linkplain EntityStateHistoryStorage#stateAt(Object, com.google.protobuf.Timestamp)
      * the "state at a time" query}. The history is <b>off by default</b>: recording adds
-     * a write to every dispatch.
+     * a write operation to every dispatch.
      *
      * <p>The aggregates of this repository read the recorded history via
      * {@link Aggregate#stateAt(Timestamp)} and {@link Aggregate#stateHistoryBackward(int)}.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -48,6 +48,7 @@ import io.spine.server.entity.QueryableRepository;
 import io.spine.server.entity.Repository;
 import io.spine.server.entity.RepositoryCache;
 import io.spine.server.entity.StateHistoryLoader;
+import io.spine.server.entity.storage.EntityEventStorage;
 import io.spine.server.entity.storage.EntityStateHistoryStorage;
 import io.spine.server.event.EventBus;
 import io.spine.server.event.EventDispatcherDelegate;
@@ -90,7 +91,9 @@ import static java.util.Objects.requireNonNull;
  *
  * <p>Since the event-sourcing cutover, an aggregate is loaded from its latest persisted
  * {@link io.spine.server.entity.EntityRecord EntityRecord} rather than by replaying its event
- * journal. The journal is kept append-only for traceability and for the opt-in
+ * journal. The repository keeps that latest state in an {@link AggregateStorage} and appends
+ * the emitted events to a separate {@linkplain #eventStorage() event journal}
+ * (an {@link EntityEventStorage}), kept append-only for traceability and for the opt-in
  * {@link IdempotencyGuard}.
  *
  * <p>Three per-repository settings tune this behavior:
@@ -120,7 +123,10 @@ import static java.util.Objects.requireNonNull;
  *         the type of the state of aggregates managed by this repository
  * @see Aggregate
  */
-@SuppressWarnings({"ClassWithTooManyMethods", "resource"})
+@SuppressWarnings({
+        "ClassWithTooManyMethods", "OverlyComplexClass" /* Acknowledged complexity. */,
+        "resource" /* Accessing `AutoClosable` properties. */
+})
 public abstract class AggregateRepository<I,
                                           A extends Aggregate<I, S, ?>,
                                           S extends AggregateState<I>>
@@ -162,6 +168,12 @@ public abstract class AggregateRepository<I,
 
     /** The storage of recent state records; created lazily once the history is first needed. */
     private @MonotonicNonNull EntityStateHistoryStorage<I> stateHistory;
+
+    /**
+     * The journal of the events emitted by the aggregates of this repository; created lazily
+     * once the journal is first needed.
+     */
+    private @MonotonicNonNull EntityEventStorage<I> eventStorage;
 
     /** Creates a new instance. */
     protected AggregateRepository() {
@@ -321,7 +333,7 @@ public abstract class AggregateRepository<I,
      */
     final void setUpHistoryReading(A aggregate, I id) {
         aggregate.setEventHistoryLoader(
-                depth -> aggregateStorage().eventHistoryBackward(id, depth));
+                depth -> eventStorage().historyBackward(id, depth));
         aggregate.setStateHistoryLoader(stateHistoryLoaderFor(id));
         if (idempotencyGuardEnabled) {
             aggregate.enableIdempotencyGuard(eventHistoryDepth);
@@ -364,8 +376,12 @@ public abstract class AggregateRepository<I,
         if (!aggregate.changed() && !aggregate.hasUncommittedEvents()) {
             return;
         }
-        var history = aggregate.uncommittedHistory();
-        aggregateStorage().writeAll(aggregate, history.get());
+        // Journal the emitted events, then store the latest state. Under a batched delivery the
+        // aggregate accumulates its events until `commitEvents()`, so the journal drops none.
+        var events = aggregate.uncommittedHistory().get();
+        var journal = eventStorage();
+        events.forEach(journal::write);
+        aggregateStorage().writeState(aggregate);
         aggregate.commitEvents();
     }
 
@@ -713,6 +729,30 @@ public abstract class AggregateRepository<I,
     }
 
     /**
+     * Returns the journal of the events emitted by the aggregates of this repository,
+     * creating it lazily on the first access.
+     *
+     * <p>Unlike the opt-in {@linkplain #stateHistory() state history}, the journal is always
+     * maintained, so this accessor has no fail-fast gate: it both creates the journal and
+     * exposes it — e.g., for the
+     * {@linkplain EntityEventStorage#truncate(com.google.protobuf.Timestamp) time-based
+     * truncation} that bounds the journal growth as a periodic maintenance operation.
+     *
+     * <p>Synchronized for the same reason as {@link #stateHistoryStorage()}: unlike the main
+     * {@linkplain #storage() storage}, the journal is first touched when a signal is dispatched,
+     * possibly by concurrent workers.
+     *
+     * @return the event journal of this repository
+     */
+    protected final synchronized EntityEventStorage<I> eventStorage() {
+        if (eventStorage == null) {
+            var factory = defaultStorageFactory();
+            eventStorage = factory.createEntityEventStorage(context().spec(), entityClass());
+        }
+        return eventStorage;
+    }
+
+    /**
      * Loads or creates an aggregate by the passed ID.
      *
      * @param id
@@ -803,11 +843,62 @@ public abstract class AggregateRepository<I,
     @OverridingMethodsMustInvokeSuper
     @Override
     public void close() {
-        super.close();
-        if (inbox != null) {
-            inbox.unregister();
+        // Release every owned resource even if one close fails: the first failure is kept as
+        // the primary exception and the later ones are attached to it as suppressed, so none of
+        // them is lost. `super.close()` is called directly (not via the helper) so that the
+        // `@OverridingMethodsMustInvokeSuper` check recognizes the super-call.
+        @Nullable RuntimeException failure = null;
+        try {
+            super.close();
+        } catch (RuntimeException e) {
+            failure = e;
         }
-        closeStateHistory();
+        if (inbox != null) {
+            failure = attemptClose(failure, inbox::unregister);
+        }
+        failure = attemptClose(failure, this::closeEventStorage);
+        failure = attemptClose(failure, this::closeStateHistory);
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    /**
+     * Runs a close step, folding any exception it throws into the accumulated failure.
+     *
+     * <p>The first failure across the steps is returned as the primary exception; a later
+     * failure is attached to it as {@linkplain Throwable#addSuppressed(Throwable) suppressed},
+     * so no failure is lost and every step is still attempted.
+     *
+     * @param failure
+     *         the failure accumulated so far, or {@code null} if every prior step succeeded
+     * @param step
+     *         the close step to run
+     * @return the accumulated failure after running the step
+     */
+    private static @Nullable RuntimeException
+    attemptClose(@Nullable RuntimeException failure, Runnable step) {
+        try {
+            step.run();
+        } catch (RuntimeException e) {
+            if (failure == null) {
+                return e;
+            }
+            failure.addSuppressed(e);
+        }
+        return failure;
+    }
+
+    /**
+     * Closes the event journal if it was created.
+     *
+     * <p>Synchronized to pair with {@link #eventStorage()}: the journal may have been
+     * created by a dispatch worker, and the closing thread must observe that write.
+     */
+    private synchronized void closeEventStorage() {
+        if (eventStorage != null && eventStorage.isOpen()) {
+            eventStorage.close();
+        }
     }
 
     /**

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -906,32 +906,6 @@ public abstract class AggregateRepository<I,
     }
 
     /**
-     * Runs a close step, folding any exception it throws into the accumulated failure.
-     *
-     * <p>The first failure across the steps is returned as the primary exception; a later
-     * failure is attached to it as {@linkplain Throwable#addSuppressed(Throwable) suppressed},
-     * so no failure is lost and every step is still attempted.
-     *
-     * @param failure
-     *         the failure accumulated so far, or {@code null} if every prior step succeeded
-     * @param step
-     *         the close step to run
-     * @return the accumulated failure after running the step
-     */
-    private static @Nullable RuntimeException
-    attemptClose(@Nullable RuntimeException failure, Runnable step) {
-        try {
-            step.run();
-        } catch (RuntimeException e) {
-            if (failure == null) {
-                return e;
-            }
-            failure.addSuppressed(e);
-        }
-        return failure;
-    }
-
-    /**
      * Closes the event journal if it was created.
      *
      * <p>Synchronized to pair with {@link #eventStorage()}: the journal may have been

--- a/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateStorage.java
@@ -26,55 +26,38 @@
 
 package io.spine.server.aggregate;
 
-import com.google.common.collect.ImmutableList;
-import com.google.protobuf.Timestamp;
 import io.spine.annotation.SPI;
 import io.spine.base.AggregateState;
 import io.spine.client.ResponseFormat;
 import io.spine.client.TargetFilters;
-import io.spine.core.Event;
-import io.spine.core.Version;
 import io.spine.query.EntityQuery;
 import io.spine.server.ContextSpec;
 import io.spine.server.entity.EntityRecord;
-import io.spine.server.entity.storage.EntityEventStorage;
 import io.spine.server.entity.storage.EntityRecordStorage;
 import io.spine.server.entity.storage.ToEntityRecordQuery;
 import io.spine.server.storage.QueryConverter;
 import io.spine.server.storage.RecordWithColumns;
 import io.spine.server.storage.StorageFactory;
-import org.jspecify.annotations.Nullable;
 
 import java.util.Iterator;
-import java.util.List;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.server.aggregate.AggregateRepository.DEFAULT_HISTORY_DEPTH;
 import static io.spine.server.storage.QueryConverter.convert;
 import static io.spine.util.Exceptions.newIllegalStateException;
-import static io.spine.util.Preconditions2.checkPositive;
 
 /**
- * A storage of the latest Aggregate states and the journal of the events emitted by Aggregates.
- *
- * <p>The instances of this type solve two problems:
- *
- * <ol>
- *     <li>storing the latest state of each Aggregate along with its lifecycle flags and version —
- *     the source of truth for loading an Aggregate by its {@link AggregateRepository};
- *
- *     <li>journaling the events emitted by the Aggregates — for traceability and for
- *     the recent-history lookups such as {@link Aggregate#eventHistoryBackward(int)} and
- *     the opt-in {@link IdempotencyGuard}.
- * </ol>
- *
- * <h2>Storing and querying the latest Aggregate states</h2>
+ * A storage of the latest states of the Aggregates.
  *
  * <p>The state of an Aggregate is persisted on each update, regardless of the
  * {@linkplain io.spine.server.entity.EntityVisibility visibility} of the Aggregate state type.
  * This storage {@code extends} {@link EntityRecordStorage}, so the latest states are persisted
  * as {@link EntityRecord}s and all state-related operations are served by the inherited
- * record storage.
+ * record storage. It is the source of truth for loading an Aggregate by its
+ * {@link AggregateRepository}.
+ *
+ * <p>Since the event-sourcing cutover, the events emitted by the Aggregates are journaled
+ * separately: the journal is an {@link io.spine.server.entity.storage.EntityEventStorage} owned
+ * by the {@link AggregateRepository}, not by this storage. The states kept here are not restored
+ * from those events.
  *
  * <p>End-users of the framework are able to set the visibility level for each Aggregate state
  * by using an {@linkplain io.spine.server.entity.EntityVisibility (entity).visibility} option
@@ -90,26 +73,6 @@ import static io.spine.util.Preconditions2.checkPositive;
  * declared entity columns. See {@code io.spine.query} package docs for more details on
  * the query language.
  *
- * <h2>Journal of the emitted events</h2>
- *
- * <p>The events emitted by the Aggregates are appended to an intermediate
- * {@link EntityEventStorage}. The journal is not used for restoring the Aggregate states.
- * It narrows down the number of records to traverse when the recent history of an Aggregate
- * is read, compared to searching the {@linkplain io.spine.server.event.EventStore Event Store}
- * of the whole Bounded Context.
- *
- * <p>The journal grows as the Aggregates emit events. To bound the growth, production
- * systems run the {@linkplain #truncate(Timestamp) time-based truncation} as a periodic
- * maintenance operation.
- *
- * <h2>Legacy journal</h2>
- *
- * <p>Before the event-sourcing cutover, the journal was persisted as
- * {@code AggregateEventRecord}s — a record kind that could also hold {@code Snapshot}s.
- * The current runtime neither writes nor reads records of that kind. They remain in the
- * underlying storage as inert data, and their proto definitions are retained so that
- * the persisted records stay parseable.
- *
  * @param <I>
  *         the type of IDs of aggregates served by this storage
  * @param <S>
@@ -118,11 +81,6 @@ import static io.spine.util.Preconditions2.checkPositive;
 @SPI
 public class AggregateStorage<I, S extends AggregateState<I>>
         extends EntityRecordStorage<I, S> {
-
-    /**
-     * Stores the events emitted by the served Aggregates.
-     */
-    private final EntityEventStorage<I> eventStorage;
 
     /**
      * Tells whether the latest aggregate states should be stored and exposed for querying.
@@ -138,13 +96,12 @@ public class AggregateStorage<I, S extends AggregateState<I>>
      * @param aggregateClass
      *         the class of stored aggregates
      * @param factory
-     *         a storage factory to create the underlying storage for the event journal
+     *         a storage factory to create the underlying record storage
      */
     public AggregateStorage(ContextSpec context,
                             Class<? extends Aggregate<I, S, ?>> aggregateClass,
                             StorageFactory factory) {
         super(context, factory, aggregateClass);
-        eventStorage = factory.createEntityEventStorage(context, aggregateClass);
     }
 
     /**
@@ -152,59 +109,6 @@ public class AggregateStorage<I, S extends AggregateState<I>>
      */
     void enableStateQuerying() {
         queryingEnabled = true;
-    }
-
-    /**
-     * Reads the most recent events emitted by the aggregate with the passed ID,
-     * listing them in the order of emission.
-     *
-     * @param id
-     *         the identifier of the aggregate for which to return the recent events
-     * @param batchSize
-     *         the maximum number of the events to read
-     * @return the recent events in the order of emission, or an empty list if the journal
-     *         has no events emitted by the aggregate
-     * @throws IllegalStateException
-     *         if the storage is closed
-     * @throws IllegalArgumentException
-     *         if the {@code batchSize} is not positive
-     */
-    public List<Event> readEvents(I id, int batchSize) {
-        checkNotClosedAndArguments(id, batchSize);
-        checkPositive(batchSize);
-        // `eventHistoryBackward` yields the events newest-first; reverse them into
-        // the order of emission.
-        return ImmutableList.copyOf(eventHistoryBackward(id, batchSize)).reverse();
-    }
-
-    /**
-     * Reads the most recent events emitted by the aggregate with the passed ID, using the
-     * default history depth, and lists them in the order of emission.
-     *
-     * @param id
-     *         the identifier of the aggregate for which to return the recent events
-     * @return the recent events in the order of emission, or an empty list if the journal
-     *         has no events emitted by the aggregate
-     */
-    public List<Event> readEvents(I id) {
-        return readEvents(id, DEFAULT_HISTORY_DEPTH);
-    }
-
-    /**
-     * Writes an event to the storage.
-     *
-     * <p>The journal storage {@linkplain io.spine.core.Event#clearEnrichments() removes
-     * the enrichments} before storing and journals the event under its producer —
-     * the aggregate which emitted it.
-     *
-     * @param id
-     *         the ID of the aggregate that emitted the event
-     * @param event
-     *         the event to write
-     */
-    void writeEvent(I id, Event event) {
-        checkNotClosedAndArguments(id, event);
-        eventStorage.write(event);
     }
 
     /**
@@ -275,124 +179,5 @@ public class AggregateStorage<I, S extends AggregateState<I>>
         var record = aggregate.toRecord();
         var result = RecordWithColumns.create(record, recordSpec());
         write(result);
-    }
-
-    /**
-     * Writes the uncommitted history of the aggregate: appends the emitted events to
-     * the journal and stores the latest state.
-     *
-     * @param aggregate
-     *         the aggregate to store
-     * @param events
-     *         the events emitted by the aggregate since it was stored last time;
-     *         may be empty if the state was modified without emitting events
-     */
-    protected void writeAll(Aggregate<I, ?, ?> aggregate, List<Event> events) {
-        checkNotClosedAndArguments(aggregate.id(), events);
-        for (var event : events) {
-            eventStorage.write(event);
-        }
-        writeState(aggregate);
-    }
-
-    /**
-     * Creates an iterator over the journal of the Aggregate, ordering the events
-     * from newer to older.
-     *
-     * <p>The iterator is lazy, reading from the journal as it advances. It serves
-     * the recent-history reads of the opt-in {@link IdempotencyGuard} and the
-     * business access via {@link Aggregate#eventHistoryBackward(int)}.
-     *
-     * <p>The iterator is empty if there's no journaled history for the aggregate with passed ID.
-     *
-     * <p>Only the events journaled by Spine 2.0 and later are read; the journal records
-     * persisted by the earlier, event-sourced versions of the framework are a separate legacy
-     * record kind, not visible to this method.
-     *
-     * @param id
-     *         the identifier of the Aggregate
-     * @param batchSize
-     *         the maximum number of the events to read
-     * @return new iterator instance
-     */
-    Iterator<Event> eventHistoryBackward(I id, int batchSize) {
-        return eventHistoryBackward(id, batchSize, null);
-    }
-
-    /**
-     * Acts similar to
-     * {@link #eventHistoryBackward(Object, int) eventHistoryBackward(id, batchSize)}, but also
-     * allows setting the Aggregate version to start the reading from.
-     *
-     * @param id
-     *         identifier of the Aggregate
-     * @param batchSize
-     *         the maximum number of the history records to read
-     * @param startingFrom
-     *         an Aggregate version from which the historical events are read
-     * @return a new instance of iterator over the results
-     */
-    protected Iterator<Event>
-    eventHistoryBackward(I id, int batchSize, @Nullable Version startingFrom) {
-        return eventStorage.historyBackward(id, batchSize, startingFrom);
-    }
-
-    /**
-     * Truncates the journal, deleting the events emitted before {@code olderThan}.
-     *
-     * <p>An event record is deleted if and only if its event was emitted strictly before
-     * the given time. To purge the whole journal of the served Aggregates, pass the current
-     * time — or any later moment.
-     *
-     * <p>Truncation bounds the {@linkplain Aggregate#eventHistoryBackward(int) recent history}
-     * available to the business logic and to the opt-in {@link IdempotencyGuard}. When the
-     * guard is {@linkplain AggregateRepository#useIdempotencyGuard() enabled}, choose a cutoff
-     * old enough to retain the {@linkplain AggregateRepository#eventHistoryDepth() event history
-     * depth} of the repository, so that the deduplication window stays intact.
-     *
-     * <p>The events are removed by a query on their creation time rather than by reading
-     * the journal into memory, so the operation scales to large journals; it remains bulk
-     * maintenance rather than a per-dispatch call.
-     *
-     * @param olderThan
-     *         only the events emitted strictly before this time are deleted
-     */
-    public void truncate(Timestamp olderThan) {
-        checkNotNull(olderThan);
-        eventStorage.truncate(olderThan);
-    }
-
-    /**
-     * Closes this storage, releasing the inherited record storage and the event journal.
-     *
-     * <p>Unlike a plain {@link EntityRecordStorage}, this storage owns an additional
-     * {@link EntityEventStorage journal}, so closing it must also close the journal.
-     *
-     * @throws IllegalStateException
-     *         if the storage was already closed
-     */
-    @Override
-    public void close() {
-        checkNotClosed();
-        try {
-            eventStorage.close();
-        } catch (RuntimeException e) {
-            // Still release the inherited record storage, but keep the journal's failure as the
-            // primary exception; a failure while closing the state storage is added as suppressed
-            // so neither is lost.
-            try {
-                super.close();
-            } catch (RuntimeException secondary) {
-                e.addSuppressed(secondary);
-            }
-            throw e;
-        }
-        super.close();
-    }
-
-    private void checkNotClosedAndArguments(I id, Object argument) {
-        checkNotClosed();
-        checkNotNull(id);
-        checkNotNull(argument);
     }
 }

--- a/server/src/main/java/io/spine/server/entity/EntityIterator.java
+++ b/server/src/main/java/io/spine/server/entity/EntityIterator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.entity;
+
+import io.spine.base.Identifier;
+
+import java.util.Iterator;
+
+import static io.spine.util.Exceptions.newIllegalStateException;
+
+/**
+ * An iterator of all entities from the storage.
+ *
+ * <p>This iterator does not allow removal.
+ *
+ * @param <I>
+ *         the type of entity identifiers
+ * @param <E>
+ *         the type of entities
+ */
+class EntityIterator<I, E extends Entity<I, ?>> implements Iterator<E> {
+
+    private final Repository<I, E> repository;
+    private final Iterator<I> index;
+
+    EntityIterator(Repository<I, E> repository) {
+        this.repository = repository;
+        this.index = repository.storage()
+                               .index();
+    }
+
+    @Override
+    public boolean hasNext() {
+        var result = index.hasNext();
+        return result;
+    }
+
+    @Override
+    public E next() {
+        var id = index.next();
+        var loaded = repository.find(id);
+        if (loaded.isEmpty()) {
+            var idStr = Identifier.toString(id);
+            throw newIllegalStateException("Unable to load entity with ID: `%s`.", idStr);
+        }
+
+        var entity = loaded.get();
+        return entity;
+    }
+}

--- a/server/src/main/java/io/spine/server/entity/EntityIterator.java
+++ b/server/src/main/java/io/spine/server/entity/EntityIterator.java
@@ -42,7 +42,7 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  * @param <E>
  *         the type of entities
  */
-class EntityIterator<I, E extends Entity<I, ?>> implements Iterator<E> {
+final class EntityIterator<I, E extends Entity<I, ?>> implements Iterator<E> {
 
     private final Repository<I, E> repository;
     private final Iterator<I> index;

--- a/server/src/main/java/io/spine/server/entity/EventProducingRepository.java
+++ b/server/src/main/java/io/spine/server/entity/EventProducingRepository.java
@@ -69,6 +69,7 @@ public interface EventProducingRepository {
     /**
      * Filters the passed events and posts the result to the EventBus.
      */
+    @SuppressWarnings("resource") // Accessing `Closeable` `EventBus`.
     default void postEvents(Collection<Event> events) {
         var filtered = filter(events);
         eventBus().post(filtered);

--- a/server/src/main/java/io/spine/server/entity/Repository.java
+++ b/server/src/main/java/io/spine/server/entity/Repository.java
@@ -358,7 +358,9 @@ public abstract class Repository<I, E extends Entity<I, ?>>
     /**
      * Closes the repository by closing the underlying storage.
      *
-     * <p>The reference to the storage becomes null after this call.
+     * <p>The reference to the storage becomes null after this call. If closing the storage
+     * fails, the storage and context references are still cleared before the failure is
+     * re-thrown, so a failed close does not leave the repository half-open.
      *
      * <p>A closed repository is not meant to be {@linkplain #registerWith(BoundedContext)
      * registered} again: not every resource it owns is re-created on a repeated
@@ -367,11 +369,15 @@ public abstract class Repository<I, E extends Entity<I, ?>>
     @Override
     @OverridingMethodsMustInvokeSuper
     public void close() {
+        @Nullable RuntimeException failure = null;
         if (isOpen()) {
-            storage().close();
+            failure = attemptClose(failure, storage()::close);
             this.storage = null;
         }
         this.context = null;
+        if (failure != null) {
+            throw failure;
+        }
     }
 
     /**

--- a/server/src/main/java/io/spine/server/entity/Repository.java
+++ b/server/src/main/java/io/spine/server/entity/Repository.java
@@ -73,7 +73,7 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  */
 @SuppressWarnings({
         "ClassWithTooManyMethods" /* OK for this core class. */,
-        "resource" /* Accessing `AutoCloseable` properties */
+        "resource" /* Accessing `Closeable` properties */
 })
 public abstract class Repository<I, E extends Entity<I, ?>>
         implements ContextAware, Closeable, WithLogging {

--- a/server/src/main/java/io/spine/server/entity/Repository.java
+++ b/server/src/main/java/io/spine/server/entity/Repository.java
@@ -375,6 +375,33 @@ public abstract class Repository<I, E extends Entity<I, ?>>
     }
 
     /**
+     * Runs one close step for a {@link #close()} override that releases several resources,
+     * folding any exception the step throws into the accumulated failure.
+     *
+     * <p>Threading each close through this method attempts them all and keeps the first failure
+     * as the primary exception; a later failure is attached to it as
+     * {@linkplain Throwable#addSuppressed(Throwable) suppressed}, so no failure is lost.
+     *
+     * @param failure
+     *         the failure accumulated so far, or {@code null} if every prior step succeeded
+     * @param step
+     *         the close step to run
+     * @return the accumulated failure after running the step
+     */
+    protected static @Nullable RuntimeException
+    attemptClose(@Nullable RuntimeException failure, Runnable step) {
+        try {
+            step.run();
+        } catch (RuntimeException e) {
+            if (failure == null) {
+                return e;
+            }
+            failure.addSuppressed(e);
+        }
+        return failure;
+    }
+
+    /**
      * Verifies if the repository is open.
      */
     @Override

--- a/server/src/main/java/io/spine/server/entity/Repository.java
+++ b/server/src/main/java/io/spine/server/entity/Repository.java
@@ -31,7 +31,6 @@ import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import io.spine.annotation.Internal;
 import io.spine.annotation.SPI;
 import io.spine.annotation.VisibleForTesting;
-import io.spine.base.Identifier;
 import io.spine.base.Routable;
 import io.spine.core.SignalContext;
 import io.spine.logging.WithLogging;
@@ -49,7 +48,6 @@ import io.spine.system.server.RoutingFailed;
 import io.spine.type.TypeUrl;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.dataflow.qual.Pure;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Iterator;
@@ -73,7 +71,10 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  * @param <E>
  *         the type of managed entities
  */
-@SuppressWarnings("ClassWithTooManyMethods") // OK for this core class.
+@SuppressWarnings({
+        "ClassWithTooManyMethods" /* OK for this core class. */,
+        "resource" /* Accessing `AutoCloseable` properties */
+})
 public abstract class Repository<I, E extends Entity<I, ?>>
         implements ContextAware, Closeable, WithLogging {
 
@@ -144,6 +145,7 @@ public abstract class Repository<I, E extends Entity<I, ?>>
      */
     public Iterator<E> iterator(Predicate<E> filter) {
         Iterator<E> unfiltered = new EntityIterator<>(this);
+        @SuppressWarnings("NullableProblems") // Safe as `E` is never `null`.
         Iterator<E> filtered = Iterators.filter(unfiltered, filter::test);
         return filtered;
     }
@@ -271,7 +273,6 @@ public abstract class Repository<I, E extends Entity<I, ?>>
      * @throws IllegalStateException
      *         if the repository has no context assigned
      */
-    @SuppressWarnings("DataFlowIssue") // non-null result ensured by `hasContext()` call.
     protected final BoundedContext context() {
         checkState(hasContext(),
                    "The repository (class: `%s`) is not registered with a `BoundedContext`.",
@@ -338,7 +339,7 @@ public abstract class Repository<I, E extends Entity<I, ?>>
      * @return passed value if it is not null
      * @throws IllegalStateException if the passed instance is null
      */
-    protected static <S extends Closeable> @NonNull S checkStorage(@Nullable S storage) {
+    protected static <S extends Closeable> S checkStorage(@Nullable S storage) {
         checkState(storage != null, ERR_MSG_STORAGE_NOT_ASSIGNED);
         return storage;
     }
@@ -408,8 +409,7 @@ public abstract class Repository<I, E extends Entity<I, ?>>
      */
     private void checkMatchesIdType(Object result) {
         Class<?> routingResultType = null;
-        if (result instanceof Iterable) {
-            var asIterable = (Iterable<?>) result;
+        if (result instanceof Iterable<?> asIterable) {
             var element = getFirst(asIterable, null);
             if (element != null) {
                 routingResultType = element.getClass();
@@ -513,47 +513,6 @@ public abstract class Repository<I, E extends Entity<I, ?>>
         @Override
         public int index() {
             return this.index;
-        }
-    }
-
-    /**
-     * An iterator of all entities from the storage.
-     *
-     * <p>This iterator does not allow removal.
-     *
-     * @param <I>
-     *         the type of entity identifiers
-     * @param <E>
-     *         the type of entities
-     */
-    private static class EntityIterator<I, E extends Entity<I, ?>> implements Iterator<E> {
-
-        private final Repository<I, E> repository;
-        private final Iterator<I> index;
-
-        private EntityIterator(Repository<I, E> repository) {
-            this.repository = repository;
-            this.index = repository.storage()
-                                   .index();
-        }
-
-        @Override
-        public boolean hasNext() {
-            var result = index.hasNext();
-            return result;
-        }
-
-        @Override
-        public E next() {
-            var id = index.next();
-            var loaded = repository.find(id);
-            if (loaded.isEmpty()) {
-                var idStr = Identifier.toString(id);
-                throw newIllegalStateException("Unable to load entity with ID: `%s`.", idStr);
-            }
-
-            var entity = loaded.get();
-            return entity;
         }
     }
 }

--- a/server/src/main/java/io/spine/server/entity/Repository.java
+++ b/server/src/main/java/io/spine/server/entity/Repository.java
@@ -338,7 +338,7 @@ public abstract class Repository<I, E extends Entity<I, ?>>
      * @return passed value if it is not null
      * @throws IllegalStateException if the passed instance is null
      */
-    protected static <S extends Closeable> S checkStorage(@Nullable S storage) {
+    private static <S extends Closeable> S checkStorage(@Nullable S storage) {
         checkState(storage != null, ERR_MSG_STORAGE_NOT_ASSIGNED);
         return storage;
     }

--- a/server/src/main/java/io/spine/server/entity/Repository.java
+++ b/server/src/main/java/io/spine/server/entity/Repository.java
@@ -145,7 +145,6 @@ public abstract class Repository<I, E extends Entity<I, ?>>
      */
     public Iterator<E> iterator(Predicate<E> filter) {
         Iterator<E> unfiltered = new EntityIterator<>(this);
-        @SuppressWarnings("NullableProblems") // Safe as `E` is never `null`.
         Iterator<E> filtered = Iterators.filter(unfiltered, filter::test);
         return filtered;
     }

--- a/server/src/test/kotlin/io/spine/server/entity/storage/HistoryStorageIdentitySpec.kt
+++ b/server/src/test/kotlin/io/spine/server/entity/storage/HistoryStorageIdentitySpec.kt
@@ -69,8 +69,8 @@ internal class HistoryStorageIdentitySpec {
     fun `give two aggregate classes two separate event journals`() {
         val factory = SpecRecordingFactory()
 
-        factory.createAggregateStorage(context, TestAggregate::class.java)
-        factory.createAggregateStorage(context, CalcAggregate::class.java)
+        factory.createEntityEventStorage(context, TestAggregate::class.java)
+        factory.createEntityEventStorage(context, CalcAggregate::class.java)
 
         factory.historyGroupsOf(Event::class.java) shouldContainExactly
                 listOf(groupOf(AggProject::class.java), groupOf(Calc::class.java))
@@ -105,8 +105,9 @@ internal class HistoryStorageIdentitySpec {
     fun `keep the histories of one entity class apart from each other and from its latest state`() {
         val factory = SpecRecordingFactory()
 
-        factory.createAggregateStorage(context, TestAggregate::class.java)
+        factory.createEntityEventStorage(context, TestAggregate::class.java)
         factory.createEntityStateHistoryStorage(context, TestAggregate::class.java)
+        factory.createAggregateStorage(context, TestAggregate::class.java)
 
         // The two histories arrive at the vendor seam with distinct identities.
         factory.historyIdentities() shouldContainExactly listOf(

--- a/server/src/testFixtures/java/io/spine/server/aggregate/AggregateStorageTest.java
+++ b/server/src/testFixtures/java/io/spine/server/aggregate/AggregateStorageTest.java
@@ -27,19 +27,8 @@
 package io.spine.server.aggregate;
 
 import com.google.common.collect.ImmutableList;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import com.google.protobuf.Timestamp;
-import com.google.protobuf.util.Durations;
 import io.spine.base.AggregateState;
 import io.spine.base.Identifier;
-import io.spine.base.Time;
-import io.spine.core.ActorContext;
-import io.spine.core.Event;
-import io.spine.core.EventContext;
-import io.spine.core.EventId;
-import io.spine.core.MessageId;
-import io.spine.core.Origin;
-import io.spine.core.Version;
 import io.spine.protobuf.AnyPacker;
 import io.spine.server.BoundedContextBuilder;
 import io.spine.server.ContextSpec;
@@ -47,51 +36,29 @@ import io.spine.server.ServerEnvironment;
 import io.spine.server.aggregate.given.repo.GivenAggregate;
 import io.spine.server.aggregate.given.repo.ProjectAggregateRepository;
 import io.spine.server.entity.EntityRecord;
-import io.spine.server.event.NoReaction;
 import io.spine.server.storage.AbstractStorageTest;
 import io.spine.test.aggregate.AggProject;
-import io.spine.test.aggregate.IntegerProject;
-import io.spine.test.aggregate.LongProject;
 import io.spine.test.aggregate.ProjectId;
-import io.spine.test.aggregate.StringProject;
 import io.spine.testdata.Sample;
-import io.spine.testing.TestValues;
-import io.spine.testing.core.given.GivenCommandContext;
-import io.spine.testing.server.TestEventFactory;
 import io.spine.testing.server.model.ModelTests;
-import io.spine.type.TypeUrl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
-import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Lists.newLinkedList;
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.protobuf.util.Timestamps.add;
-import static com.google.protobuf.util.Timestamps.subtract;
-import static io.spine.base.Identifier.newUuid;
-import static io.spine.base.Time.currentTime;
-import static io.spine.core.Versions.increment;
 import static io.spine.core.Versions.zero;
-import static io.spine.protobuf.Messages.isDefault;
-import static io.spine.server.aggregate.given.StorageRecords.sequenceFor;
-import static io.spine.server.aggregate.given.aggregate.AggregateTestEnv.event;
-import static io.spine.testing.TestValues.nullRef;
-import static io.spine.testing.core.given.GivenEnrichment.withOneAttribute;
-import static java.lang.Integer.MAX_VALUE;
-import static java.util.Collections.reverse;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * An abstract base for tests of {@link AggregateStorage} implementations.
+ *
+ * <p>Since the event-sourcing cutover, {@code AggregateStorage} keeps only the latest
+ * Aggregate states; the journal of the emitted events is owned by the
+ * {@link AggregateRepository} and covered by
+ * {@code io.spine.server.entity.storage.EntityEventStorageSpec}.
  *
  * <p>The storage under test is produced by the
  * {@linkplain ServerEnvironment#storageFactory() current} {@code StorageFactory}. Descendants
@@ -106,24 +73,6 @@ public abstract class AggregateStorageTest
     private final ProjectId id = Sample.messageOfType(ProjectId.class);
 
     private AggregateStorage<ProjectId, AggProject> storage;
-
-    private static EventId newEventId() {
-        return EventId.newBuilder()
-                      .setValue(newUuid())
-                      .build();
-    }
-
-    /**
-     * Creates an event factory producing the events on behalf of the entity with
-     * the passed identifier.
-     *
-     * <p>The journal stores an event under its producer, so the tests writing events
-     * must emit them with the identifier they later read the history by.
-     */
-    private static TestEventFactory eventFactoryFor(Object producerId) {
-        return TestEventFactory.newInstance(Identifier.pack(producerId),
-                                            AggregateStorageTest.class);
-    }
 
     @Override
     @BeforeEach
@@ -156,7 +105,7 @@ public abstract class AggregateStorageTest
     }
 
     /**
-     * Creates the storage for the specified ID and aggregate class.
+     * Creates the storage for the specified aggregate class.
      *
      * <p>The created storage should be closed manually.
      *
@@ -164,6 +113,8 @@ public abstract class AggregateStorageTest
      *         the aggregate class
      * @param <I>
      *         the type of aggregate IDs
+     * @param <S>
+     *         the type of aggregate states
      * @return a new storage instance
      */
     <I, S extends AggregateState<I>> AggregateStorage<I, S>
@@ -172,110 +123,16 @@ public abstract class AggregateStorageTest
         var result =
                 ServerEnvironment.instance()
                                  .storageFactory()
-                                 .createAggregateStorage(spec,aggregateClass);
+                                 .createAggregateStorage(spec, aggregateClass);
         return result;
     }
 
-    @Nested
-    @DisplayName("being empty, return")
-    class BeingEmptyReturn {
+    @Test
+    @DisplayName("return an empty `Optional` on reading an absent state")
+    void absentRecord() {
+        var record = storage.read(id);
 
-        @Test
-        @DisplayName("iterator over empty collection on reading history")
-        void emptyHistory() {
-            var iterator = eventHistoryBackward();
-
-            assertFalse(iterator.hasNext());
-        }
-
-        @Test
-        @DisplayName("empty `Optional` on reading an absent state")
-        void absentRecord() {
-            var record = storage.read(id);
-
-            assertFalse(record.isPresent());
-        }
-
-        @Test
-        @DisplayName("empty list on reading events")
-        void emptyEvents() {
-            assertThat(storage.readEvents(id)).isEmpty();
-        }
-    }
-
-    @Nested
-    @DisplayName("not accept `null`")
-    class NotAcceptNull {
-
-        @Test
-        @DisplayName("request ID when reading history")
-        void idForReadHistory() {
-            assertThrows(NullPointerException.class,
-                         () -> storage.eventHistoryBackward(nullRef(), 10));
-        }
-
-        @Test
-        @DisplayName("event for writing")
-        void event() {
-            assertThrows(NullPointerException.class,
-                         () -> storage.writeEvent(id, nullRef()));
-        }
-
-        @Test
-        @DisplayName("event ID for writing")
-        void eventId() {
-            assertThrows(NullPointerException.class,
-                         () -> storage.writeEvent(nullRef(), Event.getDefaultInstance()));
-        }
-    }
-
-    @Nested
-    @DisplayName("write and read single event by ID of type")
-    class WriteAndReadEvent {
-
-        @Test
-        @DisplayName("`Message`")
-        void byMessageId() {
-            writeAndReadEventTest(id, storage);
-        }
-
-        @Test
-        @DisplayName("`String`")
-        void byStringId() {
-            AggregateStorage<String, ?> storage = newStorage(TestAggregateWithIdString.class);
-            var id = newUuid();
-            writeAndReadEventTest(id, storage);
-        }
-
-        @Test
-        @DisplayName("`Long`")
-        void byLongId() {
-            AggregateStorage<Long, ?> storage = newStorage(TestAggregateWithIdLong.class);
-            var id = 10L;
-            writeAndReadEventTest(id, storage);
-        }
-
-        @Test
-        @DisplayName("`Integer`")
-        void byIntegerId() {
-            AggregateStorage<Integer, ?> storage = newStorage(TestAggregateWithIdInteger.class);
-            var id = 10;
-            writeAndReadEventTest(id, storage);
-        }
-
-        private <I> void writeAndReadEventTest(I id, AggregateStorage<I, ?> storage) {
-            var factory = eventFactoryFor(id);
-            var expectedEvent = factory.createEvent(event(AggProject.getDefaultInstance()));
-
-            storage.writeEvent(id, expectedEvent);
-
-            var events = storage.readEvents(id, MAX_VALUE);
-            assertEquals(1, events.size());
-            var actualEvent = events.get(0);
-            assertEquals(expectedEvent, actualEvent);
-
-            close(storage);
-        }
+        assertFalse(record.isPresent());
     }
 
     @Test
@@ -304,257 +161,9 @@ public abstract class AggregateStorageTest
         assertThat(actualIds).containsExactlyElementsIn(expectedIds);
     }
 
-    @Test
-    @DisplayName("throw `IllegalStateException` on reading events after being closed")
-    void throwOnReadEventsWhenClosed() {
-        var closed = newStorage(TestAggregate.class);
-        closed.close();
-        assertThrows(IllegalStateException.class, () -> closed.readEvents(id));
-    }
-
-    @Nested
-    @DisplayName("write records and return them")
-    class WriteRecordsAndReturn {
-
-        @Test
-        @DisplayName("sorted by timestamp descending")
-        void sortedByTimestamp() {
-            var events = sequenceFor(id);
-
-            writeAll(id, events);
-
-            var iterator = eventHistoryBackward();
-            List<Event> actual = newArrayList(iterator);
-            reverse(events); // expected events should be in a reverse order
-            assertEquals(events, actual);
-        }
-
-        @Test
-        @DisplayName("sorted by version descending")
-        void sortedByVersion() {
-            var eventsNumber = 5;
-            List<Event> events = newLinkedList();
-            var timestamp = currentTime();
-            var currentVersion = zero();
-            var factory = eventFactoryFor(id);
-            for (var i = 0; i < eventsNumber; i++) {
-                var state = AggProject.getDefaultInstance();
-                var event = factory.createEvent(event(state), currentVersion, timestamp);
-                events.add(event);
-                currentVersion = increment(currentVersion);
-            }
-            writeAll(id, events);
-
-            var iterator = eventHistoryBackward();
-            List<Event> actual = newArrayList(iterator);
-            reverse(events); // expected events should be in a reverse order
-            assertEquals(events, actual);
-        }
-
-        @Test
-        @DisplayName("sorted by version rather than by timestamp")
-        void sortByVersionFirstly() {
-            var state = AggProject.getDefaultInstance();
-            var minVersion = zero();
-            var maxVersion = increment(minVersion);
-            var minTimestamp = currentTime();
-            var maxTimestamp = add(minTimestamp, Durations.fromHours(1));
-
-            // The first event is an event, which is the oldest, i.e. with the minimal version.
-            var factory = eventFactoryFor(id);
-            var expectedFirst = factory.createEvent(event(state), minVersion, maxTimestamp);
-            var expectedSecond = factory.createEvent(event(state), maxVersion, minTimestamp);
-
-            storage.writeEvent(id, expectedSecond);
-            storage.writeEvent(id, expectedFirst);
-
-            var events = storedEvents(id);
-            assertTrue(events.indexOf(expectedFirst) < events.indexOf(expectedSecond));
-        }
-    }
-
-    @Nested
-    @DisplayName("write records and load history")
-    class WriteRecordsAndLoadHistory {
-
-        @Test
-        @DisplayName("in the order of emission")
-        void inOrderOfEmission() {
-            testWriteRecordsAndLoadHistory(currentTime());
-        }
-
-        @Test
-        @DisplayName("limited to the requested number of the most recent events")
-        void limitedToMostRecent() {
-            var eventCount = 5;
-            var window = 3;
-            List<Event> written = new ArrayList<>(eventCount);
-            var currentVersion = zero();
-            var factory = eventFactoryFor(id);
-            for (var i = 0; i < eventCount; i++) {
-                currentVersion = increment(currentVersion);
-                var state = AggProject.getDefaultInstance();
-                var event = factory.createEvent(event(state), currentVersion);
-                written.add(event);
-                storage.writeEvent(id, event);
-            }
-
-            var events = storage.readEvents(id, window);
-
-            var expected = written.subList(eventCount - window, eventCount);
-            assertEquals(expected, events);
-        }
-    }
-
-    @Nested
-    @DisplayName("truncate the journal")
-    class TruncateJournal {
-
-        private Version currentVersion = zero();
-
-        @Test
-        @DisplayName("deleting only the events older than the given time")
-        void olderThan() {
-            var longAgo = subtract(currentTime(), Durations.fromDays(365));
-            writeSequentialEvents(2, longAgo);
-            var recent = writeSequentialEvents(2, currentTime());
-            var cutoff = subtract(currentTime(), Durations.fromDays(30));
-
-            storage.truncate(cutoff);
-
-            var remaining = storedEvents(id);
-            assertEquals(recent, remaining);
-        }
-
-        @CanIgnoreReturnValue
-        private List<Event> writeSequentialEvents(int count, Timestamp at) {
-            List<Event> events = new ArrayList<>(count);
-            var factory = eventFactoryFor(id);
-            for (var i = 0; i < count; i++) {
-                currentVersion = increment(currentVersion);
-                var state = AggProject.getDefaultInstance();
-                var event = factory.createEvent(event(state), currentVersion, at);
-                events.add(event);
-                storage.writeEvent(id, event);
-            }
-            return events;
-        }
-    }
-
-    @Nested
-    @DisplayName("not store enrichment")
-    class NotStoreEnrichment {
-
-        @Test
-        @DisplayName("for `EventContext`")
-        void forEventContext() {
-            var context = ActorContext.newBuilder().buildPartial();
-            var messageId = MessageId.newBuilder()
-                    .setId(AnyPacker.pack(newEventId()))
-                    .setTypeUrl(TypeUrl.of(NoReaction.class)
-                                       .value())
-                    .buildPartial();
-            var origin = Origin.newBuilder()
-                    .setActorContext(context)
-                    .setMessage(messageId)
-                    .build();
-            var enrichedContext = EventContext.newBuilder()
-                    .setEnrichment(withOneAttribute())
-                    .setTimestamp(Time.currentTime())
-                    .setProducerId(Identifier.pack(id))
-                    .setPastMessage(origin)
-                    .build();
-            var event = Event.newBuilder()
-                    .setId(newEventId())
-                    .setContext(enrichedContext)
-                    .setMessage(AnyPacker.pack(TestValues.newUuidValue()))
-                    .build();
-            storage.writeEvent(id, event);
-
-            var events = storedEvents(id);
-            var loadedContext = events.get(0).context();
-            assertTrue(isDefault(loadedContext.getEnrichment()));
-        }
-
-        @SuppressWarnings("deprecation") // For backward compatibility.
-        @Test
-        @DisplayName("for origin of `EventContext` type")
-        void forEventContextOrigin() {
-            var origin = EventContext.newBuilder()
-                    .setEnrichment(withOneAttribute())
-                    .setTimestamp(Time.currentTime())
-                    .setProducerId(AnyPacker.pack(TestValues.newUuidValue()))
-                    .setCommandContext(GivenCommandContext.withRandomActor())
-                    .build();
-            var context = EventContext.newBuilder()
-                    .setEventContext(origin)
-                    .setTimestamp(Time.currentTime())
-                    .setProducerId(Identifier.pack(id))
-                    .build();
-            var event = Event.newBuilder()
-                    .setId(newEventId())
-                    .setContext(context)
-                    .setMessage(AnyPacker.pack(TestValues.newUuidValue()))
-                    .build();
-            storage.writeEvent(id, event);
-            var events = storedEvents(id);
-            var loadedOrigin = events.get(0)
-                                     .context()
-                                     .getEventContext();
-            assertTrue(isDefault(loadedOrigin.getEnrichment()));
-        }
-    }
-
-    private List<Event> storedEvents(ProjectId id) {
-        return storage.readEvents(id);
-    }
-
-    void testWriteRecordsAndLoadHistory(Timestamp firstRecordTime) {
-        var expectedEvents = sequenceFor(id, firstRecordTime);
-
-        writeAll(id, expectedEvents);
-
-        var actualEvents = storedEvents(id);
-        assertEquals(expectedEvents, actualEvents);
-    }
-
-    protected void writeAll(ProjectId id, Iterable<Event> events) {
-        for (var event : events) {
-            storage.writeEvent(id, event);
-        }
-    }
-
-    private Iterator<Event> eventHistoryBackward() {
-        return storage.eventHistoryBackward(id, MAX_VALUE);
-    }
-
     public static class TestAggregate extends Aggregate<ProjectId, AggProject, AggProject.Builder> {
 
         protected TestAggregate(ProjectId id) {
-            super(id);
-        }
-    }
-
-    private static class TestAggregateWithIdString
-            extends Aggregate<String, StringProject, StringProject.Builder> {
-
-        private TestAggregateWithIdString(String id) {
-            super(id);
-        }
-    }
-
-    private static class TestAggregateWithIdInteger
-            extends Aggregate<Integer, IntegerProject, IntegerProject.Builder> {
-
-        private TestAggregateWithIdInteger(Integer id) {
-            super(id);
-        }
-    }
-
-    private static class TestAggregateWithIdLong
-            extends Aggregate<Long, LongProject, LongProject.Builder> {
-
-        private TestAggregateWithIdLong(Long id) {
             super(id);
         }
     }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of this library.
  */
-extra.set("versionToPublish", "2.0.0-SNAPSHOT.460")
+extra.set("versionToPublish", "2.0.0-SNAPSHOT.470")


### PR DESCRIPTION
## Summary

Moves the event journal (`EntityEventStorage`) out of `AggregateStorage` and up into `AggregateRepository`. Since the event-sourcing cutover the journal is no longer part of the Aggregate *state* storage, so this removes the extra level of delegation: `AggregateStorage` becomes purely the latest-state store (`extends EntityRecordStorage`), and the repository now **owns and serves** the journal to its aggregates — symmetric with the state history (`EntityStateHistoryStorage`) it already owns.

This prepares the same "repository owns the journal and the state history" shape for `ProcessManagerRepository`.

## What changed

- **`AggregateStorage`** — drops the `eventStorage` field, the journal methods (`readEvents`, `writeEvent`, `writeAll`, `eventHistoryBackward`, `truncate`), and the `close()` override; reverts to a pure latest-state store.
- **`AggregateRepository`** — owns the journal: an `EntityEventStorage` field with a lazy `eventStorage()` accessor (mirroring `stateHistoryStorage()`); the `EventHistoryLoader` reads from it; `doStore` journals the emitted events then writes the state (order preserved); `close()` releases the journal alongside the state history.
- **Tests** — journal behavior stays covered by `EntityEventStorageSpec`; `AggregateStorageTest` is slimmed to the state-storage contract; `HistoryStorageIdentitySpec` builds the journal via `createEntityEventStorage`.

The journal is read only through the `EventHistoryLoader` seam (how `IdempotencyGuard` and `Aggregate.eventHistoryBackward` reach it), so only two production call sites — both in `AggregateRepository` — needed re-pointing.

## Custom-backend SPI hooks

Both repository-owned history storages now have an overridable creation hook, so a repository serving its aggregate state from a custom `StorageFactory`/backend can serve its journal and state history from the **same** backend instead of silently falling back to the default one:

- `createEventStorage()` — creates the event journal (added in response to Codex review).
- `createStateHistoryStorage()` — creates the state-history storage.
- `stateHistoryStorage()` is now `protected`, so subclasses can reach it for maintenance (`truncate`/`trim`) even while recording is off.

## Close-path hardening

- `attemptClose(...)` — the close-failure collector — is pulled up into `Repository` as `protected static`, so any repository closing several resources can reuse it: attempt every close, keep the first failure as the primary exception, attach the rest as suppressed. `ProcessManagerRepository` will reuse it.
- `Repository.close()` routes `storage().close()` through it, so a storage-close failure still clears the `storage`/`context` references before re-throwing — a failed close no longer leaves the repository half-open.
- `AggregateRepository.close()` collects failures across the super, journal, and state-history closes the same way.

## Also in this PR

- **`EntityIterator`** pulled out of `Repository` into a package-level `final` type.
- **Test flake fix** — `TestClientTest` binds its gRPC server to a free, OS-assigned port (`ServerSocket(0)`) instead of a randomly guessed one in a fixed range, removing the intermittent `BindException: Address already in use` that failed the Windows CI build.
- Minor cleanups: `checkStorage` made `private`, redundant `@SuppressWarnings` removed, Javadoc layout/wording polish.
- The `2.0.0-SNAPSHOT.470` version bump and the regenerated dependency reports.

## Verification

- `./gradlew build dokkaGenerate` — green across all modules.
- `:server` tests for `aggregate.*` + `entity.storage.*` pass, including `IdempotencyGuardTest` (the guard reads the journal through the re-pointed loader), `InMemoryAggregateStorageTest`, and `AggregateRepositoryStateHistorySpec`.
- Reviewers `spine-code-review`, `kotlin-engineer`, and `review-docs` approved the journal move and the `EntityIterator` extraction; the bot review comments (Codex's custom-backend concern, the `AutoClosable`→`Closeable` typo) were addressed and resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
