### PR TITLE
Serve the recent entity history from an instance-side cache

### DIFF
--- a/.agents/tasks/recent-history-cache.md
+++ b/.agents/tasks/recent-history-cache.md
@@ -1,0 +1,71 @@
+# Task: Cache-backed, writable `RecentHistory`
+
+## Origin
+
+Batch dispatch work (2026-07-20): when an entity handles several signals in
+one batch, every dispatch re-reads its recent history from storage (e.g., the
+idempotency guard scans up to 100 events per signal). `RecentHistory` is a
+stateless read-through view today. This task makes the family cache what it
+has already loaded and become writable (`append`), so repeated reads within
+an instance's lifetime are served from memory, and freshly produced items
+become readable before they are durable.
+
+**Scope: history classes only.** No repository-side `append` wiring — that is
+the follow-up batch-caching task. Loader interfaces and their four in-repo
+implementers change because the loader signature must support continuation
+reads.
+
+## Design facts (verified in code)
+
+1. `HistoryStorage.historyBackward(entityId, batchSize, startingFrom)` already
+   reads items with versions **strictly below** `startingFrom` — the
+   continuation primitive. Without it, a remainder read of `depth − cached`
+   would re-fetch the newest (already cached) items.
+2. **All events of one dispatch share one version** (the pre-dispatch version;
+   see `AggregateTransaction` KDoc and `EventEmitter.toSuccessfulOutcome`).
+   A strict-less continuation from a mid-group boundary would drop
+   same-version siblings ⇒ the cache tail must always end on a **complete
+   version group**.
+3. **State-history records never share a version** (`Phase.java`) — groups
+   there are singletons.
+4. `read()` must invoke the loader **eagerly** (lazy only in consumption):
+   `AggregateRepositoryStateHistorySpec` asserts `IllegalStateException` from
+   the `read` call itself, without traversing the iterator.
+5. Entity dispatch is single-threaded per instance; no synchronization —
+   documented assumption.
+
+## Shape
+
+- `RecentHistory<R : Any, T : Any, L : HistoryLoader<R>>`; abstract
+  `toItem(record: R): T` and `versionOf(record: R): Version`; the abstract
+  `load(loader, depth)` bridge is gone (base calls the typed loader directly).
+- Cache: `ArrayDeque<Cached<T>>` newest-first (`Cached` = converted item +
+  version); invariant: contiguous newest-first run, tail ends on a complete
+  version group. `exhausted` flag skips the loader once storage below the
+  tail is proven empty; reset by `useLoader`.
+- `append(records)` (`@Internal`): chronological input, prepended to the
+  head; contract — one call per dispatch with the complete version group.
+- `read(depth)`: serve cache snapshot, then continue below it via
+  `loader.load(depth − cached, oldestCachedVersion)`; loaded items populate
+  the cache group-by-group under an identity guard (sibling iterators cannot
+  corrupt the run). No-loader reads serve appended items now.
+- `HistoryLoader.load(depth, startingFrom)` — no default value; implementers:
+  `AggregateRepository` lambda, `AbstractEntityRepository` anonymous class,
+  two specs.
+
+Full plan: `.claude/plans/toasty-wibbling-leaf.md` (session-local).
+
+## Verification
+
+- `:server:test` for `RecentEventHistorySpec`, `RecentStateHistorySpec`,
+  `AggregateRepositoryStateHistorySpec` (fail-fast contract), then full
+  `./gradlew build`.
+
+## Status
+
+- [x] Loader interfaces extended
+- [x] `RecentHistory` reworked (cache, append, group-aligned population)
+- [x] Subclasses adapted
+- [x] Repository loader implementations adapted
+- [x] Specs extended
+- [x] Build green (`./gradlew build`, 2026-07-20)

--- a/.agents/tasks/recent-history-cache.md
+++ b/.agents/tasks/recent-history-cache.md
@@ -61,6 +61,27 @@ Full plan: `.claude/plans/toasty-wibbling-leaf.md` (session-local).
   `AggregateRepositoryStateHistorySpec` (fail-fast contract), then full
   `./gradlew build`.
 
+## Follow-up: `append` wiring (same branch, second commit)
+
+- Event side: `UncommittedHistory.record` returns the kept events;
+  `Aggregate.recordEvents` appends them to the recent event history at the
+  per-dispatch commit point (success-only, post-transaction). Visibility
+  change: earlier same-batch dispatches' events are now readable, and the
+  `IdempotencyGuard` catches duplicates within one batch; docs updated in
+  `Aggregate`, `IdempotencyGuard`, `AggregateRepository`.
+- State side: `AbstractEntityRepository.appendStateHistory` writes the
+  durable record first, then appends it to the entity instance via the new
+  `AbstractEntity.appendToStateHistory` forwarder. No visibility change —
+  read-optimization only.
+- `append` is self-healing instead of `require`-guarded: a group breaking
+  the contract (uniform version strictly above the cache head) clears the
+  cache and is dropped — reads fall back to storage. Rationale: catch-up
+  replay overlaps versions; a cache must never fail a dispatch.
+- New `AggregateRecentHistorySpec` pins: same-instance visibility,
+  own-dispatch exclusion, batch visibility (`beginBatch`/`endBatch` fixture
+  lever over `cache().startCaching/stopCaching`), same-batch duplicate
+  detection, cache-serving after storage truncation.
+
 ## Status
 
 - [x] Loader interfaces extended
@@ -68,4 +89,11 @@ Full plan: `.claude/plans/toasty-wibbling-leaf.md` (session-local).
 - [x] Subclasses adapted
 - [x] Repository loader implementations adapted
 - [x] Specs extended
-- [x] Build green (`./gradlew build`, 2026-07-20)
+- [x] Build green (`./gradlew build`, 2026-07-20); committed `7d542fc754d`
+- [x] `append` wired (events at `recordEvents`, states in `afterStore` path)
+- [x] Self-healing `append` + heal tests
+- [x] `AggregateRecentHistorySpec` (93 affected tests green)
+- [x] Wiring reviewed (kotlin-engineer + spine-code-review, findings applied);
+      `IdempotencyGuard.historyDepth` zero-initialized per owner feedback
+- [x] Final full build green (`./gradlew build`, 2026-07-20); committed
+- [ ] Version bump (once, at PR time — flagged by both reviews)

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.500`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.502`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1084,14 +1084,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 17 21:09:16 WEST 2026** using 
+This report was generated on **Mon Jul 20 21:09:08 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.500`
+# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.502`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2271,14 +2271,14 @@ This report was generated on **Fri Jul 17 21:09:16 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 17 21:09:16 WEST 2026** using 
+This report was generated on **Mon Jul 20 21:09:08 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.500`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.502`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3298,14 +3298,14 @@ This report was generated on **Fri Jul 17 21:09:16 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 17 21:09:16 WEST 2026** using 
+This report was generated on **Mon Jul 20 21:09:08 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.500`
+# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.502`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4359,14 +4359,14 @@ This report was generated on **Fri Jul 17 21:09:16 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 17 21:09:16 WEST 2026** using 
+This report was generated on **Mon Jul 20 21:09:08 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.500`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.502`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5462,14 +5462,14 @@ This report was generated on **Fri Jul 17 21:09:16 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 17 21:09:16 WEST 2026** using 
+This report was generated on **Mon Jul 20 21:09:08 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.500`
+# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.502`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -6641,14 +6641,14 @@ This report was generated on **Fri Jul 17 21:09:16 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 17 21:09:16 WEST 2026** using 
+This report was generated on **Mon Jul 20 21:09:08 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.500`
+# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.502`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -7880,6 +7880,6 @@ This report was generated on **Fri Jul 17 21:09:16 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 17 21:09:16 WEST 2026** using 
+This report was generated on **Mon Jul 20 21:09:08 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>core-jvm</artifactId>
-<version>2.0.0-SNAPSHOT.500</version>
+<version>2.0.0-SNAPSHOT.502</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -117,7 +117,7 @@ import static io.spine.server.aggregate.model.AggregateClass.asAggregateClass;
  *
  * <p>Event sourcing has been removed: an aggregate no longer declares {@code @Apply} event
  * appliers, and its state is not reconstructed by replaying events. Declaring an applier now fails
- * model building with a {@link io.spine.server.model.ModelError ModelError}. See {@link Apply}.
+ * model building with a {@link io.spine.server.model.ModelError ModelError}.
  *
  * @param <I>
  *         the type for IDs of this class of aggregates
@@ -200,7 +200,7 @@ public abstract class Aggregate<I,
 
     /**
      * Enables the opt-in {@link IdempotencyGuard} for this aggregate, scanning up to
-     * {@code historyDepth} most recent journal events for a duplicate on each dispatch.
+     * {@code historyDepth} most recent events for a duplicate on each dispatch.
      */
     final void enableIdempotencyGuard(int historyDepth) {
         idempotencyGuard.enable(historyDepth);
@@ -308,11 +308,17 @@ public abstract class Aggregate<I,
      * <p>Called by the framework after a command or reaction has been dispatched and its
      * transaction committed. Rejection events are not journaled.
      *
+     * <p>The journaled events also enter the {@linkplain #recentEventHistory() recent
+     * event history} right away, so the subsequent dispatches served by this instance —
+     * e.g., the later signals of a delivery batch — read them without waiting for
+     * the journal write, which may be deferred to the end of the batch.
+     *
      * @param events
      *         the events emitted by the current command handler or reactor
      */
     final void recordEvents(List<Event> events) {
-        uncommittedHistory.record(events);
+        var journaled = uncommittedHistory.record(events);
+        recentEventHistory().append(journaled);
     }
 
     /**
@@ -370,13 +376,13 @@ public abstract class Aggregate<I,
 
     /**
      * Creates an iterator over up to {@code depth} most recent events of this aggregate's
-     * journal, newest first.
+     * history, newest first.
      *
-     * <p>Fewer events are returned if the journal holds fewer. The events emitted by the
-     * current, not-yet-committed dispatch are excluded. Under a batched delivery, the
-     * durable writes are deferred to the end of the batch, so the events of the earlier
-     * dispatches of the same batch may not have reached the journal yet, and are then
-     * excluded too.
+     * <p>Fewer events are returned if the history retains fewer. The events emitted by the
+     * current, not-yet-committed dispatch are excluded. The events committed by the earlier
+     * dispatches served by this instance — e.g., the preceding signals of a delivery
+     * batch — are included even while the deferred journal write has not persisted
+     * them yet.
      *
      * @param depth
      *         the maximal number of the most recent events to return; must be positive
@@ -389,7 +395,7 @@ public abstract class Aggregate<I,
     }
 
     /**
-     * Verifies if up to {@code depth} most recent events of this aggregate's journal contain an
+     * Verifies if up to {@code depth} most recent events of this aggregate's history contain an
      * event that satisfies the passed predicate.
      *
      * <p>The visibility caveats of {@link #eventHistoryBackward(int)} apply to this check.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -364,7 +364,7 @@ public abstract class AggregateRepository<I,
      *
      * <p>When enabled, each dispatch scans the last {@link #eventHistoryDepth()} events of
      * the aggregate's recent history — including the events of the current delivery batch
-     * which have not reached the journal yet — and rejects a signal already seen among them,
+     * that have not reached the journal yet — and rejects a signal already seen among them,
      * however long ago it was dispatched. This mechanism is distinct from the delivery
      * layer's time-windowed deduplication. The guard is <b>off by default</b> for
      * performance: it adds a bounded history read to every dispatch.

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -72,12 +72,13 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  *
  * <p>Three per-repository settings tune this behavior:
  * <ul>
- *     <li>{@link #useIdempotencyGuard()} — enables the journal-backed {@link IdempotencyGuard},
+ *     <li>{@link #useIdempotencyGuard()} — enables the history-backed {@link IdempotencyGuard},
  *         which rejects a signal already seen among the last {@link #eventHistoryDepth()}
- *         dispatches (however long ago). It is <b>off by default</b> for performance — when
- *         enabled, every dispatch pays a bounded journal read. This is a mechanism distinct from
+ *         dispatches — however long ago, including the earlier dispatches of the current
+ *         delivery batch. It is <b>off by default</b> for performance — when enabled, every
+ *         dispatch pays a bounded history read. This is a mechanism distinct from
  *         the delivery layer's time-windowed deduplication, not a replacement for it.
- *     <li>{@linkplain #eventHistoryDepth() eventHistoryDepth} — how many recent journal events
+ *     <li>{@linkplain #eventHistoryDepth() eventHistoryDepth} — how many recent events
  *         the guard scans on each dispatch when enabled (default {@value #DEFAULT_HISTORY_DEPTH}).
  *     <li>{@link #recordStateHistory()} — records the state history of the aggregates
  *         on each dispatch. This is an opt-in feature shared by all entity repositories
@@ -337,7 +338,7 @@ public abstract class AggregateRepository<I,
     }
 
     /**
-     * Returns the number of the most recent journal events scanned by the opt-in
+     * Returns the number of the most recent events scanned by the opt-in
      * {@link IdempotencyGuard} when it is enabled.
      *
      * @return a positive integer value; the default is {@value #DEFAULT_HISTORY_DEPTH}
@@ -350,7 +351,7 @@ public abstract class AggregateRepository<I,
      * Sets the {@linkplain #eventHistoryDepth() event history depth} to the passed value.
      *
      * @param depth
-     *         a positive number of recent journal events the idempotency guard scans
+     *         a positive number of recent events the idempotency guard scans
      */
     protected void setEventHistoryDepth(int depth) {
         checkArgument(depth > 0);
@@ -358,13 +359,15 @@ public abstract class AggregateRepository<I,
     }
 
     /**
-     * Enables the opt-in, journal-backed {@link IdempotencyGuard} for the aggregates of
+     * Enables the opt-in, history-backed {@link IdempotencyGuard} for the aggregates of
      * this repository.
      *
-     * <p>When enabled, each dispatch scans the last {@link #eventHistoryDepth()} journal events and
-     * rejects a signal already seen among them, however long ago it was dispatched — a mechanism
-     * distinct from the delivery layer's time-windowed deduplication. The guard is
-     * <b>off by default</b> for performance: it adds a bounded journal read to every dispatch.
+     * <p>When enabled, each dispatch scans the last {@link #eventHistoryDepth()} events of
+     * the aggregate's recent history — including the events of the current delivery batch
+     * which have not reached the journal yet — and rejects a signal already seen among them,
+     * however long ago it was dispatched. This mechanism is distinct from the delivery
+     * layer's time-windowed deduplication. The guard is <b>off by default</b> for
+     * performance: it adds a bounded history read to every dispatch.
      */
     protected void useIdempotencyGuard() {
         this.idempotencyGuardEnabled = true;

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -205,7 +205,8 @@ public abstract class AggregateRepository<I,
      */
     final void setUpHistoryReading(A aggregate, I id) {
         aggregate.setEventHistoryLoader(
-                depth -> eventStorage().historyBackward(id, depth));
+                (depth, startingFrom) ->
+                        eventStorage().historyBackward(id, depth, startingFrom));
         if (idempotencyGuardEnabled) {
             aggregate.enableIdempotencyGuard(eventHistoryDepth);
         }

--- a/server/src/main/java/io/spine/server/aggregate/IdempotencyGuard.java
+++ b/server/src/main/java/io/spine/server/aggregate/IdempotencyGuard.java
@@ -43,13 +43,17 @@ import static java.lang.String.format;
 
 /**
  * This guard ensures that the message was not yet dispatched to the {@link Aggregate aggregate}.
+ *
+ * <p>The check scans the aggregate's recent event history, which includes the events
+ * committed by the earlier dispatches of the current delivery batch even before they
+ * reach the durable journal — so a duplicate arriving within one batch is caught too.
  */
 final class IdempotencyGuard {
 
     private final Aggregate<?, ?, ?> aggregate;
 
     /**
-     * Whether this journal-backed guard is active.
+     * Whether this history-backed guard is active.
      *
      * <p>Off by default: deduplication is primarily the delivery layer's responsibility, and this
      * guard is an opt-in per-repository backstop (see
@@ -57,15 +61,20 @@ final class IdempotencyGuard {
      */
     private boolean enabled = false;
 
-    /** The number of the most recent journal events scanned for a duplicate when enabled. */
-    private int historyDepth = 100;
+    /**
+     * The number of the most recent events scanned for a duplicate.
+     *
+     * <p>Zero while the guard is disabled: both fields are assigned together
+     * in {@link #enable(int)}, and the depth is never read before that.
+     */
+    private int historyDepth = 0;
 
     IdempotencyGuard(Aggregate<?, ?, ?> aggregate) {
         this.aggregate = aggregate;
     }
 
     /**
-     * Enables the guard, scanning up to {@code historyDepth} most recent journal events for a
+     * Enables the guard, scanning up to {@code historyDepth} most recent events for a
      * duplicate on each dispatch.
      */
     void enable(int historyDepth) {
@@ -129,8 +138,8 @@ final class IdempotencyGuard {
     /**
      * Checks if the event was already handled by the aggregate recently.
      *
-     * <p>The check is performed by searching the {@code historyDepth} most recent journal
-     * events for an event caused by this event.
+     * <p>The check is performed by searching the {@code historyDepth} most recent
+     * events of the aggregate's history for an event caused by this event.
      *
      * <p>This functionality supports the ability to stop duplicate events from being dispatched
      * to the aggregate.
@@ -159,8 +168,8 @@ final class IdempotencyGuard {
     /**
      * Checks if the command was already handled by the aggregate recently.
      *
-     * <p>The check is performed by searching the {@code historyDepth} most recent journal
-     * events for an event caused by this command.
+     * <p>The check is performed by searching the {@code historyDepth} most recent
+     * events of the aggregate's history for an event caused by this command.
      *
      * <p>This functionality supports the ability to stop duplicate commands from being dispatched
      * to the aggregate.

--- a/server/src/main/java/io/spine/server/aggregate/UncommittedHistory.java
+++ b/server/src/main/java/io/spine/server/aggregate/UncommittedHistory.java
@@ -53,13 +53,17 @@ final class UncommittedHistory {
      *
      * @param produced
      *         the events emitted by the current command handler or reactor
+     * @return the events kept for journaling by this call, in the order of emission
      */
-    void record(Iterable<Event> produced) {
+    List<Event> record(Iterable<Event> produced) {
+        var kept = ImmutableList.<Event>builder();
         for (var event : produced) {
             if (!event.isRejection()) {
                 events.add(event);
+                kept.add(event);
             }
         }
+        return kept.build();
     }
 
     /**

--- a/server/src/main/java/io/spine/server/entity/AbstractEntityRepository.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractEntityRepository.java
@@ -272,7 +272,7 @@ public abstract class AbstractEntityRepository<I,
      *
      * <p>The switch may be flipped at runtime: dispatch workers observe it on their
      * next dispatch. A dispatch already past its recording check may append one more
-     * record after this call returns. An entity instance which cached the records
+     * record after this call returns. An entity instance that cached the records
      * appended while the recording was on — e.g., in the middle of a delivery
      * batch — keeps serving them from memory for the rest of its lifetime.
      *

--- a/server/src/main/java/io/spine/server/entity/AbstractEntityRepository.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractEntityRepository.java
@@ -30,6 +30,7 @@ import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper;
 import com.google.errorprone.annotations.concurrent.LazyInit;
 import com.google.protobuf.Timestamp;
 import io.spine.base.EntityState;
+import io.spine.core.Version;
 import io.spine.server.BoundedContext;
 import io.spine.server.entity.storage.EntityStateHistoryStorage;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -197,8 +198,8 @@ public abstract class AbstractEntityRepository<I,
         return new StateHistoryLoader() {
 
             @Override
-            public Iterator<EntityRecord> load(int depth) {
-                return stateHistory().historyBackward(id, depth);
+            public Iterator<EntityRecord> load(int depth, @Nullable Version startingFrom) {
+                return stateHistory().historyBackward(id, depth, startingFrom);
             }
 
             @Override

--- a/server/src/main/java/io/spine/server/entity/AbstractEntityRepository.java
+++ b/server/src/main/java/io/spine/server/entity/AbstractEntityRepository.java
@@ -181,10 +181,17 @@ public abstract class AbstractEntityRepository<I,
      * <p>A failure to record the history fails the dispatch. Under a batched delivery,
      * the durable state write may happen later, at the batch flush, so a history record
      * may briefly precede the state it captures.
+     *
+     * <p>Once the durable write succeeds, the record also enters the
+     * {@linkplain AbstractEntity#appendToStateHistory(EntityRecord) recent state history}
+     * of the entity instance, so the reads served by this instance — e.g., during the
+     * later dispatches of a delivery batch — come from memory.
      */
     private void appendStateHistory(E entity) {
         var history = stateHistoryStorage();
-        history.write(StorageConverter.toEntityRecord(entity).build());
+        var record = StorageConverter.toEntityRecord(entity).build();
+        history.write(record);
+        entity.appendToStateHistory(record);
     }
 
     /**
@@ -265,7 +272,9 @@ public abstract class AbstractEntityRepository<I,
      *
      * <p>The switch may be flipped at runtime: dispatch workers observe it on their
      * next dispatch. A dispatch already past its recording check may append one more
-     * record after this call returns.
+     * record after this call returns. An entity instance which cached the records
+     * appended while the recording was on — e.g., in the middle of a delivery
+     * batch — keeps serving them from memory for the rest of its lifetime.
      *
      * <p>To also purge the retained records, truncate the history up to the present
      * <em>before</em> stopping: {@code stateHistory().truncate(currentTime())}.

--- a/server/src/main/kotlin/io/spine/server/entity/AbstractEntity.kt
+++ b/server/src/main/kotlin/io/spine/server/entity/AbstractEntity.kt
@@ -526,6 +526,20 @@ public abstract class AbstractEntity<I : Any, S : EntityState<I>> :
     }
 
     /**
+     * Appends the given record to the [recent state history][recentStateHistory]
+     * of this entity.
+     *
+     * Called by the repository once per successful dispatch, right after
+     * the record is written to the durable state history, so that the
+     * subsequent reads served by this instance — e.g., during the later
+     * dispatches of a delivery batch — come from memory.
+     */
+    @Internal
+    public fun appendToStateHistory(record: EntityRecord) {
+        recentStateHistory.append(record)
+    }
+
+    /**
      * Obtains the state this entity had at the given time, if the recorded
      * state history retains it.
      *

--- a/server/src/main/kotlin/io/spine/server/entity/EventHistoryLoader.kt
+++ b/server/src/main/kotlin/io/spine/server/entity/EventHistoryLoader.kt
@@ -28,6 +28,7 @@ package io.spine.server.entity
 
 import io.spine.annotation.Internal
 import io.spine.core.Event
+import io.spine.core.Version
 
 /**
  * Lazily loads up to a requested number of an entity's most recent journal
@@ -46,8 +47,12 @@ public fun interface EventHistoryLoader : HistoryLoader<Event> {
     /**
      * Loads up to [depth] most recent events of the entity's journal, newest first.
      *
+     * When [startingFrom] is given, only the events with versions strictly
+     * lower than it are loaded. `null` starts from the newest event.
+     *
      * @param depth The maximum number of the most recent events to load; positive.
+     * @param startingFrom If set, only the events with versions lower than this one are loaded.
      * @return An iterator over the loaded events, newest first.
      */
-    override fun load(depth: Int): Iterator<Event>
+    override fun load(depth: Int, startingFrom: Version?): Iterator<Event>
 }

--- a/server/src/main/kotlin/io/spine/server/entity/HistoryLoader.kt
+++ b/server/src/main/kotlin/io/spine/server/entity/HistoryLoader.kt
@@ -27,6 +27,7 @@
 package io.spine.server.entity
 
 import io.spine.annotation.Internal
+import io.spine.core.Version
 
 /**
  * Lazily loads up to a requested number of the most recent items of
@@ -48,8 +49,13 @@ public interface HistoryLoader<R : Any> {
      * Loads up to [depth] most recent items of the entity's history,
      * newest first.
      *
+     * When [startingFrom] is given, only the items with versions strictly
+     * lower than it are loaded — so a read may continue below the items
+     * it has already obtained. `null` starts from the newest item.
+     *
      * @param depth The maximum number of the most recent items to load; positive.
+     * @param startingFrom If set, only the items with versions lower than this one are loaded.
      * @return An iterator over the loaded items, newest first.
      */
-    public fun load(depth: Int): Iterator<R>
+    public fun load(depth: Int, startingFrom: Version?): Iterator<R>
 }

--- a/server/src/main/kotlin/io/spine/server/entity/RecentEventHistory.kt
+++ b/server/src/main/kotlin/io/spine/server/entity/RecentEventHistory.kt
@@ -27,20 +27,23 @@
 package io.spine.server.entity
 
 import io.spine.core.Event
+import io.spine.core.Version
 
 /**
  * The recent history of events of a [TransactionalEntity].
  *
  * The events are read from the durable journal of the entity via the loader
  * [installed][TransactionalEntity.setEventHistoryLoader] by the repository
- * managing the entity.
+ * managing the entity, and cached for the lifetime of the entity instance —
+ * see [RecentHistory].
  *
  * An entity created outside a repository has no journal, so the reads
- * return no events.
+ * serve only the [appended][append] events, if any.
  */
 public class RecentEventHistory internal constructor() :
-    RecentHistory<Event, EventHistoryLoader>() {
+    RecentHistory<Event, Event, EventHistoryLoader>() {
 
-    override fun load(loader: EventHistoryLoader, depth: Int): Iterator<Event> =
-        loader.load(depth)
+    override fun toItem(record: Event): Event = record
+
+    override fun versionOf(record: Event): Version = record.context.version
 }

--- a/server/src/main/kotlin/io/spine/server/entity/RecentEventHistory.kt
+++ b/server/src/main/kotlin/io/spine/server/entity/RecentEventHistory.kt
@@ -43,7 +43,18 @@ import io.spine.core.Version
 public class RecentEventHistory internal constructor() :
     RecentHistory<Event, Event, EventHistoryLoader>() {
 
-    override fun toItem(record: Event): Event = record
+    /**
+     * Clears the enrichments from the event before it enters the cache.
+     *
+     * The durable journal stores every event enrichment-free — see
+     * `EntityEventStorage.write()`. Normalizing the same way here keeps
+     * a read consistent whether it is served from the cache or from
+     * the storage: an [appended][append] event does not carry enrichments
+     * that would vanish once the journal write flushes or the entity is
+     * reloaded. Clearing is idempotent, so an event loaded from the already
+     * enrichment-free journal is unaffected.
+     */
+    override fun toItem(record: Event): Event = record.clearEnrichments()
 
     override fun versionOf(record: Event): Version = record.context.version
 }

--- a/server/src/main/kotlin/io/spine/server/entity/RecentHistory.kt
+++ b/server/src/main/kotlin/io/spine/server/entity/RecentHistory.kt
@@ -117,7 +117,7 @@ internal constructor() {
     /**
      * Appends the given records to this history as its newest items.
      *
-     * The records must arrive in the chronological order, so that the last
+     * The records must arrive in chronological order, so that the last
      * of them becomes the newest item of the history.
      *
      * The caller — the framework code persisting the outcome of

--- a/server/src/main/kotlin/io/spine/server/entity/RecentHistory.kt
+++ b/server/src/main/kotlin/io/spine/server/entity/RecentHistory.kt
@@ -111,7 +111,7 @@ internal constructor() {
      */
     @Internal
     public fun append(record: R) {
-        cache.addFirst(cachedFrom(record))
+        append(listOf(record))
     }
 
     /**
@@ -125,10 +125,27 @@ internal constructor() {
      * call: a complete version group, never split between calls, with
      * versions above everything this history has seen. This keeps
      * the cached run contiguous and its reads exact.
+     *
+     * The contract is not enforced by failing: a history cache must never
+     * fail a dispatch. A group breaking it — e.g., a catch-up replay
+     * re-producing the versions already seen — instead drops the whole
+     * cache and is itself discarded, so the further reads fall back to
+     * the storage, the source of truth. A breaking group offered to
+     * an empty cache cannot be told from a legitimate one and is accepted;
+     * the mismatch is bounded by the lifetime of the entity instance.
      */
     @Internal
     public fun append(records: Iterable<R>) {
-        records.forEach { append(it) }
+        val group = records.map { cachedFrom(it) }
+        if (group.isEmpty()) {
+            return
+        }
+        if (extendsHistory(group)) {
+            group.forEach { cache.addFirst(it) }
+        } else {
+            cache.clear()
+            exhausted = false
+        }
     }
 
     /**
@@ -205,6 +222,23 @@ internal constructor() {
         if (consumed < remaining && population.complete()) {
             exhausted = true
         }
+    }
+
+    /**
+     * Tells if the given group can extend this history at its newest end:
+     * the records share one version, strictly above everything cached.
+     *
+     * The "strictly above" comparison tolerates numeric gaps — a dispatch
+     * may advance the entity version without producing a history record.
+     */
+    private fun extendsHistory(group: List<Cached<T>>): Boolean {
+        val number = group.first().version.number
+        val uniform = group.all { it.version.number == number }
+        if (!uniform) {
+            return false
+        }
+        val head = cache.firstOrNull()
+        return head == null || number > head.version.number
     }
 
     private fun cachedFrom(record: R): Cached<T> =

--- a/server/src/main/kotlin/io/spine/server/entity/RecentHistory.kt
+++ b/server/src/main/kotlin/io/spine/server/entity/RecentHistory.kt
@@ -26,29 +26,39 @@
 
 package io.spine.server.entity
 
-import java.util.Collections
+import io.spine.annotation.Internal
+import io.spine.core.Version
 
 /**
- * A view on the recent history of a [TransactionalEntity], read lazily from
- * a durable storage.
+ * A view on the recent history of an [AbstractEntity], read lazily from
+ * a durable storage and cached for the lifetime of the entity instance.
  *
  * The history serves its reads through a loader, installed by the
- * repository managing the entity. The items are not cached on the entity
- * side: an entity serves its signals and leaves the memory; caching, if
- * any, belongs to the storage side.
+ * repository managing the entity. The items obtained from the loader — and
+ * the items [appended][append] by the framework as the entity produces
+ * them — are kept in an instance-scoped cache, so that an entity handling
+ * several signals in a batch does not re-read the same items from the
+ * storage on every dispatch. The cache lives and dies with the entity
+ * instance; a repeated [read] hits the storage only below the items
+ * already cached.
  *
  * An entity created outside a repository has no loader installed, so its
- * reads return no items.
+ * reads serve only the [appended][append] items, if any.
+ *
+ * The instance is confined to the thread dispatching the signals of
+ * the entity, as the entity itself is; the cache is not synchronized.
  *
  * The kinds of recent histories are fixed by the framework:
  * the constructor is `internal`.
  *
- * @param T The type of the history items.
+ * @param R The type of the records persisted in the durable storage.
+ * @param T The type of the history items served to the entity.
  * @param L The type of the loader serving the reads.
  * @see RecentEventHistory
  * @see RecentStateHistory
  */
-public abstract class RecentHistory<T : Any, L : HistoryLoader<*>> internal constructor() {
+public abstract class RecentHistory<R : Any, T : Any, L : HistoryLoader<R>>
+internal constructor() {
 
     /**
      * If set, serves the reads from the durable storage of the entity.
@@ -56,11 +66,36 @@ public abstract class RecentHistory<T : Any, L : HistoryLoader<*>> internal cons
     private var loader: L? = null
 
     /**
+     * The items of the history known to this instance, newest first.
+     *
+     * The cache is a contiguous run of the recent history: the front item
+     * is the newest known one, and no items are missing in between. The
+     * run always ends on a complete version group — the items sharing one
+     * entity version, e.g., the events of a single dispatch, are never
+     * split between the cache and the storage. This keeps the
+     * [continuation reads][HistoryLoader.load] below the cache exact:
+     * they resume strictly below the version of the oldest cached item.
+     */
+    private val cache = ArrayDeque<Cached<T>>()
+
+    /**
+     * Becomes `true` when the loader proves that the storage holds
+     * nothing below the oldest cached item, so further reads do not
+     * consult the storage at all.
+     */
+    private var exhausted = false
+
+    /**
      * Installs the loader serving the reads from the durable storage
      * of the entity.
+     *
+     * The cached items are retained: a new loader serves the same
+     * history. The knowledge of its bottom is [reset][exhausted], though,
+     * since the new storage window is yet to be discovered.
      */
     internal fun useLoader(loader: L) {
         this.loader = loader
+        exhausted = false
     }
 
     /**
@@ -70,11 +105,43 @@ public abstract class RecentHistory<T : Any, L : HistoryLoader<*>> internal cons
     protected fun loader(): L? = loader
 
     /**
+     * Appends the given record to this history as its newest item.
+     *
+     * See the batch overload of [append] for the contract.
+     */
+    @Internal
+    public fun append(record: R) {
+        cache.addFirst(cachedFrom(record))
+    }
+
+    /**
+     * Appends the given records to this history as its newest items.
+     *
+     * The records must arrive in the chronological order, so that the last
+     * of them becomes the newest item of the history.
+     *
+     * The caller — the framework code persisting the outcome of
+     * a dispatch — passes all the records the dispatch committed in one
+     * call: a complete version group, never split between calls, with
+     * versions above everything this history has seen. This keeps
+     * the cached run contiguous and its reads exact.
+     */
+    @Internal
+    public fun append(records: Iterable<R>) {
+        records.forEach { append(it) }
+    }
+
+    /**
      * Reads up to [depth] most recent items of the history, newest first.
      *
-     * Fewer items are returned if the history retains fewer. If no loader
-     * is [installed][useLoader] — the entity was created outside
-     * a repository — no items are returned.
+     * The items already known to this instance — cached by the previous
+     * reads or [appended][append] — are served from memory. If more items
+     * are requested than cached, the read continues below the cached run
+     * through the installed loader, caching the traversed items on its
+     * way. If no loader is [installed][useLoader] — the entity was created
+     * outside a repository — only the cached items are served.
+     *
+     * Fewer items are returned if the history retains fewer.
      *
      * @param depth The maximum number of the most recent items to read.
      * @return An iterator over the items, newest first.
@@ -82,15 +149,131 @@ public abstract class RecentHistory<T : Any, L : HistoryLoader<*>> internal cons
      */
     public fun read(depth: Int): Iterator<T> {
         require(depth > 0) { "History depth must be positive. Got $depth." }
-        val installed = loader ?: return Collections.emptyIterator()
-        return load(installed, depth)
+        val fromCache = cache.take(depth)
+        val remaining = depth - fromCache.size
+        val installed = loader
+        if (remaining == 0 || installed == null || exhausted) {
+            return fromCache.map { it.item }.iterator()
+        }
+        val tail = fromCache.lastOrNull()
+        val loaded = installed.load(remaining, tail?.version)
+        return continueReading(
+            fromCache = fromCache,
+            loaded = loaded,
+            remaining = remaining,
+            tail = tail
+        )
     }
 
     /**
-     * Loads up to [depth] most recent items using the installed [loader].
-     *
-     * @param loader The installed loader.
-     * @param depth The maximum number of the most recent items to load; positive.
+     * Converts the given stored record into a history item.
      */
-    protected abstract fun load(loader: L, depth: Int): Iterator<T>
+    protected abstract fun toItem(record: R): T
+
+    /**
+     * Obtains the version of the entity the given stored record belongs to.
+     */
+    protected abstract fun versionOf(record: R): Version
+
+    /**
+     * Creates an iterator serving the cached items first and then
+     * the items loaded from the storage, populating the cache with them.
+     *
+     * The loader has been invoked [eagerly][read]; only the traversal of
+     * its result is lazy. Once the loader supply ends short of [remaining],
+     * the storage is proven to hold nothing below, and the further reads
+     * are served from the cache alone. A read satisfied with exactly
+     * [remaining] items leaves its oldest version group uncached — its
+     * completeness cannot be proven — so the next deeper read re-reads
+     * that one group from the storage.
+     */
+    private fun continueReading(
+        fromCache: List<Cached<T>>,
+        loaded: Iterator<R>,
+        remaining: Int,
+        tail: Cached<T>?
+    ): Iterator<T> = iterator {
+        fromCache.forEach { yield(it.item) }
+        val population = Population(tail)
+        var consumed = 0
+        for (record in loaded) {
+            consumed++
+            val cached = cachedFrom(record)
+            population.offer(cached)
+            yield(cached.item)
+        }
+        if (consumed < remaining && population.complete()) {
+            exhausted = true
+        }
+    }
+
+    private fun cachedFrom(record: R): Cached<T> =
+        Cached(toItem(record), versionOf(record))
+
+    /**
+     * A history item converted for serving, together with the version
+     * of the entity it belongs to.
+     */
+    private class Cached<T : Any>(val item: T, val version: Version)
+
+    /**
+     * Populates the cache with the items traversed by a continued [read],
+     * extending the cached run at its old end.
+     *
+     * The items are added group by group: a version group reaches
+     * the cache only when proven complete — the traversal has met the next
+     * group, or the storage supply has ended. A group cut short by
+     * an abandoned iterator is discarded, keeping the cached run aligned
+     * to group boundaries.
+     *
+     * Before every extension, the current end of the cache is checked to
+     * be [the one this read started below][expectedTail]. A mismatch means
+     * another read has populated the cache in the meantime; this population
+     * then stops for good, while the read goes on serving its items.
+     */
+    private inner class Population(private var expectedTail: Cached<T>?) {
+
+        private val group = mutableListOf<Cached<T>>()
+        private var populating = true
+
+        /**
+         * Accepts the next traversed item.
+         */
+        fun offer(cached: Cached<T>) {
+            if (!populating) {
+                return
+            }
+            val groupChanged = group.isNotEmpty() &&
+                    group.last().version.number != cached.version.number
+            if (groupChanged) {
+                flushGroup()
+            }
+            if (populating) {
+                group.add(cached)
+            }
+        }
+
+        /**
+         * Flushes the last group after the storage supply has ended,
+         * telling if the cache now provably holds the whole history.
+         */
+        fun complete(): Boolean {
+            if (!populating || cache.lastOrNull() !== expectedTail) {
+                return false
+            }
+            cache.addAll(group)
+            group.clear()
+            return true
+        }
+
+        private fun flushGroup() {
+            if (cache.lastOrNull() === expectedTail) {
+                cache.addAll(group)
+                expectedTail = cache.last()
+            } else {
+                populating = false
+            }
+            group.clear()
+        }
+    }
 }

--- a/server/src/main/kotlin/io/spine/server/entity/RecentStateHistory.kt
+++ b/server/src/main/kotlin/io/spine/server/entity/RecentStateHistory.kt
@@ -28,6 +28,7 @@ package io.spine.server.entity
 
 import com.google.protobuf.Timestamp
 import io.spine.base.EntityState
+import io.spine.core.Version
 import io.spine.protobuf.AnyPacker
 
 /**
@@ -35,18 +36,20 @@ import io.spine.protobuf.AnyPacker
  *
  * The states are read from the durable state history via the loader
  * [installed][AbstractEntity.setStateHistoryLoader] by the repository
- * of the entity. The stored records are unpacked into the entity state type.
+ * of the entity, and cached for the lifetime of the entity instance —
+ * see [RecentHistory]. The stored records are unpacked into the entity
+ * state type once, when first traversed.
  *
  * The repository installs the loader unconditionally; whether it records
  * the state history gates only the loader behavior — while the recording
  * is off, reading through the loader fails fast. An entity created outside
- * a repository has no loader at all, so the reads return no states and
- * [stateAt] answers `null`.
+ * a repository has no loader at all, so the reads serve only
+ * the [appended][append] states, if any, and [stateAt] answers `null`.
  *
  * @param S The type of the entity state.
  */
 public class RecentStateHistory<S : EntityState<*>> internal constructor() :
-    RecentHistory<S, StateHistoryLoader>() {
+    RecentHistory<EntityRecord, S, StateHistoryLoader>() {
 
     /**
      * Returns the state the entity had at the given time, if the recorded
@@ -63,11 +66,9 @@ public class RecentStateHistory<S : EntityState<*>> internal constructor() :
         loader()?.stateAt(at)
             ?.unpackState()
 
-    override fun load(loader: StateHistoryLoader, depth: Int): Iterator<S> =
-        loader.load(depth)
-            .asSequence()
-            .map { it.unpackState<S>() }
-            .iterator()
+    override fun toItem(record: EntityRecord): S = record.unpackState()
+
+    override fun versionOf(record: EntityRecord): Version = record.version
 }
 
 /**

--- a/server/src/main/kotlin/io/spine/server/entity/StateHistoryLoader.kt
+++ b/server/src/main/kotlin/io/spine/server/entity/StateHistoryLoader.kt
@@ -28,6 +28,7 @@ package io.spine.server.entity
 
 import com.google.protobuf.Timestamp
 import io.spine.annotation.Internal
+import io.spine.core.Version
 
 /**
  * Loads the recorded state history of an entity from the durable storage.
@@ -46,9 +47,13 @@ public interface StateHistoryLoader : HistoryLoader<EntityRecord> {
      * Loads up to [depth] most recent state records of the entity,
      * ordered from newer to older.
      *
+     * When [startingFrom] is given, only the records with versions strictly
+     * lower than it are loaded. `null` starts from the newest record.
+     *
      * @param depth The maximum number of the records to load.
+     * @param startingFrom If set, only the records with versions lower than this one are loaded.
      */
-    override fun load(depth: Int): Iterator<EntityRecord>
+    override fun load(depth: Int, startingFrom: Version?): Iterator<EntityRecord>
 
     /**
      * Loads the state record the entity had at the given time, or `null`

--- a/server/src/test/kotlin/io/spine/server/aggregate/AggregateRecentHistorySpec.kt
+++ b/server/src/test/kotlin/io/spine/server/aggregate/AggregateRecentHistorySpec.kt
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.aggregate
+
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.spine.base.Time.currentTime
+import io.spine.core.Command
+import io.spine.core.CommandValidationError.DUPLICATE_COMMAND_VALUE
+import io.spine.grpc.StreamObservers.noOpObserver
+import io.spine.server.BoundedContext
+import io.spine.server.BoundedContextBuilder
+import io.spine.server.aggregate.given.Given
+import io.spine.server.aggregate.given.history.HistoryReadingAggregate
+import io.spine.server.aggregate.given.history.StateHistoryTestRepository
+import io.spine.server.type.CommandEnvelope
+import io.spine.test.aggregate.ProjectId
+import io.spine.test.aggregate.event.AggProjectCreated
+import io.spine.test.aggregate.event.AggTaskAdded
+import io.spine.testing.logging.mute.MuteLogging
+import io.spine.testing.server.model.ModelTests
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies that the events and states an aggregate produces enter its
+ * recent history right away, before the durable writes.
+ *
+ * See `AggregateRepositoryStateHistorySpec` for the durable side of
+ * the state history.
+ */
+@DisplayName("The recent history of an `Aggregate` should")
+internal class AggregateRecentHistorySpec {
+
+    private lateinit var context: BoundedContext
+    private lateinit var repository: StateHistoryTestRepository
+    private lateinit var projectId: ProjectId
+
+    @BeforeEach
+    fun setUp() {
+        ModelTests.dropAllModels()
+        context = BoundedContextBuilder.assumingTests().build()
+        repository = StateHistoryTestRepository()
+        context.internalAccess()
+            .register(repository)
+        projectId = ProjectId.generate()
+        HistoryReadingAggregate.statesSeenOnStart = emptyList()
+        HistoryReadingAggregate.eventsSeenOnStart = emptyList()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        repository.close()
+        context.close()
+        ModelTests.dropAllModels()
+    }
+
+    @Test
+    fun `serve the events a dispatch produced to the same instance right away`() {
+        val aggregate = repository.create(projectId)
+
+        dispatch(aggregate, Given.ACommand.createProject(projectId))
+
+        // The journal write has not happened — `store()` was never called —
+        // yet the produced event is already readable on this instance.
+        val events = aggregate.readEventsBackward(10)
+            .asSequence()
+            .toList()
+        events shouldHaveSize 1
+        events.first()
+            .enclosedMessage()
+            .shouldBeInstanceOf<AggProjectCreated>()
+    }
+
+    @Test
+    fun `hide the events of a dispatch from its own receptor`() {
+        // The `AggStartProject` receptor also reads the state history.
+        repository.enableStateHistory()
+        val aggregate = repository.create(projectId)
+        dispatch(aggregate, Given.ACommand.createProject(projectId))
+
+        dispatch(aggregate, Given.ACommand.startProject(projectId))
+
+        // The `AggStartProject` receptor saw the event of the earlier
+        // dispatch, but not its own `AggProjectStarted`.
+        val seen = HistoryReadingAggregate.eventsSeenOnStart
+        seen shouldHaveSize 1
+        seen.first()
+            .enclosedMessage()
+            .shouldBeInstanceOf<AggProjectCreated>()
+    }
+
+    @Test
+    fun `let a receptor see the events of the earlier dispatches of a batch`() {
+        repository.enableStateHistory()
+        repository.beginBatch(projectId)
+
+        post(Given.ACommand.createProject(projectId))
+        post(Given.ACommand.addTask(projectId))
+        post(Given.ACommand.startProject(projectId))
+
+        // Mid-batch, the journal writes are deferred, yet the receptor of
+        // the third command saw the events of the first two, newest first.
+        val seen = HistoryReadingAggregate.eventsSeenOnStart
+        seen shouldHaveSize 2
+        seen[0].enclosedMessage().shouldBeInstanceOf<AggTaskAdded>()
+        seen[1].enclosedMessage().shouldBeInstanceOf<AggProjectCreated>()
+
+        repository.endBatch(projectId)
+
+        // The batch flush journals all the produced events.
+        repository.journal()
+            .historyBackward(projectId, 10)
+            .asSequence()
+            .toList() shouldHaveSize 3
+    }
+
+    @Test
+    @MuteLogging
+    fun `let the idempotency guard catch a duplicate within one batch`() {
+        repository.enableGuard()
+        val aggregate = repository.create(projectId)
+        val command = Given.ACommand.createProject(projectId)
+
+        val first = dispatch(aggregate, command)
+        val second = dispatch(aggregate, command)
+
+        first.hasError() shouldBe false
+        // The duplicate is caught before the journal write: the produced
+        // event reached only the recent history of this instance.
+        second.hasError() shouldBe true
+        second.error.code shouldBe DUPLICATE_COMMAND_VALUE
+    }
+
+    @Test
+    fun `serve stored states from the instance cache`() {
+        repository.enableStateHistory()
+        val aggregate = repository.create(projectId)
+        dispatch(aggregate, Given.ACommand.createProject(projectId))
+        repository.store(aggregate)
+
+        repository.history()
+            .truncate(olderThan = currentTime())
+
+        // The held instance serves the state from its cache even though
+        // the durable records are gone...
+        val states = aggregate.readStatesBackward(1)
+            .asSequence()
+            .toList()
+        states shouldHaveSize 1
+        states.first().id shouldBe projectId
+
+        // ...while a freshly loaded instance sees the truncated storage.
+        repository.loadAggregate(projectId)
+            .readStatesBackward(1)
+            .asSequence()
+            .toList()
+            .shouldBeEmpty()
+    }
+
+    private fun dispatch(aggregate: HistoryReadingAggregate, command: Command) =
+        AggregateTestSupport.dispatchCommand(
+            repository = repository,
+            aggregate = aggregate,
+            command = CommandEnvelope.of(command)
+        )
+
+    private fun post(command: Command) {
+        context.commandBus()
+            .post(command, noOpObserver())
+    }
+}

--- a/server/src/test/kotlin/io/spine/server/aggregate/given/history/HistoryReadingAggregate.kt
+++ b/server/src/test/kotlin/io/spine/server/aggregate/given/history/HistoryReadingAggregate.kt
@@ -27,6 +27,7 @@
 package io.spine.server.aggregate.given.history
 
 import com.google.protobuf.Timestamp
+import io.spine.core.Event
 import io.spine.server.aggregate.Aggregate
 import io.spine.server.command.Assign
 import io.spine.server.event.NoReaction
@@ -105,6 +106,9 @@ internal class HistoryReadingAggregate(id: ProjectId) :
         statesSeenOnStart = stateHistoryBackward(10)
             .asSequence()
             .toList()
+        eventsSeenOnStart = eventHistoryBackward(10)
+            .asSequence()
+            .toList()
         alter {
             status = Status.STARTED
         }
@@ -123,6 +127,11 @@ internal class HistoryReadingAggregate(id: ProjectId) :
      */
     fun readStatesBackward(depth: Int): Iterator<AggProject> = stateHistoryBackward(depth)
 
+    /**
+     * Reads up to [depth] most recent events of this aggregate, newest first.
+     */
+    fun readEventsBackward(depth: Int): Iterator<Event> = eventHistoryBackward(depth)
+
     internal companion object {
 
         /**
@@ -133,5 +142,13 @@ internal class HistoryReadingAggregate(id: ProjectId) :
          * the one a test can obtain from the repository afterwards.
          */
         var statesSeenOnStart: List<AggProject> = emptyList()
+
+        /**
+         * The recent events the [AggStartProject] receptor saw during
+         * the dispatch, newest first.
+         *
+         * Captured statically for the same reason as [statesSeenOnStart].
+         */
+        var eventsSeenOnStart: List<Event> = emptyList()
     }
 }

--- a/server/src/test/kotlin/io/spine/server/aggregate/given/history/StateHistoryTestRepository.kt
+++ b/server/src/test/kotlin/io/spine/server/aggregate/given/history/StateHistoryTestRepository.kt
@@ -27,6 +27,7 @@
 package io.spine.server.aggregate.given.history
 
 import io.spine.server.aggregate.given.aggregate.AbstractAggregateTestRepository
+import io.spine.server.entity.storage.EntityEventStorage
 import io.spine.server.entity.storage.EntityStateHistoryStorage
 import io.spine.test.aggregate.AggProject
 import io.spine.test.aggregate.ProjectId
@@ -77,4 +78,26 @@ internal class StateHistoryTestRepository :
      * Returns the state history storage of this repository.
      */
     fun history(): EntityStateHistoryStorage<ProjectId> = stateHistory()
+
+    /**
+     * Returns the event journal of this repository.
+     */
+    fun journal(): EntityEventStorage<ProjectId> = eventStorage()
+
+    /**
+     * Enables the idempotency guard for the aggregates of this repository.
+     */
+    fun enableGuard() = useIdempotencyGuard()
+
+    /**
+     * Starts routing the writes of the aggregate with the given identifier
+     * through the repository cache, as a delivery batch does.
+     */
+    fun beginBatch(id: ProjectId) = cache().startCaching(id)
+
+    /**
+     * Flushes the deferred writes of the aggregate with the given identifier,
+     * as the end of a delivery batch does.
+     */
+    fun endBatch(id: ProjectId) = cache().stopCaching(id)
 }

--- a/server/src/test/kotlin/io/spine/server/entity/RecentEventHistorySpec.kt
+++ b/server/src/test/kotlin/io/spine/server/entity/RecentEventHistorySpec.kt
@@ -126,7 +126,7 @@ internal class RecentEventHistorySpec {
         full shouldContainExactly listOf(eB, eA, eC)
         again shouldContainExactly listOf(eB, eA, eC)
         // The continuation resumes from the oldest cached item — a group
-        // boundary — so `eA` is never lost to the strict-less version
+        // boundary — so `eA` is never lost to the exclusive version
         // filter of the storage.
         journal.lastStartingFrom shouldBe eA.context.version
     }
@@ -281,10 +281,10 @@ internal class RecentEventHistorySpec {
 }
 
 /**
- * A loader over an in-memory journal which records how it was called.
+ * A loader over an in-memory journal that records how it was called.
  *
- * The events arrive in the chronological order and are [served][load]
- * newest first, honoring the strict-less `startingFrom` filter of
+ * The events arrive in chronological order and are [served][load]
+ * newest first, honoring the exclusive `startingFrom` filter of
  * the real storage.
  */
 private class StubJournal(vararg chronological: Event) : EventHistoryLoader {

--- a/server/src/test/kotlin/io/spine/server/entity/RecentEventHistorySpec.kt
+++ b/server/src/test/kotlin/io/spine/server/entity/RecentEventHistorySpec.kt
@@ -154,9 +154,57 @@ internal class RecentEventHistorySpec {
         val e1 = newEvent(version = 1)
         val e2 = newEvent(version = 2)
 
-        history.append(listOf(e1, e2))
+        history.append(e1)
+        history.append(e2)
 
         history.read(5).asSequence().toList() shouldContainExactly listOf(e2, e1)
+    }
+
+    @Test
+    fun `serve a uniform appended group newest first`() {
+        val eA = newEvent(version = 5)
+        val eB = newEvent(version = 5)
+
+        history.append(listOf(eA, eB))
+
+        history.read(5).asSequence().toList() shouldContainExactly listOf(eB, eA)
+    }
+
+    @Test
+    fun `drop the cache when an appended group mixes versions`() {
+        val e1 = newEvent(version = 1)
+        val journal = StubJournal(e1)
+        history.useLoader(journal)
+        history.read(5).asSequence().toList()
+
+        history.append(listOf(newEvent(version = 2), newEvent(version = 3)))
+
+        val read = history.read(5).asSequence().toList()
+        read shouldContainExactly listOf(e1)
+        // The healing also reset `exhausted`, so the storage was consulted again.
+        journal.calls shouldBe 2
+    }
+
+    @Test
+    fun `drop the cache when an appended group does not extend the history`() {
+        history.append(newEvent(version = 2))
+
+        history.append(newEvent(version = 2))
+
+        history.read(5)
+            .asSequence()
+            .toList()
+            .shouldBeEmpty()
+    }
+
+    @Test
+    fun `ignore an empty append`() {
+        val e2 = newEvent(version = 2)
+        history.append(e2)
+
+        history.append(emptyList())
+
+        history.read(5).asSequence().toList() shouldContainExactly listOf(e2)
     }
 
     @Test

--- a/server/src/test/kotlin/io/spine/server/entity/RecentEventHistorySpec.kt
+++ b/server/src/test/kotlin/io/spine/server/entity/RecentEventHistorySpec.kt
@@ -31,6 +31,7 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.spine.base.Time.currentTime
+import io.spine.core.Enrichment
 import io.spine.core.Event
 import io.spine.core.Version
 import io.spine.core.Versions
@@ -208,6 +209,20 @@ internal class RecentEventHistorySpec {
     }
 
     @Test
+    fun `clear the enrichments from an appended event`() {
+        val enriched = enriched(newEvent(version = 1))
+        enriched.context.hasEnrichment() shouldBe true
+
+        history.append(enriched)
+
+        // The cache serves the event enrichment-free, matching the journal,
+        // so a read does not depend on whether it is cached or stored.
+        val read = history.read(1).asSequence().toList()
+        read shouldContainExactly listOf(enriched.clearEnrichments())
+        read.single().context.hasEnrichment() shouldBe false
+    }
+
+    @Test
     fun `serve a read started before an append from the pre-append window`() {
         val e1 = newEvent(version = 1)
         val e2 = newEvent(version = 2)
@@ -249,6 +264,14 @@ internal class RecentEventHistorySpec {
             Sample.messageOfType(StgProjectCreated::class.java),
             Versions.newVersion(version, currentTime())
         )
+
+    private fun enriched(event: Event): Event =
+        event.toBuilder()
+            .setContext(
+                event.context.toBuilder()
+                    .setEnrichment(Enrichment.newBuilder().setDoNotEnrich(true))
+            )
+            .build()
 
     private companion object {
 

--- a/server/src/test/kotlin/io/spine/server/entity/RecentEventHistorySpec.kt
+++ b/server/src/test/kotlin/io/spine/server/entity/RecentEventHistorySpec.kt
@@ -30,7 +30,10 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
+import io.spine.base.Time.currentTime
 import io.spine.core.Event
+import io.spine.core.Version
+import io.spine.core.Versions
 import io.spine.test.storage.event.StgProjectCreated
 import io.spine.testdata.Sample
 import io.spine.testing.server.TestEventFactory
@@ -44,19 +47,14 @@ internal class RecentEventHistorySpec {
 
     @Test
     fun `serve the reads through the installed loader`() {
-        val fromJournal = newEvents(count = 2).reversed()
-        var requestedDepth = 0
-        history.useLoader(
-            EventHistoryLoader { depth ->
-                requestedDepth = depth
-                fromJournal.iterator()
-            }
-        )
+        val journal = StubJournal(newEvent(version = 1), newEvent(version = 2))
+        history.useLoader(journal)
 
         val read = history.read(7).asSequence().toList()
 
-        read shouldContainExactly fromJournal
-        requestedDepth shouldBe 7
+        read shouldContainExactly journal.events
+        journal.lastDepth shouldBe 7
+        journal.lastStartingFrom shouldBe null
     }
 
     @Test
@@ -77,13 +75,170 @@ internal class RecentEventHistorySpec {
         }
     }
 
-    private fun newEvents(count: Int): List<Event> = List(count) {
-        eventFactory.createEvent(Sample.messageOfType(StgProjectCreated::class.java))
+    @Test
+    fun `cache loaded events and stop querying an exhausted journal`() {
+        val journal = StubJournal(newEvent(version = 1), newEvent(version = 2))
+        history.useLoader(journal)
+
+        val first = history.read(5).asSequence().toList()
+        val second = history.read(5).asSequence().toList()
+        val shallow = history.read(2).asSequence().toList()
+
+        first shouldContainExactly journal.events
+        second shouldContainExactly journal.events
+        shallow shouldContainExactly journal.events
+        journal.calls shouldBe 1
     }
+
+    @Test
+    fun `continue a deeper read below the cached events`() {
+        val e1 = newEvent(version = 1)
+        val e2 = newEvent(version = 2)
+        val e3 = newEvent(version = 3)
+        val journal = StubJournal(e1, e2, e3)
+        history.useLoader(journal)
+        history.read(2).asSequence().toList() shouldContainExactly listOf(e3, e2)
+
+        val deeper = history.read(3).asSequence().toList()
+
+        deeper shouldContainExactly listOf(e3, e2, e1)
+        journal.calls shouldBe 2
+        // Three events requested, one served from the cache.
+        journal.lastDepth shouldBe 2
+        journal.lastStartingFrom shouldBe e3.context.version
+    }
+
+    @Test
+    fun `not split a same-version group between the cache and the storage`() {
+        val eC = newEvent(version = 4)
+        // One dispatch: two events under one version, `eB` newer by time.
+        val eA = newEvent(version = 5)
+        val eB = newEvent(version = 5)
+        val journal = StubJournal(eC, eA, eB)
+        history.useLoader(journal)
+
+        val shallow = history.read(2).asSequence().toList()
+        val full = history.read(3).asSequence().toList()
+        val again = history.read(3).asSequence().toList()
+
+        shallow shouldContainExactly listOf(eB, eA)
+        full shouldContainExactly listOf(eB, eA, eC)
+        again shouldContainExactly listOf(eB, eA, eC)
+        // The continuation resumes from the oldest cached item — a group
+        // boundary — so `eA` is never lost to the strict-less version
+        // filter of the storage.
+        journal.lastStartingFrom shouldBe eA.context.version
+    }
+
+    @Test
+    fun `serve appended events before the stored ones`() {
+        val e1 = newEvent(version = 1)
+        val e2 = newEvent(version = 2)
+        val journal = StubJournal(e1)
+        history.useLoader(journal)
+        history.append(e2)
+
+        val read = history.read(3).asSequence().toList()
+        val again = history.read(3).asSequence().toList()
+
+        read shouldContainExactly listOf(e2, e1)
+        again shouldContainExactly listOf(e2, e1)
+        journal.calls shouldBe 1
+        // Three events requested, the appended one served from the cache.
+        journal.lastDepth shouldBe 2
+        journal.lastStartingFrom shouldBe e2.context.version
+    }
+
+    @Test
+    fun `serve appended events without any loader`() {
+        val e1 = newEvent(version = 1)
+        val e2 = newEvent(version = 2)
+
+        history.append(listOf(e1, e2))
+
+        history.read(5).asSequence().toList() shouldContainExactly listOf(e2, e1)
+    }
+
+    @Test
+    fun `serve a read started before an append from the pre-append window`() {
+        val e1 = newEvent(version = 1)
+        val e2 = newEvent(version = 2)
+        history.useLoader(StubJournal(e1))
+        val started = history.read(3)
+
+        history.append(e2)
+
+        started.asSequence().toList() shouldContainExactly listOf(e1)
+        history.read(3).asSequence().toList() shouldContainExactly listOf(e2, e1)
+    }
+
+    @Test
+    fun `keep the cache consistent under interleaved readers`() {
+        val e1 = newEvent(version = 1)
+        val e2 = newEvent(version = 2)
+        val e3 = newEvent(version = 3)
+        val journal = StubJournal(e1, e2, e3)
+        history.useLoader(journal)
+        val one = history.read(3)
+        val two = history.read(3)
+
+        val fromOne = mutableListOf<Event>()
+        val fromTwo = mutableListOf<Event>()
+        repeat(3) {
+            fromOne += one.next()
+            fromTwo += two.next()
+        }
+
+        val expected = listOf(e3, e2, e1)
+        fromOne shouldContainExactly expected
+        fromTwo shouldContainExactly expected
+        history.read(3).asSequence().toList() shouldContainExactly expected
+        journal.calls shouldBe 3
+    }
+
+    private fun newEvent(version: Int): Event =
+        eventFactory.createEvent(
+            Sample.messageOfType(StgProjectCreated::class.java),
+            Versions.newVersion(version, currentTime())
+        )
 
     private companion object {
 
         private val eventFactory =
             TestEventFactory.newInstance(RecentEventHistorySpec::class.java)
+    }
+}
+
+/**
+ * A loader over an in-memory journal which records how it was called.
+ *
+ * The events arrive in the chronological order and are [served][load]
+ * newest first, honoring the strict-less `startingFrom` filter of
+ * the real storage.
+ */
+private class StubJournal(vararg chronological: Event) : EventHistoryLoader {
+
+    /**
+     * The journal events, newest first.
+     */
+    val events: List<Event> = chronological.reversed()
+
+    var calls = 0
+        private set
+
+    var lastDepth = 0
+        private set
+
+    var lastStartingFrom: Version? = null
+        private set
+
+    override fun load(depth: Int, startingFrom: Version?): Iterator<Event> {
+        calls++
+        lastDepth = depth
+        lastStartingFrom = startingFrom
+        return events
+            .filter { startingFrom == null || it.context.version.number < startingFrom.number }
+            .take(depth)
+            .iterator()
     }
 }

--- a/server/src/test/kotlin/io/spine/server/entity/RecentStateHistorySpec.kt
+++ b/server/src/test/kotlin/io/spine/server/entity/RecentStateHistorySpec.kt
@@ -31,8 +31,10 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.spine.base.Identifier
 import io.spine.base.Time.currentTime
+import io.spine.core.Version
 import io.spine.core.Versions
 import io.spine.protobuf.AnyPacker
 import io.spine.test.storage.StgProject
@@ -49,32 +51,21 @@ internal class RecentStateHistorySpec {
     fun `serve the reads through the installed loader, unpacking the states`() {
         val states = List(2) { newState() }
         val records = states.mapIndexed { index, state -> record(state, index + 1) }
-        var requestedDepth = 0
-        history.useLoader(object : StateHistoryLoader {
-            override fun load(depth: Int): Iterator<EntityRecord> {
-                requestedDepth = depth
-                return records.reversed().iterator()
-            }
-
-            override fun stateAt(at: Timestamp): EntityRecord? = null
-        })
+        val loader = StubStateHistory(records)
+        history.useLoader(loader)
 
         val read = history.read(7).asSequence().toList()
 
         read shouldContainExactly states.reversed()
-        requestedDepth shouldBe 7
+        loader.lastDepth shouldBe 7
+        loader.lastStartingFrom shouldBe null
     }
 
     @Test
     fun `answer the state at a time through the installed loader`() {
         val state = newState()
         val retained = record(state, number = 1)
-        history.useLoader(object : StateHistoryLoader {
-            override fun load(depth: Int): Iterator<EntityRecord> =
-                emptyList<EntityRecord>().iterator()
-
-            override fun stateAt(at: Timestamp): EntityRecord? = retained
-        })
+        history.useLoader(StubStateHistory(emptyList(), atAnswer = retained))
 
         history.stateAt(currentTime()) shouldBe state
     }
@@ -98,6 +89,94 @@ internal class RecentStateHistorySpec {
         }
     }
 
+    @Test
+    fun `cache loaded states and stop querying an exhausted history`() {
+        val states = List(2) { newState() }
+        val records = states.mapIndexed { index, state -> record(state, index + 1) }
+        val loader = StubStateHistory(records)
+        history.useLoader(loader)
+
+        val first = history.read(5).asSequence().toList()
+        val second = history.read(5).asSequence().toList()
+
+        first shouldContainExactly states.reversed()
+        second shouldContainExactly states.reversed()
+        loader.calls shouldBe 1
+    }
+
+    @Test
+    fun `serve repeated reads with the same unpacked instances`() {
+        val records = List(2) { newState() }
+            .mapIndexed { index, state -> record(state, index + 1) }
+        history.useLoader(StubStateHistory(records))
+
+        val first = history.read(3).asSequence().toList()
+        val second = history.read(3).asSequence().toList()
+
+        first[0] shouldBeSameInstanceAs second[0]
+        first[1] shouldBeSameInstanceAs second[1]
+    }
+
+    @Test
+    fun `continue a deeper read below the cached states`() {
+        val states = List(3) { newState() }
+        val records = states.mapIndexed { index, state -> record(state, index + 1) }
+        val loader = StubStateHistory(records)
+        history.useLoader(loader)
+        history.read(2).asSequence().toList() shouldContainExactly
+                listOf(states[2], states[1])
+
+        val deeper = history.read(3).asSequence().toList()
+
+        deeper shouldContainExactly states.reversed()
+        loader.calls shouldBe 2
+        // Three states requested, one served from the cache.
+        loader.lastDepth shouldBe 2
+        loader.lastStartingFrom shouldBe records[2].version
+    }
+
+    @Test
+    fun `serve an appended record before the stored ones`() {
+        val older = newState()
+        val newer = newState()
+        val appended = record(newer, number = 2)
+        val loader = StubStateHistory(listOf(record(older, number = 1)))
+        history.useLoader(loader)
+        history.append(appended)
+
+        val read = history.read(3).asSequence().toList()
+        val again = history.read(3).asSequence().toList()
+
+        read shouldContainExactly listOf(newer, older)
+        again shouldContainExactly listOf(newer, older)
+        loader.calls shouldBe 1
+        loader.lastStartingFrom shouldBe appended.version
+    }
+
+    @Test
+    fun `serve appended records without any loader`() {
+        val older = newState()
+        val newer = newState()
+
+        history.append(listOf(record(older, number = 1), record(newer, number = 2)))
+
+        history.read(5).asSequence().toList() shouldContainExactly listOf(newer, older)
+    }
+
+    @Test
+    fun `fail fast at read time when the loader rejects the reading`() {
+        history.useLoader(object : StateHistoryLoader {
+            override fun load(depth: Int, startingFrom: Version?): Iterator<EntityRecord> =
+                error("The state history is not recorded.")
+
+            override fun stateAt(at: Timestamp): EntityRecord? = null
+        })
+
+        shouldThrow<IllegalStateException> {
+            history.read(5)
+        }
+    }
+
     private fun newState(): StgProject = Sample.messageOfType(StgProject::class.java)
 
     private fun record(of: StgProject, number: Int): EntityRecord = entityRecord {
@@ -105,4 +184,43 @@ internal class RecentStateHistorySpec {
         state = AnyPacker.pack(of)
         version = Versions.newVersion(number, currentTime())
     }
+}
+
+/**
+ * A loader over an in-memory state history which records how it was called.
+ *
+ * The records arrive in the chronological order and are [served][load]
+ * newest first, honoring the strict-less `startingFrom` filter of
+ * the real storage.
+ */
+private class StubStateHistory(
+    chronological: List<EntityRecord>,
+    private val atAnswer: EntityRecord? = null
+) : StateHistoryLoader {
+
+    /**
+     * The stored records, newest first.
+     */
+    private val records: List<EntityRecord> = chronological.reversed()
+
+    var calls = 0
+        private set
+
+    var lastDepth = 0
+        private set
+
+    var lastStartingFrom: Version? = null
+        private set
+
+    override fun load(depth: Int, startingFrom: Version?): Iterator<EntityRecord> {
+        calls++
+        lastDepth = depth
+        lastStartingFrom = startingFrom
+        return records
+            .filter { startingFrom == null || it.version.number < startingFrom.number }
+            .take(depth)
+            .iterator()
+    }
+
+    override fun stateAt(at: Timestamp): EntityRecord? = atAnswer
 }

--- a/server/src/test/kotlin/io/spine/server/entity/RecentStateHistorySpec.kt
+++ b/server/src/test/kotlin/io/spine/server/entity/RecentStateHistorySpec.kt
@@ -200,10 +200,10 @@ internal class RecentStateHistorySpec {
 }
 
 /**
- * A loader over an in-memory state history which records how it was called.
+ * A loader over an in-memory state history that records how it was called.
  *
- * The records arrive in the chronological order and are [served][load]
- * newest first, honoring the strict-less `startingFrom` filter of
+ * The records arrive in chronological order and are [served][load]
+ * newest first, honoring the exclusive `startingFrom` filter of
  * the real storage.
  */
 private class StubStateHistory(

--- a/server/src/test/kotlin/io/spine/server/entity/RecentStateHistorySpec.kt
+++ b/server/src/test/kotlin/io/spine/server/entity/RecentStateHistorySpec.kt
@@ -158,9 +158,22 @@ internal class RecentStateHistorySpec {
         val older = newState()
         val newer = newState()
 
-        history.append(listOf(record(older, number = 1), record(newer, number = 2)))
+        history.append(record(older, number = 1))
+        history.append(record(newer, number = 2))
 
         history.read(5).asSequence().toList() shouldContainExactly listOf(newer, older)
+    }
+
+    @Test
+    fun `drop the cache when an appended record is not newer than the cached ones`() {
+        history.append(record(newState(), number = 2))
+
+        history.append(record(newState(), number = 1))
+
+        history.read(5)
+            .asSequence()
+            .toList()
+            .shouldBeEmpty()
     }
 
     @Test

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of this library.
  */
-extra.set("versionToPublish", "2.0.0-SNAPSHOT.500")
+extra.set("versionToPublish", "2.0.0-SNAPSHOT.502")


### PR DESCRIPTION
## What

`RecentHistory` — the read surface behind `eventHistoryBackward`, `stateHistoryBackward`, and the `IdempotencyGuard` — now caches what it loads and accepts the items an entity produces:

- **Cache-backed reads.** `RecentHistory<R, T, L>` keeps an instance-scoped, newest-first cache. A read serves cached items first and continues *below* them through the new `HistoryLoader.load(depth, startingFrom)` continuation (backed by the existing strict-less `historyBackward` storage query). Traversed items populate the cache; once the storage is proven empty below the cached run, further reads skip it entirely.
- **Version-group alignment.** All events of one dispatch share the pre-dispatch version, so the cache tail only ever ends on a *complete* version group — otherwise the strict-less continuation would silently drop same-version siblings.
- **Writable history.** `append` feeds the cache as items are produced: events at `Aggregate.recordEvents` (post-commit, success-only), state records in `AbstractEntityRepository.appendStateHistory` right after the durable write. `append` is self-healing: a group breaking the contract (e.g., a catch-up replay re-producing seen versions) drops the cache instead of failing the dispatch, and reads fall back to storage.

## Why

When an entity handles several signals in one delivery batch, every dispatch re-read its history from storage — the idempotency guard alone scans up to 100 events per signal. Worse, the journal writes defer to the batch flush, so the events of earlier same-batch dispatches were *invisible* to later ones.

## Behavior changes

- Events committed by earlier dispatches of a batch are now readable by later dispatches of the same instance (a dispatch's own events remain invisible to its own receptor).
- The `IdempotencyGuard` now catches duplicates within one batch. Its `historyDepth` field is zero-initialized, in sync with `enabled` — both are set together in `enable(int)`.
- Reads on an entity created outside a repository serve appended items (previously always empty).

## Verification

Full `./gradlew clean build dokkaGenerate` is green. New `AggregateRecentHistorySpec` pins same-instance visibility, own-dispatch exclusion, mid-batch visibility, in-batch duplicate detection, and cache-serving after storage truncation; the extended `RecentEventHistorySpec`/`RecentStateHistorySpec` cover caching, exhaustion, continuation depth/version arithmetic, group alignment, self-healing, and interleaved readers. Pre-PR reviewers: `kotlin-engineer` APPROVE, `spine-code-review` APPROVE, `review-docs` APPROVE WITH CHANGES (minor grammar polish, to follow).

## Notes for reviewers

- The version is bumped to `2.0.0-SNAPSHOT.502`; `.501` is reserved by a parallel branch.
- Repository-side batch caching hooks are untouched — this PR wires the entity-side cache only; the delivery batch listener and `RepositoryCache` deferral work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
