### PR TITLE
Event history for Process Managers

### DIFF
--- a/.agents/tasks/de-event-sourcing-plan.md
+++ b/.agents/tasks/de-event-sourcing-plan.md
@@ -626,6 +626,25 @@ by authoring a detailed task doc the way
 [`state-history-for-all-entities.md`](state-history-for-all-entities.md)
 opened Phase F. Needs Phase D (merged 2026-07-10) only.
 
+> **Implemented on `more-on-signal-dispatching-entities` (2026-07-22)** —
+> items 1–3, with item 4 satisfied by the `eventStorage()` move itself
+> (the truncate maintenance rides on the accessor). Detailed task:
+> [`event-history-for-process-managers.md`](event-history-for-process-managers.md).
+> Settled while implementing (product owner): `SignalDispatchingRepository`
+> re-binds `E` to `SignalDispatchingEntity` and `ProcessManager` re-parents
+> onto it, which turns the guard flag into enforceable shared behavior;
+> **`eventHistoryDepth` moved up too** — the "stays put" note in item 1
+> predated the guard going shared, and the depth is the guard's scan window;
+> the PM opt-in is `ProcessManagerRepository.recordEventHistory()`
+> (naming parallels `recordStateHistory()`); **guard-on + journal-off fails
+> fast at context registration** (2026-07-22) — the knobs stay orthogonal,
+> no implicit enabling; the journaling-off read fail-fast follows the
+> Phase F pattern — the loader is installed unconditionally and gates the
+> reads itself. Empirically confirmed while testing: a re-posted identical
+> command is dropped by the delivery layer before reaching the entity —
+> A5's "delivery owns primary dedup" — so the guard specs assert the
+> journal-backed detection on a freshly loaded instance.
+
 The entity layer has been ready since PR #1649/#1650: `RecentEventHistory`
 reads lazily through `EventHistoryLoader`, installed via
 `TransactionalEntity.setEventHistoryLoader`, and

--- a/.agents/tasks/event-history-for-process-managers.md
+++ b/.agents/tasks/event-history-for-process-managers.md
@@ -1,0 +1,123 @@
+# Task: Event history for Process Managers (Phase G)
+
+## Origin
+
+Phase G of [de-event-sourcing-plan.md](de-event-sourcing-plan.md): Process
+Managers gain the opt-in event journal with full business-API parity, and the
+aggregate journal machinery moves up so one implementation serves both entity
+types. Direction from the product owner (2026-07-22):
+
+1. **`SignalDispatchingRepository` manages `SignalDispatchingEntity`** — the
+   `E` parameter re-binds from `AbstractEntity<I, S>` to
+   `SignalDispatchingEntity<I, S, ?>`. This is what lets the shared repository
+   call `setEventHistoryLoader(...)` / `enableDoubleDispatchGuard(...)`
+   generically.
+2. **`ProcessManager` descends from `SignalDispatchingEntity`** (was:
+   `AssigneeEntity`).
+3. **The double-dispatch guard becomes a feature of `ProcessManager` and
+   `ProcessManagerRepository`.** Both entity kinds receive client-side signals
+   subject to accidental re-submission — a weakly connected client app re-sends
+   a command the server did not acknowledge.
+
+The entity layer has been ready since PR #1664: `SignalDispatchingEntity`
+carries `RecentEventHistory`, `UncommittedEventHistory`, `DoubleDispatchGuard`,
+`recordEvents`, and the depth-explicit `eventHistoryBackward` /
+`eventHistoryContains`; `Aggregate` already extends it.
+
+## Decisions
+
+- **Guard-on + journal-off fails fast at context registration** (product
+  owner, 2026-07-22): the guard requires the journal that feeds it; requesting
+  the guard without the journal is a configuration error raised by
+  `SignalDispatchingRepository.registerWith`. The knobs stay orthogonal and
+  explicit — no implicit enabling (Phase E/F "fail fast on a disabled
+  recorder" philosophy).
+- **PM journal is opt-in, off by default** (locked, 2026-07-16); the
+  aggregate journal stays unconditional. The posture is expressed by the
+  `abstract SignalDispatchingRepository.eventHistoryEnabled()` — each concrete
+  repository kind states its own (renamed from `eventJournalEnabled` and made
+  abstract on owner review, 2026-07-22: "history" is the term in API names,
+  "journal" stays a documentation word; a default implementation confused the
+  design). `AggregateRepository` returns `true` (final); `ProcessManagerRepository`
+  returns a flag raised by `recordEventHistory()` (name parallels the
+  state-history `recordStateHistory()`).
+- **Fail-fast reads via the installed loader** — the state-history pattern of
+  `AbstractEntityRepository.setUpStateHistoryReading`: the loader is installed
+  unconditionally; when journaling is off, reading through it throws with
+  configuration guidance. A bare instance (no loader) keeps reading empty.
+- **Deviation from the plan text:** Phase G item 1 said `eventHistoryDepth`
+  "stays put" in `AggregateRepository` — written when the guard was expected
+  to remain aggregate-only. With the guard shared, the depth is its shared
+  scan window and moves to `SignalDispatchingRepository`.
+- Rejections and emitted commands are never journaled (parity with
+  aggregates; `UncommittedEventHistory.record()` also filters rejections).
+- No `IdempotencyGuard` revival; delivery still owns primary dedup (A5/D5).
+
+## What moves — repository side
+
+From `AggregateRepository` to `SignalDispatchingRepository` (Java; edited
+code stays Java):
+
+| Member                                                 | Today (`AggregateRepository.java`) | Delta while moving                                                |
+|--------------------------------------------------------|------------------------------------|-------------------------------------------------------------------|
+| `eventHistoryDepth` field + accessor + setter          | `:111`, `:343`, `:353`             | none                                                              |
+| `eventStorage` field + lazy `eventStorage()`           | `:118`, `:392`                     | Javadoc de-aggregatized                                           |
+| `createEventStorage()` seam                            | `:373`                             | Javadoc de-aggregatized                                           |
+| `setUpHistoryReading(A, I)`                            | `:203`                             | renamed `setUpEventHistoryReading`; loader gains fail-fast gate   |
+| `create(id)` / `toEntity(record)` history-wiring calls | `:185`, `:438`                     | become base-class overrides (`@OverridingMethodsMustInvokeSuper`) |
+| `doStore(A)` journal write + `commitEvents()`          | `:235-250`                         | untouched-skip precheck STAYS in `AggregateRepository`            |
+| `store(Collection)` per-entity override                | `:261-263`                         | none (bulk `RecordBasedRepository.store` bypasses `doStore`)      |
+| `close()` override + `closeEventStorage()`             | `:462-489`                         | none (`Repository.attemptClose` is `protected static`)            |
+
+## What changes — PM side
+
+- `ProcessManager`: re-parent; `dispatchEvent` package-private → `protected
+  @Override` (the Kotlin base declares it `protected abstract`; `protected`
+  keeps same-package access for `PmTransaction`); guard checks in
+  `dispatchCommand` / `dispatchEvent` via a new shared
+  `SignalDispatchingEntity` helper also adopted by `Aggregate`.
+- `ProcessManagerRepository`: `recordEventHistory()` +
+  `eventHistoryEnabled()` override; settings Javadoc.
+- `PmEndpoint.runTransactionFor`: after commit, `recordEvents(...)` when the
+  repository journals — mirroring `AggregateEndpoint.runTransactionFor`;
+  `isModified` becomes `changed() || hasUncommittedEvents()`.
+
+## Tests (Kotlin, JUnit 5 + Kotest, `Spec` suffix)
+
+Under `server/src/test/kotlin/io/spine/server/procman/`, mirroring
+`server/src/test/java/io/spine/server/aggregate/DoubleDispatchGuardTest.java`:
+
+- `PmDoubleDispatchGuardSpec` — duplicate command/event rejected; outside-window
+  and unrelated signals pass; guard-off duplicates dispatch normally; dedup
+  holds against a reloaded instance (journal-backed).
+- `PmEventJournalSpec` — journaling-on writes per successful dispatch; off
+  writes nothing; rejections and commander output not journaled; `close()`
+  closes the journal.
+- `PmEventHistorySpec` — depth window honored; journaling-off managed instance
+  fails fast; bare instance reads empty.
+- Registration validation — guard-on + journal-off `registerWith` fails;
+  guard-on + journal-on registers.
+- Aggregate suites stay green — the hoist is behavior-preserving for
+  aggregates.
+
+## Acceptance
+
+- `./gradlew build` and `./gradlew dokkaGenerate` pass.
+- Version bumped once on the branch (`version-bumped` guard) at pre-PR time.
+- Phase G items 1–3 of the plan marked done; item 4 (truncate maintenance)
+  satisfied by the `eventStorage()` move; item 5 (non-goals) unchanged.
+
+## Status
+
+- 2026-07-22 — task opened; implementation in progress on
+  `more-on-signal-dispatching-entities`.
+- 2026-07-22 — implemented and verified: full `./gradlew build` green,
+  `dokkaGenerate` green, 18 new PM spec tests + full aggregate/procman/entity
+  regression pass. Version bumped to `2.0.0-SNAPSHOT.511`. Reviewed by
+  `spine-code-review` and `kotlin-engineer` (both APPROVE WITH CHANGES;
+  all findings applied — Kotlin-idiomatic `detectDuplicate`, proto-DSL
+  `duplicateOutcome`, dead test field removed, stale `resource`
+  suppression dropped). Empirical note for testers: the delivery layer
+  drops a re-posted identical command before it reaches the entity, so
+  guard specs assert journal-backed detection on a freshly loaded
+  instance rather than double-posting end-to-end.

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.510`
+# Dependencies of `io.spine:spine-client:2.0.0-SNAPSHOT.511`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -1084,14 +1084,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 21 16:30:05 WEST 2026** using 
+This report was generated on **Wed Jul 22 18:27:41 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.510`
+# Dependencies of `io.spine.tools:client-testlib:2.0.0-SNAPSHOT.511`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -2271,14 +2271,14 @@ This report was generated on **Tue Jul 21 16:30:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 21 16:30:05 WEST 2026** using 
+This report was generated on **Wed Jul 22 18:27:41 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.510`
+# Dependencies of `io.spine:spine-core:2.0.0-SNAPSHOT.511`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3298,14 +3298,14 @@ This report was generated on **Tue Jul 21 16:30:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 21 16:30:05 WEST 2026** using 
+This report was generated on **Wed Jul 22 18:27:41 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.510`
+# Dependencies of `io.spine.tools:core-testlib:2.0.0-SNAPSHOT.511`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -4359,14 +4359,14 @@ This report was generated on **Tue Jul 21 16:30:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 21 16:30:05 WEST 2026** using 
+This report was generated on **Wed Jul 22 18:27:41 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.510`
+# Dependencies of `io.spine:spine-server:2.0.0-SNAPSHOT.511`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -5462,14 +5462,14 @@ This report was generated on **Tue Jul 21 16:30:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 21 16:30:05 WEST 2026** using 
+This report was generated on **Wed Jul 22 18:27:41 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.510`
+# Dependencies of `io.spine:spine-server-otel:2.0.0-SNAPSHOT.511`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -6641,14 +6641,14 @@ This report was generated on **Tue Jul 21 16:30:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 21 16:30:05 WEST 2026** using 
+This report was generated on **Wed Jul 22 18:27:41 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.510`
+# Dependencies of `io.spine.tools:server-testlib:2.0.0-SNAPSHOT.511`
 
 ## Runtime
 1.  **Group** : com.google.android. **Name** : annotations. **Version** : 4.1.1.4.
@@ -7880,6 +7880,6 @@ This report was generated on **Tue Jul 21 16:30:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 21 16:30:05 WEST 2026** using 
+This report was generated on **Wed Jul 22 18:27:41 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>core-jvm</artifactId>
-<version>2.0.0-SNAPSHOT.510</version>
+<version>2.0.0-SNAPSHOT.511</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/server/src/main/java/io/spine/server/aggregate/Aggregate.java
+++ b/server/src/main/java/io/spine/server/aggregate/Aggregate.java
@@ -218,18 +218,13 @@ public abstract class Aggregate<I,
      */
     @Override
     protected DispatchOutcome dispatchCommand(CommandEnvelope command) {
-        var error = doubleDispatchGuard().check(command);
-        if (error.isPresent()) {
-            var outcome = DispatchOutcome.newBuilder()
-                    .setPropagatedSignal(command.messageId())
-                    .setError(error.get())
-                    .build();
-            return outcome;
-        } else {
-            var method = thisClass().receptorOf(command);
-            var outcome = method.invoke(this, command);
-            return outcome;
+        var duplicate = detectDuplicate(command);
+        if (duplicate != null) {
+            return duplicate;
         }
+        var method = thisClass().receptorOf(command);
+        var outcome = method.invoke(this, command);
+        return outcome;
     }
 
     /**
@@ -245,13 +240,9 @@ public abstract class Aggregate<I,
      */
     @Override
     protected DispatchOutcome dispatchEvent(EventEnvelope event) {
-        var error = doubleDispatchGuard().check(event);
-        if (error.isPresent()) {
-            var outcome = DispatchOutcome.newBuilder()
-                    .setPropagatedSignal(event.messageId())
-                    .setError(error.get())
-                    .build();
-            return outcome;
+        var duplicate = detectDuplicate(event);
+        if (duplicate != null) {
+            return duplicate;
         }
         var method = thisClass().reactorOf(event);
         return method.map(reactorMethod -> reactorMethod.invoke(this, event))

--- a/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
+++ b/server/src/main/java/io/spine/server/aggregate/AggregateRepository.java
@@ -44,13 +44,10 @@ import io.spine.server.type.CommandClass;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
 import io.spine.server.type.SignalEnvelope;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
-import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.spine.option.EntityOption.Kind.AGGREGATE;
 import static io.spine.server.aggregate.model.AggregateClass.asAggregateClass;
 import static io.spine.server.delivery.InboxLabel.HANDLE_COMMAND;
@@ -101,21 +98,11 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  *         the type of the state of aggregates managed by this repository
  * @see Aggregate
  */
-@SuppressWarnings("resource" /* Accessing `Closeable` properties. */)
 public abstract class AggregateRepository<I,
                                           A extends Aggregate<I, S, ?>,
                                           S extends AggregateState<I>>
         extends SignalDispatchingRepository<I, A, S>
         implements EventProducingRepository {
-
-    /** The window (in journal events) the opt-in double-dispatch guard scans. */
-    private int eventHistoryDepth = SignalDispatchingEntity.DEFAULT_HISTORY_DEPTH;
-
-    /**
-     * The journal of the events emitted by the aggregates of this repository; created lazily
-     * once the journal is first needed.
-     */
-    private @MonotonicNonNull EntityEventStorage<I> eventStorage;
 
     /** Creates a new instance. */
     protected AggregateRepository() {
@@ -174,39 +161,15 @@ public abstract class AggregateRepository<I,
      * {@inheritDoc}
      *
      * <p>Also posts the {@linkplain io.spine.system.server.event.EntityCreated
-     * entity-created} system event, and installs the history loaders and, when enabled,
-     * the double-dispatch guard on the created aggregate.
+     * entity-created} system event. The history loaders and, when enabled, the
+     * double-dispatch guard are installed by the parent repository classes.
      */
     @Override
     @OverridingMethodsMustInvokeSuper
     public A create(I id) {
         var aggregate = super.create(id);
         lifecycleOf(id).onEntityCreated(AGGREGATE);
-        setUpHistoryReading(aggregate, id);
         return aggregate;
-    }
-
-    /**
-     * Installs the event history loader and, when enabled, the double-dispatch guard
-     * on a newly created aggregate.
-     *
-     * <p>The state history loader is installed by the base repository on the
-     * {@linkplain #create(Object) creation} and
-     * {@linkplain #toEntity(EntityRecord) reconstruction} paths; both of those paths
-     * call this method for the event-side reading.
-     *
-     * @param aggregate
-     *         the newly created aggregate
-     * @param id
-     *         the identifier of the aggregate
-     */
-    final void setUpHistoryReading(A aggregate, I id) {
-        aggregate.setEventHistoryLoader(
-                (depth, startingFrom) ->
-                        eventStorage().historyBackward(id, depth, startingFrom));
-        if (doubleDispatchGuardEnabled()) {
-            aggregate.enableDoubleDispatchGuard(eventHistoryDepth);
-        }
     }
 
     /** Obtains class information of aggregates managed by this repository. */
@@ -222,9 +185,16 @@ public abstract class AggregateRepository<I,
     /**
      * {@inheritDoc}
      *
-     * <p>Journals the events the aggregate emitted, then writes its latest state — rather
-     * than delegating to {@link #store(io.spine.server.entity.Entity) store()}, which routes
-     * through the cache.
+     * <p>Always {@code true}: an aggregate repository journals the events emitted by
+     * its aggregates unconditionally.
+     */
+    @Override
+    protected final boolean eventHistoryEnabled() {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
      *
      * @implSpec Skips an aggregate that was neither changed nor produced events. An
      *         overriding repository is expected to call {@code super}: writing an untouched
@@ -240,26 +210,7 @@ public abstract class AggregateRepository<I,
         if (!aggregate.changed() && !aggregate.hasUncommittedEvents()) {
             return;
         }
-        // Journal the emitted events, then store the latest state. Under a batched delivery the
-        // aggregate accumulates its events until `commitEvents()`, so the journal drops none.
-        var events = aggregate.uncommittedEventHistory().get();
-        var journal = eventStorage();
-        events.forEach(journal::write);
         super.doStore(aggregate);
-        aggregate.commitEvents();
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * <p>Stores each aggregate individually via
-     * {@link #store(io.spine.server.entity.Entity) store()}, so that the emitted events
-     * are journaled and an untouched instance is skipped — the bulk write of the parent
-     * class would bypass both.
-     */
-    @Override
-    public final void store(Collection<A> aggregates) {
-        aggregates.forEach(this::store);
     }
 
     /**
@@ -334,69 +285,6 @@ public abstract class AggregateRepository<I,
     }
 
     /**
-     * Returns the number of the most recent events scanned by the opt-in
-     * double-dispatch guard when it is enabled.
-     *
-     * @return a positive integer value; the default is
-     *         {@value SignalDispatchingEntity#DEFAULT_HISTORY_DEPTH}
-     */
-    protected int eventHistoryDepth() {
-        return this.eventHistoryDepth;
-    }
-
-    /**
-     * Sets the {@linkplain #eventHistoryDepth() event history depth} to the passed value.
-     *
-     * @param depth
-     *         a positive number of recent events the double-dispatch guard scans
-     */
-    protected void setEventHistoryDepth(int depth) {
-        checkArgument(depth > 0);
-        this.eventHistoryDepth = depth;
-    }
-
-    /**
-     * Creates the journal of the events emitted by the aggregates of this repository.
-     *
-     * <p>Mirrors {@link #createStorage()}: the default implementation uses the
-     * {@linkplain #defaultStorageFactory() default storage factory} — the same one the default
-     * {@code createStorage()} uses for the aggregate state. A repository that overrides
-     * {@code createStorage()} to serve the aggregate state from a custom
-     * {@link io.spine.server.storage.StorageFactory} or backend should override this method as
-     * well, so the journal — feeding the double-dispatch guard and the
-     * {@linkplain SignalDispatchingEntity#eventHistoryBackward(int) recent-history}
-     * reads — is served by the same backend as the state, rather than silently falling
-     * back to the default one.
-     *
-     * @return a new event journal
-     */
-    protected EntityEventStorage<I> createEventStorage() {
-        return defaultStorageFactory().createEntityEventStorage(context().spec(), entityClass());
-    }
-
-    /**
-     * Returns the journal of the events emitted by the aggregates of this repository,
-     * creating it lazily via {@link #createEventStorage()} on the first access.
-     *
-     * <p>Unlike the opt-in {@linkplain #stateHistory() state history}, the journal is always
-     * maintained, so this accessor has no fail-fast gate: it exposes the journal — e.g., for the
-     * {@linkplain EntityEventStorage#truncate(com.google.protobuf.Timestamp) time-based
-     * truncation} that bounds the journal growth as a periodic maintenance operation.
-     *
-     * <p>Synchronized for the same reason as {@link #stateHistoryStorage()}: unlike the main
-     * {@linkplain #storage() storage}, the journal is first touched when a signal is dispatched,
-     * possibly by concurrent workers.
-     *
-     * @return the event journal of this repository
-     */
-    protected final synchronized EntityEventStorage<I> eventStorage() {
-        if (eventStorage == null) {
-            eventStorage = createEventStorage();
-        }
-        return eventStorage;
-    }
-
-    /**
      * Loads or creates an aggregate by the passed ID.
      *
      * @param id
@@ -427,19 +315,6 @@ public abstract class AggregateRepository<I,
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * <p>Installs the history loaders and, when enabled, the double-dispatch guard on
-     * the reconstructed aggregate.
-     */
-    @Override
-    protected final A toEntity(EntityRecord record) {
-        var result = super.toEntity(record);
-        setUpHistoryReading(result, result.id());
-        return result;
-    }
-
-    /**
      * Loads an aggregate by the passed ID.
      *
      * <p>An aggregate will be loaded even if the
@@ -455,36 +330,5 @@ public abstract class AggregateRepository<I,
     @Override
     public Optional<A> find(I id) throws IllegalStateException {
         return load(id);
-    }
-
-    @OverridingMethodsMustInvokeSuper
-    @Override
-    public void close() {
-        // Release every owned resource even if one close fails: the first failure is kept as
-        // the primary exception and the later ones are attached to it as suppressed, so none of
-        // them is lost. `super.close()` is called directly (not via the helper) so that the
-        // `@OverridingMethodsMustInvokeSuper` check recognizes the super-call.
-        RuntimeException failure = null;
-        try {
-            super.close();
-        } catch (RuntimeException e) {
-            failure = e;
-        }
-        failure = attemptClose(failure, this::closeEventStorage);
-        if (failure != null) {
-            throw failure;
-        }
-    }
-
-    /**
-     * Closes the event journal if it was created.
-     *
-     * <p>Synchronized to pair with {@link #eventStorage()}: the journal may have been
-     * created by a dispatch worker, and the closing thread must observe that write.
-     */
-    private synchronized void closeEventStorage() {
-        if (eventStorage != null && eventStorage.isOpen()) {
-            eventStorage.close();
-        }
     }
 }

--- a/server/src/main/java/io/spine/server/entity/DoubleDispatchGuard.java
+++ b/server/src/main/java/io/spine/server/entity/DoubleDispatchGuard.java
@@ -61,7 +61,7 @@ public final class DoubleDispatchGuard {
      *
      * <p>Off by default: deduplication is primarily the delivery layer's responsibility, and this
      * guard is an opt-in per-repository backstop (see
-     * {@link io.spine.server.aggregate.AggregateRepository#useDoubleDispatchGuard()}).
+     * {@link SignalDispatchingRepository#useDoubleDispatchGuard()}).
      */
     private boolean enabled = false;
 

--- a/server/src/main/java/io/spine/server/entity/SignalDispatchingRepository.java
+++ b/server/src/main/java/io/spine/server/entity/SignalDispatchingRepository.java
@@ -54,9 +54,9 @@ import static io.spine.util.Suppliers2.memoize;
  *
  * <p>The entities of such a repository emit events. The repository appends the emitted
  * events to the per-entity {@linkplain #eventStorage() event journal}, kept append-only
- * for traceability, for the
- * {@linkplain SignalDispatchingEntity#eventHistoryBackward(int) recent-history reads},
- * and for the opt-in double-dispatch guard. Whether the journal is written is told by
+ * for traceability. The journal serves the
+ * {@linkplain SignalDispatchingEntity#eventHistoryBackward(int) recent-history reads}
+ * and the opt-in double-dispatch guard. Whether the journal is written is determined by
  * {@link #eventHistoryEnabled()}: the journaling is unconditional for aggregates and
  * opt-in for process managers.
  *
@@ -110,9 +110,11 @@ public abstract class SignalDispatchingRepository<I,
      * (via a {@linkplain io.spine.server.commandbus.DelegatingCommandDispatcher
      * delegating dispatcher}), and sets up the routing of the commands.
      *
-     * <p>Also verifies that the configuration of this repository is consistent — e.g.,
-     * that the {@linkplain #useDoubleDispatchGuard() double-dispatch guard}, if enabled,
-     * has the {@linkplain #eventHistoryEnabled() event journal} it scans.
+     * <p>Before any of that, verifies that the configuration of this repository is
+     * consistent — e.g., that the {@linkplain #useDoubleDispatchGuard() double-dispatch
+     * guard}, if enabled, has the {@linkplain #eventHistoryEnabled() event journal} it
+     * scans. The check precedes the registration side effects, so a misconfigured
+     * repository is never left subscribed to the buses of the context.
      *
      * @param context
      *         the {@code BoundedContext} of this repository
@@ -120,9 +122,9 @@ public abstract class SignalDispatchingRepository<I,
     @Override
     @OverridingMethodsMustInvokeSuper
     public void registerWith(BoundedContext context) {
+        checkGuardHasJournal();
         super.registerWith(context);
         doSetupCommandRouting();
-        checkGuardHasJournal();
     }
 
     private void doSetupCommandRouting() {
@@ -216,8 +218,7 @@ public abstract class SignalDispatchingRepository<I,
     }
 
     /**
-     * Creates a loader reading the journaled events of the entity with the given
-     * identifier.
+     * Creates a loader reading the journaled events of the entity with the given identifier.
      */
     private EventHistoryLoader eventHistoryLoaderFor(I id) {
         return (depth, startingFrom) -> {
@@ -352,12 +353,12 @@ public abstract class SignalDispatchingRepository<I,
      * Returns the journal of the events emitted by the entities of this repository,
      * creating it lazily via {@link #createEventStorage()} on the first access.
      *
-     * <p>Unlike the opt-in state history, this accessor has no fail-fast gate on
-     * {@link #eventHistoryEnabled()}: it exposes the journal — e.g., for the
-     * {@linkplain EntityEventStorage#truncate(com.google.protobuf.Timestamp) time-based
-     * truncation} that bounds the journal growth as a periodic maintenance operation.
-     * The entity history reads fail fast instead through the loader installed on
-     * the managed entities.
+     * <p>Unlike the opt-in {@linkplain #stateHistory() state history}, this accessor has
+     * no fail-fast gate on {@link #eventHistoryEnabled()}: it exposes the journal — e.g.,
+     * for the {@linkplain EntityEventStorage#truncate(com.google.protobuf.Timestamp)
+     * time-based truncation} that bounds the journal growth as a periodic maintenance
+     * operation. The entity history reads still fail fast, but through the loader
+     * installed on the managed entities.
      *
      * <p>Synchronized for the same reason as {@code stateHistoryStorage()}: unlike the main
      * {@linkplain #storage() storage}, the journal is first touched when a signal is

--- a/server/src/main/java/io/spine/server/entity/SignalDispatchingRepository.java
+++ b/server/src/main/java/io/spine/server/entity/SignalDispatchingRepository.java
@@ -31,21 +31,43 @@ import io.spine.base.EntityState;
 import io.spine.server.BoundedContext;
 import io.spine.server.commandbus.CommandDispatcherDelegate;
 import io.spine.server.dispatch.DispatchOutcome;
+import io.spine.server.entity.storage.EntityEventStorage;
 import io.spine.server.route.CommandRouting;
 import io.spine.server.route.setup.CommandRoutingSetup;
 import io.spine.server.type.CommandEnvelope;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
+import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.server.dispatch.DispatchOutcomes.maybeSentToInbox;
 import static io.spine.server.tenant.TenantAwareRunner.with;
+import static io.spine.util.Exceptions.newIllegalStateException;
 import static io.spine.util.Suppliers2.memoize;
 
 /**
  * Abstract base for repositories that dispatch signals — both events and commands —
  * to the entities they manage.
+ *
+ * <p>The entities of such a repository emit events. The repository appends the emitted
+ * events to the per-entity {@linkplain #eventStorage() event journal}, kept append-only
+ * for traceability, for the
+ * {@linkplain SignalDispatchingEntity#eventHistoryBackward(int) recent-history reads},
+ * and for the opt-in double-dispatch guard. Whether the journal is written is told by
+ * {@link #eventHistoryEnabled()}: the journaling is unconditional for aggregates and
+ * opt-in for process managers.
+ *
+ * <p>Two per-repository settings tune the machinery:
+ * <ul>
+ *     <li>{@link #useDoubleDispatchGuard()} — enables the history-backed double-dispatch
+ *         guard, which rejects a signal already seen among the last
+ *         {@link #eventHistoryDepth()} dispatches;
+ *     <li>{@linkplain #eventHistoryDepth() eventHistoryDepth} — how many recent events
+ *         the guard scans on each dispatch when enabled.
+ * </ul>
  *
  * @param <I>
  *         the type of the entity identifiers
@@ -54,8 +76,9 @@ import static io.spine.util.Suppliers2.memoize;
  * @param <S>
  *         the type of the entity state
  */
+@SuppressWarnings("resource" /* Accessing `Closeable` properties. */)
 public abstract class SignalDispatchingRepository<I,
-                                                  E extends AbstractEntity<I, S>,
+                                                  E extends SignalDispatchingEntity<I, S, ?>,
                                                   S extends EntityState<I>>
         extends EventDispatchingRepository<I, E, S>
         implements CommandDispatcherDelegate {
@@ -65,6 +88,15 @@ public abstract class SignalDispatchingRepository<I,
 
     /** Whether the opt-in double-dispatch guard is enabled for this repository. */
     private boolean doubleDispatchGuardEnabled = false;
+
+    /** The window (in journal events) the opt-in double-dispatch guard scans. */
+    private int eventHistoryDepth = SignalDispatchingEntity.DEFAULT_HISTORY_DEPTH;
+
+    /**
+     * The journal of the events emitted by the entities of this repository; created
+     * lazily once the journal is first needed.
+     */
+    private @MonotonicNonNull EntityEventStorage<I> eventStorage;
 
     protected SignalDispatchingRepository() {
         super();
@@ -78,6 +110,10 @@ public abstract class SignalDispatchingRepository<I,
      * (via a {@linkplain io.spine.server.commandbus.DelegatingCommandDispatcher
      * delegating dispatcher}), and sets up the routing of the commands.
      *
+     * <p>Also verifies that the configuration of this repository is consistent — e.g.,
+     * that the {@linkplain #useDoubleDispatchGuard() double-dispatch guard}, if enabled,
+     * has the {@linkplain #eventHistoryEnabled() event journal} it scans.
+     *
      * @param context
      *         the {@code BoundedContext} of this repository
      */
@@ -86,6 +122,7 @@ public abstract class SignalDispatchingRepository<I,
     public void registerWith(BoundedContext context) {
         super.registerWith(context);
         doSetupCommandRouting();
+        checkGuardHasJournal();
     }
 
     private void doSetupCommandRouting() {
@@ -93,6 +130,23 @@ public abstract class SignalDispatchingRepository<I,
         var entityClass = entityClass();
         CommandRoutingSetup.apply(entityClass, cmdRouting);
         setupCommandRouting(cmdRouting);
+    }
+
+    /**
+     * Ensures the double-dispatch guard, if enabled, is backed by the event journal.
+     *
+     * <p>The guard scans the journal of the entity — with the journaling disabled it
+     * could see only the events of the current instance, silently missing the duplicates
+     * arriving after a cache eviction or a restart. Such a configuration is an error.
+     */
+    private void checkGuardHasJournal() {
+        if (doubleDispatchGuardEnabled() && !eventHistoryEnabled()) {
+            throw newIllegalStateException(
+                    "The double-dispatch guard of the repository `%s` requires the event" +
+                            " journal it scans, but the event journaling is disabled for" +
+                            " this repository. Enable the journaling along with the guard.",
+                    this);
+        }
     }
 
     /**
@@ -110,6 +164,73 @@ public abstract class SignalDispatchingRepository<I,
      */
     private CommandRouting<I> commandRouting() {
         return commandRouting.get();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Installs the event history loader and, when enabled, the double-dispatch guard
+     * on the created entity.
+     */
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public E create(I id) {
+        var entity = super.create(id);
+        setUpEventHistoryReading(entity, id);
+        return entity;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Installs the event history loader and, when enabled, the double-dispatch guard
+     * on the reconstructed entity.
+     */
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    protected E toEntity(EntityRecord record) {
+        var entity = super.toEntity(record);
+        setUpEventHistoryReading(entity, entity.id());
+        return entity;
+    }
+
+    /**
+     * Installs the event history loader and, when enabled, the double-dispatch guard
+     * on a newly created or reconstructed entity.
+     *
+     * <p>The loader is installed unconditionally: whether this repository journals the
+     * emitted events gates only the behavior of the installed loader — while the
+     * journaling is off, reading through it fails fast rather than serving an empty
+     * history. An entity created outside a repository has no loader and reads empty.
+     *
+     * @param entity
+     *         the entity to set up
+     * @param id
+     *         the identifier of the entity
+     */
+    private void setUpEventHistoryReading(E entity, I id) {
+        entity.setEventHistoryLoader(eventHistoryLoaderFor(id));
+        if (doubleDispatchGuardEnabled()) {
+            entity.enableDoubleDispatchGuard(eventHistoryDepth());
+        }
+    }
+
+    /**
+     * Creates a loader reading the journaled events of the entity with the given
+     * identifier.
+     */
+    private EventHistoryLoader eventHistoryLoaderFor(I id) {
+        return (depth, startingFrom) -> {
+            if (!eventHistoryEnabled()) {
+                throw newIllegalStateException(
+                        "The repository `%s` does not journal the events emitted by its" +
+                                " entities, so their event history is not readable." +
+                                " Enable the journaling for this repository — see" +
+                                " `eventHistoryEnabled()` — before reading the history.",
+                        this);
+            }
+            return eventStorage().historyBackward(id, depth, startingFrom);
+        };
     }
 
     /**
@@ -154,12 +275,10 @@ public abstract class SignalDispatchingRepository<I,
      * guard is <b>off by default</b> for performance: it adds a bounded history read to every
      * dispatch.
      *
-     * <p><b>Note:</b> this flag takes effect only in repositories that also wire the entity
-     * side of the history machinery — installing the event-history loader on each entity and
-     * enabling the guard on it. {@link io.spine.server.aggregate.AggregateRepository
-     * AggregateRepository} performs this wiring for aggregates. In a repository whose entities
-     * are not {@link SignalDispatchingEntity} — such as a process-manager repository at
-     * present — enabling the guard has no effect until that wiring is added.
+     * <p>The guard scans the {@linkplain #eventStorage() event journal} of the entity, so it
+     * requires the {@linkplain #eventHistoryEnabled() journaling to be enabled}: registering
+     * a repository that enables the guard while leaving the journaling off fails with a
+     * configuration error.
      */
     protected void useDoubleDispatchGuard() {
         this.doubleDispatchGuardEnabled = true;
@@ -172,5 +291,146 @@ public abstract class SignalDispatchingRepository<I,
      */
     protected boolean doubleDispatchGuardEnabled() {
         return doubleDispatchGuardEnabled;
+    }
+
+    /**
+     * Returns the number of the most recent events scanned by the opt-in
+     * double-dispatch guard when it is enabled.
+     *
+     * @return a positive integer value; the default is
+     *         {@value SignalDispatchingEntity#DEFAULT_HISTORY_DEPTH}
+     */
+    protected int eventHistoryDepth() {
+        return this.eventHistoryDepth;
+    }
+
+    /**
+     * Sets the {@linkplain #eventHistoryDepth() event history depth} to the passed value.
+     *
+     * @param depth
+     *         a positive number of recent events the double-dispatch guard scans
+     */
+    protected void setEventHistoryDepth(int depth) {
+        checkArgument(depth > 0);
+        this.eventHistoryDepth = depth;
+    }
+
+    /**
+     * Tells whether this repository maintains the event history — the journal of the
+     * events emitted by its entities.
+     *
+     * <p>Each concrete repository kind states its posture: the journaling is
+     * unconditional for aggregates and opt-in for process managers.
+     *
+     * <p>While the journaling is disabled, the emitted events are not written to the
+     * {@linkplain #eventStorage() journal}, and reading the
+     * {@linkplain SignalDispatchingEntity#eventHistoryBackward(int) event history} of an
+     * entity managed by this repository fails fast.
+     */
+    protected abstract boolean eventHistoryEnabled();
+
+    /**
+     * Creates the journal of the events emitted by the entities of this repository.
+     *
+     * <p>Mirrors {@link #createStorage()}: the default implementation uses the
+     * {@linkplain #defaultStorageFactory() default storage factory} — the same one the default
+     * {@code createStorage()} uses for the entity state. A repository that overrides
+     * {@code createStorage()} to serve the entity state from a custom
+     * {@link io.spine.server.storage.StorageFactory} or backend should override this method as
+     * well, so the journal — feeding the double-dispatch guard and the
+     * {@linkplain SignalDispatchingEntity#eventHistoryBackward(int) recent-history}
+     * reads — is served by the same backend as the state, rather than silently falling
+     * back to the default one.
+     *
+     * @return a new event journal
+     */
+    protected EntityEventStorage<I> createEventStorage() {
+        return defaultStorageFactory().createEntityEventStorage(context().spec(), entityClass());
+    }
+
+    /**
+     * Returns the journal of the events emitted by the entities of this repository,
+     * creating it lazily via {@link #createEventStorage()} on the first access.
+     *
+     * <p>Unlike the opt-in state history, this accessor has no fail-fast gate on
+     * {@link #eventHistoryEnabled()}: it exposes the journal — e.g., for the
+     * {@linkplain EntityEventStorage#truncate(com.google.protobuf.Timestamp) time-based
+     * truncation} that bounds the journal growth as a periodic maintenance operation.
+     * The entity history reads fail fast instead through the loader installed on
+     * the managed entities.
+     *
+     * <p>Synchronized for the same reason as {@code stateHistoryStorage()}: unlike the main
+     * {@linkplain #storage() storage}, the journal is first touched when a signal is
+     * dispatched, possibly by concurrent workers.
+     *
+     * @return the event journal of this repository
+     */
+    protected final synchronized EntityEventStorage<I> eventStorage() {
+        if (eventStorage == null) {
+            eventStorage = createEventStorage();
+        }
+        return eventStorage;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>When the {@linkplain #eventHistoryEnabled() journaling is enabled}, writes the
+     * events the entity emitted to the {@linkplain #eventStorage() journal} before storing
+     * its latest state, and marks them committed after. Under a batched delivery the
+     * entity accumulates its events until {@code commitEvents()}, so the journal drops none.
+     */
+    @Override
+    protected void doStore(E entity) {
+        if (eventHistoryEnabled()) {
+            var events = entity.uncommittedEventHistory().get();
+            var journal = eventStorage();
+            events.forEach(journal::write);
+        }
+        super.doStore(entity);
+        entity.commitEvents();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Stores each entity individually via
+     * {@link #store(io.spine.server.entity.Entity) store()}, so that the emitted events
+     * are journaled — the bulk write of the parent class would bypass the journaling.
+     */
+    @Override
+    public final void store(Collection<E> entities) {
+        entities.forEach(this::store);
+    }
+
+    @OverridingMethodsMustInvokeSuper
+    @Override
+    public void close() {
+        // Release every owned resource even if one close fails: the first failure is kept as
+        // the primary exception and the later ones are attached to it as suppressed, so none of
+        // them is lost. `super.close()` is called directly (not via the helper) so that the
+        // `@OverridingMethodsMustInvokeSuper` check recognizes the super-call.
+        RuntimeException failure = null;
+        try {
+            super.close();
+        } catch (RuntimeException e) {
+            failure = e;
+        }
+        failure = attemptClose(failure, this::closeEventStorage);
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    /**
+     * Closes the event journal if it was created.
+     *
+     * <p>Synchronized to pair with {@link #eventStorage()}: the journal may have been
+     * created by a dispatch worker, and the closing thread must observe that write.
+     */
+    private synchronized void closeEventStorage() {
+        if (eventStorage != null && eventStorage.isOpen()) {
+            eventStorage.close();
+        }
     }
 }

--- a/server/src/main/java/io/spine/server/procman/PmEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmEndpoint.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -54,7 +54,7 @@ abstract class PmEndpoint<I,
 
     @Override
     protected boolean isModified(P processManager) {
-        var result = processManager.changed();
+        var result = processManager.changed() || processManager.hasUncommittedEvents();
         return result;
     }
 
@@ -101,6 +101,16 @@ abstract class PmEndpoint<I,
         PmTransaction<?, ?, ?> tx = repository().beginTransactionFor(processManager);
         var outcome = invokeDispatcher(processManager);
         tx.commitIfActive();
+        // Record the produced events as the process manager's uncommitted history right after
+        // the transaction commits (success only), so that the repository journals them on
+        // store. A rolled-back dispatch leaves nothing to record.
+        if (repository().eventHistoryEnabled()
+                && outcome.hasSuccess()
+                && outcome.getSuccess().hasEvents()) {
+            processManager.recordEvents(outcome.getSuccess()
+                                               .getProducedEvents()
+                                               .getEventList());
+        }
         return outcome;
     }
 }

--- a/server/src/main/java/io/spine/server/procman/PmEndpoint.java
+++ b/server/src/main/java/io/spine/server/procman/PmEndpoint.java
@@ -103,7 +103,7 @@ abstract class PmEndpoint<I,
         tx.commitIfActive();
         // Record the produced events as the process manager's uncommitted history right after
         // the transaction commits (success only), so that the repository journals them on
-        // store. A rolled-back dispatch leaves nothing to record.
+        // `store()`. A rolled-back dispatch leaves nothing to record.
         if (repository().eventHistoryEnabled()
                 && outcome.hasSuccess()
                 && outcome.getSuccess().hasEvents()) {

--- a/server/src/main/java/io/spine/server/procman/ProcessManager.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManager.java
@@ -34,9 +34,9 @@ import io.spine.base.ProcessManagerState;
 import io.spine.logging.WithLogging;
 import io.spine.server.BoundedContext;
 import io.spine.server.command.Assign;
-import io.spine.server.command.AssigneeEntity;
 import io.spine.server.command.Commander;
 import io.spine.server.dispatch.DispatchOutcome;
+import io.spine.server.entity.SignalDispatchingEntity;
 import io.spine.server.entity.Transaction;
 import io.spine.server.entity.TransactionalEntity;
 import io.spine.server.event.EventReactor;
@@ -65,6 +65,11 @@ import static java.lang.String.format;
  * <p>Event- and command-handling methods are invoked by the {@link ProcessManagerRepository}
  * that manages instances of a process manager class.
  *
+ * <p>When the repository {@linkplain ProcessManagerRepository#recordEventHistory() journals}
+ * the emitted events, a process manager may consult its recent event history via the
+ * inherited {@link #eventHistoryBackward(int)} and
+ * {@link #eventHistoryContains(int, java.util.function.Predicate)}.
+ *
  * <p>For more information on Process Managers, please see:
  * <ul>
  * <li>
@@ -88,7 +93,7 @@ import static java.lang.String.format;
 public abstract class ProcessManager<I,
                                      S extends ProcessManagerState<I>,
                                      B extends ValidatingBuilder<S>>
-        extends AssigneeEntity<I, S, B>
+        extends SignalDispatchingEntity<I, S, B>
         implements EventReactor,
                    Commander,
                    Querying,
@@ -204,6 +209,10 @@ public abstract class ProcessManager<I,
      */
     @Override
     protected DispatchOutcome dispatchCommand(CommandEnvelope command) {
+        var duplicate = detectDuplicate(command);
+        if (duplicate != null) {
+            return duplicate;
+        }
         ProcessManagerClass<?> thisClass = thisClass();
         var commandClass = command.messageClass();
 
@@ -243,7 +252,12 @@ public abstract class ProcessManager<I,
      *                 in response to the event.
      *         </ul>
      */
-    DispatchOutcome dispatchEvent(EventEnvelope event) {
+    @Override
+    protected DispatchOutcome dispatchEvent(EventEnvelope event) {
+        var duplicate = detectDuplicate(event);
+        if (duplicate != null) {
+            return duplicate;
+        }
         ProcessManagerClass<?> thisClass = thisClass();
         var eventClass = event.messageClass();
         var reactorMethod = thisClass.reactorOf(event);

--- a/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
+++ b/server/src/main/java/io/spine/server/procman/ProcessManagerRepository.java
@@ -39,6 +39,7 @@ import io.spine.server.dispatch.DispatchOutcome;
 import io.spine.server.entity.EntityLifecycleMonitor;
 import io.spine.server.entity.EntityRecord;
 import io.spine.server.entity.EventProducingRepository;
+import io.spine.server.entity.SignalDispatchingEntity;
 import io.spine.server.entity.SignalDispatchingRepository;
 import io.spine.server.entity.TransactionListener;
 import io.spine.server.event.EventBus;
@@ -63,6 +64,27 @@ import static io.spine.util.Exceptions.newIllegalStateException;
 /**
  * The abstract base for Process Managers repositories.
  *
+ * <p>Three per-repository settings tune the optional machinery:
+ * <ul>
+ *     <li>{@link #recordEventHistory()} — journals the events emitted by the process
+ *         managers into the per-entity {@linkplain #eventStorage() event journal}. It is
+ *         <b>off by default</b>: the emitted events are durable in the
+ *         {@link io.spine.server.event.EventStore EventStore} regardless, and the
+ *         per-entity journal is a deliberate diagnostics and history index. While the
+ *         journaling is off, reading the
+ *         {@linkplain SignalDispatchingEntity#eventHistoryBackward(int) event history} of
+ *         a managed process manager fails fast.
+ *     <li>{@link #useDoubleDispatchGuard()} — enables the history-backed double-dispatch
+ *         guard, which rejects a signal already seen among the last
+ *         {@link #eventHistoryDepth()} dispatches. It is <b>off by default</b>, and
+ *         requires the event journal it scans — enable it together with
+ *         {@link #recordEventHistory()}.
+ *     <li>{@link #recordStateHistory()} — records the state history of the process
+ *         managers on each dispatch. This is an opt-in feature shared by all entity
+ *         repositories (see {@link io.spine.server.entity.AbstractEntityRepository}).
+ *         It is <b>off by default</b>.
+ * </ul>
+ *
  * @param <I>
  *         the type of IDs of process managers
  * @param <P>
@@ -77,8 +99,41 @@ public abstract class ProcessManagerRepository<I,
         extends SignalDispatchingRepository<I, P, S>
         implements EventProducingRepository {
 
+    /** Whether this repository journals the events emitted by its process managers. */
+    private boolean eventHistoryEnabled = false;
+
     protected ProcessManagerRepository() {
         super();
+    }
+
+    /**
+     * Enables journaling the events emitted by the process managers of this repository.
+     *
+     * <p>Unlike aggregates, whose journal is written unconditionally, process managers
+     * journal their events on an opt-in basis: the emitted events are durable in the
+     * {@link io.spine.server.event.EventStore EventStore} once posted, and the per-entity
+     * journal is a deliberate diagnostics and history index. When the journaling is
+     * enabled, the repository appends the emitted events to the
+     * {@linkplain #eventStorage() journal} on each successful dispatch, and the process
+     * managers may consult their
+     * {@linkplain SignalDispatchingEntity#eventHistoryBackward(int) recent event history}.
+     *
+     * <p>The journal is also required by the {@linkplain #useDoubleDispatchGuard()
+     * double-dispatch guard}.
+     */
+    protected final void recordEventHistory() {
+        this.eventHistoryEnabled = true;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>For process managers, the journaling is opt-in and off by default — see
+     * {@link #recordEventHistory()}.
+     */
+    @Override
+    protected final boolean eventHistoryEnabled() {
+        return eventHistoryEnabled;
     }
 
     /**

--- a/server/src/main/kotlin/io/spine/server/entity/EventHistoryLoader.kt
+++ b/server/src/main/kotlin/io/spine/server/entity/EventHistoryLoader.kt
@@ -37,8 +37,7 @@ import io.spine.core.Version
  * A repository installs a loader on each entity it creates or loads — via
  * [SignalDispatchingEntity.setEventHistoryLoader] — so that the
  * [recent event history reads][RecentEventHistory.read] are served from the
- * durable journal of the entity. See [SignalDispatchingRepository] for
- * the wiring.
+ * durable journal of the entity. See [SignalDispatchingRepository] for the wiring.
  */
 @Internal
 public fun interface EventHistoryLoader : HistoryLoader<Event> {

--- a/server/src/main/kotlin/io/spine/server/entity/SignalDispatchingEntity.kt
+++ b/server/src/main/kotlin/io/spine/server/entity/SignalDispatchingEntity.kt
@@ -29,12 +29,17 @@ package io.spine.server.entity
 import io.spine.annotation.Internal
 import io.spine.annotation.VisibleForTesting
 import io.spine.base.EntityState
+import io.spine.base.Error
 import io.spine.core.Event
+import io.spine.core.MessageId
 import io.spine.server.command.AssigneeEntity
 import io.spine.server.dispatch.DispatchOutcome
+import io.spine.server.dispatch.dispatchOutcome
+import io.spine.server.type.CommandEnvelope
 import io.spine.server.type.EventEnvelope
 import io.spine.validation.ValidatingBuilder
 import java.util.function.Predicate
+import kotlin.jvm.optionals.getOrNull
 
 /**
  * Abstract base for entities that dispatch signals — both commands and events —
@@ -182,6 +187,34 @@ public abstract class SignalDispatchingEntity<I : Any,
      * Returns the guard against dispatching the same signal to this entity more than once.
      */
     protected fun doubleDispatchGuard(): DoubleDispatchGuard = doubleDispatchGuard
+
+    /**
+     * Checks the passed command against the [double-dispatch guard][doubleDispatchGuard].
+     *
+     * @param command The envelope with the command about to be dispatched.
+     * @return The erroneous outcome to return instead of dispatching, if the command was
+     *   already dispatched to this entity, or `null` if the dispatch may proceed.
+     */
+    protected fun detectDuplicate(command: CommandEnvelope): DispatchOutcome? =
+        doubleDispatchGuard.check(command).getOrNull()
+            ?.let { error -> duplicateOutcome(command.messageId(), error) }
+
+    /**
+     * Checks the passed event against the [double-dispatch guard][doubleDispatchGuard].
+     *
+     * @param event The envelope with the event about to be dispatched.
+     * @return The erroneous outcome to return instead of dispatching, if the event was
+     *   already dispatched to this entity, or `null` if the dispatch may proceed.
+     */
+    protected fun detectDuplicate(event: EventEnvelope): DispatchOutcome? =
+        doubleDispatchGuard.check(event).getOrNull()
+            ?.let { error -> duplicateOutcome(event.messageId(), error) }
+
+    private fun duplicateOutcome(signal: MessageId, error: Error): DispatchOutcome =
+        dispatchOutcome {
+            propagatedSignal = signal
+            this.error = error
+        }
 
     /**
      * Enables the opt-in double-dispatch guard for this entity, scanning up to

--- a/server/src/main/kotlin/io/spine/server/entity/TransactionalEntity.kt
+++ b/server/src/main/kotlin/io/spine/server/entity/TransactionalEntity.kt
@@ -173,17 +173,14 @@ public abstract class TransactionalEntity<I : Any, S : EntityState<I>, B : Valid
      * Provides the `alter` block for changing properties of the entity
      * state [builder].
      *
-     * For example, a receptor of a [ProcessManager][io.spine.server.procman.ProcessManager]
-     * handling a command may look like this:
+     * For example, a receptor of a [Projection][io.spine.server.projection.Projection]
+     * may look like this:
      *
      * ```kotlin
-     * @Assign
-     * fun handle(command: CreateTask): TaskCreated {
-     *     alter {
-     *         title = command.title
-     *         description = command.description
-     *     }
-     *     return taskCreated { title = command.title }
+     * @Subscribe
+     * fun on(e: TaskCreated) = alter {
+     *     title = e.title
+     *     description = e.description
      * }
      * ```
      * **API Note:** This function is not `inline` because [builder] is

--- a/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryTest.java
+++ b/server/src/test/java/io/spine/server/aggregate/AggregateRepositoryTest.java
@@ -36,7 +36,6 @@ import io.spine.server.aggregate.given.repo.AnemicAggregateRepository;
 import io.spine.server.aggregate.given.repo.EventDiscardingAggregateRepository;
 import io.spine.server.aggregate.given.repo.FailingAggregateRepository;
 import io.spine.server.aggregate.given.repo.ProjectAggregate;
-import io.spine.server.aggregate.given.repo.ProjectAggregateRepository;
 import io.spine.server.aggregate.given.repo.ReactingAggregate;
 import io.spine.server.aggregate.given.repo.ReactingRepository;
 import io.spine.server.aggregate.given.repo.RejectingRepository;
@@ -47,7 +46,6 @@ import io.spine.server.type.CommandEnvelope;
 import io.spine.server.type.EventClass;
 import io.spine.server.type.EventEnvelope;
 import io.spine.system.server.DiagnosticMonitor;
-import io.spine.test.aggregate.AggProject;
 import io.spine.test.aggregate.ProjectId;
 import io.spine.test.aggregate.Task;
 import io.spine.test.aggregate.command.AggAddTask;
@@ -65,7 +63,6 @@ import io.spine.testing.server.TestEventFactory;
 import io.spine.testing.server.blackbox.BlackBox;
 import io.spine.testing.server.model.ModelTests;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -75,7 +72,6 @@ import java.util.List;
 import java.util.Set;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.spine.base.Time.currentTime;
 import static io.spine.grpc.StreamObservers.noOpObserver;
 import static io.spine.protobuf.Messages.isNotDefault;
 import static io.spine.server.aggregate.given.repo.AggregateRepositoryTestEnv.context;
@@ -173,7 +169,7 @@ class AggregateRepositoryTest {
 
             assertFound(firstId);
             assertFound(secondId);
-            var journal = repository().eventStorage();
+            var journal = repository().journal();
             assertTrue(journal.historyBackward(firstId, 1).hasNext());
             assertTrue(journal.historyBackward(secondId, 1).hasNext());
         }
@@ -191,7 +187,7 @@ class AggregateRepositoryTest {
             assertTrue(history.hasNext());
         }
 
-        private ProjectAggregate assertFound(ProjectId id) {
+        private static ProjectAggregate assertFound(ProjectId id) {
             var optional = repository().find(id);
             assertTrue(optional.isPresent());
             return optional.get();

--- a/server/src/test/kotlin/io/spine/server/procman/PmDoubleDispatchGuardSpec.kt
+++ b/server/src/test/kotlin/io/spine/server/procman/PmDoubleDispatchGuardSpec.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.procman
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.spine.core.Command
+import io.spine.core.CommandValidationError
+import io.spine.core.Event
+import io.spine.core.EventValidationError
+import io.spine.grpc.StreamObservers.noOpObserver
+import io.spine.server.BoundedContext
+import io.spine.server.BoundedContextBuilder
+import io.spine.server.procman.given.journal.JournalTestEnv.createProject
+import io.spine.server.procman.given.journal.JournalTestEnv.newProjectId
+import io.spine.server.procman.given.journal.JournalTestEnv.ownerChanged
+import io.spine.server.procman.given.journal.JournalTestEnv.startProject
+import io.spine.server.procman.given.journal.JournalTestPmRepo
+import io.spine.server.procman.given.journal.JournalTestProcman
+import io.spine.server.type.CommandEnvelope
+import io.spine.server.type.EventEnvelope
+import io.spine.test.procman.ProjectId
+import io.spine.testing.server.model.ModelTests
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("`ProcessManager` double-dispatch guard should")
+internal class PmDoubleDispatchGuardSpec {
+
+    private lateinit var context: BoundedContext
+    private lateinit var id: ProjectId
+
+    @BeforeEach
+    fun setUp() {
+        ModelTests.dropAllModels()
+        context = BoundedContextBuilder.assumingTests().build()
+        id = newProjectId()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        context.close()
+        ModelTests.dropAllModels()
+    }
+
+    private fun register(journaling: Boolean = true, guard: Boolean = true): JournalTestPmRepo {
+        val repo = JournalTestPmRepo(journaling = journaling, guard = guard)
+        context.internalAccess().register(repo)
+        return repo
+    }
+
+    private fun post(command: Command) = context.commandBus().post(command, noOpObserver())
+
+    private fun post(event: Event) = context.eventBus().post(event)
+
+    /**
+     * Loads a fresh instance whose in-memory history is empty, so that
+     * the duplicate detection below reads through the durable journal.
+     */
+    private fun freshInstance(repo: JournalTestPmRepo): JournalTestProcman =
+        repo.find(id).orElseThrow()
+
+    @Test
+    fun `reject a command already dispatched to the entity`() {
+        val repo = register()
+        val command = createProject(id)
+        post(command)
+
+        val duplicate = freshInstance(repo).checkDuplicate(CommandEnvelope.of(command))
+
+        duplicate.shouldNotBeNull()
+        duplicate.error.type shouldBe CommandValidationError::class.java.simpleName
+        duplicate.error.code shouldBe CommandValidationError.DUPLICATE_COMMAND_VALUE
+    }
+
+    @Test
+    fun `reject an event already dispatched to the entity`() {
+        val repo = register()
+        val event = ownerChanged(id)
+        post(event)
+
+        val duplicate = freshInstance(repo).checkDuplicate(EventEnvelope.of(event))
+
+        duplicate.shouldNotBeNull()
+        duplicate.error.type shouldBe EventValidationError::class.java.simpleName
+        duplicate.error.code shouldBe EventValidationError.DUPLICATE_EVENT_VALUE
+    }
+
+    @Test
+    fun `permit a command outside the scanned window`() {
+        val repo = register()
+        repo.depth(1)
+        val command = createProject(id)
+        post(command)
+        // Push the created event out of the depth-1 window with a newer dispatch.
+        post(startProject(id))
+
+        freshInstance(repo).checkDuplicate(CommandEnvelope.of(command)).shouldBeNull()
+    }
+
+    @Test
+    fun `permit a command which was not dispatched`() {
+        val repo = register()
+
+        val instance = repo.create(id)
+
+        instance.checkDuplicate(CommandEnvelope.of(createProject(id))).shouldBeNull()
+    }
+
+    @Test
+    fun `permit a command when another command was dispatched`() {
+        val repo = register()
+        post(createProject(id))
+
+        freshInstance(repo)
+            .checkDuplicate(CommandEnvelope.of(startProject(id)))
+            .shouldBeNull()
+    }
+
+    @Test
+    fun `permit duplicates while the guard is off`() {
+        val repo = register(guard = false)
+        val command = createProject(id)
+
+        post(command)
+
+        // The delivery layer drops a re-posted identical command before it reaches the
+        // entity, so the guard-off posture is asserted directly: the dispatched command
+        // is present in the journaled history, yet the disabled guard does not flag it.
+        val journaled = repo.journal()
+            .historyBackward(id, DEPTH)
+            .asSequence()
+            .toList()
+        journaled shouldHaveSize 1
+        freshInstance(repo).checkDuplicate(CommandEnvelope.of(command)).shouldBeNull()
+    }
+
+    @Nested inner class
+    `require the event journal and` {
+
+        @Test
+        fun `fail to register with the guard enabled and the journaling off`() {
+            val repo = JournalTestPmRepo(journaling = false, guard = true)
+
+            val failure = shouldThrow<IllegalStateException> {
+                context.internalAccess().register(repo)
+            }
+
+            failure.message.shouldNotBeNull() shouldContain "double-dispatch guard"
+        }
+
+        @Test
+        fun `register with both the guard and the journaling enabled`() {
+            shouldNotThrowAny {
+                register(journaling = true, guard = true)
+            }
+        }
+    }
+
+    private companion object {
+
+        /** The journal read window wide enough for every case of this spec. */
+        private const val DEPTH = 10
+    }
+}

--- a/server/src/test/kotlin/io/spine/server/procman/PmEventHistorySpec.kt
+++ b/server/src/test/kotlin/io/spine/server/procman/PmEventHistorySpec.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.procman
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.spine.core.Command
+import io.spine.grpc.StreamObservers.noOpObserver
+import io.spine.server.BoundedContext
+import io.spine.server.BoundedContextBuilder
+import io.spine.server.procman.given.journal.JournalTestEnv.addTask
+import io.spine.server.procman.given.journal.JournalTestEnv.createProject
+import io.spine.server.procman.given.journal.JournalTestEnv.newProjectId
+import io.spine.server.procman.given.journal.JournalTestEnv.startProject
+import io.spine.server.procman.given.journal.JournalTestPmRepo
+import io.spine.server.procman.given.journal.JournalTestProcman
+import io.spine.test.procman.ProjectId
+import io.spine.test.procman.event.PmProjectCreated
+import io.spine.test.procman.event.PmProjectStarted
+import io.spine.test.procman.event.PmTaskAdded
+import io.spine.testing.server.model.ModelTests
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`ProcessManager` event history should")
+internal class PmEventHistorySpec {
+
+    private lateinit var context: BoundedContext
+    private lateinit var id: ProjectId
+
+    @BeforeEach
+    fun setUp() {
+        ModelTests.dropAllModels()
+        context = BoundedContextBuilder.assumingTests().build()
+        id = newProjectId()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        context.close()
+        ModelTests.dropAllModels()
+    }
+
+    private fun register(journaling: Boolean): JournalTestPmRepo {
+        val repo = JournalTestPmRepo(journaling)
+        context.internalAccess().register(repo)
+        return repo
+    }
+
+    private fun post(command: Command) = context.commandBus().post(command, noOpObserver())
+
+    @Test
+    fun `read up to the requested depth, newest first`() {
+        val repo = register(journaling = true)
+        post(createProject(id))
+        post(addTask(id))
+        post(startProject(id))
+        val instance = repo.find(id).orElseThrow()
+
+        val recent = instance.readEventsBackward(2)
+            .asSequence()
+            .toList()
+
+        recent shouldHaveSize 2
+        recent[0].enclosedMessage().shouldBeInstanceOf<PmProjectStarted>()
+        recent[1].enclosedMessage().shouldBeInstanceOf<PmTaskAdded>()
+    }
+
+    @Test
+    fun `tell if the recent events contain a match`() {
+        val repo = register(journaling = true)
+        post(createProject(id))
+        post(addTask(id))
+        post(startProject(id))
+        val instance = repo.find(id).orElseThrow()
+
+        instance.containsEvent(3) { it.enclosedMessage() is PmProjectCreated } shouldBe true
+        instance.containsEvent(1) { it.enclosedMessage() is PmProjectCreated } shouldBe false
+    }
+
+    @Test
+    fun `fail fast when the managing repository does not journal the events`() {
+        val repo = register(journaling = false)
+        post(createProject(id))
+        val instance = repo.find(id).orElseThrow()
+
+        val failure = shouldThrow<IllegalStateException> {
+            instance.readEventsBackward(5).hasNext()
+        }
+
+        failure.message.shouldNotBeNull() shouldContain "does not journal"
+    }
+
+    @Test
+    fun `serve empty history on an instance created outside a repository`() {
+        val instance = JournalTestProcman()
+
+        instance.readEventsBackward(5).hasNext() shouldBe false
+    }
+}

--- a/server/src/test/kotlin/io/spine/server/procman/PmEventHistorySpec.kt
+++ b/server/src/test/kotlin/io/spine/server/procman/PmEventHistorySpec.kt
@@ -37,15 +37,18 @@ import io.spine.grpc.StreamObservers.noOpObserver
 import io.spine.server.BoundedContext
 import io.spine.server.BoundedContextBuilder
 import io.spine.server.procman.given.journal.JournalTestEnv.addTask
+import io.spine.server.procman.given.journal.JournalTestEnv.completeProject
 import io.spine.server.procman.given.journal.JournalTestEnv.createProject
 import io.spine.server.procman.given.journal.JournalTestEnv.newProjectId
 import io.spine.server.procman.given.journal.JournalTestEnv.startProject
 import io.spine.server.procman.given.journal.JournalTestPmRepo
 import io.spine.server.procman.given.journal.JournalTestProcman
+import io.spine.system.server.DiagnosticMonitor
 import io.spine.test.procman.ProjectId
 import io.spine.test.procman.event.PmProjectCreated
 import io.spine.test.procman.event.PmProjectStarted
 import io.spine.test.procman.event.PmTaskAdded
+import io.spine.testing.logging.mute.MuteLogging
 import io.spine.testing.server.model.ModelTests
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -72,7 +75,7 @@ internal class PmEventHistorySpec {
     }
 
     private fun register(journaling: Boolean): JournalTestPmRepo {
-        val repo = JournalTestPmRepo(journaling)
+        val repo = JournalTestPmRepo(journaling = journaling)
         context.internalAccess().register(repo)
         return repo
     }
@@ -119,6 +122,32 @@ internal class PmEventHistorySpec {
         }
 
         failure.message.shouldNotBeNull() shouldContain "does not journal"
+    }
+
+    /**
+     * Unlike the case above, which reads on a freshly loaded instance, this case reads
+     * on the very instance which has just dispatched a signal within the same delivery
+     * batch. The read must fail fast too: were the endpoint to record the produced
+     * events on a non-journaling repository, they would serve this read from memory,
+     * silently defeating the fail-fast contract.
+     */
+    @Test
+    @MuteLogging
+    fun `fail fast on the instance which just dispatched`() {
+        val repo = register(journaling = false)
+        val monitor = DiagnosticMonitor()
+        context.internalAccess().registerEventDispatcher(monitor)
+
+        repo.beginBatch(id)
+        post(createProject(id))
+        post(completeProject(id))
+        repo.endBatch(id)
+
+        val failures = monitor.handlerFailureEvents()
+        failures shouldHaveSize 1
+        val error = failures[0].error
+        error.type shouldBe IllegalStateException::class.java.canonicalName
+        error.message shouldContain "does not journal"
     }
 
     @Test

--- a/server/src/test/kotlin/io/spine/server/procman/PmEventJournalSpec.kt
+++ b/server/src/test/kotlin/io/spine/server/procman/PmEventJournalSpec.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.procman
+
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.spine.core.Command
+import io.spine.core.Event
+import io.spine.grpc.StreamObservers.noOpObserver
+import io.spine.server.BoundedContext
+import io.spine.server.BoundedContextBuilder
+import io.spine.server.procman.given.journal.JournalTestEnv.addTask
+import io.spine.server.procman.given.journal.JournalTestEnv.createProject
+import io.spine.server.procman.given.journal.JournalTestEnv.newProjectId
+import io.spine.server.procman.given.journal.JournalTestEnv.reviewBacklog
+import io.spine.server.procman.given.journal.JournalTestEnv.throwEntityAlreadyArchived
+import io.spine.server.procman.given.journal.JournalTestPmRepo
+import io.spine.test.procman.ProjectId
+import io.spine.test.procman.event.PmProjectCreated
+import io.spine.test.procman.event.PmTaskAdded
+import io.spine.testing.server.model.ModelTests
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`ProcessManagerRepository` event journal should")
+internal class PmEventJournalSpec {
+
+    private lateinit var context: BoundedContext
+    private lateinit var id: ProjectId
+
+    @BeforeEach
+    fun setUp() {
+        ModelTests.dropAllModels()
+        context = BoundedContextBuilder.assumingTests().build()
+        id = newProjectId()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        context.close()
+        ModelTests.dropAllModels()
+    }
+
+    private fun register(journaling: Boolean): JournalTestPmRepo {
+        val repo = JournalTestPmRepo(journaling = journaling)
+        context.internalAccess().register(repo)
+        return repo
+    }
+
+    private fun post(command: Command) = context.commandBus().post(command, noOpObserver())
+
+    private fun journalOf(repo: JournalTestPmRepo): List<Event> =
+        repo.journal()
+            .historyBackward(id, DEPTH)
+            .asSequence()
+            .toList()
+
+    @Test
+    fun `journal the events emitted by successful dispatches, newest first`() {
+        val repo = register(journaling = true)
+
+        post(createProject(id))
+        post(addTask(id))
+
+        val journaled = journalOf(repo)
+        journaled shouldHaveSize 2
+        journaled[0].enclosedMessage().shouldBeInstanceOf<PmTaskAdded>()
+        journaled[1].enclosedMessage().shouldBeInstanceOf<PmProjectCreated>()
+    }
+
+    @Test
+    fun `journal an event-emitting dispatch which leaves the state unchanged`() {
+        val repo = register(journaling = true)
+
+        post(addTask(id))
+
+        val journaled = journalOf(repo)
+        journaled shouldHaveSize 1
+        journaled[0].enclosedMessage().shouldBeInstanceOf<PmTaskAdded>()
+    }
+
+    @Test
+    fun `journal nothing while the journaling is not enabled`() {
+        val repo = register(journaling = false)
+
+        post(createProject(id))
+
+        journalOf(repo).shouldBeEmpty()
+    }
+
+    @Test
+    fun `not journal rejections`() {
+        val repo = register(journaling = true)
+
+        post(throwEntityAlreadyArchived(id))
+
+        journalOf(repo).shouldBeEmpty()
+    }
+
+    @Test
+    fun `not journal the commands emitted by a commander`() {
+        val repo = register(journaling = true)
+
+        post(reviewBacklog(id))
+
+        val journaled = journalOf(repo)
+        journaled shouldHaveSize 1
+        journaled[0].enclosedMessage().shouldBeInstanceOf<PmTaskAdded>()
+    }
+
+    @Test
+    fun `close the journal when the repository is closed`() {
+        val repo = register(journaling = true)
+        val journal = repo.journal()
+
+        context.close()
+
+        journal.isOpen shouldBe false
+        // Re-create the context so that `tearDown()` closes a live one.
+        context = BoundedContextBuilder.assumingTests().build()
+    }
+
+    private companion object {
+
+        /** The read window wide enough for every case of this spec. */
+        private const val DEPTH = 10
+    }
+}

--- a/server/src/test/kotlin/io/spine/server/procman/given/journal/JournalTestEnv.kt
+++ b/server/src/test/kotlin/io/spine/server/procman/given/journal/JournalTestEnv.kt
@@ -31,6 +31,7 @@ import io.spine.core.Command
 import io.spine.core.Event
 import io.spine.test.procman.ProjectId
 import io.spine.test.procman.command.pmAddTask
+import io.spine.test.procman.command.pmCompleteProject
 import io.spine.test.procman.command.pmCreateProject
 import io.spine.test.procman.command.pmReviewBacklog
 import io.spine.test.procman.command.pmStartProject
@@ -58,6 +59,9 @@ internal object JournalTestEnv {
 
     fun startProject(id: ProjectId): Command =
         command(pmStartProject { projectId = id })
+
+    fun completeProject(id: ProjectId): Command =
+        command(pmCompleteProject { projectId = id })
 
     fun reviewBacklog(id: ProjectId): Command =
         command(pmReviewBacklog { projectId = id })

--- a/server/src/test/kotlin/io/spine/server/procman/given/journal/JournalTestEnv.kt
+++ b/server/src/test/kotlin/io/spine/server/procman/given/journal/JournalTestEnv.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.procman.given.journal
+
+import io.spine.base.CommandMessage
+import io.spine.core.Command
+import io.spine.core.Event
+import io.spine.test.procman.ProjectId
+import io.spine.test.procman.command.pmAddTask
+import io.spine.test.procman.command.pmCreateProject
+import io.spine.test.procman.command.pmReviewBacklog
+import io.spine.test.procman.command.pmStartProject
+import io.spine.test.procman.command.pmThrowEntityAlreadyArchived
+import io.spine.test.procman.event.pmOwnerChanged
+import io.spine.testdata.Sample
+import io.spine.testing.client.TestActorRequestFactory
+import io.spine.testing.server.TestEventFactory
+
+/**
+ * Signal factories for the process-manager journaling and double-dispatch specs.
+ */
+internal object JournalTestEnv {
+
+    private val eventFactory = TestEventFactory.newInstance(JournalTestEnv::class.java)
+    private val requestFactory = TestActorRequestFactory(JournalTestEnv::class.java)
+
+    fun newProjectId(): ProjectId = Sample.messageOfType(ProjectId::class.java)
+
+    fun createProject(id: ProjectId): Command =
+        command(pmCreateProject { projectId = id })
+
+    fun addTask(id: ProjectId): Command =
+        command(pmAddTask { projectId = id })
+
+    fun startProject(id: ProjectId): Command =
+        command(pmStartProject { projectId = id })
+
+    fun reviewBacklog(id: ProjectId): Command =
+        command(pmReviewBacklog { projectId = id })
+
+    fun throwEntityAlreadyArchived(id: ProjectId): Command =
+        command(pmThrowEntityAlreadyArchived { projectId = id })
+
+    fun ownerChanged(id: ProjectId): Event =
+        eventFactory.createEvent(pmOwnerChanged { projectId = id })
+
+    private fun command(message: CommandMessage): Command =
+        requestFactory.command().create(message)
+}

--- a/server/src/test/kotlin/io/spine/server/procman/given/journal/JournalTestPmRepo.kt
+++ b/server/src/test/kotlin/io/spine/server/procman/given/journal/JournalTestPmRepo.kt
@@ -60,4 +60,14 @@ internal class JournalTestPmRepo(
     fun depth(value: Int) {
         setEventHistoryDepth(value)
     }
+
+    /**
+     * Starts serving the given entity from the cache, as a batched delivery would.
+     */
+    fun beginBatch(id: ProjectId) = cache().startCaching(id)
+
+    /**
+     * Stops serving the given entity from the cache, flushing the deferred store.
+     */
+    fun endBatch(id: ProjectId) = cache().stopCaching(id)
 }

--- a/server/src/test/kotlin/io/spine/server/procman/given/journal/JournalTestPmRepo.kt
+++ b/server/src/test/kotlin/io/spine/server/procman/given/journal/JournalTestPmRepo.kt
@@ -24,34 +24,40 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.server.entity
+package io.spine.server.procman.given.journal
 
-import io.spine.annotation.Internal
-import io.spine.core.Event
-import io.spine.core.Version
+import io.spine.server.entity.storage.EntityEventStorage
+import io.spine.server.procman.ProcessManagerRepository
+import io.spine.test.procman.ElephantProcess
+import io.spine.test.procman.ProjectId
 
 /**
- * Lazily loads up to a requested number of an entity's most recent journal
- * events, newest first.
- *
- * A repository installs a loader on each entity it creates or loads — via
- * [SignalDispatchingEntity.setEventHistoryLoader] — so that the
- * [recent event history reads][RecentEventHistory.read] are served from the
- * durable journal of the entity. See [SignalDispatchingRepository] for
- * the wiring.
+ * A test repository of [JournalTestProcman], configuring the event journaling
+ * and the double-dispatch guard as the specs require.
  */
-@Internal
-public fun interface EventHistoryLoader : HistoryLoader<Event> {
+internal class JournalTestPmRepo(
+    journaling: Boolean = true,
+    guard: Boolean = false
+) : ProcessManagerRepository<ProjectId, JournalTestProcman, ElephantProcess>() {
+
+    init {
+        if (journaling) {
+            recordEventHistory()
+        }
+        if (guard) {
+            useDoubleDispatchGuard()
+        }
+    }
 
     /**
-     * Loads up to [depth] most recent events of the entity's journal, newest first.
-     *
-     * When [startingFrom] is given, only the events with versions strictly
-     * lower than it are loaded. `null` starts from the newest event.
-     *
-     * @param depth The maximum number of the most recent events to load; positive.
-     * @param startingFrom If set, only the events with versions lower than this one are loaded.
-     * @return An iterator over the loaded events, newest first.
+     * Exposes the event journal to the tests.
      */
-    override fun load(depth: Int, startingFrom: Version?): Iterator<Event>
+    fun journal(): EntityEventStorage<ProjectId> = eventStorage()
+
+    /**
+     * Exposes the event-history depth setter to the tests.
+     */
+    fun depth(value: Int) {
+        setEventHistoryDepth(value)
+    }
 }

--- a/server/src/test/kotlin/io/spine/server/procman/given/journal/JournalTestProcman.kt
+++ b/server/src/test/kotlin/io/spine/server/procman/given/journal/JournalTestProcman.kt
@@ -65,6 +65,7 @@ import io.spine.test.procman.event.pmTaskAdded
  * emit events while leaving the state unchanged, so the specs can tell the
  * stored-because-changed dispatches from the stored-because-emitted ones.
  */
+@Suppress("TooManyFunctions") // The fixture exposes many `protected` members to the specs.
 internal class JournalTestProcman :
     ProcessManager<ProjectId, ElephantProcess, ElephantProcess.Builder>() {
 

--- a/server/src/test/kotlin/io/spine/server/procman/given/journal/JournalTestProcman.kt
+++ b/server/src/test/kotlin/io/spine/server/procman/given/journal/JournalTestProcman.kt
@@ -39,16 +39,19 @@ import io.spine.server.type.EventEnvelope
 import io.spine.test.procman.ElephantProcess
 import io.spine.test.procman.ProjectId
 import io.spine.test.procman.command.PmAddTask
+import io.spine.test.procman.command.PmCompleteProject
 import io.spine.test.procman.command.PmCreateProject
 import io.spine.test.procman.command.PmReviewBacklog
 import io.spine.test.procman.command.PmStartProject
 import io.spine.test.procman.command.PmThrowEntityAlreadyArchived
 import io.spine.test.procman.command.pmAddTask
+import io.spine.test.procman.event.PmNothingDone
 import io.spine.test.procman.event.PmNotificationSent
 import io.spine.test.procman.event.PmOwnerChanged
 import io.spine.test.procman.event.PmProjectCreated
 import io.spine.test.procman.event.PmProjectStarted
 import io.spine.test.procman.event.PmTaskAdded
+import io.spine.test.procman.event.pmNothingDone
 import io.spine.test.procman.event.pmNotificationSent
 import io.spine.test.procman.event.pmProjectCreated
 import io.spine.test.procman.event.pmProjectStarted
@@ -90,6 +93,18 @@ internal class JournalTestProcman :
         pmProjectStarted {
             projectId = command.projectId
         }
+
+    /**
+     * Reads the recent event history while handling, serving the cases which
+     * verify the reads made by the dispatching instance itself.
+     */
+    @Assign
+    fun handle(command: PmCompleteProject): PmNothingDone {
+        eventHistoryBackward(1).hasNext()
+        return pmNothingDone {
+            projectId = command.projectId
+        }
+    }
 
     /**
      * Always rejects, serving the rejections-are-not-journaled cases.

--- a/server/src/test/kotlin/io/spine/server/procman/given/journal/JournalTestProcman.kt
+++ b/server/src/test/kotlin/io/spine/server/procman/given/journal/JournalTestProcman.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.server.procman.given.journal
+
+import io.spine.base.Identifier
+import io.spine.core.Event
+import io.spine.server.command.Assign
+import io.spine.server.command.Command
+import io.spine.server.dispatch.DispatchOutcome
+import io.spine.server.entity.rejection.EntityAlreadyArchived
+import io.spine.server.event.React
+import io.spine.server.procman.ProcessManager
+import io.spine.server.type.CommandEnvelope
+import io.spine.server.type.EventEnvelope
+import io.spine.test.procman.ElephantProcess
+import io.spine.test.procman.ProjectId
+import io.spine.test.procman.command.PmAddTask
+import io.spine.test.procman.command.PmCreateProject
+import io.spine.test.procman.command.PmReviewBacklog
+import io.spine.test.procman.command.PmStartProject
+import io.spine.test.procman.command.PmThrowEntityAlreadyArchived
+import io.spine.test.procman.command.pmAddTask
+import io.spine.test.procman.event.PmNotificationSent
+import io.spine.test.procman.event.PmOwnerChanged
+import io.spine.test.procman.event.PmProjectCreated
+import io.spine.test.procman.event.PmProjectStarted
+import io.spine.test.procman.event.PmTaskAdded
+import io.spine.test.procman.event.pmNotificationSent
+import io.spine.test.procman.event.pmProjectCreated
+import io.spine.test.procman.event.pmProjectStarted
+import io.spine.test.procman.event.pmTaskAdded
+
+/**
+ * A test process manager opening the `protected` event history reads and
+ * the duplicate detection of [ProcessManager] to Kotlin tests.
+ *
+ * Only the [PmCreateProject] handler mutates the state: the other receptors
+ * emit events while leaving the state unchanged, so the specs can tell the
+ * stored-because-changed dispatches from the stored-because-emitted ones.
+ */
+internal class JournalTestProcman :
+    ProcessManager<ProjectId, ElephantProcess, ElephantProcess.Builder>() {
+
+    @Assign
+    fun handle(command: PmCreateProject): PmProjectCreated {
+        alter {
+            id = command.projectId
+        }
+        return pmProjectCreated {
+            projectId = command.projectId
+        }
+    }
+
+    /**
+     * Emits an event without touching the state, so the dispatch is stored —
+     * and journaled — only because of the emitted event.
+     */
+    @Assign
+    fun handle(command: PmAddTask): PmTaskAdded =
+        pmTaskAdded {
+            projectId = command.projectId
+        }
+
+    @Assign
+    fun handle(command: PmStartProject): PmProjectStarted =
+        pmProjectStarted {
+            projectId = command.projectId
+        }
+
+    /**
+     * Always rejects, serving the rejections-are-not-journaled cases.
+     */
+    @Assign
+    @Throws(EntityAlreadyArchived::class)
+    fun handle(command: PmThrowEntityAlreadyArchived): PmProjectCreated {
+        throw EntityAlreadyArchived.newBuilder()
+            .setEntityId(Identifier.pack(command.projectId))
+            .build()
+    }
+
+    /**
+     * Substitutes the command with another one, serving the
+     * commands-are-not-journaled cases.
+     */
+    @Command
+    fun transform(command: PmReviewBacklog): PmAddTask =
+        pmAddTask {
+            projectId = command.projectId
+        }
+
+    @React
+    fun on(event: PmOwnerChanged): PmNotificationSent =
+        pmNotificationSent {
+            projectId = event.projectId
+        }
+
+    /**
+     * Reads up to [depth] most recent events of this process manager, newest first.
+     */
+    fun readEventsBackward(depth: Int): Iterator<Event> = eventHistoryBackward(depth)
+
+    /**
+     * Tells whether the [depth] most recent events of this process manager contain
+     * an event that satisfies the [predicate].
+     */
+    fun containsEvent(depth: Int, predicate: (Event) -> Boolean): Boolean =
+        eventHistoryContains(depth) { predicate(it) }
+
+    /**
+     * Exposes the duplicate detection for the passed command to the tests.
+     */
+    fun checkDuplicate(command: CommandEnvelope): DispatchOutcome? = detectDuplicate(command)
+
+    /**
+     * Exposes the duplicate detection for the passed event to the tests.
+     */
+    fun checkDuplicate(event: EventEnvelope): DispatchOutcome? = detectDuplicate(event)
+}

--- a/server/src/testFixtures/java/io/spine/server/aggregate/given/aggregate/AbstractAggregateTestRepository.java
+++ b/server/src/testFixtures/java/io/spine/server/aggregate/given/aggregate/AbstractAggregateTestRepository.java
@@ -26,6 +26,7 @@
 
 package io.spine.server.aggregate.given.aggregate;
 
+import io.spine.annotation.VisibleForTesting;
 import io.spine.base.AggregateState;
 import io.spine.core.TenantId;
 import io.spine.server.aggregate.Aggregate;
@@ -66,12 +67,14 @@ public class AbstractAggregateTestRepository<I,
 
     /** Exposes the event-history depth to the tests. */
     @Override
+    @VisibleForTesting
     public int eventHistoryDepth() {
         return super.eventHistoryDepth();
     }
 
     /** Exposes the event-history depth setter to the tests. */
     @Override
+    @VisibleForTesting
     public void setEventHistoryDepth(int depth) {
         super.setEventHistoryDepth(depth);
     }

--- a/server/src/testFixtures/java/io/spine/server/aggregate/given/aggregate/AbstractAggregateTestRepository.java
+++ b/server/src/testFixtures/java/io/spine/server/aggregate/given/aggregate/AbstractAggregateTestRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,5 +62,17 @@ public class AbstractAggregateTestRepository<I,
         var runner = TenantAwareRunner.with(tenantId);
         var result = runner.evaluate(() -> loadAggregate(id));
         return result;
+    }
+
+    /** Exposes the event-history depth to the tests. */
+    @Override
+    public int eventHistoryDepth() {
+        return super.eventHistoryDepth();
+    }
+
+    /** Exposes the event-history depth setter to the tests. */
+    @Override
+    public void setEventHistoryDepth(int depth) {
+        super.setEventHistoryDepth(depth);
     }
 }

--- a/server/src/testFixtures/java/io/spine/server/aggregate/given/repo/ProjectAggregateRepository.java
+++ b/server/src/testFixtures/java/io/spine/server/aggregate/given/repo/ProjectAggregateRepository.java
@@ -35,6 +35,7 @@ import io.spine.server.Identity;
 import io.spine.server.aggregate.AggregateRepository;
 import io.spine.server.entity.EntityRecord;
 import io.spine.server.entity.EntityRecordChange;
+import io.spine.server.entity.storage.EntityEventStorage;
 import io.spine.server.route.EventRouting;
 import io.spine.test.aggregate.AggProject;
 import io.spine.test.aggregate.ProjectId;
@@ -94,5 +95,23 @@ public class ProjectAggregateRepository
     @VisibleForTesting
     public boolean guardEnabled() {
         return doubleDispatchGuardEnabled();
+    }
+
+    /** Exposes the event-history depth to the tests. */
+    @Override
+    public int eventHistoryDepth() {
+        return super.eventHistoryDepth();
+    }
+
+    /** Exposes the event-history depth setter to the tests. */
+    @Override
+    public void setEventHistoryDepth(int depth) {
+        super.setEventHistoryDepth(depth);
+    }
+
+    /** Exposes the event journal to the tests. */
+    @VisibleForTesting
+    public EntityEventStorage<ProjectId> journal() {
+        return eventStorage();
     }
 }

--- a/server/src/testFixtures/java/io/spine/server/aggregate/given/repo/ProjectAggregateRepository.java
+++ b/server/src/testFixtures/java/io/spine/server/aggregate/given/repo/ProjectAggregateRepository.java
@@ -99,12 +99,14 @@ public class ProjectAggregateRepository
 
     /** Exposes the event-history depth to the tests. */
     @Override
+    @VisibleForTesting
     public int eventHistoryDepth() {
         return super.eventHistoryDepth();
     }
 
     /** Exposes the event-history depth setter to the tests. */
     @Override
+    @VisibleForTesting
     public void setEventHistoryDepth(int depth) {
         super.setEventHistoryDepth(depth);
     }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of this library.
  */
-extra.set("versionToPublish", "2.0.0-SNAPSHOT.510")
+extra.set("versionToPublish", "2.0.0-SNAPSHOT.511")


### PR DESCRIPTION
Implements the core of **Phase G** of the de-event-sourcing plan: Process Managers gain the opt-in event journal with full business-API parity, and the journal machinery moves to its shared home so one implementation serves both entity types.

## What changed

**Hierarchy unification**
- `SignalDispatchingRepository` re-binds its `E` parameter from `AbstractEntity` to `SignalDispatchingEntity` — the change that lets the shared repository install the event-history loader and the double-dispatch guard on its entities generically.
- `ProcessManager` re-parents from `AssigneeEntity` onto `SignalDispatchingEntity` (its `dispatchEvent` becomes a `protected @Override` of the base's abstract method).

**Shared journal home** — moved verbatim from `AggregateRepository` to `SignalDispatchingRepository`:
- the `eventStorage()` accessor with its `createEventStorage()` seam, the `eventHistoryDepth` setting, the loader/guard installation on `create()`/`toEntity()`, the `doStore()` journal write, the per-entity bulk `store(Collection)`, and the close-chain participation.
- The journaling posture is the new **`abstract eventHistoryEnabled()`** — each concrete repository kind states its own: `AggregateRepository` returns `true` (`final`, the unconditional posture), `ProcessManagerRepository` returns a flag raised by the new opt-in **`recordEventHistory()`** (naming parallels the state-history `recordStateHistory()`).

**Double-dispatch guard for PMs**
- Both entity kinds receive client-side signals subject to accidental re-submission, so the guard is now a feature of both: `PmEndpoint` records the produced events after commit (journaling repositories only) and stores on `changed() || hasUncommittedEvents()`; both `Aggregate` and `ProcessManager` check duplicates via the new shared `SignalDispatchingEntity.detectDuplicate`.
- **Fail-fast rules:** registering a repository with the guard enabled but journaling off throws a configuration error (the guard requires the journal it scans; the knobs stay orthogonal — no implicit enabling). Reading the event history of a managed instance whose repository does not journal fails fast through the installed loader; a bare instance reads empty — the exact pattern of the Phase F state history.

## Tests

Three new Kotlin specs with dedicated fixtures (18 tests): duplicate command/event rejection on a freshly reloaded instance (journal-backed), window eviction, guard-off behavior, journaling on/off postures, rejections and commander output never journaled, fail-fast reads, journal closing, and the registration validation. All existing aggregate/procman/entity suites pass unchanged — the hoist is behavior-preserving for aggregates.

## Notes for reviewers

- An e2e test that re-posts the same command twice showed the **delivery layer already drops the identical signal** before it reaches the entity — empirically confirming A5's "delivery owns primary dedup". The guard specs therefore assert the journal-backed detection on a freshly loaded instance, which is the case the guard exists for (restarts, cache evictions).
- The `recordEvents` gate on `eventHistoryEnabled()` in `PmEndpoint` is load-bearing, not an optimization: recorded events would serve reads from the in-memory window and silently defeat the journaling-off fail-fast.
- The public widening overrides added to the aggregate test-fixture repositories re-expose protected members that moved to a different package (`io.spine.server.aggregate` → `io.spine.server.entity`), keeping the existing Java suites compiling.
- Pre-PR gate: `./gradlew build dokkaGenerate` green; `spine-code-review` APPROVE, `kotlin-engineer` APPROVE, `review-docs` APPROVE WITH CHANGES — its small prose items (a widow reflow in `SignalDispatchingRepository`, a class-doc run-on, minor wording) are not applied per the no-auto-apply policy and can land as a follow-up doc commit on this PR if wanted.

Detailed task doc: `.agents/tasks/event-history-for-process-managers.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)